### PR TITLE
Use exports to getDependencies

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -151,12 +151,21 @@ function getDependencies(config, exports, callback) {
         cwd: root
       };
     }
+    /** Handling of exports file.
+     * If there are no exports, the file returned has 1 newline, so check for
+     * absence of goog functions.
+     * If there are exports, pass this to getDependencies as the main script,
+     * so it can get the dependencies for the exports.
+     */
+    if (exports.indexOf('goog') !== -1) {
+      options.main = exportsPath;
+    }
+
     closure.getDependencies(options, function(err, paths) {
       if (err) {
         callback(err);
         return;
       }
-      paths.push(exportsPath);
       callback(null, paths);
     });
   });


### PR DESCRIPTION
Proposed change to build.js which should speed things up, especially for custom builds.

At the moment, the script runs generateExports before getDependencies but doesn't pass the exports to getDependencies, so the latter always returns the dependency tree for the whole library and passes it to the compiler. With this change the exports are passed to getDependencies, so only those sources needed for the exports are passed to the compiler.

I had to put in a hack to cater for the case where there are no exports, as when compiling app code with the library. It would be better if the script were changed; if there are no exports, then generateExports can be skipped, as there's no point passing an empty file to the compiler. However, that's really a separate issue.

I have tested this with a variety of custom builds, but there may be use cases I haven't considered.

I'm working on an option to use the compiler webservice instead of the jar, and this change is really essential for that, as it makes no sense to always pass the entire library to the compiler over the network.