### PR TITLE
Add parsing of some WMS 1.1.1 specific nodes

### DIFF
--- a/examples/data/ogcsample111.xml
+++ b/examples/data/ogcsample111.xml
@@ -1,0 +1,263 @@
+<?xml version='1.0' encoding="UTF-8" standalone="no" ?>
+<!-- The DTD (Document Type Definition) given here must correspond to the version number declared in the WMT_MS_Capabilities element below. -->
+<!DOCTYPE WMT_MS_Capabilities
+  SYSTEM 'http://www.digitalearth.gov/wmt/xml/capabilities_1_1_1.dtd' [
+<!-- Vendor-specific elements are defined here if needed. --><!-- If not needed, you can omit these [] and everything inside. --><!ELEMENT VendorSpecificCapabilities EMPTY>]>
+<!-- end of DOCTYPE declaration -->
+<!-- Note: this XML is just an EXAMPLE that attempts to show all required and optional elements for illustration. Consult the Web Map Service 1.1.0 specification and the DTD for guidance on what to actually include and what to leave out. -->
+<!-- The version number listed in the WMT_MS_Capabilities element here must correspond to the DTD declared above. See the WMT specification document for how to respond when a client requests a version number not implemented by the server. -->
+<WMT_MS_Capabilities updateSequence="0" version="1.1.1">
+  <!-- Service Metadata -->
+  <Service>
+    <!-- The WMT-defined name for this type of service -->
+    <Name>OGC:WMS</Name>
+    <!-- Human-readable title for pick lists -->
+    <Title>Acme Corp. Map Server</Title>
+    <!-- Narrative description providing additional information -->
+    <Abstract>WMT Map Server maintained by Acme Corporation. Contact: webmaster@wmt.acme.com. High-quality maps showing roadrunner nests and possible ambush locations.</Abstract>
+    <KeywordList>
+      <Keyword>bird</Keyword>
+      <Keyword>roadrunner</Keyword>
+      <Keyword>ambush</Keyword>
+    </KeywordList>
+    <!-- Top-level web address of service or service provider. See also OnlineResource elements under <DCPType>. -->
+    <OnlineResource xlink:href="http://hostname/" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+    <!-- Contact information -->
+    <ContactInformation>
+      <ContactPersonPrimary>
+        <ContactPerson>Jeff deLaBeaujardiere</ContactPerson>
+        <ContactOrganization>NASA</ContactOrganization>
+      </ContactPersonPrimary>
+      <ContactPosition>Computer Scientist</ContactPosition>
+      <ContactAddress>
+        <AddressType>postal</AddressType>
+        <Address>NASA Goddard Space Flight Center, Code 933</Address>
+        <City>Greenbelt</City>
+        <StateOrProvince>MD</StateOrProvince>
+        <PostCode>20771</PostCode>
+        <Country>USA</Country>
+      </ContactAddress>
+      <ContactVoiceTelephone>+1 301 286-1569</ContactVoiceTelephone>
+      <ContactFacsimileTelephone>+1 301 286-1777</ContactFacsimileTelephone>
+      <ContactElectronicMailAddress>delabeau@iniki.gsfc.nasa.gov</ContactElectronicMailAddress>
+    </ContactInformation>
+    <!-- Fees or access constraints imposed. -->
+    <Fees>none</Fees>
+    <AccessConstraints>none</AccessConstraints>
+  </Service>
+  <Capability>
+    <Request>
+      <GetCapabilities>
+        <Format>application/vnd.ogc.wms_xml</Format>
+        <DCPType>
+          <HTTP>
+            <Get>
+              <!-- The URL here for invoking GetCapabilities using HTTP GET is only a prefix to which a query string is appended. -->
+              <OnlineResource xlink:href="http://hostname:port/path" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+            </Get>
+            <Post>
+              <!-- The URL here for invoking GetCapabilities using HTTP POST includes the complete address to which a query would be sent in XML format. This is here for future expansion; no POST encoding
+has yet been defined. -->
+              <OnlineResource xlink:href="http://hostname:port/path" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+            </Post>
+          </HTTP>
+        </DCPType>
+      </GetCapabilities>
+      <GetMap>
+        <Format>image/gif</Format>
+        <Format>image/png</Format>
+        <Format>image/jpeg</Format>
+        <DCPType>
+          <HTTP>
+            <Get>
+              <!-- The URL here for invoking GetCapabilities using HTTP GET is only a prefix to which a query string is appended. -->
+              <OnlineResource xlink:href="http://hostname:port/path" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+            </Get>
+          </HTTP>
+        </DCPType>
+      </GetMap>
+      <GetFeatureInfo>
+        <Format>application/vnd.ogc.gml</Format>
+        <Format>text/plain</Format>
+        <Format>text/html</Format>
+        <DCPType>
+          <HTTP>
+            <Get>
+              <OnlineResource xlink:href="http://hostname:port/path" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+            </Get>
+          </HTTP>
+        </DCPType>
+      </GetFeatureInfo>
+      <DescribeLayer>
+        <!--optional; used only by SLD-enabled WMS-->
+        <Format>application/vnd.ogc.gml</Format>
+        <DCPType>
+          <HTTP>
+            <Get>
+              <OnlineResource xlink:href="http://hostname:port/path" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+            </Get>
+          </HTTP>
+        </DCPType>
+      </DescribeLayer>
+    </Request>
+    <Exception>
+      <Format>application/vnd.ogc.se_xml</Format>
+      <Format>application/vnd.ogc.se_inimage</Format>
+      <Format>application/vnd.ogc.se_blank</Format>
+    </Exception>
+    <!-- Any text or markup is allowed here, as required to describe
+vendor-specific capabilities. Please define elements and attributes
+in the DOCTYPE declaration at the start of the document. -->
+    <!-- This example is empty because no VSPs were defined in preamble -->
+    <VendorSpecificCapabilities/>
+    <!-- Place-holder for Styled Layer Descriptor (SLD)-enabled WMSes.
+This element is absent for a basic WMS. -->
+    <UserDefinedSymbolization RemoteWFS="1" SupportSLD="1" UserLayer="1" UserStyle="1"/>
+    <Layer>
+      <Title>Acme Corp. Map Server</Title>
+      <SRS>EPSG:4326</SRS>
+      <!-- all layers are available in at least this SRS -->
+      <AuthorityURL name="DIF_ID">
+        <OnlineResource xlink:href="http://gcmd.gsfc.nasa.gov/difguide/whatisadif.html" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+      </AuthorityURL>
+      <Layer>
+        <!-- This parent layer has a Name and can therefore be requested from a Map Server, yielding a map of all subsidiary layers. -->
+        <Name>ROADS_RIVERS</Name>
+        <Title>Roads and Rivers</Title>
+        <!-- See the spec to learn how some characteristics are inherited by
+subsidiary layers. -->
+        <SRS>EPSG:26986</SRS>
+        <!-- An additional SRS for this layer -->
+        <LatLonBoundingBox maxx="-70.78" maxy="42.90" minx="-71.63" miny="41.75"/>
+        <!-- The optional resx and resy attributes below indicate the X and Y spatial
+resolution in the units of that SRS. -->
+        <!-- The EPSG:4326 BoundingBox duplicates some of the info in LatLonBoundingBox
+and is therefore optional, but using it here allows the additional
+resolution attributes. -->
+        <BoundingBox SRS="EPSG:4326" maxx="-70.78" maxy="42.90" minx="-71.63" miny="41.75" resx="0.01" resy="0.01"/>
+        <BoundingBox SRS="EPSG:26986" maxx="285000" maxy="962000" minx="189000" miny="834000" resx="1" resy="1"/>
+        <!-- Optional Title, URL and logo image of data provider. -->
+        <Attribution>
+          <Title>State College University</Title>
+          <OnlineResource xlink:href="http://www.university.edu/" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+          <LogoURL height="100" width="100">
+            <Format>image/gif</Format>
+            <OnlineResource xlink:href="http://www.university.edu/icons/logo.gif" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+          </LogoURL>
+        </Attribution>
+        <!-- Identifier whose meaning is defined in an AuthorityURL element -->
+        <Identifier authority="DIF_ID">123456</Identifier>
+        <FeatureListURL>
+          <Format>application/vnd.ogc.se_xml&quot;</Format>
+          <OnlineResource xlink:href="http://www.university.edu/data/roads_rivers.gml" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+        </FeatureListURL>
+        <Style>
+          <Name>USGS</Name>
+          <Title>USGS Topo Map Style</Title>
+          <Abstract>Features are shown in a style like that used in USGS topographic
+maps.</Abstract>
+          <!-- A picture of a legend for a Layer in this Style -->
+          <LegendURL height="72" width="72">
+            <Format>image/gif</Format>
+            <OnlineResource xlink:href="http://www.university.edu/legends/usgs.gif" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+          </LegendURL>
+          <!-- An XSL stylesheet describing how GML feature data will rendered to create
+             a map of this layer. -->
+          <StyleSheetURL>
+            <Format>text/xsl</Format>
+            <OnlineResource xlink:href="http://www.university.edu/stylesheets/usgs.xsl" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+          </StyleSheetURL>
+        </Style>
+        <ScaleHint max="35000" min="4000"/>
+        <Layer queryable="1">
+          <Name>ROADS_1M</Name>
+          <Title>Roads at 1:1M scale</Title>
+          <Abstract>Roads at a scale of 1 to 1 million.</Abstract>
+          <KeywordList>
+            <Keyword>road</Keyword>
+            <Keyword>transportation</Keyword>
+            <Keyword>atlas</Keyword>
+          </KeywordList>
+          <Identifier authority="DIF_ID">123456</Identifier>
+          <!-- Metadata specific to this particular layer. The same FGDC metadata is
+offered in two formats. -->
+          <MetadataURL type="FGDC">
+            <Format>text/plain</Format>
+            <OnlineResource xlink:href="http://www.university.edu/metadata/roads.txt" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+          </MetadataURL>
+          <MetadataURL type="FGDC">
+            <Format>text/xml</Format>
+            <OnlineResource xlink:href="http://www.university.edu/metadata/roads.xml" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+          </MetadataURL>
+          <!-- In addition to the Style specified in the parent Layer, this Layer is available in this style. -->
+          <Style>
+            <Name>ATLAS</Name>
+            <Title>Road atlas style</Title>
+            <Abstract>Roads are shown in a style like that used in a commercial road
+atlas.</Abstract>
+            <LegendURL height="72" width="72">
+              <Format>image/gif</Format>
+              <OnlineResource xlink:href="http://www.university.edu/legends/atlas.gif" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+            </LegendURL>
+          </Style>
+        </Layer>
+        <Layer queryable="1">
+          <Name>RIVERS_1M</Name>
+          <Title>Rivers at 1:1M scale</Title>
+          <Abstract>Rivers at a scale of 1 to 1 million.</Abstract>
+          <KeywordList>
+            <Keyword>river</Keyword>
+            <Keyword>canal</Keyword>
+            <Keyword>waterway</Keyword>
+          </KeywordList>
+        </Layer>
+      </Layer>
+      <Layer queryable="1">
+        <Title>Weather Forecast Data</Title>
+        <SRS>EPSG:4326</SRS>
+        <!-- harmless repetition of common SRS -->
+        <LatLonBoundingBox maxx="180" maxy="90" minx="-180" miny="-90"/>
+        <!-- These weather data are available daily from 1999-01-01 through
+2000-08-22. -->
+        <Dimension name="time" units="ISO8601"/>
+        <Extent default="2000-08-22" name="time">1999-01-01/2000-08-22/P1D</Extent>
+        <Layer>
+          <Name>Clouds</Name>
+          <Title>Forecast cloud cover</Title>
+        </Layer>
+        <Layer>
+          <Name>Temperature</Name>
+          <Title>Forecast temperature</Title>
+        </Layer>
+        <Layer>
+          <Name>Pressure</Name>
+          <Title>Forecast barometric pressure</Title>
+          <!-- Pressure is available at several elevations.
+EPSG:5030 is WGS 84 ellipsoid, units in metres.
+Pressure is also available at several times.
+NOTE: first list all Dimension elements, then all Extent elements. -->
+          <Dimension name="time" units="ISO8601"/>
+          <Dimension name="elevation" units="EPSG:5030"/>
+          <Extent default="2000-08-22" name="time">1999-01-01/2000-08-22/P1D</Extent>
+          <Extent default="0" name="elevation" nearestValue="1">0,1000,3000,5000,10000</Extent>
+        </Layer>
+      </Layer>
+      <!-- Example of a layer which is a static map of fixed
+size which the server cannot subset or make transparent -->
+      <Layer fixedHeight="256" fixedWidth="512" noSubsets="1" opaque="1">
+        <Name>ozone_image</Name>
+        <Title>Global ozone distribution (1992)</Title>
+        <LatLonBoundingBox maxx="180" maxy="90" minx="-180" miny="-90"/>
+        <Extent default="1992" name="time">1992</Extent>
+      </Layer>
+      <!-- Example of a layer which originated from another WMS and has been
+         "cascaded" by this WMS. -->
+      <Layer cascaded="1">
+        <Name>population</Name>
+        <Title>World population, annual</Title>
+        <LatLonBoundingBox maxx="180" maxy="90" minx="-180" miny="-90"/>
+        <Extent default="2000" name="time">1990/2000/P1Y</Extent>
+      </Layer>
+    </Layer>
+  </Capability>
+</WMT_MS_Capabilities>

