### PR TITLE
Wmts featureinfo

### DIFF
--- a/examples/wmtsgetfeatureinfo.html
+++ b/examples/wmtsgetfeatureinfo.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <link rel="stylesheet" href="../css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap.min.css" type="text/css">
+    <link rel="stylesheet" href="../resources/layout.css" type="text/css">
+    <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap-responsive.min.css" type="text/css">
+    <title>WMTS Get feature info example</title>
+  </head>
+  <body>
+
+    <div class="navbar navbar-inverse navbar-fixed-top">
+      <div class="navbar-inner">
+        <div class="container">
+          <a class="brand" href="./"><img src="../resources/logo.png"> OpenLayers 3 Examples</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="container-fluid">
+
+      <div class="row-fluid">
+        <div class="span12">
+          <div id="map" class="map"></div>
+        </div>
+      </div>
+
+      <div class="row-fluid">
+
+        <div class="span4">
+          <h4 id="title">WMTS GetFeatureInfo example</h4>
+          <p id="shortdesc">This example shows how to trigger WMTS GetFeatureInfo requests on click for a WMTS image layer.</p>
+          <div id="docs">
+            <p>See the <a href="getfeatureinfo.js" target="_blank">wmtsgetfeatureinfo.js source</a> to see how this is done.</p>
+          </div>
+          <div id="tags">getfeatureinfo</div>
+        </div>
+        <div class="span4 offset4">
+          <div id="info" class="alert alert-success">
+            &nbsp;
+          </div>
+        </div>
+
+      </div>
+
+    </div>
+
+    <script src="jquery.min.js" type="text/javascript"></script>
+    <script src="../resources/example-behaviour.js" type="text/javascript"></script>
+    <script src="loader.js?id=wmtsgetfeatureinfo" type="text/javascript"></script>
+
+  </body>
+</html>

--- a/examples/wmtsgetfeatureinfo.js
+++ b/examples/wmtsgetfeatureinfo.js
@@ -1,14 +1,13 @@
+goog.require('ol.Attribution');
 goog.require('ol.Map');
 goog.require('ol.View');
-goog.require('ol.layer.Tile');
-goog.require('ol.Attribution');
 goog.require('ol.control');
 goog.require('ol.extent');
+goog.require('ol.layer.Tile');
 goog.require('ol.proj');
 goog.require('ol.source.OSM');
 goog.require('ol.source.WMTS');
 goog.require('ol.tilegrid.WMTS');
-
 
 var projection = ol.proj.get('EPSG:900913');
 var projectionExtent = projection.getExtent();

--- a/examples/wmtsgetfeatureinfo.js
+++ b/examples/wmtsgetfeatureinfo.js
@@ -1,11 +1,9 @@
 goog.require('ol.Attribution');
 goog.require('ol.Map');
 goog.require('ol.View');
-goog.require('ol.control');
 goog.require('ol.extent');
 goog.require('ol.layer.Tile');
 goog.require('ol.proj');
-goog.require('ol.source.OSM');
 goog.require('ol.source.WMTS');
 goog.require('ol.tilegrid.WMTS');
 

