### PR TITLE
Export PDF's using jsPDF

### DIFF
--- a/build.py
+++ b/build.py
@@ -283,6 +283,7 @@ def examples_star_json(name, match):
               "externs/example.js",
               "externs/geojson.js",
               "externs/jquery-1.9.js",
+              "externs/jspdf.js",
               "externs/proj4js.js",
               "externs/tilejson.js",
               "externs/topojson.js",

--- a/config/examples-all.json
+++ b/config/examples-all.json
@@ -16,6 +16,7 @@
       "externs/example.js",
       "externs/geojson.js",
       "externs/jquery-1.9.js",
+      "externs/jspdf.js",
       "externs/proj4js.js",
       "externs/tilejson.js",
       "externs/topojson.js",

--- a/config/ol.json
+++ b/config/ol.json
@@ -5,6 +5,7 @@
       "externs/bingmaps.js",
       "externs/closure-compiler.js",
       "externs/geojson.js",
+      "externs/jspdf.js",
       "externs/oli.js",
       "externs/olx.js",
       "externs/proj4js.js",

--- a/examples/export-pdf.html
+++ b/examples/export-pdf.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <link rel="stylesheet" href="../css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap.min.css" type="text/css">
+    <link rel="stylesheet" href="../resources/layout.css" type="text/css">
+    <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap-responsive.min.css" type="text/css">
+    <style>
+      .map {
+        width: 1188px;
+        height: 842px;
+      }
+    </style>
+    <title>Export map example</title>
+  </head>
+  <body>
+
+    <div class="navbar navbar-inverse navbar-fixed-top">
+      <div class="navbar-inner">
+        <div class="container">
+          <a class="brand" href="./"><img src="../resources/logo.png"> OpenLayers 3 Examples</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="container-fluid">
+
+      <div class="row-fluid">
+        <div class="span12">
+          <div id="map" class="map"></div>
+          <a id="export-pdf" class="btn"><i class="icon-download"></i> Export PDF</a>
+        </div>
+      </div>
+
+      <div class="row-fluid">
+
+        <div class="span12">
+          <h4 id="title">Export map example</h4>
+          <p id="shortdesc">Example of exporting a map as a PDF using the <a href="https://github.com/MrRio/jsPDF" target="_blank">jsPDF</a> library.</p>
+          <div id="docs">
+            <p>See the <a href="export-pdf.js" target="_blank">export-pdf.js source</a> to see how this is done.</p>
+          </div>
+          <div id="tags">export, pdf, openstreetmap</div>
+        </div>
+
+      </div>
+
+    </div>
+
+    <script src="jquery.min.js" type="text/javascript"></script>
+    <script src="http://mrrio.github.io/jsPDF/dist/jspdf.min.js" type="text/javascript"></script>
+    <script src="../resources/example-behaviour.js" type="text/javascript"></script>
+    <script src="loader.js?id=export-pdf" type="text/javascript"></script>
+
+  </body>
+</html>

--- a/examples/export-pdf.html
+++ b/examples/export-pdf.html
@@ -60,7 +60,7 @@
                 <option value="300">300 dpi (slow)</option>
               </select>
             </form>
-            <a id="export-pdf" class="btn"><i class="icon-download"></i> Export PDF</a>
+            <a id="export-pdf" class="btn"><i class="icon-download"></i><span id="button-label"> Export PDF<span></a>
           </div>
           <div id="tags">export, pdf, openstreetmap</div>
         </div>

--- a/examples/export-pdf.html
+++ b/examples/export-pdf.html
@@ -38,9 +38,9 @@
 
         <div class="span12">
           <h4 id="title">Export map example</h4>
-          <p id="shortdesc">Example of exporting a map as a PDF using the <a href="https://github.com/MrRio/jsPDF" target="_blank">jsPDF</a> library.</p>
+          <p id="shortdesc">Example of exporting a map as a PDF.</p>
           <div id="docs">
-            <p>See the <a href="export-pdf.js" target="_blank">export-pdf.js source</a> to see how this is done.</p>
+            <p>See the <a href="export-pdf.js" target="_blank">export-pdf.js source</a> to see how this is done using the <a href="https://github.com/MrRio/jsPDF" target="_blank">jsPDF</a> library.</p>
           </div>
           <div>
             <form class="form">

--- a/examples/export-pdf.html
+++ b/examples/export-pdf.html
@@ -10,8 +10,8 @@
     <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap-responsive.min.css" type="text/css">
     <style>
       .map {
-        width: 1188px;
-        height: 842px;
+        height: 400px;
+        width: 566px;
       }
     </style>
     <title>Export map example</title>
