### PR TITLE
Custom build tutorial

### DIFF
--- a/doc/tutorials/buildExamples.md
+++ b/doc/tutorials/buildExamples.md
@@ -1,0 +1,154 @@
+---
+title: Custom build examples
+layout: doc.hbs
+---
+
+# Custom Build Examples
+
+_Note_: the tutorial assumes Unix-style filesystem; those using Windows will have to adjust the addressing as appropriate. It also assumes the `node` binary is called `node`.
+
+## Requirements
+Obviously, you will need the OL source to build from, and the build scripts, so clone the Github repo or download one of the archives. The build tools run under Node, so you will need to install that if it is not already installed. The compiler runs under Java, so this will have to be installed too. If you're not very familiar with the Java environment, run `java -version` in the command line to test that this is installed correctly.
+
+You will then need to install the dependencies in the directory you install the OL repository to; as these are in `dependencies` in the `package.json`, `npm i --production` should suffice. This includes the `closure-util` module, which will download the Closure library and the compiler.
+
+Now you need an html file to load in the browser. A simple skeleton might be:
+```html
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>OL3 example</title>
+    <link rel="stylesheet" href="http://openlayers.org/en/master/css/ol.css" />
+</head>
+<body>
+    <div id="map" style="height: 400px"></div>
+    <script src="ol-build.js"></script>
+    <script src="myApp.js"></script>
+</body>
+</html>
+```
+Note that the CSS is being loaded from `master`; change this as appropriate if you want the file for a specific version.
+
+`build/` is in `.gitignore`, so you can put what you like in there without Git thinking this is a file it needs to track. This is a suggested place to put the various files you need for this tutorial.
+
+Now read the `readme` in `tasks/`, which gives some more details of how to run the `build.js` script. You need a config file to tell the script what to do, and then specify an output file; in the html file above, this is `ol-build.js` but of course you can call this whatever you like.
+
+As discussed before, you can compile your app in with the ol build or load it separately. It's likely that most developers will want to load their app separately, so we'll look at examples for that first.
+
+## Simple example
+Let's start with something simple, namely `examples/simple.js`. The html above will load the OL build and then the script. The examples in the repo are set up to be compiled in with the OL code, so include `goog.require`s. You can't use these in your app, as `goog` isn't defined anywhere. So you can either copy the repo example into your working directory and then edit out the requires, or you can copy the hosted version which has already stripped these out: `http://openlayers.org/en/master/examples/simple.js` (as with `ol.css`, change `master` as appropriate). You'll also have to edit out the `renderer` line, as `examplesNS` isn't in your environment. You can also remove the typecast for the attributionOptions, though it doesn't harm anything if you leave it in there. See `examples/readme` for an explanation of the differences between the repo examples and application code.
+
+`tasks/readme` gives a sample config file for the full build. This uses advanced optimizations, and defines the exports and externs. The compiler needs to know which symbols are used in the app &ndash; the _exports_ &ndash; so those we use need to be entered in the exports section of the config file. We also need the `olx` externs (more on this below), so our config file looks like this:
+
+```json
+{
+  "exports": ["ol.Map",
+              "ol.View",
+              "ol.control.defaults",
+              "ol.layer.Tile",
+              "ol.source.OSM"
+             ],
+  "compile": {
+    "externs": [
+      "externs/olx.js"
+    ],
+    "define": [
+      "goog.dom.ASSUME_STANDARDS_MODE=true",
+      "goog.DEBUG=false"
+    ],
+    "compilation_level": "ADVANCED_OPTIMIZATIONS",
+    "use_types_for_optimization": true,
+    "manage_closure_dependencies": true
+  }
+}
+```
+
+As `tasks/readme` explains, the paths in the config file are relative to the directory where the task is run. So this assumes that we're running the build task from the root of the OL directory, with the externs file in `externs/`. The symbols (classes) are as in the require statements; we use the `control.defaults` property, so exporting this automatically gives us the `control` namespace.
+
+Now, build this with
+```
+node tasks/build.js build/config.json build/ol-build.js
+```
+assuming you have put the config in `build/config.json`. It tells you it is 'Parsing dependencies' and 'Compiling sources'. When it's finished, if you look at `build/` you will see there are 2 new files, the build itself and another one called `info.json`. This is a complete list of dependencies in json format, used for generating the dependency tree, and is produced by `tasks/generate-info.js`, run by the build script.
+
+The build is now ready, so if you load your html file, the map should now be displayed. Success! If you look in console, you will see there is an `ol` object containing the exported names, plus a `map` object which is the instance created by the script. Note that the `map` object only contains those methods you exported; you cannot for example do `map.getControls()` as you did not export that name.
+
+The build script runs `tasks/generate-exports.js`, which generates an export file based on the list defined in the config file. This uses a temporary file, but if you want to see the output you can run it as a separate task: `node tasks/generate-exports.js -c build/config.json exports.js`. If you then look at the `exports.js` output, you can see that the exported symbols and properties are listed as the appropriate `goog` functions. You may notice a couple of other symbols, like `ol.ViewHint`, which are dependencies and need to be exported, but aren't directly used in applications.
+
+## More on the config file
+### define
+Closure allows you to define constants that can be set at compile time. The `define` config property above sets 2 `goog` properties for the Closure library, and the OL code also has defined values you can set. Setting some of these to false means that the portions of the code relating to this setting become 'dead', i.e. are never executed. As advanced mode removes dead code, this makes the size of the advanced compiled file smaller. You might have noticed that the build file you've just created is considerably smaller than the full build, but it can be reduced further. This is because all 3 renderers and all layer types are included by default. We only need one renderer, and only need the tile layer, so can exclude the others by setting these properties with `define`s. So add the following to the define section of the config above:
+```
+      "ol.ENABLE_DOM=false",
+      "ol.ENABLE_WEBGL=false",
+      "ol.ENABLE_PROJ4JS=false",
+      "ol.ENABLE_IMAGE=false",
+      "ol.ENABLE_VECTOR=false",
+```
+and re-run the build script. The build size should now be smaller.
+
+### Externs
+The Closure documentation explains that 'externs' are for external names used in the code being compiled. The compiler includes externs for built-ins such as `document`. The `externs` directory of the OL code includes files for all those used in some part of the library. For example, if you use Bings maps, you should include the Bing externs file in the `externs` section of the config file.
+
+`oli` is a special namespace, originally for those functions needed if you want to extend an OL object, for example, a custom control. Event properties are also part of the `oli` namespace, so include this file if you want to use a property returned in an event object, for example, `event.pixel`.
+
+The constructor options are not exported in the usual way, but are in a separate `olx` namespace and handled as externs. This is a problematic area, because it means the options are not directly tied to the exported properties/symbols. `externs/olx.js` includes all the options, including those you are not using. This means firstly that the compiled file is larger than it needs to be. Secondly, it means the externs file includes options for namespaces that are not in your build; for example, the map options include `overlays`, which refers to `ol.Overlay` which is not in the example build above. You can create your own `olx` externs file which only includes those that you use, and if you compile using this instead of the OL-supplied file, you will see that the compiled file is a bit smaller. However, your build file will include references for other options that you do not use, for example, `olx.ProjectionOptions`. The compiler by default treats these missing references as warnings not errors, so the file will be compiled and will work correctly with both the OL-supplied externs file and the app-specific file, but if you change the reporting level, for example, with `warning_level: verbose`, you will see a large number of warnings about missing this and unknown that. Up to you how you want to handle this; the simplest is always to use the full supplied `olx.js` and ignore the warnings.
+
+### Other compiler options
+There are a couple of other compiler options in the config file above. `manage_closure_dependencies` should always be used. `use_types_for_optimization` should be used when you are compiling the OL library on its own.
+
+The config file used by the supplied full build (`config/ol.json`) uses specific settings for error reporting (`jscomp_error`), but the defaults should be sufficient for most purposes. It also specifies `"output_wrapper": "(function(){%output%})();"`; advanced_optimizations creates a number of global variables, so wrapping the output in a function like this keeps them out of the global namespace.
+
+You can specify any of the other compiler options here as needed, such as the renaming reports, output manifest, or source maps. There is a full list of available options in [closure-util](https://github.com/openlayers/closure-util/blob/master/compiler-options.txt). Note that `build.js` currently requires you to enter an output file and will write the output from the compiler to it; it does not use the `js_output_file` compiler option. If you specify this in the config file, there will be no compiler output, so `build.js`'s output file will be empty.
+
+## A more complicated example
+As the name suggests, the simple example is, well, simple. Now let's try a more complicated example: `heatmaps-earthquakes.js`. Again, you will have to remove the `goog.require` statements if you copy this from `examples/`. The config file looks like this:
+
+```json
+{
+  "exports": [
+    "ol.layer.Heatmap",
+    "ol.source.KML",
+    "ol.layer.Heatmap#getSource",
+    "ol.source.KML#on",
+    "ol.source.VectorEvent#feature",
+    "ol.Feature#get",
+    "ol.Feature#set",
+    "ol.layer.Tile",
+    "ol.source.Stamen",
+    "ol.Map",
+    "ol.View"
+  ],
+  "compile": {
+    "externs": [
+      "externs/olx.js",
+      "externs/oli.js"
+    ],
+    "define": [
+      "ol.ENABLE_DOM=false",
+      "ol.ENABLE_WEBGL=false",
+      "ol.ENABLE_PROJ4JS=false",
+      "ol.ENABLE_IMAGE=false",
+      "goog.dom.ASSUME_STANDARDS_MODE=true",
+      "goog.DEBUG=false"
+    ],
+    "compilation_level": "ADVANCED_OPTIMIZATIONS",
+    "use_types_for_optimization": true,
+    "manage_closure_dependencies": true
+  }
+}
+```
+
+The exports are given here in the order in which they occur in the script. In this script we not only have the `ol...` symbols, but also prototype methods where the `ol` namespace is not directly used. In the code, we have for example `vector.getSource().on()`. This means we are using the `getSource` method of `layer.Heatmap` and the `on` method of `source.KML`, so this is what has to be exported. Similarly, `event.feature.get()` means we are using the `feature` property of `source.VectorEvent` and the `get` method of `Feature`. If any of these names are left out, the compile will complete successfully, but the missing names will be obfuscated and you will get a 'property undefined' error when you try and run the script.
+
+As this script uses a vector layer, this has to be enabled by removing `"ol.ENABLE_VECTOR=false"` in the `define` section of the config. Also, as we are using event objects, `"externs/oli.js"` has to be included in the `externs` section.
+
+Rerun the build script, and reload the html file, and you should now see this new map. The build will of course be larger, as you are exporting more (which means your app is doing more).
+
+You should now have the basic principles of defining the appropriate exports and compile options; try more complicated examples, or apply these principles to your own code. Don't forget to include externs for the external code you use, such as proj4js or GeoJSON.
+
+For those who want to compile application code together with the OL3 library, a [further page](buildInExamples.md) describes an example.
+
+## A note on simple/whitespace builds
+Although advanced optimizations is recommended for production code, if you want to create a simple or even whitespace build for development, you can use `build.js` for this too. In this case, define the `exports` section as before, and change `compilation_level`. `externs` should be removed, as should `use_types_for_optimization`, which is only relevant for advanced builds. You can use the `define` flags, but the build size will not be reduced, as only advanced optimizations removes unused code. If you use whitespace, use an `output_wrapper` of `var CLOSURE_NO_DEPS=true;%output%` so it doesn't try and load a non-existent `deps.js`.

--- a/doc/tutorials/buildInExamples.md
+++ b/doc/tutorials/buildInExamples.md
@@ -1,0 +1,41 @@
+---
+title: Example for building application and library code together
+layout: doc.hbs
+---
+
+# Example for building application and library code together
+This page gives the same example as the previous one, except this time we will compile the application together with the OL3 library.
+
+The skeleton html will be the same as the one given in the previous page, with the exception that there will be no separate `myApp.js` script to load.
+
+## Simple example
+We'll use `examples/simple.js` again. This time, you do need the `goog.require`s, so can simply copy the code over from the `examples` directory; you will though still have to edit out the `renderer` line. Leave the typecast in there.
+
+As the namespaces the app uses are already defined with `goog.require`, nothing more needs to be done. As we're compiling our code with OL, we don't need any exports. We do however need the `olx` externs, so our config file looks like this:
+
+```json
+{
+  "src": ["src/**/*.js", "build/simple.js", "externs/olx.js"],
+  "exports": [],
+  "compile": {
+    "define": [
+      "goog.dom.ASSUME_STANDARDS_MODE=true",
+      "goog.DEBUG=false"
+    ],
+    "compilation_level": "ADVANCED_OPTIMIZATIONS",
+    "use_types_for_optimization": true,
+    "manage_closure_dependencies": true
+  }
+}
+```
+
+This assumes that we're running the build task from the root of the OL directory, with the app source in build, OL source in `src`, and externs in `externs`. So what this means is 'take the source in `src` and `build/simple.js`, compile it, and don't export anything'.
+
+Now, run this with `node tasks/build.js build/config.json build/ol-build.js` again. As before, it tells you it is 'Parsing dependencies' and 'Compiling sources'. When it is finished, if you reload your html file, the map should be displayed.
+
+## Exporting your own variables
+If you load your html file with the build created above, and open the browser console, you will notice that the difference with having a separate build is that there is now no `ol` variable and not even a `map` variable; nor is there a `goog` variable. These have been optimized away. If you want to keep your map var, so you can inspect it in the console, you should export it. You might think you can just add `map` to the exports section of the config file, but, as the readme explains, this is for the OL variables, not application ones. So you will have to export it in your script:
+```js
+goog.exportSymbol('map', map);
+```
+Now rebuild and reload, and you should now have a map variable you can inspect.

--- a/doc/tutorials/builds.md
+++ b/doc/tutorials/builds.md
@@ -1,0 +1,78 @@
+---
+title: Creating custom builds
+layout: doc.hbs
+---
+
+# Creating Custom Builds
+
+## Basics
+The [introduction](introduction.md) has a brief description of full and custom builds and the public API. Creating custom builds is reasonably straightforward once you get the hang of it, but it requires knowledge of both the library and how the compiler works, so is not recommended for the complete beginner. If you just want to try things out or quickly create a mapping app, the hosted version should be sufficient. Having said that, this tutorial should also help if you want to know more about how things fit together.
+
+If you're now sure you want to continue, this tutorial is split into 2 sections:
+- an introductory page (this one) including
+  - summary of terms
+  - overview of Closure library and compiler, and types of build
+  - how that compares to the OL2 process
+  - pros and cons of compiling your code separately or together with OL
+- some examples of using the build tool to create custom builds
+
+If you already know much of the introductory material, and/or just want a quick primer on creating a custom build, feel free to skip to the [next page](buildExamples.md).
+
+## Summary of terms
+Let's start with a brief summary of the terms used here. When you have a large body of code like OpenLayers, you have to divide it up into manageable self-contained units of code; these are often called __modules__ (though see below for Closure's different naming). When you do this, you have to have a standard way of specifying the relationships between the different modules: which functions a module provides, commonly called __exports__, and which other modules/functions it needs, commonly called __imports__. This establishes a __dependency__: if module1 uses functions from module2, it is dependent on it.
+ __Module loading__ is easy on server-based systems, as you can pre-install the modules you need, and then an app can simply import them from the local filesystem as needed. This however doesn't work on the browser, which doesn't have a filesystem; in addition, loading large numbers of separate scripts is inefficient. So you need to, first, __optimize__ or __compile__ code so it takes up less space and so requires less bandwidth, and, second, minimise the amount of IO by combining all the modules needed by an application into a __build__.
+
+## Closure tools and comparison with OL2
+Many of those coming to OL3 will be familiar with OL2, so here's a brief summary of its build process. When it was originally written, there wasn't much in the way of standardised ways of handling modules and not much in the way of build tools. So it invented its own ([Readme](https://github.com/openlayers/openlayers/tree/master/build)). Releases of OL2 reflected the evolution of optimization tools as they became available:
+* the code was split into 'classes', with one page per class; dependencies were defined using `@requires` in comments at the top of each page
+* a config file listed the classes to be used, and a build script then used these classes' dependencies to create a dependency tree, build that into a single file, and then optionally optimize that file
+* the first optimizers, such as Douglas Crockford's [JSMin](http://www.crockford.com/javascript/jsmin.html), simply removed comments and unneeded whitespace
+* later updates included the option of using the simple_optimizations option of the Closure compiler
+* the latest versions include the option of using [UglifyJS](http://lisperator.net/uglifyjs/), written in Javascript, now the most commonly used JS optimization tool, which produces sizes similar to Closure's simple option.
+
+OL3 uses Google's Closure tools. There are two principal elements to this: the [__library__](https://developers.google.com/closure/library/) and the [__compiler__](https://developers.google.com/closure/compiler/). Whereas OL2 used little in the way of external software (with the exception of Proj4js) and included its own utility functions, OL3 is based on the Closure library, which has the advantage of tried and tested library functions. You do not have to use the Closure library and compiler together &ndash; you can use the compiler on any code &ndash; but, if you do use the library, then the optimum is to use the compiler as well, as this will create the smallest build file. The disadvantage of using the Closure library is that it's very large, in terms of both numbers of classes and numbers of functions in those classes, which in turn means that the simple optimization option used in OL2 still creates large files. Making full use of advanced compilation, for example by defining types, also adds to the complexity, and means there's a long learning curve in trying to use it fully. However, OL3 takes care to hide this complexity from API users - none of the Closure code is exposed - so you don't have to worry about these details when creating a custom build.
+
+OL3 follows Closure's system:
+* code is divided into 'namespaces', i.e. simple JS objects; Closure's namespace is `goog`, OL3's is `ol`
+* definition is done with `goog.provide('namespaceA')`; there is no 1-to-1 namespace/file relationship as with, for example, Node's modules: 1 file can provide several namespaces
+* dependencies are specified with `goog.require('namespaceB')`
+* Closure has `goog.exportProperty(propA)` and `goog.exportSymbol(symA)` but a key difference from other systems is that exports don't have to be in the namespace/module itself and can be defined separately, at compile/optimize time. This makes the system very flexible. An export is essentially any unoptimized variable name, so they can also be defined by using literal notation: `namespaceA["propb"]=xxx` will ensure that 'propb' is available for public use
+* because there is no 1-to-1 file/namespace, the first step is to search through files and create a dependency tree; Closure library provides two (Python) programs &ndash; `calcDeps.py` and `closureBuilder.py` &ndash; but these have both been deprecated; the preferred way to do this is to pass all the source files along with the `manage_closure_dependencies` flag to the compiler. OL3's build script includes its own dependency tree generator
+* Closure compiler is available as a Java jar, a webservice API, or an interactive web UI
+* to confuse things, the Closure compiler includes the ability to split the build file into separate bundles of code, which can be loaded separately on demand; it calls these 'modules'. However, this is not used by OL3's build tools, and in any case Closure's definition is currently being changed to make it compatible with ES6 modules; this subject is not dealt with further in this tutorial.
+
+Although OL2 added the ability to optimize with UglifyJS, this is not really practical with Closure library and hence OL3. Closure compiler knows about `goog.provide` and `goog.require` and strips them out; it also works optimally with other features of Closure library. UglifyJS doesn't, so its output will be large and probably won't work.
+
+## OL3 build tools
+You can of course use the compiler directly yourself, but OL3 includes its own build tools. `build.py` (and the equivalent for Windows `build.cmd`) was created for those developing the library, and includes testing, creating API docs, and other options not needed by apps developers. See the [contributors guide](https://github.com/openlayers/ol3/blob/master/CONTRIBUTING.md) for more on this. For building, these scripts use the tools in the `tasks` directory, especially `build.js`. This is what is discussed here. As with OL2, you provide a config file to control the script.
+
+`build.js` uses the `getDependencies` and `compile` functions of [closure-util](https://github.com/openlayers/closure-util).
+
+## Types of Build
+The [Closure Library documentation](https://developers.google.com/closure/library/docs/gettingstarted) shows an example which loads each file/module individually, starting from `goog.base`. OL2 had a similar ability to load unbuilt code. OL3's hosted examples also have this capability, called 'raw mode'. For example, http://openlayers.org/en/master/examples/simple.html?mode=raw will load each required file individually. However, you will probably notice that this takes a long time to load even on a fast connection. This could be speeded up with HTTP2/SPDY push but, as the dependency tree for even a modest OL3 application is likely to be well over 100 files, loading them individually is not really recommended for anything other than occasional use. This 'unbuilt' code is not dealt with further in this tutorial.
+
+Closure compiler has 3 optimization levels: __whitespace__, equivalent to basic optimizers like JSMin; __simple__, as used in OL2; and __advanced__. See [Google's documentation](https://developers.google.com/closure/compiler/docs/compilation_levels) for more information on these. The OL3 website only provides advanced builds, though the build tools do have an additional __debug__ option, which is an unoptimized build: the same code as 'raw', but all in one file.
+
+As stated above, with Closure's system, you have the ability to specify what you want to export, effectively what you use in your app/site. This is what is meant by a __custom build__: one that is customized to your needs and only exports those properties and methods you need. This is particularly effective with advanced optimization, and is recommended for production software.
+
+## Compiling with or without your own code
+There are 2 basic approaches to building and compiling, both dealt with here:
+
+* you can build/compile your code in with the OL/Closure code, producing one script, loaded in one script tag
+* you can build/compile the OL/Closure code as a separate file, similar to OL's hosted build, and load that in a separate script tag from your own code
+
+These approaches both have pros and cons, so here are some things to consider:
+
+* one script is better from the optimization point of view, as all the code will be optimized; there's no need to define exports, as there is no external code that needs to refer to the unoptimized names
+* one script is also better if you want to use Closure library functions, as these can be optimized too; if your code is separate, then you would also have to define exports for those functions your code uses
+* against that, if you want to use advanced_optimizations with typedefs for maximum optimization (which OL3 does by default), you have to define these in your code
+* if your code is large and/or spread over many pages, you have to decide whether you want everything in one build, or a different build for each page
+* if you use a lot of 3rd-party software, compiling all this in with your code and OL can soon get complicated; alternatively, you may need a lot of externs
+* the compiler does not work well with some JS code; in particular, it does not handle the module pattern correctly
+* if your code is separate, this means you can use whatever you normally use for compressing it; for example, you can use UglifyJS on your code, with a separate task for compiling OL with the Closure compiler
+
+## A note on CSS
+The CSS file supplied in the [repo](https://github.com/openlayers/ol3/blob/master/css/ol.css) contains styling for all the controls supported by the library. The hosted version of this is used in the example html in this tutorial. Clearly, for production use, you should customize this for your own site, but this is not discussed further in this tutorial.
+
+## Examples
+Right, that's enough theory. On to some [practical examples](buildExamples.md).

--- a/doc/tutorials/introduction.md
+++ b/doc/tutorials/introduction.md
@@ -12,16 +12,21 @@ The initial release aims to support much of the functionality provided by versio
 
 It is also designed such that major new features, such as displaying 3D maps, or using WebGL to quickly display large vector data sets, can be added in later releases.
 
+## Using the Library
+The simplest way to use OL3 in your apps is to use one of the complete library builds hosted on the OL3 website. There is one for each release, and a build is also generated frequently from the master (main development) branch. See the [Quickstart page](quickstart.md) on where to find and how to use this. This is the recommended way to use the library whilst familiarising yourself with the OL3 library/API.
+
+The source is hosted on [Github](https://github.com/openlayers/ol3) where development occurs and proposed changes are discussed. You can of course also download the Github repository yourself, by clicking a download button from the [releases/tags page](https://github.com/openlayers/ol3/tags) or for the current master branch, or by forking it and using `git clone`.
+
 ## Closure Tools
 OL3 is based on Google's Closure Tools. It makes heavy use of parts of the [__Closure Library__](https://developers.google.com/closure/library/). Using this to handle basics like DOM or event handling means the developers can concentrate on mapping functionality, and be sure that the underlying software is well-tested and cross-browser. Closure Library is specially designed to be optimized by the [__Closure Compiler__](https://developers.google.com/closure/compiler/). The 'advanced' optimizations that this provides offers a level of compression that far exceeds anything else available. OL3 has been designed to make full use of this.
 
 ## Public API
-Using the advanced optimizations of the Closure Compiler means that properties and methods are renamed &ndash; `longMeaningfulName` might become `xB` &ndash; and so are effectively unusable in applications using the library. To be usable, they have to be explicitly `exported`. This means the exported names, those not renamed, effectively become the public API of the library. These __exportable__ properties and methods are marked in the source, and documented in the [API docs](../../apidoc). This is the officially supported API of the library. A build containing all these exportable names is known as a __full build__. A hosted version of this is available, which can be used by any application.
+Using the advanced optimizations of the Closure Compiler means that properties and methods are renamed &ndash; `longMeaningfulName` might become `xB` &ndash; and so are effectively unusable in applications using the library. To be usable, they have to be explicitly `exported`. This means the exported names, those not renamed, effectively become the public API of the library. These __exportable__ properties and methods are marked in the source, and documented in the [API docs](../../apidoc).
 
 Although Closure library functions are widely used within OL3, none of them are exported. You will see references to them (they are all in the `goog` namespace) in the API docs, but these are for information only. You can use the Closure library in your own applications if you like, but this is not required.
 
-## Custom Builds
-Unlike in, say, Node, where a module's exports are fixed in the source, with Closure Compiler, exports can be defined at compile time. This makes it easy to create builds that are customized to the needs of a particular site or application: a __custom build__ only exports those properties and methods needed by the site or application. As the full build is large, and will probably become larger as new features are added to the API, it's recommended that sites create a custom build for production software.
+## Full and Custom Builds
+The hosted builds mentioned above are __full builds__, that is, of the complete public API, with all the exportable names. This is large, and will probably become larger as new features are added to the API. So, once you are familiar with the API, and have developed your own apps, it's recommended that you create a __custom build__ for production software; that is, one which only exports those properties and methods needed by your site or application. See the [separate tutorial](builds.md) for more on this.
 
 ## Renderers and Browser Support
 The library currently includes three renderers: Canvas, DOM, and WebGL. All three support raster data from tile/image servers, but only the Canvas renderer currently supports vector data. This means that only those browsers that [support Canvas](http://caniuse.com/canvas) can handle vector data. In particular, this excludes Internet Explorer versions before 9, though there is some support for those in the DOM renderer. Clearly, the WebGL renderer can only be used on those devices and browsers supporting WebGL.


### PR DESCRIPTION
Long promised ...

I've included an amended version of the introduction tutorial, which should help with #2437. The references to the hosted builds will have to be changed if and when these move to openlayers.org.

Unfortunately, I happened to use heatmap-earthquakes example, which has a problem #2477. The tutorial will need changing to handle the changes in this PR.

I've not changed the index for the moment, as I have another 'exploring the api' tutorial coming up, and will probably suggest some restructuring when I submit that.