--- a/test/spec/ol/format/wms/ogcsample111.xml
+++ b/test/spec/ol/format/wms/ogcsample111.xml
@@ -1,0 +1,262 @@
+<?xml version='1.0' encoding="UTF-8" standalone="no" ?>
+<!-- The DTD (Document Type Definition) given here must correspond to the version number declared in the WMT_MS_Capabilities element below. -->
+<!DOCTYPE WMT_MS_Capabilities
+  SYSTEM 'http://www.digitalearth.gov/wmt/xml/capabilities_1_1_1.dtd' [
+<!-- Vendor-specific elements are defined here if needed. --><!-- If not needed, you can omit these [] and everything inside. --><!ELEMENT VendorSpecificCapabilities EMPTY>]>
+<!-- end of DOCTYPE declaration -->
+<!-- Note: this XML is just an EXAMPLE that attempts to show all required and optional elements for illustration. Consult the Web Map Service 1.1.0 specification and the DTD for guidance on what to actually include and what to leave out. -->
+<!-- The version number listed in the WMT_MS_Capabilities element here must correspond to the DTD declared above. See the WMT specification document for how to respond when a client requests a version number not implemented by the server. -->
+<WMT_MS_Capabilities updateSequence="0" version="1.1.1">
+  <!-- Service Metadata -->
+  <Service>
+    <!-- The WMT-defined name for this type of service -->
+    <Name>OGC:WMS</Name>
+    <!-- Human-readable title for pick lists -->
+    <Title>Acme Corp. Map Server</Title>
+    <!-- Narrative description providing additional information -->
+    <Abstract>WMT Map Server maintained by Acme Corporation. Contact: webmaster@wmt.acme.com. High-quality maps showing roadrunner nests and possible ambush locations.</Abstract>
+    <KeywordList>
+      <Keyword>bird</Keyword>
+      <Keyword>roadrunner</Keyword>
+      <Keyword>ambush</Keyword>
+    </KeywordList>
+    <!-- Top-level web address of service or service provider. See also OnlineResource elements under <DCPType>. -->
+    <OnlineResource xlink:href="http://hostname/" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+    <!-- Contact information -->
+    <ContactInformation>
+      <ContactPersonPrimary>
+        <ContactPerson>Jeff deLaBeaujardiere</ContactPerson>
+        <ContactOrganization>NASA</ContactOrganization>
+      </ContactPersonPrimary>
+      <ContactPosition>Computer Scientist</ContactPosition>
+      <ContactAddress>
+        <AddressType>postal</AddressType>
+        <Address>NASA Goddard Space Flight Center, Code 933</Address>
+        <City>Greenbelt</City>
+        <StateOrProvince>MD</StateOrProvince>
+        <PostCode>20771</PostCode>
+        <Country>USA</Country>
+      </ContactAddress>
+      <ContactVoiceTelephone>+1 301 286-1569</ContactVoiceTelephone>
+      <ContactFacsimileTelephone>+1 301 286-1777</ContactFacsimileTelephone>
+      <ContactElectronicMailAddress>delabeau@iniki.gsfc.nasa.gov</ContactElectronicMailAddress>
+    </ContactInformation>
+    <!-- Fees or access constraints imposed. -->
+    <Fees>none</Fees>
+    <AccessConstraints>none</AccessConstraints>
+  </Service>
+  <Capability>
+    <Request>
+      <GetCapabilities>
+        <Format>application/vnd.ogc.wms_xml</Format>
+        <DCPType>
+          <HTTP>
+            <Get>
+              <!-- The URL here for invoking GetCapabilities using HTTP GET is only a prefix to which a query string is appended. -->
+              <OnlineResource xlink:href="http://hostname:port/path" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+            </Get>
+            <Post>
+              <!-- The URL here for invoking GetCapabilities using HTTP POST includes the complete address to which a query would be sent in XML format. This is here for future expansion; no POST encoding
+has yet been defined. -->
+              <OnlineResource xlink:href="http://hostname:port/path" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+            </Post>
+          </HTTP>
+        </DCPType>
+      </GetCapabilities>
+      <GetMap>
+        <Format>image/gif</Format>
+        <Format>image/png</Format>
+        <Format>image/jpeg</Format>
+        <DCPType>
+          <HTTP>
+            <Get>
+              <!-- The URL here for invoking GetCapabilities using HTTP GET is only a prefix to which a query string is appended. -->
+              <OnlineResource xlink:href="http://hostname:port/path" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+            </Get>
+          </HTTP>
+        </DCPType>
+      </GetMap>
+      <GetFeatureInfo>
+        <Format>application/vnd.ogc.gml</Format>
+        <Format>text/plain</Format>
+        <Format>text/html</Format>
+        <DCPType>
+          <HTTP>
+            <Get>
+              <OnlineResource xlink:href="http://hostname:port/path" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+            </Get>
+          </HTTP>
+        </DCPType>
+      </GetFeatureInfo>
+      <DescribeLayer>
+        <!--optional; used only by SLD-enabled WMS-->
+        <Format>application/vnd.ogc.gml</Format>
+        <DCPType>
+          <HTTP>
+            <Get>
+              <OnlineResource xlink:href="http://hostname:port/path" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+            </Get>
+          </HTTP>
+        </DCPType>
+      </DescribeLayer>
+    </Request>
+    <Exception>
+      <Format>application/vnd.ogc.se_xml</Format>
+      <Format>application/vnd.ogc.se_inimage</Format>
+      <Format>application/vnd.ogc.se_blank</Format>
+    </Exception>
+    <!-- Any text or markup is allowed here, as required to describe
+vendor-specific capabilities. Please define elements and attributes
+in the DOCTYPE declaration at the start of the document. -->
+    <!-- This example is empty because no VSPs were defined in preamble -->
+    <VendorSpecificCapabilities/>
+    <!-- Place-holder for Styled Layer Descriptor (SLD)-enabled WMSes.
+This element is absent for a basic WMS. -->
+    <UserDefinedSymbolization RemoteWFS="1" SupportSLD="1" UserLayer="1" UserStyle="1"/>
+    <Layer>
+      <Title>Acme Corp. Map Server</Title>
+      <SRS>EPSG:4326</SRS>
+      <!-- all layers are available in at least this SRS -->
+      <AuthorityURL name="DIF_ID">
+        <OnlineResource xlink:href="http://gcmd.gsfc.nasa.gov/difguide/whatisadif.html" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+      </AuthorityURL>
+      <Layer>
+        <!-- This parent layer has a Name and can therefore be requested from a Map Server, yielding a map of all subsidiary layers. -->
+        <Name>ROADS_RIVERS</Name>
+        <Title>Roads and Rivers</Title>
+        <!-- See the spec to learn how some characteristics are inherited by
+subsidiary layers. -->
+        <SRS>EPSG:26986</SRS>
+        <!-- An additional SRS for this layer -->
+        <LatLonBoundingBox maxx="-70.78" maxy="42.90" minx="-71.63" miny="41.75"/>
+        <!-- The optional resx and resy attributes below indicate the X and Y spatial
+resolution in the units of that SRS. -->
+        <!-- The EPSG:4326 BoundingBox duplicates some of the info in LatLonBoundingBox
+and is therefore optional, but using it here allows the additional
+resolution attributes. -->
+        <BoundingBox SRS="EPSG:4326" maxx="-70.78" maxy="42.90" minx="-71.63" miny="41.75" resx="0.01" resy="0.01"/>
+        <BoundingBox SRS="EPSG:26986" maxx="285000" maxy="962000" minx="189000" miny="834000" resx="1" resy="1"/>
+        <!-- Optional Title, URL and logo image of data provider. -->
+        <Attribution>
+          <Title>State College University</Title>
+          <OnlineResource xlink:href="http://www.university.edu/" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+          <LogoURL height="100" width="100">
+            <Format>image/gif</Format>
+            <OnlineResource xlink:href="http://www.university.edu/icons/logo.gif" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+          </LogoURL>
+        </Attribution>
+        <!-- Identifier whose meaning is defined in an AuthorityURL element -->
+        <Identifier authority="DIF_ID">123456</Identifier>
+        <FeatureListURL>
+          <Format>application/vnd.ogc.se_xml</Format>
+          <OnlineResource xlink:href="http://www.university.edu/data/roads_rivers.gml" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+        </FeatureListURL>
+        <Style>
+          <Name>USGS</Name>
+          <Title>USGS Topo Map Style</Title>
+          <Abstract>Features are shown in a style like that used in USGS topographic maps.</Abstract>
+          <!-- A picture of a legend for a Layer in this Style -->
+          <LegendURL height="72" width="72">
+            <Format>image/gif</Format>
+            <OnlineResource xlink:href="http://www.university.edu/legends/usgs.gif" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+          </LegendURL>
+          <!-- An XSL stylesheet describing how GML feature data will rendered to create
+             a map of this layer. -->
+          <StyleSheetURL>
+            <Format>text/xsl</Format>
+            <OnlineResource xlink:href="http://www.university.edu/stylesheets/usgs.xsl" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+          </StyleSheetURL>
+        </Style>
+        <ScaleHint max="35000" min="4000"/>
+        <Layer queryable="1">
+          <Name>ROADS_1M</Name>
+          <Title>Roads at 1:1M scale</Title>
+          <Abstract>Roads at a scale of 1 to 1 million.</Abstract>
+          <KeywordList>
+            <Keyword>road</Keyword>
+            <Keyword>transportation</Keyword>
+            <Keyword>atlas</Keyword>
+          </KeywordList>
+          <Identifier authority="DIF_ID">123456</Identifier>
+          <!-- Metadata specific to this particular layer. The same FGDC metadata is
+offered in two formats. -->
+          <MetadataURL type="FGDC">
+            <Format>text/plain</Format>
+            <OnlineResource xlink:href="http://www.university.edu/metadata/roads.txt" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+          </MetadataURL>
+          <MetadataURL type="FGDC">
+            <Format>text/xml</Format>
+            <OnlineResource xlink:href="http://www.university.edu/metadata/roads.xml" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+          </MetadataURL>
+          <!-- In addition to the Style specified in the parent Layer, this Layer is available in this style. -->
+          <Style>
+            <Name>ATLAS</Name>
+            <Title>Road atlas style</Title>
+            <Abstract>Roads are shown in a style like that used in a commercial road
+atlas.</Abstract>
+            <LegendURL height="72" width="72">
+              <Format>image/gif</Format>
+              <OnlineResource xlink:href="http://www.university.edu/legends/atlas.gif" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+            </LegendURL>
+          </Style>
+        </Layer>
+        <Layer queryable="1">
+          <Name>RIVERS_1M</Name>
+          <Title>Rivers at 1:1M scale</Title>
+          <Abstract>Rivers at a scale of 1 to 1 million.</Abstract>
+          <KeywordList>
+            <Keyword>river</Keyword>
+            <Keyword>canal</Keyword>
+            <Keyword>waterway</Keyword>
+          </KeywordList>
+        </Layer>
+      </Layer>
+      <Layer queryable="1">
+        <Title>Weather Forecast Data</Title>
+        <SRS>EPSG:4326</SRS>
+        <!-- harmless repetition of common SRS -->
+        <LatLonBoundingBox maxx="180" maxy="90" minx="-180" miny="-90"/>
+        <!-- These weather data are available daily from 1999-01-01 through
+2000-08-22. -->
+        <Dimension name="time" units="ISO8601"/>
+        <Extent default="2000-08-22" name="time">1999-01-01/2000-08-22/P1D</Extent>
+        <Layer>
+          <Name>Clouds</Name>
+          <Title>Forecast cloud cover</Title>
+        </Layer>
+        <Layer>
+          <Name>Temperature</Name>
+          <Title>Forecast temperature</Title>
+        </Layer>
+        <Layer>
+          <Name>Pressure</Name>
+          <Title>Forecast barometric pressure</Title>
+          <!-- Pressure is available at several elevations.
+EPSG:5030 is WGS 84 ellipsoid, units in metres.
+Pressure is also available at several times.
+NOTE: first list all Dimension elements, then all Extent elements. -->
+          <Dimension name="time" units="ISO8601"/>
+          <Dimension name="elevation" units="EPSG:5030"/>
+          <Extent default="2000-08-22" name="time">1999-01-01/2000-08-22/P1D</Extent>
+          <Extent default="0" name="elevation" nearestValue="1">0,1000,3000,5000,10000</Extent>
+        </Layer>
+      </Layer>
+      <!-- Example of a layer which is a static map of fixed
+size which the server cannot subset or make transparent -->
+      <Layer fixedHeight="256" fixedWidth="512" noSubsets="1" opaque="1">
+        <Name>ozone_image</Name>
+        <Title>Global ozone distribution (1992)</Title>
+        <LatLonBoundingBox maxx="180" maxy="90" minx="-180" miny="-90"/>
+        <Extent default="1992" name="time">1992</Extent>
+      </Layer>
+      <!-- Example of a layer which originated from another WMS and has been
+         "cascaded" by this WMS. -->
+      <Layer cascaded="1">
+        <Name>population</Name>
+        <Title>World population, annual</Title>
+        <LatLonBoundingBox maxx="180" maxy="90" minx="-180" miny="-90"/>
+        <Extent default="2000" name="time">1990/2000/P1Y</Extent>
+      </Layer>
+    </Layer>
+  </Capability>
+</WMT_MS_Capabilities>

