### PR TITLE
Strict LinearRing (WKT) parsing

### DIFF
--- a/src/ol/format/wktformat.js
+++ b/src/ol/format/wktformat.js
@@ -760,10 +760,10 @@ ol.format.WKT.Parser.prototype.parsePoint_ = function() {
  * @private
  */
 ol.format.WKT.Parser.prototype.parsePointList_ = function() {
-  var coordinates = [this.parsePoint_()];
-  while (this.match(ol.format.WKT.TokenType.COMMA)) {
+  var coordinates = [];
+  do {
     coordinates.push(this.parsePoint_());
-  }
+  } while (this.match(ol.format.WKT.TokenType.COMMA));
   return coordinates;
 };
 
@@ -773,10 +773,10 @@ ol.format.WKT.Parser.prototype.parsePointList_ = function() {
  * @private
  */
 ol.format.WKT.Parser.prototype.parsePointTextList_ = function() {
-  var coordinates = [this.parsePointText_()];
-  while (this.match(ol.format.WKT.TokenType.COMMA)) {
+  var coordinates = [];
+  do {
     coordinates.push(this.parsePointText_());
-  }
+  } while (this.match(ol.format.WKT.TokenType.COMMA));
   return coordinates;
 };
 
@@ -786,10 +786,10 @@ ol.format.WKT.Parser.prototype.parsePointTextList_ = function() {
  * @private
  */
 ol.format.WKT.Parser.prototype.parseLineStringTextList_ = function() {
-  var coordinates = [this.parseLineStringText_()];
-  while (this.match(ol.format.WKT.TokenType.COMMA)) {
+  var coordinates = [];
+  do {
     coordinates.push(this.parseLineStringText_());
-  }
+  } while (this.match(ol.format.WKT.TokenType.COMMA));
   return coordinates;
 };
 
@@ -799,10 +799,10 @@ ol.format.WKT.Parser.prototype.parseLineStringTextList_ = function() {
  * @private
  */
 ol.format.WKT.Parser.prototype.parsePolygonTextList_ = function() {
-  var coordinates = [this.parsePolygonText_()];
-  while (this.match(ol.format.WKT.TokenType.COMMA)) {
+  var coordinates = [];
+  do {
     coordinates.push(this.parsePolygonText_());
-  }
+  } while (this.match(ol.format.WKT.TokenType.COMMA));
   return coordinates;
 };
 


### PR DESCRIPTION
After reading #2679 I realized the WKT does not strictly parse polygons.
The OGC defines a LinearRing as follows: "A LinearRing is a LineString that is both closed and simple"[1]. It also states that if the exterior linear ring of a polygon is defined in a counter clockwise direction it will be seen from the "top". Any interior linear rings should be defined in opposite fashion compared to the exterior ring, in this case, clockwise.

This pull request **only** asserts linear rings are closed. However, three questions remain:
* Shouldn't `ol.geom.LinearRing` assert the ring is closed? (OpenLayers 2 closes linear rings automatically.)
* Is it desired to have a check on the ring being _simple_[2] as well?
* Is it desired to have a check on the direction of interior/exterior rings as well?

Doing all these checks may be a bit exorbitant and would require some advanced algorithms. As I am always in for a challenge, I don't mind extending this pull request to do so. But I realize it might be a bit overkill. So I'm curious what other people have to say on this matter.

[1] <http://www.opengeospatial.org/standards/sfa>
[2] <http://en.wikipedia.org/wiki/Simple_polygon>