### PR TITLE
Generate source map of minified ol.js

### DIFF
--- a/build.py
+++ b/build.py
@@ -172,7 +172,8 @@ virtual('ci', 'lint', 'build', 'test',
     'build/examples/all.combined.js', 'check-examples', 'apidoc')
 
 
-virtual('build', 'build/ol.css', 'build/ol.js', 'build/ol-debug.js')
+virtual('build', 'build/ol.css', 'build/ol.js', 'build/ol-debug.js',
+    'build/ol.js.map')
 
 
 virtual('check', 'lint', 'build/ol.js', 'test')
@@ -192,10 +193,19 @@ def build_ol_css(t):
     t.output('%(CLEANCSS)s', 'css/ol.css')
 
 
-@target('build/ol.js', SRC, SHADER_SRC, 'config/ol.json', NPM_INSTALL)
-def build_ol_new_js(t):
+def _build_js(t):
     t.run('node', 'tasks/build.js', 'config/ol.json', 'build/ol.js')
+
+
+@target('build/ol.js', SRC, SHADER_SRC, 'config/ol.json', NPM_INSTALL)
+def build_ol_js(t):
+    _build_js(t)
     report_sizes(t)
+
+
+@target('build/ol.js.map', SRC, SHADER_SRC, 'config/ol.json', NPM_INSTALL)
+def build_ol_js_map(t):
+    _build_js(t)
 
 
 @target('build/ol-debug.js', SRC, SHADER_SRC, 'config/ol-debug.json',

--- a/config/ol.json
+++ b/config/ol.json
@@ -61,6 +61,8 @@
     "compilation_level": "ADVANCED",
     "warning_level": "VERBOSE",
     "use_types_for_optimization": true,
-    "manage_closure_dependencies": true
+    "manage_closure_dependencies": true,
+    "create_source_map": "build/ol.js.map",
+    "source_map_format": "V3"
   }
 }


### PR DESCRIPTION
Allows automatic unminification by the browser.

A postprocessing is required.
If someone knows how to do this in Python or nodejs, please provide a
patch:
\#!/bin/sh
map='build/ol.js.map'
pwd=`pwd`
sed -i "s!$pwd/build!olsource!g" $map
sed -i "s!$pwd!olsource!g" $map
echo '//# sourceMappingURL=ol.js.map' >> build/ol.js

Then create an alias / copy ol3 directory to /olsource in your
deployed environment.