### PR TITLE
Re enable rotation button transition

### DIFF
--- a/css/ol.css
+++ b/css/ol.css
@@ -53,11 +53,12 @@
 .ol-rotate {
   top: .5em;
   right: .5em;
-  transition: opacity .25s;
+  transition: opacity .25s linear, visibility 0s linear;
 }
 .ol-rotate.ol-hidden {
   opacity: 0;
-  display: none;
+  visibility: hidden;
+  transition: opacity .25s linear, visibility 0s linear .25s;
 }
 .ol-zoom-extent {
   top: 4.643em;


### PR DESCRIPTION
The opacity transition was broken with #2782

Tested with FF 32 and chrome 36