--- a/examples/wmtsgetfeatureinfo.js
+++ b/examples/wmtsgetfeatureinfo.js
@@ -1,0 +1,75 @@
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.layer.Tile');
+goog.require('ol.Attribution');
+goog.require('ol.control');
+goog.require('ol.extent');
+goog.require('ol.proj');
+goog.require('ol.source.OSM');
+goog.require('ol.source.WMTS');
+goog.require('ol.tilegrid.WMTS');
+
+
+var projection = ol.proj.get('EPSG:900913');
+var projectionExtent = projection.getExtent();
+var size = ol.extent.getWidth(projectionExtent) / 256;
+var resolutions = new Array(14);
+var matrixIds = new Array(14);
+for (var z = 0; z < 14; ++z) {
+  // generate resolutions and matrixIds arrays for this WMTS
+  resolutions[z] = size / Math.pow(2, z);
+  matrixIds[z] = 'EPSG:900913:'+z;
+}
+
+var attribution = new ol.Attribution({
+  html: 'Tiles &copy; <a href="http://maps.opengeo.org/geowebcache/service/wmts">opengeo</a>'
+});
+
+var wmtsSource =  new ol.source.WMTS({
+  attributions: [attribution],
+  url: 'http://maps.opengeo.org/geowebcache/service/wmts',
+  layer: 'graphite',
+  matrixSet: 'EPSG:900913',
+  format: 'image/png',
+  projection: projection,
+  tileGrid: new ol.tilegrid.WMTS({
+    origin: ol.extent.getTopLeft(projectionExtent),
+    resolutions: resolutions,
+    matrixIds: matrixIds
+  }),
+  extent: projectionExtent,
+  //style: '_null'
+})
+
+
+var wmtsLayer = new ol.layer.Tile({
+  source: wmtsSource
+});
+
+
+var view = new ol.View({
+  center: [0, 0],
+  zoom: 2
+});
+
+var viewProjection = /** @type {ol.proj.Projection} */
+    (view.getProjection());
+
+var map = new ol.Map({
+  layers: [wmtsLayer],
+  target: 'map',
+  view: view
+});
+
+map.on('singleclick', function(evt) {
+  console.log("clicked")
+  document.getElementById('info').innerHTML = '';
+  var viewResolution = /** @type {number} */ (view.getResolution());
+  var url = wmtsSource.getGetFeatureInfoUrl(
+      evt.coordinate, viewResolution, viewProjection,
+      {'INFOFORMAT': 'text/html'});
+  if (url) {
+    document.getElementById('info').innerHTML =
+        '<iframe seamless src="' + url + '"></iframe>';
+  }
+});

--- a/examples/wmtsgetfeatureinfo.js
+++ b/examples/wmtsgetfeatureinfo.js
@@ -17,14 +17,14 @@ var matrixIds = new Array(14);
 for (var z = 0; z < 14; ++z) {
   // generate resolutions and matrixIds arrays for this WMTS
   resolutions[z] = size / Math.pow(2, z);
-  matrixIds[z] = 'EPSG:900913:'+z;
+  matrixIds[z] = 'EPSG:900913:' + z;
 }
 
 var attribution = new ol.Attribution({
   html: 'Tiles &copy; <a href="http://maps.opengeo.org/geowebcache/service/wmts">opengeo</a>'
 });
 
