### PR TITLE
Preventing form submission on button controls

### DIFF
--- a/src/ol/control/fullscreencontrol.js
+++ b/src/ol/control/fullscreencontrol.js
@@ -46,7 +46,8 @@ ol.control.FullScreen = function(opt_options) {
 
   var button = goog.dom.createDom(goog.dom.TagName.BUTTON, {
     'class': this.cssClassName_ + '-' + goog.dom.fullscreen.isFullScreen() +
-        ' ol-has-tooltip'
+        ' ol-has-tooltip',
+    'type': 'button'
   });
   goog.dom.appendChild(button, tip);
   var buttonHandler = new ol.pointer.PointerEventHandler(button);
@@ -92,6 +93,7 @@ goog.inherits(ol.control.FullScreen, ol.control.Control);
  * @private
  */
 ol.control.FullScreen.prototype.handleClick_ = function(event) {
+  event.preventDefault();
   if (event.screenX !== 0 && event.screenY !== 0) {
     return;
   }
@@ -104,7 +106,6 @@ ol.control.FullScreen.prototype.handleClick_ = function(event) {
  * @private
  */
 ol.control.FullScreen.prototype.handlePointerUp_ = function(pointerEvent) {
-  pointerEvent.browserEvent.preventDefault();
   this.handleFullScreen_();
 };
 

--- a/src/ol/control/rotatecontrol.js
+++ b/src/ol/control/rotatecontrol.js
@@ -103,6 +103,7 @@ goog.inherits(ol.control.Rotate, ol.control.Control);
  * @private
  */
 ol.control.Rotate.prototype.handleClick_ = function(event) {
+  event.preventDefault();
   if (event.screenX !== 0 && event.screenY !== 0) {
     return;
   }
@@ -115,7 +116,6 @@ ol.control.Rotate.prototype.handleClick_ = function(event) {
  * @private
  */
 ol.control.Rotate.prototype.handlePointerUp_ = function(pointerEvent) {
-  pointerEvent.browserEvent.preventDefault();
   this.resetNorth_();
 };
 

--- a/src/ol/control/zoomcontrol.js
+++ b/src/ol/control/zoomcontrol.js
@@ -115,6 +115,7 @@ goog.inherits(ol.control.Zoom, ol.control.Control);
  * @private
  */
 ol.control.Zoom.prototype.handleClick_ = function(delta, event) {
+  event.preventDefault();
   if (event.screenX !== 0 && event.screenY !== 0) {
     return;
   }
@@ -128,7 +129,6 @@ ol.control.Zoom.prototype.handleClick_ = function(delta, event) {
  * @private
  */
 ol.control.Zoom.prototype.handlePointerUp_ = function(delta, pointerEvent) {
-  pointerEvent.browserEvent.preventDefault();
   this.zoomByDelta_(delta);
 };
 

--- a/src/ol/control/zoomtoextentcontrol.js
+++ b/src/ol/control/zoomtoextentcontrol.js
@@ -40,6 +40,7 @@ ol.control.ZoomToExtent = function(opt_options) {
   }, tipLabel);
   var button = goog.dom.createDom(goog.dom.TagName.BUTTON, {
     'class': 'ol-has-tooltip'
+    'type' : 'button'
   });
   goog.dom.appendChild(button, tip);
 
@@ -74,6 +75,7 @@ goog.inherits(ol.control.ZoomToExtent, ol.control.Control);
  * @private
  */
 ol.control.ZoomToExtent.prototype.handleClick_ = function(event) {
+  event.browserEvent.preventDefault();
   if (event.screenX !== 0 && event.screenY !== 0) {
     return;
   }
@@ -86,7 +88,6 @@ ol.control.ZoomToExtent.prototype.handleClick_ = function(event) {
  * @private
  */
 ol.control.ZoomToExtent.prototype.handlePointerUp_ = function(pointerEvent) {
-  pointerEvent.browserEvent.preventDefault();
   this.handleZoomToExtent_();
 };
 

--- a/src/ol/control/zoomtoextentcontrol.js
+++ b/src/ol/control/zoomtoextentcontrol.js
@@ -75,7 +75,7 @@ goog.inherits(ol.control.ZoomToExtent, ol.control.Control);
  * @private
  */
 ol.control.ZoomToExtent.prototype.handleClick_ = function(event) {
-  event.browserEvent.preventDefault();
+  event.preventDefault();
   if (event.screenX !== 0 && event.screenY !== 0) {
     return;
   }


### PR DESCRIPTION
1. Changed type attribute to "button" on <button> elements where it wasn't already set and thus used to fall back to type="submit", which leads to submitting the page on click if control is contained within a <form> element (e.g. in an ASP.NET or Oracle APEX application).
2. Moving event.preventDefault() calls to handleClick_. Calling preventDefault() inside a handler for mouseup is useless, since only click or keypress are responsible for triggering the DOMActivate event which the form is actually submitted on. Since we use type="button", most browsers already won't submit anyway, but this case probably needs some more testing in the older ones.