### PR TITLE
SVG icons on Internet Explorer

### DIFF
--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -294,6 +294,7 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         var scale = /** @type {number} */ (instruction[12]);
         var snapToPixel = /** @type {boolean} */ (instruction[13]);
         var width = /** @type {number} */ (instruction[14]);
+        goog.asserts.assert(width > 0 && height > 0);
         if (rotateWithView) {
           rotation += viewRotation;
         }

--- a/src/ol/style/iconstyle.js
+++ b/src/ol/style/iconstyle.js
@@ -258,7 +258,7 @@ ol.style.Icon.prototype.getImageState = function() {
  * @inheritDoc
  */
 ol.style.Icon.prototype.getHitDetectionImage = function(pixelRatio) {
-  return this.iconImage_.getHitDetectionImage(pixelRatio);
+  return this.iconImage_.getHitDetectionImage(pixelRatio, this.getSize());
 };
 
 
@@ -482,17 +482,22 @@ ol.style.IconImage_.prototype.getImageState = function() {
 
 /**
  * @param {number} pixelRatio Pixel ratio.
+ * @param {ol.Size} size The size of SVG icons is unknown on IE, so provide it.
  * @return {Image|HTMLCanvasElement} Image element.
  */
-ol.style.IconImage_.prototype.getHitDetectionImage = function(pixelRatio) {
+ol.style.IconImage_.prototype.getHitDetectionImage =
+    function(pixelRatio, size) {
   if (goog.isNull(this.hitDetectionImage_)) {
-    if (this.tainting_) {
-      var width = this.size_[0];
-      var height = this.size_[1];
-      var context = ol.dom.createCanvasContext2D(width, height);
-      context.fillRect(0, 0, width, height);
-      this.hitDetectionImage_ = context.canvas;
-    } else {
+    if (this.tainting_ && !goog.isNull(size)) {
+      var width = size[0];
+      var height = size[1];
+      if (width > 0 && height > 0) {
+        var context = ol.dom.createCanvasContext2D(width, height);
+        context.fillRect(0, 0, width, height);
+        this.hitDetectionImage_ = context.canvas;
+      }
+    }
+    if (goog.isNull(this.hitDetectionImage_)) {
       this.hitDetectionImage_ = this.image_;
     }
   }


### PR DESCRIPTION
When testing my website (which runs smoothly on Chrome) on Internet Explorer, I was surprised to see my SVG icons did not show up and even caused an error:

```
SCRIPT5022: InvalidStateError
File: canvasreplay.js, Line: 326, Column: 11
```

After some investigation, I found out IE does not know the size of the SVG icon (see also [1]) causing

```
context.drawImage(image, originX, originY, width, height,
              x, y, width * pixelRatio, height * pixelRatio);
```

to fail, as `width` and `height` both equal zero.

Although this can be fixed easily by providing a `size` to `ol.style.Icon`, I'd rather have no icon than a crashing library. See the first commit of this PR for a solution.



After running my website several times using this fix, I randomly get either the same error, or this one:

```
SCRIPT65535: Unexpected call to method or property access.
File: iconstyle.js, Line: 427, Column: 3
```

I checked the `image` variable in `canvasreplay.js:236` and apparently another 'empty' image is added: `<canvas width="0" height="0"></canvas>`, even though `width` and `height` (the variables, _not_ the `image` attributes) are non-empty now. This image is the 'hit detection icon', making my icons interact. Again, the SVG icons have no size (according to IE), so the hit detection icon has none either. See the second commit of this PR for my solution.

[1] <http://stackoverflow.com/questions/4472086/getting-image-width-on-image-load-fails-on-ie>

Edit: added a link to stackoverflow, which may contain a better solution.