@@ -31,7 +31,6 @@
       <div class="row-fluid">
         <div class="span12">
           <div id="map" class="map"></div>
-          <a id="export-pdf" class="btn"><i class="icon-download"></i> Export PDF</a>
         </div>
       </div>
 
@@ -42,6 +41,26 @@
           <p id="shortdesc">Example of exporting a map as a PDF using the <a href="https://github.com/MrRio/jsPDF" target="_blank">jsPDF</a> library.</p>
           <div id="docs">
             <p>See the <a href="export-pdf.js" target="_blank">export-pdf.js source</a> to see how this is done.</p>
+          </div>
+          <div>
+            <form class="form">
+              <label>Page size </label>
+              <select id="format">
+                <option value="a0">A0 (slow)</option>
+                <option value="a1">A1</option>
+                <option value="a2">A2</option>
+                <option value="a3">A3</option>
+                <option value="a4" selected>A4</option>
+                <option value="a5">A5 (fast)</option>
+              </select>
+              <label>Resolution </label>
+              <select id="resolution">
+                <option value="72">72 dpi (fast)</option>
+                <option value="150">150 dpi</option>
+                <option value="300">300 dpi (slow)</option>
+              </select>
+            </form>
+            <a id="export-pdf" class="btn"><i class="icon-download"></i> Export PDF</a>
           </div>
           <div id="tags">export, pdf, openstreetmap</div>
         </div>

--- a/examples/export-pdf.html
+++ b/examples/export-pdf.html
@@ -14,7 +14,7 @@
         width: 566px;
       }
     </style>
-    <title>Export map example</title>
+    <title>Export PDF example</title>
   </head>
   <body>
 
@@ -37,7 +37,7 @@
       <div class="row-fluid">
 
         <div class="span12">
-          <h4 id="title">Export map example</h4>
+          <h4 id="title">Export PDF example</h4>
           <p id="shortdesc">Example of exporting a map as a PDF.</p>
           <div id="docs">
             <p>See the <a href="export-pdf.js" target="_blank">export-pdf.js source</a> to see how this is done using the <a href="https://github.com/MrRio/jsPDF" target="_blank">jsPDF</a> library.</p>

--- a/examples/export-pdf.html
+++ b/examples/export-pdf.html
@@ -10,8 +10,7 @@
     <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap-responsive.min.css" type="text/css">
     <style>
       .map {
-        height: 400px;
-        width: 566px;
+        max-width: 566px;
       }
     </style>
     <title>Export PDF example</title>

--- a/examples/export-pdf.html
+++ b/examples/export-pdf.html
@@ -68,9 +68,9 @@
 
     </div>
 
-    <script src="jquery.min.js" type="text/javascript"></script>
-    <script src="http://mrrio.github.io/jsPDF/dist/jspdf.min.js" type="text/javascript"></script>
+    <script src="../resources/jquery.min.js" type="text/javascript"></script>
     <script src="../resources/example-behaviour.js" type="text/javascript"></script>
+    <script src="http://mrrio.github.io/jsPDF/dist/jspdf.min.js" type="text/javascript"></script>
     <script src="loader.js?id=export-pdf" type="text/javascript"></script>
 
   </body>

