### PR TITLE
Compile using flagfile so runs on Windows

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -181,8 +181,23 @@ function build(config, paths, callback) {
     concatenate(paths, callback);
   } else {
     log.info('ol', 'Compiling ' + paths.length + ' sources');
-    options.compile.js = paths.concat(options.compile.js || []);
-    closure.compile(options, callback);
+    var flags = paths.concat(options.compile.js || []).join(' ');
+    temp.open({prefix: 'flagfile'}, function(err, info) {
+      fs.writeFile(info.path, flags, function(err) {
+        if (err) {
+          callback(err);
+          return;
+        }
+        fs.close(info.fd, function(err) {
+          if (err) {
+            callback(err);
+            return;
+          }
+          options.compile.flagfile = info.path;
+          closure.compile(options, callback);
+        });
+      });
+    });
   }
 }
 


### PR DESCRIPTION
As discussed in https://github.com/openlayers/ol3/issues/2100#issuecomment-51303801 a simple way to reduce the length of the command line is to use a flagfile. This PR uses the temp module in a similar way to the exports file. It could be changed to put all the compile options in a flagfile rather than just the js input sources.

As with #2591, needs someone with Windows to check that this fixes the problems.