### PR TITLE
Support extensions to ol.Feature

### DIFF
--- a/src/ol/format/featureformat.js
+++ b/src/ol/format/featureformat.js
@@ -1,6 +1,7 @@
 goog.provide('ol.format.Feature');
 
 goog.require('goog.array');
+goog.require('ol.Feature');
 goog.require('ol.geom.Geometry');
 goog.require('ol.proj');
 
@@ -18,12 +19,28 @@ goog.require('ol.proj');
  * @constructor
  */
 ol.format.Feature = function() {
-
   /**
    * @protected
    * @type {ol.proj.Projection}
    */
   this.defaultDataProjection = null;
+
+  /**
+   * @type {!function((ol.geom.Geometry|Object.<string, *>)=):!ol.Feature}
+   * @protected
+   */
+  this.createFeature = ol.format.Feature.defaultFeatureFunc_;
+};
+
+
+/**
+ * @param {(ol.geom.Geometry|Object.<string, *>)=} opt_arg The optional
+ *  constructor arguments
+ * @return {!ol.Feature} The feature
+ * @private
+ */
+ol.format.Feature.defaultFeatureFunc_ = function(opt_arg) {
+  return new ol.Feature(opt_arg);
 };
 
 
@@ -78,6 +95,15 @@ ol.format.Feature.prototype.adaptOptions = function(
 
 
 /**
+ * @return {!function((ol.geom.Geometry|Object.<string, *>)=):!ol.Feature}
+ *  The function that creates features
+ */
+ol.format.Feature.prototype.getCreateFeatureFunction = function() {
+  return this.createFeature;
+};
+
+
+/**
  * @return {ol.format.FormatType} Format.
  */
 ol.format.Feature.prototype.getType = goog.abstractMethod;
@@ -120,6 +146,16 @@ ol.format.Feature.prototype.readGeometry = goog.abstractMethod;
  * @return {ol.proj.Projection} Projection.
  */
 ol.format.Feature.prototype.readProjection = goog.abstractMethod;
+
+
+/**
+ * Sets the class for creating new features.
+ * @param {!function((ol.geom.Geometry|Object.<string, *>)=):!ol.Feature}
+ *   func The create feature function
+ */
+ol.format.Feature.prototype.setCreateFeatureFunction = function(func) {
+  this.createFeature = func;
+};
 
 
 /**

--- a/src/ol/format/geojsonformat.js
+++ b/src/ol/format/geojsonformat.js
@@ -377,7 +377,7 @@ ol.format.GeoJSON.prototype.readFeatureFromObject = function(
   goog.asserts.assert(geoJSONFeature.type == 'Feature');
   var geometry = ol.format.GeoJSON.readGeometry_(geoJSONFeature.geometry,
       opt_options);
-  var feature = new ol.Feature();
+  var feature = this.createFeature();
   if (goog.isDef(this.geometryName_)) {
     feature.setGeometryName(this.geometryName_);
   }

--- a/src/ol/format/gmlformat.js
+++ b/src/ol/format/gmlformat.js
@@ -202,7 +202,8 @@ ol.format.GML.readFeature_ = function(node, objectStack) {
       values[geometryName] = ol.format.GML.readGeometry(n, objectStack);
     }
   }
-  var feature = new ol.Feature(values);
+
+  var feature = ol.format.XMLFeature.createFeature(objectStack, values);
   if (goog.isDef(geometryName)) {
     feature.setGeometryName(geometryName);
   }
@@ -1067,7 +1068,8 @@ ol.format.GML.prototype.readFeatures;
 ol.format.GML.prototype.readFeaturesFromNode = function(node, opt_options) {
   var options = {
     'featureType': this.featureType_,
-    'featureNS': this.featureNS_
+    'featureNS': this.featureNS_,
+    'createFeature': goog.bind(this.createFeature, this)
   };
   if (goog.isDef(opt_options)) {
     goog.object.extend(options, this.getReadOptions(node, opt_options));

--- a/src/ol/format/gpxformat.js
+++ b/src/ol/format/gpxformat.js
@@ -194,7 +194,7 @@ ol.format.GPX.readRte_ = function(node, objectStack) {
   var geometry = new ol.geom.LineString(null);
   geometry.setFlatCoordinates(ol.geom.GeometryLayout.XYZM, flatCoordinates);
   ol.format.Feature.transformWithOptions(geometry, false, options);
-  var feature = new ol.Feature(geometry);
+  var feature = ol.format.XMLFeature.createFeature(objectStack, geometry);
   feature.setProperties(values);
   return feature;
 };
@@ -226,7 +226,7 @@ ol.format.GPX.readTrk_ = function(node, objectStack) {
   geometry.setFlatCoordinates(
       ol.geom.GeometryLayout.XYZM, flatCoordinates, ends);
   ol.format.Feature.transformWithOptions(geometry, false, options);
-  var feature = new ol.Feature(geometry);
+  var feature = ol.format.XMLFeature.createFeature(objectStack, geometry);
   feature.setProperties(values);
   return feature;
 };
@@ -251,7 +251,7 @@ ol.format.GPX.readWpt_ = function(node, objectStack) {
   var geometry = new ol.geom.Point(
       coordinates, ol.geom.GeometryLayout.XYZM);
   ol.format.Feature.transformWithOptions(geometry, false, options);
-  var feature = new ol.Feature(geometry);
+  var feature = ol.format.XMLFeature.createFeature(objectStack, geometry);
   feature.setProperties(values);
   return feature;
 };
@@ -475,10 +475,16 @@ ol.format.GPX.prototype.readFeaturesFromNode = function(node, opt_options) {
   if (!goog.array.contains(ol.format.GPX.NAMESPACE_URIS_, node.namespaceURI)) {
     return [];
   }
+
+  var options = {
+    'createFeature': goog.bind(this.createFeature, this)
+  };
+  goog.object.extend(options, this.getReadOptions(node, opt_options) || {});
+
   if (node.localName == 'gpx') {
     var features = ol.xml.pushParseAndPop(
         /** @type {Array.<ol.Feature>} */ ([]), ol.format.GPX.GPX_PARSERS_,
-        node, [this.getReadOptions(node, opt_options)]);
+        node, [options]);
     if (goog.isDef(features)) {
       this.handleReadExtensions_(features);
       return features;

--- a/src/ol/format/igcformat.js
+++ b/src/ol/format/igcformat.js
@@ -176,7 +176,7 @@ ol.format.IGC.prototype.readFeatureFromText = function(text, opt_options) {
   var layout = altitudeMode == ol.format.IGCZ.NONE ?
       ol.geom.GeometryLayout.XYM : ol.geom.GeometryLayout.XYZM;
   lineString.setFlatCoordinates(layout, flatCoordinates);
-  var feature = new ol.Feature(ol.format.Feature.transformWithOptions(
+  var feature = this.createFeature(ol.format.Feature.transformWithOptions(
       lineString, false, opt_options));
   feature.setProperties(properties);
   return feature;

--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -1435,7 +1435,7 @@ ol.format.KML.prototype.readPlacemark_ = function(node, objectStack) {
   if (!goog.isDef(object)) {
     return undefined;
   }
-  var feature = new ol.Feature();
+  var feature = this.createFeature();
   var id = node.getAttribute('id');
   if (!goog.isNull(id)) {
     feature.setId(id);

--- a/src/ol/format/osmxmlformat.js
+++ b/src/ol/format/osmxmlformat.js
@@ -75,7 +75,7 @@ ol.format.OSMXML.readNode_ = function(node, objectStack) {
   if (!goog.object.isEmpty(values.tags)) {
     var geometry = new ol.geom.Point(coordinates);
     ol.format.Feature.transformWithOptions(geometry, false, options);
-    var feature = new ol.Feature(geometry);
+    var feature = ol.format.XMLFeature.createFeature(objectStack, geometry);
     feature.setId(id);
     feature.setProperties(values.tags);
     state.features.push(feature);
@@ -114,7 +114,7 @@ ol.format.OSMXML.readWay_ = function(node, objectStack) {
     geometry.setFlatCoordinates(ol.geom.GeometryLayout.XY, flatCoordinates);
   }
   ol.format.Feature.transformWithOptions(geometry, false, options);
-  var feature = new ol.Feature(geometry);
+  var feature = ol.format.XMLFeature.createFeature(objectStack, geometry);
   feature.setId(id);
   feature.setProperties(values.tags);
   state.features.push(feature);
@@ -211,7 +211,11 @@ ol.format.OSMXML.prototype.readFeatures;
  */
 ol.format.OSMXML.prototype.readFeaturesFromNode = function(node, opt_options) {
   goog.asserts.assert(node.nodeType == goog.dom.NodeType.ELEMENT);
-  var options = this.getReadOptions(node, opt_options);
+  var options = {
+    'createFeature': goog.bind(this.createFeature, this)
+  };
+  goog.object.extend(options, this.getReadOptions(node, opt_options) || {});
+
   if (node.localName == 'osm') {
     var state = ol.xml.pushParseAndPop({
       nodes: {},

--- a/src/ol/format/polylineformat.js
+++ b/src/ol/format/polylineformat.js
@@ -266,7 +266,7 @@ ol.format.Polyline.prototype.readFeature;
  */
 ol.format.Polyline.prototype.readFeatureFromText = function(text, opt_options) {
   var geometry = this.readGeometryFromText(text, opt_options);
-  return new ol.Feature(geometry);
+  return this.createFeature(geometry);
 };
 
 

--- a/src/ol/format/wfsformat.js
+++ b/src/ol/format/wfsformat.js
@@ -113,7 +113,8 @@ ol.format.WFS.prototype.readFeatures;
 ol.format.WFS.prototype.readFeaturesFromNode = function(node, opt_options) {
   var context = {
     'featureType': this.featureType_,
-    'featureNS': this.featureNS_
+    'featureNS': this.featureNS_,
+    'createFeature': goog.bind(this.createFeature, this)
   };
   goog.object.extend(context, this.getReadOptions(node,
       goog.isDef(opt_options) ? opt_options : {}));

--- a/src/ol/format/wktformat.js
+++ b/src/ol/format/wktformat.js
@@ -222,7 +222,7 @@ ol.format.WKT.prototype.readFeature;
 ol.format.WKT.prototype.readFeatureFromText = function(text, opt_options) {
   var geom = this.readGeometryFromText(text, opt_options);
   if (goog.isDef(geom)) {
-    var feature = new ol.Feature();
+    var feature = this.createFeature();
     feature.setGeometry(geom);
     return feature;
   }
@@ -257,7 +257,7 @@ ol.format.WKT.prototype.readFeaturesFromText = function(text, opt_options) {
   }
   var feature, features = [];
   for (var i = 0, ii = geometries.length; i < ii; ++i) {
-    feature = new ol.Feature();
+    feature = this.createFeature();
     feature.setGeometry(geometries[i]);
     features.push(feature);
   }

--- a/src/ol/format/xmlfeatureformat.js
+++ b/src/ol/format/xmlfeatureformat.js
@@ -3,6 +3,8 @@ goog.provide('ol.format.XMLFeature');
 goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.dom.NodeType');
+goog.require('goog.object');
+goog.require('ol.Feature');
 goog.require('ol.format.Feature');
 goog.require('ol.format.FormatType');
 goog.require('ol.proj');
@@ -23,6 +25,25 @@ ol.format.XMLFeature = function() {
   goog.base(this);
 };
 goog.inherits(ol.format.XMLFeature, ol.format.Feature);
+
+
+/**
+ * @param {Array.<*>} objectStack Object stack
+ * @param {ol.geom.Geometry|Object.<string, *>=} opt_arg
+ * The argument to pass to the constructor of the feature class
+ * @return {!ol.Feature} The new feature
+ */
+ol.format.XMLFeature.createFeature = function(objectStack, opt_arg) {
+  if (objectStack && objectStack.length > 0) {
+    var context = objectStack[0];
+    goog.asserts.assert(goog.isObject(context));
+    var createFeature = goog.object.get(context, 'createFeature');
+    goog.asserts.assert(goog.isFunction(createFeature));
+    return createFeature(opt_arg);
+  }
+
+  return new ol.Feature(opt_arg);
+};
 
 
 /**

--- a/test/spec/ol/format/geojsonformat.test.js
+++ b/test/spec/ol/format/geojsonformat.test.js
@@ -211,6 +211,26 @@ describe('ol.format.GeoJSON', function() {
       expect(feature.getGeometry()).to.be.an(ol.geom.Point);
     });
 
+    it('can use a custom feature function', function() {
+      var CustomClass = function(opt_stuff) {
+        goog.base(this, opt_stuff);
+      };
+      goog.inherits(CustomClass, ol.Feature);
+      CustomClass.prototype.answer = function() {
+        return 42;
+      };
+      var custom = function(stuff) {
+        return new CustomClass(stuff);
+      };
+
+      var format = new ol.format.GeoJSON({geometryName: 'the_geom'});
+      format.setCreateFeatureFunction(custom);
+
+      var feature = format.readFeature(pointGeoJSON);
+      expect(feature).to.be.a(CustomClass);
+      expect(feature.getGeometryName()).to.be('the_geom');
+      expect(feature.answer()).to.be(42);
+    });
   });
 
   describe('#readFeatures', function() {

--- a/test/spec/ol/format/gmlformat.test.js
+++ b/test/spec/ol/format/gmlformat.test.js
@@ -868,6 +868,44 @@ describe('ol.format.GML', function() {
 
   });
 
+  describe('when using a custom feature function', function() {
+    var CustomClass = function(opt_stuff) {
+      goog.base(this, opt_stuff);
+    };
+    goog.inherits(CustomClass, ol.Feature);
+    CustomClass.prototype.answer = function() {
+      return 42;
+    };
+    var custom = function(stuff) {
+      return new CustomClass(stuff);
+    };
+
+    var features, feature;
+    before(function(done) {
+      afterLoadText('spec/ol/format/gml/more-geoms.xml', function(xml) {
+        try {
+          var config = {
+            'featureNS': 'http://opengeo.org/#medford',
+            'featureType': 'zoning'
+          };
+          var format = new ol.format.GML(config);
+          format.setCreateFeatureFunction(custom);
+          features = format.readFeatures(xml);
+        } catch (e) {
+          done(e);
+        }
+        done();
+      });
+    });
+
+    it('creates the proper class', function() {
+      var feature = features[0];
+
+      expect(feature).to.be.a(CustomClass);
+      expect(feature.answer()).to.be(42);
+    });
+  });
+
   describe('when parsing an attribute name equal to featureType', function() {
 
     var features;
@@ -908,3 +946,4 @@ goog.require('ol.xml');
 goog.require('ol.geom.Point');
 goog.require('ol.geom.Polygon');
 goog.require('ol.proj');
+goog.require('ol.Feature');

--- a/test/spec/ol/format/gpxformat.test.js
+++ b/test/spec/ol/format/gpxformat.test.js
@@ -8,6 +8,17 @@ describe('ol.format.GPX', function() {
   });
 
   describe('readFeatures', function() {
+    // for testing custom feature classes
+    var CustomClass = function(opt_stuff) {
+      goog.base(this, opt_stuff);
+    };
+    goog.inherits(CustomClass, ol.Feature);
+    CustomClass.prototype.answer = function() {
+      return 42;
+    };
+    var custom = function(stuff) {
+      return new CustomClass(stuff);
+    };
 
     describe('rte', function() {
 
@@ -105,6 +116,19 @@ describe('ol.format.GPX', function() {
           featureProjection: 'EPSG:3857'
         });
         expect(serialized).to.xmleql(ol.xml.load(text));
+      });
+
+      it('can read an rte with a custom feature function', function() {
+        var text =
+            '<gpx xmlns="http://www.topografix.com/GPX/1/1">' +
+            '  <rte/>' +
+            '</gpx>';
+        format.setCreateFeatureFunction(custom);
+        var fs = format.readFeatures(text);
+        expect(fs).to.have.length(1);
+        var f = fs[0];
+        expect(f).to.be.a(CustomClass);
+        expect(f.answer()).to.be(42);
       });
 
     });
@@ -285,6 +309,19 @@ describe('ol.format.GPX', function() {
         expect(serialized).to.xmleql(ol.xml.load(text));
       });
 
+      it('can read a trk with a custom feature function', function() {
+        var text =
+            '<gpx xmlns="http://www.topografix.com/GPX/1/1">' +
+            '  <trk/>' +
+            '</gpx>';
+        format.setCreateFeatureFunction(custom);
+        var fs = format.readFeatures(text);
+        expect(fs).to.have.length(1);
+        var f = fs[0];
+        expect(f).to.be.a(CustomClass);
+        expect(f.answer()).to.be(42);
+      });
+
     });
 
     describe('wpt', function() {
@@ -435,6 +472,19 @@ describe('ol.format.GPX', function() {
         expect(f.get('dgpsid')).to.be(10);
         var serialized = format.writeFeatures(fs);
         expect(serialized).to.xmleql(ol.xml.load(text));
+      });
+
+      it('can read a wpt with a custom feature function', function() {
+        var text =
+            '<gpx xmlns="http://www.topografix.com/GPX/1/1">' +
+            '  <wpt lat="1" lon="2"/>' +
+            '</gpx>';
+        format.setCreateFeatureFunction(custom);
+        var fs = format.readFeatures(text);
+        expect(fs).to.have.length(1);
+        var f = fs[0];
+        expect(f).to.be.a(CustomClass);
+        expect(f.answer()).to.be(42);
       });
 
     });

--- a/test/spec/ol/format/kmlformat.test.js
+++ b/test/spec/ol/format/kmlformat.test.js
@@ -66,6 +66,29 @@ describe('ol.format.KML', function() {
         expect(node).to.xmleql(ol.xml.load(text));
       });
 
+      it('can use a custom feature function', function() {
+        var CustomClass = function(opt_stuff) {
+          goog.base(this, opt_stuff);
+        };
+        goog.inherits(CustomClass, ol.Feature);
+        CustomClass.prototype.answer = function() {
+          return 42;
+        };
+        var custom = function(stuff) {
+          return new CustomClass(stuff);
+        };
+
+        var text =
+            '<kml xmlns="http://earth.google.com/kml/2.2">' +
+            '  <Placemark id="foo"/>' +
+            '</kml>';
+
+        format.setCreateFeatureFunction(custom);
+        var feature = format.readFeatures(text)[0];
+        expect(feature).to.be.a(CustomClass);
+        expect(feature.answer()).to.be(42);
+      });
+
     });
 
     describe('geometry', function() {

--- a/test/spec/ol/format/polylineformat.test.js
+++ b/test/spec/ol/format/polylineformat.test.js
@@ -295,6 +295,24 @@ describe('ol.format.Polyline', function() {
       expect(geometry.getCoordinates()).to.eql(points3857);
     });
 
+    it('can use a custom feature function', function() {
+      var CustomClass = function(opt_stuff) {
+        goog.base(this, opt_stuff);
+      };
+      goog.inherits(CustomClass, ol.Feature);
+      CustomClass.prototype.answer = function() {
+        return 42;
+      };
+      var custom = function(stuff) {
+        return new CustomClass(stuff);
+      };
+
+      format.setCreateFeatureFunction(custom);
+      var feature = format.readFeatures(encodedFlatPoints)[0];
+      expect(feature).to.be.a(CustomClass);
+      expect(feature.answer()).to.be(42);
+    });
+
   });
 
   describe('#readGeometry', function() {

--- a/test/spec/ol/format/topojson.test.js
+++ b/test/spec/ol/format/topojson.test.js
@@ -150,6 +150,27 @@ describe('ol.format.TopoJSON', function() {
       });
     });
 
+    it('can use a custom feature function', function(done) {
+      var CustomClass = function(opt_stuff) {
+        goog.base(this, opt_stuff);
+      };
+      goog.inherits(CustomClass, ol.Feature);
+      CustomClass.prototype.answer = function() {
+        return 42;
+      };
+      var custom = function(stuff) {
+        return new CustomClass(stuff);
+      };
+
+      afterLoadText('spec/ol/format/topojson/simple.json', function(text) {
+        format.setCreateFeatureFunction(custom);
+        var feature = format.readFeatures(text)[0];
+        expect(feature).to.be.a(CustomClass);
+        expect(feature.answer()).to.be(42);
+        done();
+      });
+    });
+
   });
 
 });

--- a/test/spec/ol/format/wfsformat.test.js
+++ b/test/spec/ol/format/wfsformat.test.js
@@ -50,6 +50,45 @@ describe('ol.format.WFS', function() {
 
   });
 
+  describe('when using a custom feature function', function() {
+    var CustomClass = function(opt_stuff) {
+      goog.base(this, opt_stuff);
+    };
+    goog.inherits(CustomClass, ol.Feature);
+    CustomClass.prototype.answer = function() {
+      return 42;
+    };
+    var custom = function(stuff) {
+      return new CustomClass(stuff);
+    };
+
+    var features, feature;
+    before(function(done) {
+      proj4.defs('urn:x-ogc:def:crs:EPSG:4326', proj4.defs('EPSG:4326'));
+      afterLoadText('spec/ol/format/wfs/topp-states-wfs.xml', function(xml) {
+        try {
+          var config = {
+            'featureNS': 'http://www.openplans.org/topp',
+            'featureType': 'states'
+          };
+          var format = new ol.format.WFS(config);
+          format.setCreateFeatureFunction(custom);
+          features = format.readFeatures(xml);
+        } catch (e) {
+          done(e);
+        }
+        done();
+      });
+    });
+
+    it('creates the correct feature class', function() {
+      var f = features[0];
+      expect(f).to.be.a(CustomClass);
+      expect(f.answer()).to.be(42);
+    });
+
+  });
+
   describe('when parsing FeatureCollection', function() {
     var response;
     before(function(done) {

--- a/test/spec/ol/format/wktformat.test.js
+++ b/test/spec/ol/format/wktformat.test.js
@@ -305,8 +305,29 @@ describe('ol.format.WKT', function() {
     expect(newWkt).to.eql(wkt);
   });
 
+  it('can use a custom feature function', function() {
+    var CustomClass = function(opt_stuff) {
+      goog.base(this, opt_stuff);
+    };
+    goog.inherits(CustomClass, ol.Feature);
+    CustomClass.prototype.answer = function() {
+      return 42;
+    };
+    var custom = function(stuff) {
+      return new CustomClass(stuff);
+    };
+
+    format = new ol.format.WKT({splitCollection: true});
+    format.setCreateFeatureFunction(custom);
+    var wkt = 'GEOMETRYCOLLECTION(POINT(4 6),LINESTRING(4 6,7 10))';
+    var f = format.readFeatures(wkt)[0];
+    expect(f).to.be.a(CustomClass);
+    expect(f.answer()).to.be(42);
+  });
+
 });
 
 goog.require('ol.geom.GeometryType');
 goog.require('ol.format.WKT');
 goog.require('ol.proj');
+goog.require('ol.Feature');


### PR DESCRIPTION
OL3 should support custom extensions of `ol.Feature`. I would like to be able to supply a custom extension of `ol.Feature` to any of the formats and have them return instances of that class. I believe this is significantly less necessary for the `ol.interactions` package - which is the only other place in `src` that I see "new ol.Feature(".

Example: Displaying a list of features using a grid library such as SlickGrid or ng-grid in an application compiled using Google Closure. SlickGrid requires each grid item to have an ID field (not a function). In this case you could override `ol.Feature.setId()` and force such a field to exist.

I should have a pull request for this shortly after I finish adding the tests.