### PR TITLE
Add option to allow Select interaction logic to select overlapping features

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -2519,7 +2519,8 @@ olx.interaction.PointerOptions.prototype.handleUpEvent;
  *     layers: (Array.<ol.layer.Layer>|function(ol.layer.Layer): boolean|undefined),
  *     style: (ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined),
  *     removeCondition: (ol.events.ConditionType|undefined),
- *     toggleCondition: (ol.events.ConditionType|undefined)}}
+ *     toggleCondition: (ol.events.ConditionType|undefined),
+ *     multi: (boolean|undefined)}}
  * @api
  */
 olx.interaction.SelectOptions;
@@ -2595,6 +2596,15 @@ olx.interaction.SelectOptions.prototype.removeCondition;
  * @api
  */
 olx.interaction.SelectOptions.prototype.toggleCondition;
+
+/**
+ * A boolean that determines if the default behaviour should select only
+ * single features or all (overlapping) features at the clicked map
+ * position. Default is false i.e single select
+ * @type {boolean|undefined}
+ * @api
+ */
+olx.interaction.SelectOptions.prototype.multi;
 
 
 /**

--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -62,6 +62,12 @@ ol.interaction.Select = function(opt_options) {
   this.toggleCondition_ = goog.isDef(options.toggleCondition) ?
       options.toggleCondition : ol.events.condition.shiftKeyOnly;
 
+  /**
+   * @private
+   * @type {boolean}
+   */
+  this.multi_ = goog.isDef(options.multi) ? options.multi : false;
+
   var layerFilter;
   if (goog.isDef(options.layers)) {
     if (goog.isFunction(options.layers)) {
@@ -132,34 +138,36 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
   var set = !add && !remove && !toggle;
   var map = mapBrowserEvent.map;
   var features = this.featureOverlay_.getFeatures();
+  var /** @type {Array.<ol.Feature>} */ deselected = [];
+  var /** @type {Array.<ol.Feature>} */ selected = [];
   if (set) {
-    // Replace the currently selected feature(s) with the feature at the pixel,
-    // or clear the selected feature(s) if there is no feature at the pixel.
-    /** @type {ol.Feature|undefined} */
-    var feature = map.forEachFeatureAtPixel(mapBrowserEvent.pixel,
+    // Replace the currently selected feature(s) with the feature(s) at the
+    // pixel, or clear the selected feature(s) if there is no feature at
+    // the pixel.
+    map.forEachFeatureAtPixel(mapBrowserEvent.pixel,
         /**
          * @param {ol.Feature} feature Feature.
          * @param {ol.layer.Layer} layer Layer.
          */
         function(feature, layer) {
-          return feature;
+          selected.push(feature);
         }, undefined, this.layerFilter_);
-    if (goog.isDef(feature) &&
+    if (selected.length > 0 &&
         features.getLength() == 1 &&
-        features.item(0) == feature) {
+        features.item(0) == selected[selected.length - 1]) {
       // No change
     } else {
       if (features.getLength() !== 0) {
         features.clear();
       }
-      if (goog.isDef(feature)) {
-        features.push(feature);
+      if (this.multi_) {
+        features.extend(selected);
+      } else if (selected.length > 0) {
+        features.push(selected[selected.length - 1]);
       }
     }
   } else {
     // Modify the currently selected feature(s).
-    var /** @type {Array.<ol.Feature>} */ deselected = [];
-    var /** @type {Array.<ol.Feature>} */ selected = [];
     map.forEachFeatureAtPixel(mapBrowserEvent.pixel,
         /**
          * @param {ol.Feature} feature Feature.


### PR DESCRIPTION
The original default behaviour of the Select interaction is to "Replace the currently selected feature(s) with the feature at the pixel". I made this code change to change the semantics to "Replace the currently selected feature(s) with the feature(s) at the pixel". I could not find a way to configure to get the desired behaviour with add/remove/toggle conditions).

This PR is a proposal with some unanswered questions. The "no change" condition was and is at fault since it only compares the first of the current selected features. I'm prepared to rework the PR if the questions can be resolved.

What is a sensible default behaviour? 

Should the default behaviour be configurable? 
