### PR TITLE
Add will-change CSS properties

### DIFF
--- a/css/ol.css
+++ b/css/ol.css
@@ -23,6 +23,10 @@
   margin: 1px;
   will-change: contents, width;
 }
+.ol-overlay-container {
+  will-change: left,right,top,bottom;
+}
+
 .ol-unsupported {
   display: none;
 }

--- a/css/ol.css
+++ b/css/ol.css
@@ -21,6 +21,7 @@
   font-size: 10px;
   text-align: center;
   margin: 1px;
+  will-change: contents, width;
 }
 .ol-unsupported {
   display: none;
@@ -101,6 +102,7 @@
   display: block;
   font-weight: normal;
   font-size: 1.2em;
+  will-change: transform;
 }
 .ol-touch .ol-control button {
   font-size: 1.5em;

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -90,7 +90,9 @@ ol.Overlay = function(options) {
    * @private
    * @type {Element}
    */
-  this.element_ = goog.dom.createElement(goog.dom.TagName.DIV);
+  this.element_ = goog.dom.createDom(goog.dom.TagName.DIV, {
+    'class': 'ol-overlay-container'
+  });
   this.element_.style.position = 'absolute';
 
   /**


### PR DESCRIPTION
Tested with Chrome 37; with this property the overlays are rendered into their own rendering layer.
This can be seen by checking the "Show composited layer borders" in the chrome dev tools