### PR TITLE
Avoid unnecessary nesting in ol.Overlay

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -133,6 +133,8 @@
 
 * The experimental `ol.loadingstrategy.createTile` function has been renamed to `ol.loadingstrategy.tile`. The signature of the function hasn't changed. See http://openlayers.org/en/master/examples/vector-osm.html for an example.
 
+* The `ol.Overlay` has one few nesting level: the `element` you give is now the one which is absolutely positioned. Previously one intermediate div element containing the element was positioned.
+
 #### Change to `ol.style.Icon`
 
 * When manually loading an image for `ol.style.Icon`, the image size should now be set

--- a/examples/overlay.css
+++ b/examples/overlay.css
@@ -16,3 +16,8 @@
 .popover-content {
   min-width: 180px;
 }
+#popup {
+  display: block;
+  top: auto;
+  transition: bottom .2s, left .2s;
+}

--- a/examples/overlay.html
+++ b/examples/overlay.html
@@ -18,5 +18,10 @@ resources:
   <a class="overlay" id="vienna" target="_blank" href="http://en.wikipedia.org/wiki/Vienna">Vienna</a>
   <div id="marker" title="Marker"></div>
   <!-- Popup -->
-  <div id="popup" title="Welcome to ol3"></div>
+  <div class="popover top" id="popup">
+    <div class="arrow"></div>
+    <h3 class="popover-title">Welcome to ol3</h3>
+    <div class="popover-content">
+    </div>
+  </div>
 </div>

--- a/examples/overlay.js
+++ b/examples/overlay.js
@@ -41,7 +41,9 @@ map.addOverlay(vienna);
 
 // Popup showing the position the user clicked
 var popup = new ol.Overlay({
-  element: document.getElementById('popup')
+  element: document.getElementById('popup'),
+  positioning: 'bottom-center',
+  offset: [-2, -10]
 });
 map.addOverlay(popup);
 
@@ -51,14 +53,7 @@ map.on('click', function(evt) {
   var hdms = ol.coordinate.toStringHDMS(ol.proj.transform(
       coordinate, 'EPSG:3857', 'EPSG:4326'));
 
-  $(element).popover('destroy');
   popup.setPosition(coordinate);
-  // the keys are quoted to prevent renaming in ADVANCED mode.
-  $(element).popover({
-    'placement': 'top',
-    'animation': false,
-    'html': true,
-    'content': '<p>The location you clicked was:</p><code>' + hdms + '</code>'
-  });
-  $(element).popover('show');
+  $(element).find('.popover-content').html(
+      '<p>The location you clicked was:</p><code>' + hdms + '</code>');
 });

--- a/examples/popup.css
+++ b/examples/popup.css
@@ -1,13 +1,12 @@
 .ol-popup {
-  position: absolute;
   background-color: white;
+  -moz-box-shadow: 0 1px 4px rgba(0,0,0,0.2);
   -webkit-filter: drop-shadow(0 1px 4px rgba(0,0,0,0.2));
   filter: drop-shadow(0 1px 4px rgba(0,0,0,0.2));
   padding: 15px;
   border-radius: 10px;
   border: 1px solid #cccccc;
   bottom: 12px;
-  left: -50px;
 }
 .ol-popup:after, .ol-popup:before {
   top: 100%;

--- a/examples/popup.js
+++ b/examples/popup.js
@@ -31,6 +31,8 @@ closer.onclick = function() {
  */
 var overlay = new ol.Overlay(/** @type {olx.OverlayOptions} */ ({
   element: container,
+  positioning: 'bottom-left',
+  offset: [-50, -10],
   autoPan: true,
   autoPanAnimation: {
     duration: 250


### PR DESCRIPTION
So that the positioned element is the one passed to `ol.Overlay`, not its parent.

One of my motivation to do it is to be able to set CSS transitions on my overlay’s element:
```css
.overlay {
  transition: top .2s, left .2s;
}
```

And then to have animated transition when setting position.