-var wmtsSource =  new ol.source.WMTS({
+var wmtsSource = new ol.source.WMTS({
   attributions: [attribution],
   url: 'http://maps.opengeo.org/geowebcache/service/wmts',
   layer: 'graphite',
@@ -36,9 +36,9 @@ var wmtsSource =  new ol.source.WMTS({
     resolutions: resolutions,
     matrixIds: matrixIds
   }),
-  extent: projectionExtent,
+  extent: projectionExtent
   //style: '_null'
-})
+});
 
 
 var wmtsLayer = new ol.layer.Tile({
@@ -61,7 +61,6 @@ var map = new ol.Map({
 });
 
 map.on('singleclick', function(evt) {
-  console.log("clicked")
   document.getElementById('info').innerHTML = '';
   var viewResolution = /** @type {number} */ (view.getResolution());
   var url = wmtsSource.getGetFeatureInfoUrl(

--- a/examples/wmtsgetfeatureinfo.js
+++ b/examples/wmtsgetfeatureinfo.js
@@ -21,7 +21,8 @@ for (var z = 0; z < 14; ++z) {
 }
 
 var attribution = new ol.Attribution({
-  html: 'Tiles &copy; <a href="http://maps.opengeo.org/geowebcache/service/wmts">opengeo</a>'
+  html: 'Tiles &copy; <a href="http://maps.opengeo.org/geowebcache/'+
+    'service/wmts">opengeo</a>'
 });
 
 var wmtsSource = new ol.source.WMTS({

--- a/examples/wmtsgetfeatureinfo.js
+++ b/examples/wmtsgetfeatureinfo.js
@@ -22,7 +22,7 @@ for (var z = 0; z < 14; ++z) {
 
 var attribution = new ol.Attribution({
   html: 'Tiles &copy; <a href="http://maps.opengeo.org/geowebcache/' +
-    'service/wmts">opengeo</a>'
+      'service/wmts">opengeo</a>'
 });
 
 var wmtsSource = new ol.source.WMTS({

--- a/examples/wmtsgetfeatureinfo.js
+++ b/examples/wmtsgetfeatureinfo.js
@@ -25,7 +25,7 @@ var attribution = new ol.Attribution({
 
 var wmtsSource = new ol.source.WMTS({
   attributions: [attribution],
-  url: 'http://maps.opengeo.org/geowebcache/service/wmts',
+  extent: projectionExtent,
   layer: 'graphite',
   matrixSet: 'EPSG:900913',
   format: 'image/png',
@@ -35,7 +35,7 @@ var wmtsSource = new ol.source.WMTS({
     resolutions: resolutions,
     matrixIds: matrixIds
   }),
-  extent: projectionExtent
+  url: 'http://maps.opengeo.org/geowebcache/service/wmts'
   //style: '_null'
 });
 

--- a/examples/wmtsgetfeatureinfo.js
+++ b/examples/wmtsgetfeatureinfo.js
@@ -21,7 +21,7 @@ for (var z = 0; z < 14; ++z) {
 }
 
 var attribution = new ol.Attribution({
-  html: 'Tiles &copy; <a href="http://maps.opengeo.org/geowebcache/'+
+  html: 'Tiles &copy; <a href="http://maps.opengeo.org/geowebcache/' +
     'service/wmts">opengeo</a>'
 });
 

--- a/examples/wmtsgetfeatureinfo.js
+++ b/examples/wmtsgetfeatureinfo.js
@@ -30,13 +30,13 @@ var wmtsSource = new ol.source.WMTS({
   matrixSet: 'EPSG:900913',
   format: 'image/png',
   projection: projection,
+  style: '_null',
   tileGrid: new ol.tilegrid.WMTS({
     origin: ol.extent.getTopLeft(projectionExtent),
     resolutions: resolutions,
     matrixIds: matrixIds
   }),
   url: 'http://maps.opengeo.org/geowebcache/service/wmts'
-  //style: '_null'
 });
 
 

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -420,7 +420,8 @@ ol.source.WMTS.prototype.getGetFeatureInfoUrl =
   };
 
   var tileExtent = tileGrid.getTileCoordExtent(tileCoord);
-  var transformedTileCoord = getTransformedTileCoord(tileCoord, tileGrid, projection);
+  var transformedTileCoord = getTransformedTileCoord(tileCoord, 
+    tileGrid, projection);
 
   if (tileGrid.getResolutions().length <= tileCoord.z) {
     return undefined;
@@ -429,8 +430,7 @@ ol.source.WMTS.prototype.getGetFeatureInfoUrl =
   var tileResolution = tileGrid.getResolution(tileCoord.z);
   //var tileExtent = tileGrid.getTileCoordExtent(
   //    tileCoord, this.tmpExtent_);
-
-  var tileSize = tileGrid.getTileSize(tileCoord.z);
+  //var tileSize = tileGrid.getTileSize(tileCoord.z);
   var tileMatrix = tileGrid.getMatrixId(tileCoord.z);
 
   var baseParams = {

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -54,6 +54,21 @@ ol.source.WMTS = function(options) {
   this.coordKeyPrefix_ = '';
   this.resetCoordKeyPrefix_();
 
+
+  /**
+   * @private
+   * @type {string}
+   */
+  this.layer_ = options.layer;
+
+
+  /**
+   * @private
+   * @type {Array}
+   */
+  this.matrixSet_ = options.matrixSet;
+
+
   // FIXME: should we guess this requestEncoding from options.url(s)
   //        structure? that would mean KVP only if a template is not provided.
   var requestEncoding = goog.isDef(options.requestEncoding) ?
@@ -136,6 +151,11 @@ ol.source.WMTS = function(options) {
     tileUrlFunction = ol.TileUrlFunction.createFromTileUrlFunctions(
         goog.array.map(urls, createFromWMTSTemplate));
   }
+   /**
+   * @private
+   * @type {Array}
+   */
+  this.urls_ = urls;
 
   var tmpExtent = ol.extent.createEmpty();
   var tmpTileCoord = new ol.TileCoord(0, 0, 0);
@@ -337,4 +357,108 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, layer) {
 
   /* jshint +W069 */
 
+};
+
+
+/**
+ * Return the GetFeatureInfo URL for the passed coordinate, resolution, and
+ * projection. Return `undefined` if the GetFeatureInfo URL cannot be
+ * constructed.
+ * @param {ol.Coordinate} coordinate Coordinate.
+ * @param {number} resolution Resolution.
+ * @param {ol.proj.Projection} projection Projection.
+ * @param {!Object} params GetFeatureInfo params. `INFOFORMAT` at least should
+ *     be provided. 
+ * @return {string|undefined} GetFeatureInfo URL.
+ * @api
+ */
+ol.source.WMTS.prototype.getGetFeatureInfoUrl =
+    function(coordinate, resolution, projection, params) {
+
+  goog.asserts.assert(!('VERSION' in params));
+
+  var pixelRatio = this.tilePixelRatio_;
+  if (isNaN(this.tilePixelRatio_)) {
+    return undefined;
+  }
+
+  var tileGrid = this.getTileGrid();
+  if (goog.isNull(tileGrid)) {
+    tileGrid = this.getTileGridForProjection(projection);
+  }
+
+  var tileCoord = tileGrid.getTileCoordForCoordAndResolution(
+      coordinate, resolution);
+
+  // TODO: this code is duplicated from createFromWMTSTemplate function
+  var getTransformedTileCoord = function(tileCoord, tileGrid, projection){
+      var tmpTileCoord = new ol.TileCoord(0, 0, 0);
+      var tmpExtent = ol.extent.createEmpty();
+      var x = tileCoord.x;
+      var y = -tileCoord.y - 1;
+      var tileExtent = tileGrid.getTileCoordExtent(tileCoord);
+      var projectionExtent = projection.getExtent();
+      var extent = projectionExtent;
+
+      if (!goog.isNull(extent) && projection.isGlobal() &&
+          extent[0] === projectionExtent[0] &&
+          extent[2] === projectionExtent[2]) {
+        var numCols = Math.ceil(
+            ol.extent.getWidth(extent) /
+            ol.extent.getWidth(tileExtent));
+        x = goog.math.modulo(x, numCols);
+        tmpTileCoord.z = tileCoord.z;
+        tmpTileCoord.x = x;
+        tmpTileCoord.y = tileCoord.y;
+        tileExtent = tileGrid.getTileCoordExtent(tmpTileCoord, tmpExtent);
+      }
+      if (!ol.extent.intersects(tileExtent, extent) ||
+          ol.extent.touches(tileExtent, extent)) {
+        return null;
+      }
+      return new ol.TileCoord(tileCoord.z, x, y);
+    };
+
+  var tileExtent = tileGrid.getTileCoordExtent(tileCoord)
+  var transformedTileCoord = getTransformedTileCoord(tileCoord, tileGrid, projection);
+  
+  if (tileGrid.getResolutions().length <= tileCoord.z) {
+    return undefined;
+  }
+
+  var tileResolution = tileGrid.getResolution(tileCoord.z);
+  //var tileExtent = tileGrid.getTileCoordExtent(
+  //    tileCoord, this.tmpExtent_);
+  
+  var tileSize = tileGrid.getTileSize(tileCoord.z);
+  var tileMatrix = tileGrid.getMatrixId(tileCoord.z);
+
+  var baseParams = {
+    'SERVICE': 'WMTS',
+    'VERSION': '1.0.0',
+    'REQUEST': 'GetFeatureInfo',
+    'LAYER': this.layer_,
+    'TileCol': transformedTileCoord.x,
+    'TileRow': transformedTileCoord.y,
+    'TileMatrix': tileMatrix,
+    'TileMatrixSet': this.matrixSet_,
+  };
+  
+  goog.object.extend(baseParams, params);
+
+  var x = Math.floor((coordinate[0] - tileExtent[0]) /
+      (tileResolution / pixelRatio));
+  var y = Math.floor((tileExtent[3] - coordinate[1]) /
+      (tileResolution / pixelRatio));
+
+  goog.object.set(baseParams, 'I', x);
+  goog.object.set(baseParams, 'J', y);
+
+  var url = this.urls_[0];
+
+  // TODO: this is working only for WMTSRequestEncoding == 'KVP'
+  // the function for creating the url shoul be abstracted
+  var featureInfoUrl = goog.uri.utils.appendParamsFromMap(url, baseParams);
+  
+  return featureInfoUrl;
 };

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -151,10 +151,10 @@ ol.source.WMTS = function(options) {
     tileUrlFunction = ol.TileUrlFunction.createFromTileUrlFunctions(
         goog.array.map(urls, createFromWMTSTemplate));
   }
-   /**
-   * @private
-   * @type {Array}
-   */
+  /**
+  * @private
+  * @type {Array}
+  */
   this.urls_ = urls;
 
   var tmpExtent = ol.extent.createEmpty();
@@ -368,7 +368,7 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, layer) {
  * @param {number} resolution Resolution.
  * @param {ol.proj.Projection} projection Projection.
  * @param {!Object} params GetFeatureInfo params. `INFOFORMAT` at least should
- *     be provided. 
+ *     be provided.
  * @return {string|undefined} GetFeatureInfo URL.
  * @api
  */
@@ -391,33 +391,33 @@ ol.source.WMTS.prototype.getGetFeatureInfoUrl =
       coordinate, resolution);
 
   // TODO: this code is duplicated from createFromWMTSTemplate function
-  var getTransformedTileCoord = function(tileCoord, tileGrid, projection){
-      var tmpTileCoord = new ol.TileCoord(0, 0, 0);
-      var tmpExtent = ol.extent.createEmpty();
-      var x = tileCoord.x;
-      var y = -tileCoord.y - 1;
-      var tileExtent = tileGrid.getTileCoordExtent(tileCoord);
-      var projectionExtent = projection.getExtent();
-      var extent = projectionExtent;
+  var getTransformedTileCoord = function(tileCoord, tileGrid, projection) {
+    var tmpTileCoord = new ol.TileCoord(0, 0, 0);
+    var tmpExtent = ol.extent.createEmpty();
+    var x = tileCoord.x;
+    var y = -tileCoord.y - 1;
+    var tileExtent = tileGrid.getTileCoordExtent(tileCoord);
+    var projectionExtent = projection.getExtent();
+    var extent = projectionExtent;
 
-      if (!goog.isNull(extent) && projection.isGlobal() &&
-          extent[0] === projectionExtent[0] &&
-          extent[2] === projectionExtent[2]) {
-        var numCols = Math.ceil(
-            ol.extent.getWidth(extent) /
-            ol.extent.getWidth(tileExtent));
-        x = goog.math.modulo(x, numCols);
-        tmpTileCoord.z = tileCoord.z;
-        tmpTileCoord.x = x;
-        tmpTileCoord.y = tileCoord.y;
-        tileExtent = tileGrid.getTileCoordExtent(tmpTileCoord, tmpExtent);
-      }
-      if (!ol.extent.intersects(tileExtent, extent) ||
-          ol.extent.touches(tileExtent, extent)) {
-        return null;
-      }
-      return new ol.TileCoord(tileCoord.z, x, y);
-    };
+    if (!goog.isNull(extent) && projection.isGlobal() &&
+        extent[0] === projectionExtent[0] &&
+        extent[2] === projectionExtent[2]) {
+      var numCols = Math.ceil(
+          ol.extent.getWidth(extent) /
+          ol.extent.getWidth(tileExtent));
+      x = goog.math.modulo(x, numCols);
+      tmpTileCoord.z = tileCoord.z;
+      tmpTileCoord.x = x;
+      tmpTileCoord.y = tileCoord.y;
+      tileExtent = tileGrid.getTileCoordExtent(tmpTileCoord, tmpExtent);
+    }
+    if (!ol.extent.intersects(tileExtent, extent) ||
+        ol.extent.touches(tileExtent, extent)) {
+      return null;
+    }
+    return new ol.TileCoord(tileCoord.z, x, y);
+  };
 
   var tileExtent = tileGrid.getTileCoordExtent(tileCoord)
   var transformedTileCoord = getTransformedTileCoord(tileCoord, tileGrid, projection);

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -64,7 +64,14 @@ ol.source.WMTS = function(options) {
 
   /**
    * @private
-   * @type {Array}
+   * @type {?number}
+   */
+  this.pixelRatio_ = options.tilePixelRatio || 1;
+
+
+  /**
+   * @private
+   * @type {string}
    */
   this.matrixSet_ = options.matrixSet;
 
@@ -77,6 +84,12 @@ ol.source.WMTS = function(options) {
   // FIXME: should we create a default tileGrid?
   // we could issue a getCapabilities xhr to retrieve missing configuration
   var tileGrid = options.tileGrid;
+
+  /**
+   * @private
+   * @type {?Object}
+   */
+  this.tileGrid_ = tileGrid;
 
   var context = {
     'Layer': options.layer,
@@ -151,10 +164,7 @@ ol.source.WMTS = function(options) {
     tileUrlFunction = ol.TileUrlFunction.createFromTileUrlFunctions(
         goog.array.map(urls, createFromWMTSTemplate));
   }
-  /**
-  * @private
-  * @type {Array}
-  */
+
   this.urls_ = urls;
 
   var tmpExtent = ol.extent.createEmpty();
@@ -377,12 +387,12 @@ ol.source.WMTS.prototype.getGetFeatureInfoUrl =
 
   goog.asserts.assert(!('VERSION' in params));
 
-  var pixelRatio = this.tilePixelRatio_;
-  if (isNaN(this.tilePixelRatio_)) {
+  var pixelRatio = this.pixelRatio_;
+  if (isNaN(pixelRatio)) {
     return undefined;
   }
 
-  var tileGrid = this.getTileGrid();
+  var tileGrid = this.tileGrid_;
   if (goog.isNull(tileGrid)) {
     tileGrid = this.getTileGridForProjection(projection);
   }
@@ -431,7 +441,7 @@ ol.source.WMTS.prototype.getGetFeatureInfoUrl =
   //var tileExtent = tileGrid.getTileCoordExtent(
   //    tileCoord, this.tmpExtent_);
   //var tileSize = tileGrid.getTileSize(tileCoord.z);
-  var tileMatrix = tileGrid.getMatrixId(tileCoord.z);
+  var tileMatrix = tileGrid.getMatrixIds()[tileCoord.z];
 
   var baseParams = {
     'SERVICE': 'WMTS',

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -420,8 +420,8 @@ ol.source.WMTS.prototype.getGetFeatureInfoUrl =
   };
 
   var tileExtent = tileGrid.getTileCoordExtent(tileCoord);
-  var transformedTileCoord = getTransformedTileCoord(tileCoord, 
-    tileGrid, projection);
+  var transformedTileCoord = getTransformedTileCoord(tileCoord,
+      tileGrid, projection);
 
   if (tileGrid.getResolutions().length <= tileCoord.z) {
     return undefined;

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -419,9 +419,9 @@ ol.source.WMTS.prototype.getGetFeatureInfoUrl =
     return new ol.TileCoord(tileCoord.z, x, y);
   };
 
-  var tileExtent = tileGrid.getTileCoordExtent(tileCoord)
+  var tileExtent = tileGrid.getTileCoordExtent(tileCoord);
   var transformedTileCoord = getTransformedTileCoord(tileCoord, tileGrid, projection);
-  
+
   if (tileGrid.getResolutions().length <= tileCoord.z) {
     return undefined;
   }
@@ -429,7 +429,7 @@ ol.source.WMTS.prototype.getGetFeatureInfoUrl =
   var tileResolution = tileGrid.getResolution(tileCoord.z);
   //var tileExtent = tileGrid.getTileCoordExtent(
   //    tileCoord, this.tmpExtent_);
-  
+
   var tileSize = tileGrid.getTileSize(tileCoord.z);
   var tileMatrix = tileGrid.getMatrixId(tileCoord.z);
 
@@ -441,9 +441,9 @@ ol.source.WMTS.prototype.getGetFeatureInfoUrl =
     'TileCol': transformedTileCoord.x,
     'TileRow': transformedTileCoord.y,
     'TileMatrix': tileMatrix,
-    'TileMatrixSet': this.matrixSet_,
+    'TileMatrixSet': this.matrixSet_
   };
-  
+
   goog.object.extend(baseParams, params);
 
   var x = Math.floor((coordinate[0] - tileExtent[0]) /
@@ -459,6 +459,6 @@ ol.source.WMTS.prototype.getGetFeatureInfoUrl =
   // TODO: this is working only for WMTSRequestEncoding == 'KVP'
   // the function for creating the url shoul be abstracted
   var featureInfoUrl = goog.uri.utils.appendParamsFromMap(url, baseParams);
-  
+
   return featureInfoUrl;
 };


### PR DESCRIPTION
This is a first implementation of the method ol.source.WMTS.getGetFeatureInfoUrl.
It adds an example of WMTS GetFeatureInfo and the method implementation.

This implementation is working only for WMTSRequestEncoding == 'KVP', and the example covers this case.