--- a/test/spec/ol/format/wmscapabilities.test.js
+++ b/test/spec/ol/format/wmscapabilities.test.js
@@ -141,6 +141,143 @@ describe('ol.format.WMSCapabilities', function() {
 
     });
 
+  });
+
+  describe('when parsing ogcsample111.xml', function() {
+
+    var parser = new ol.format.WMSCapabilities();
+    var capabilities;
+    before(function(done) {
+      afterLoadText('spec/ol/format/wms/ogcsample111.xml', function(xml) {
+        try {
+          capabilities = parser.read(xml);
+        } catch (e) {
+          done(e);
+        }
+        done();
+      });
+    });
+
+    it('can read version', function() {
+      expect(capabilities.version).to.eql('1.1.1');
+    });
+
+    it('can read Service section', function() {
+      // FIXME not all fields are tested
+      var service = capabilities.Service;
+      var contact = service.ContactInformation;
+
+      expect(service.Name).to.eql('OGC:WMS');
+      expect(service.Title).to.eql('Acme Corp. Map Server');
+      expect(service.KeywordList).to.eql(['bird', 'roadrunner', 'ambush']);
+      expect(service.OnlineResource).to.eql('http://hostname/');
+      expect(service.Fees).to.eql('none');
+      expect(service.AccessConstraints).to.eql('none');
+
+      expect(contact.ContactPosition).to.eql('Computer Scientist');
+      expect(contact.ContactPersonPrimary).to.eql({
+        ContactPerson: 'Jeff deLaBeaujardiere',
+        ContactOrganization: 'NASA'
+      });
+    });
+
+    it('can read Capability.Exception', function() {
+      var exception = capabilities.Capability.Exception;
+
+      expect(exception).to.eql([
+        'application/vnd.ogc.se_xml',
+        'application/vnd.ogc.se_inimage',
+        'application/vnd.ogc.se_blank'
+      ]);
+    });
+
+    it('can read Capability.Request.GetCapabilities', function() {
+      var getCapabilities = capabilities.Capability.Request.GetCapabilities;
+
+      expect(getCapabilities.Format).to.eql(['application/vnd.ogc.wms_xml']);
+      expect(getCapabilities.DCPType.length).to.eql(1);
+      var http = getCapabilities.DCPType[0].HTTP;
+      expect(http.Get.OnlineResource).to.eql('http://hostname:port/path');
+      expect(http.Post.OnlineResource).to.eql('http://hostname:port/path');
+    });
+
+    it('can read Capability.Request.GetFeatureInfo', function() {
+      var getFeatureInfo = capabilities.Capability.Request.GetFeatureInfo;
+
+      expect(getFeatureInfo.Format).to.eql(
+          ['application/vnd.ogc.gml', 'text/plain', 'text/html']);
+      expect(getFeatureInfo.DCPType.length).to.eql(1);
+      var http = getFeatureInfo.DCPType[0].HTTP;
+      expect(http.Get.OnlineResource).to.eql('http://hostname:port/path');
+    });
+
+    it('can read Capability.Request.GetMap', function() {
+      var getMap = capabilities.Capability.Request.GetMap;
+
+      expect(getMap.Format).to.eql(['image/gif', 'image/png', 'image/jpeg']);
+      expect(getMap.DCPType.length).to.eql(1);
+      var http = getMap.DCPType[0].HTTP;
+      expect(http.Get.OnlineResource).to.eql('http://hostname:port/path');
+    });
+
+    it('can read Capability.Layer', function() {
+      var layer = capabilities.Capability.Layer;
+
+      expect(layer.Title).to.eql('Acme Corp. Map Server');
+      expect(layer.Name).to.be(undefined);
+      expect(layer.SRS).to.eql(['EPSG:4326']);
+      expect(layer.AuthorityURL).to.eql([{
+        name: 'DIF_ID',
+        OnlineResource: 'http://gcmd.gsfc.nasa.gov/difguide/whatisadif.html'
+      }]);
+      expect(layer.BoundingBox).to.eql(undefined);
+
+      expect(layer.Layer.length).to.eql(4);
+      expect(layer.Layer[0].Name).to.eql('ROADS_RIVERS');
+      expect(layer.Layer[0].Title).to.eql('Roads and Rivers');
+      expect(layer.Layer[0].SRS).to.eql(['EPSG:26986', 'EPSG:4326']);
+      expect(layer.Layer[0].Identifier).to.eql(['123456']);
+      expect(layer.Layer[0].BoundingBox).to.eql([{
+        srs: 'EPSG:4326',
+        extent: [-71.63, 41.75, -70.78, 42.9],
+        res: [0.01, 0.01]
+      }, {
+        srs: 'EPSG:26986',
+        extent: [189000, 834000, 285000, 962000],
+        res: [1, 1]
+      }]);
+      expect(layer.Layer[0].LatLonBoundingBox).to.eql(
+          [-71.63, 41.75, -70.78, 42.9]);
+      expect(layer.Layer[0].Style).to.eql([{
+        Name: 'USGS',
+        Title: 'USGS Topo Map Style',
+        Abstract: 'Features are shown in a style like that used in USGS ' +
+            'topographic maps.',
+        StyleSheetURL: {
+          Format: 'text/xsl',
+          OnlineResource: 'http://www.university.edu/stylesheets/usgs.xsl'
+        },
+        LegendURL: [{
+          Format: 'image/gif',
+          OnlineResource: 'http://www.university.edu/legends/usgs.gif',
+          size: [72, 72]
+        }]
+      }]);
+      expect(layer.Layer[0].FeatureListURL).to.eql([{
+        Format: 'application/vnd.ogc.se_xml',
+        OnlineResource: 'http://www.university.edu/data/roads_rivers.gml'
+      }]);
+      expect(layer.Layer[0].Attribution).to.eql({
+        Title: 'State College University',
+        OnlineResource: 'http://www.university.edu/',
+        LogoURL: {
+          Format: 'image/gif',
+          OnlineResource: 'http://www.university.edu/icons/logo.gif',
+          size: [100, 100]
+        }
+      });
+
+    });
 
   });
 });


### PR DESCRIPTION
This PR add the parsing of `<SRS>` and `<LatLonBoundingBox>` nodes (WMS 1.1.1)

Adds also tests for parsing of a WMS  Getcapabilities 1.1.1 file