--- a/examples/export-pdf.js
+++ b/examples/export-pdf.js
@@ -44,6 +44,8 @@ exportElement.addEventListener('click', function(e) {
 
   var format = document.getElementById('format').value;
   var resolution = document.getElementById('resolution').value;
+  var buttonLabelElement = document.getElementById('button-label');
+  var label = buttonLabelElement.innerText;
   var dim = dims[format];
   var width = Math.round(dim[0] * resolution / 25.4);
   var height = Math.round(dim[1] * resolution / 25.4);
@@ -59,10 +61,10 @@ exportElement.addEventListener('click', function(e) {
     interval = setInterval(function() {
       var tileCount = tileQueue.getCount();
       var ratio = 1 - tileCount / tileTotalCount;
-      exportElement.innerText = (100 * ratio).toFixed(1) + '%';
+      buttonLabelElement.innerText = ' ' + (100 * ratio).toFixed(1) + '%';
       if (ratio == 1 && !tileQueue.getTilesLoading()) {
         clearInterval(interval);
-        exportElement.innerText = 'Done';
+        buttonLabelElement.innerText = label;
         var canvas = event.context.canvas;
         var data = canvas.toDataURL('image/jpeg');
         var pdf = new jsPDF('landscape', undefined, format);
@@ -71,7 +73,8 @@ exportElement.addEventListener('click', function(e) {
         map.setSize(size);
         map.getView().fitExtent(extent, size);
         map.renderSync();
-        // TODO restore button
+        exportElement.className =
+            exportElement.className.replace(' disabled', '');
       }
     }, 100);
   });

--- a/examples/export-pdf.js
+++ b/examples/export-pdf.js
@@ -24,15 +24,42 @@ var map = new ol.Map({
 });
 
 
+var dims = {
+  a0: [1189, 841],
+  a1: [841, 594],
+  a2: [594, 420],
+  a3: [420, 297],
+  a4: [297, 210],
+  a5: [210, 148]
+};
+
 var exportElement = document.getElementById('export-pdf');
 
 exportElement.addEventListener('click', function(e) {
+
+  if (exportElement.className.indexOf('disabled') > -1) {
+    return;
+  }
+  exportElement.className += ' disabled';
+
+  var format = document.getElementById('format').value;
+  var resolution = document.getElementById('resolution').value;
+  var dim = dims[format];
+  var width = Math.round(dim[0] * resolution / 25.4);
+  var height = Math.round(dim[1] * resolution / 25.4);
+
   map.once('postcompose', function(event) {
     var canvas = event.context.canvas;
     var data = canvas.toDataURL('image/jpeg');
-    var pdf = new jsPDF('landscape');
-    pdf.addImage(data, 'JPEG', 0, 0, 297, 210);
+    var pdf = new jsPDF('landscape', undefined, format);
+    pdf.addImage(data, 'JPEG', 0, 0, dim[0], dim[1]);
     pdf.save('map.pdf');
   });
+
+  var extent = map.getView().calculateExtent(
+      /** @type {ol.Size} */ (map.getSize()));
+  map.setSize([width, height]);
+  map.getView().fitExtent(extent, /** @type {ol.Size} */ (map.getSize()));
   map.renderSync();
+
 }, false);

--- a/examples/export-pdf.js
+++ b/examples/export-pdf.js
@@ -47,6 +47,8 @@ exportElement.addEventListener('click', function(e) {
   var dim = dims[format];
   var width = Math.round(dim[0] * resolution / 25.4);
   var height = Math.round(dim[1] * resolution / 25.4);
+  var size = /** @type {ol.Size} */ (map.getSize());
+  var extent = map.getView().calculateExtent(size);
 
   map.once('postcompose', function(event) {
     var tileQueue = map.getTileQueue();
@@ -66,14 +68,14 @@ exportElement.addEventListener('click', function(e) {
         var pdf = new jsPDF('landscape', undefined, format);
         pdf.addImage(data, 'JPEG', 0, 0, dim[0], dim[1]);
         pdf.save('map.pdf');
-        // TODO restore size
+        map.setSize(size);
+        map.getView().fitExtent(extent, size);
+        map.renderSync();
         // TODO restore button
       }
     }, 100);
   });
 
-  var extent = map.getView().calculateExtent(
-      /** @type {ol.Size} */ (map.getSize()));
   map.setSize([width, height]);
   map.getView().fitExtent(extent, /** @type {ol.Size} */ (map.getSize()));
   map.renderSync();

--- a/examples/export-pdf.js
+++ b/examples/export-pdf.js
@@ -1,16 +1,32 @@
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.control');
+goog.require('ol.format.WKT');
 goog.require('ol.layer.Tile');
+goog.require('ol.layer.Vector');
 goog.require('ol.source.OSM');
+goog.require('ol.source.Vector');
+
+var raster = new ol.layer.Tile({
+  source: new ol.source.OSM()
+});
+
+var format = new ol.format.WKT();
+var feature = format.readFeature(
+    'POLYGON((10.689697265625 -25.0927734375, 34.595947265625 ' +
+        '-20.1708984375, 38.814697265625 -35.6396484375, 13.502197265625 ' +
+        '-39.1552734375, 10.689697265625 -25.0927734375))');
+feature.getGeometry().transform('EPSG:4326', 'EPSG:3857');
+
+var vector = new ol.layer.Vector({
+  source: new ol.source.Vector({
+    features: [feature]
+  })
+});
 
 
 var map = new ol.Map({
-  layers: [
-    new ol.layer.Tile({
-      source: new ol.source.OSM()
-    })
-  ],
+  layers: [raster, vector],
   target: 'map',
   controls: ol.control.defaults({
     attributionOptions: /** @type {olx.control.AttributionOptions} */ ({

--- a/examples/export-pdf.js
+++ b/examples/export-pdf.js
@@ -1,0 +1,38 @@
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.control');
+goog.require('ol.layer.Tile');
+goog.require('ol.source.OSM');
+
+
+var map = new ol.Map({
+  layers: [
+    new ol.layer.Tile({
+      source: new ol.source.OSM()
+    })
+  ],
+  target: 'map',
+  controls: ol.control.defaults({
+    attributionOptions: /** @type {olx.control.AttributionOptions} */ ({
+      collapsible: false
+    })
+  }),
+  view: new ol.View({
+    center: [0, 0],
+    zoom: 2
+  })
+});
+
+
+var exportElement = document.getElementById('export-pdf');
+
+exportElement.addEventListener('click', function(e) {
+  map.once('postcompose', function(event) {
+    var canvas = event.context.canvas;
+    var data = canvas.toDataURL('image/jpeg');
+    var pdf = new jsPDF('landscape');
+    pdf.addImage(data, 'JPEG', 0, 0, 297, 210);
+    pdf.save('map.pdf');
+  });
+  map.renderSync();
+}, false);

--- a/externs/jspdf.js
+++ b/externs/jspdf.js
@@ -1,0 +1,46 @@
+/**
+ * @fileoverview jsPDF PDF generator.
+ * @see https://github.com/MrRio/jsPDF
+ */
+
+/**
+ * @constructor
+ * @param {string=} orientation One of `portrait` or `landscape`
+ *     (or shortcuts `p` (default), `l`).
+ * @param {string=} unit Measurement unit to be used when coordinates are specified.
+ *     One of `pt`, `mm` (default), `cm`, `in`.
+ * @param {string=} format Default: `a4`.
+ * @param {boolean=} compressPdf
+ */
+var jsPDF = function(orientation, unit, format, compressPdf) {};
+
+/**
+ * @param {string} imageData
+ * @param {string} format
+ * @param {number} x
+ * @param {number} y
+ * @param {number} w
+ * @param {number} h
+ * @param {string=} alias
+ * @param {number=} compression
+ * @return {jsPDF}
+ */
+jsPDF.prototype.addImage = function(imageData, format, x, y, w, h, alias, compression) {};
+
+/**
+ * @return {jsPDF}
+ */
+jsPDF.prototype.autoPrint = function() {};
+
+/**
+ * @param {string} type
+ * @param {Object=} options
+ * @return {jsPDF}
+ */
+jsPDF.prototype.output = function(type, options) {};
+
+/**
+ * @param {string} filename
+ * @return {jsPDF}
+ */
+jsPDF.prototype.save = function(filename) {};

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -830,6 +830,14 @@ ol.Map.prototype.getTilePriority =
 
 
 /**
+ * @return {ol.TileQueue} Tile queue.
+ */
+ol.Map.prototype.getTileQueue = function() {
+  return this.tileQueue_;
+};
+
+
+/**
  * @param {goog.events.BrowserEvent} browserEvent Browser event.
  * @param {string=} opt_type Type.
  */

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -831,6 +831,7 @@ ol.Map.prototype.getTilePriority =
 
 /**
  * @return {ol.TileQueue} Tile queue.
+ * @api
  */
 ol.Map.prototype.getTileQueue = function() {
   return this.tileQueue_;

--- a/src/ol/structs/priorityqueue.js
+++ b/src/ol/structs/priorityqueue.js
@@ -131,6 +131,7 @@ ol.structs.PriorityQueue.prototype.enqueue = function(element) {
 
 /**
  * @return {number} Count.
+ * @api
  */
 ol.structs.PriorityQueue.prototype.getCount = function() {
   return this.elements_.length;

--- a/src/ol/tilequeue.js
+++ b/src/ol/tilequeue.js
@@ -60,6 +60,7 @@ goog.inherits(ol.TileQueue, ol.structs.PriorityQueue);
 
 /**
  * @return {number} Number of tiles loading.
+ * @api
  */
 ol.TileQueue.prototype.getTilesLoading = function() {
   return this.tilesLoading_;


### PR DESCRIPTION
As promised, here is an example on using the jsPDF library to creating PDF's from an `ol.Map`.

Each commit adds some additional feature to the export:

* The first only adds an example that exports a PDF, similar to the existing PNG example;
* The second commit gives the user the options to select an output size and resolution;
* As increasing the map size and/or resolution requires many more tiles, the third commit ensures these tiles have been loaded before exporting the map;
* The fourth & fifth commit simply restore the example so another export can be made.
