### PR TITLE
Do not use call when calling feature style function

### DIFF
--- a/src/ol/feature.js
+++ b/src/ol/feature.js
@@ -286,10 +286,9 @@ ol.Feature.prototype.setGeometryName = function(name) {
 /**
  * A function that takes a `{number}` representing the view's resolution. It
  * returns an Array of {@link ol.style.Style}. This way individual features
- * can be styled. The this keyword inside the function references the
- * {@link ol.Feature} to be styled.
+ * can be styled.
  *
- * @typedef {function(this: ol.Feature, number): Array.<ol.style.Style>}
+ * @typedef {function(number): Array.<ol.style.Style>}
  * @api stable
  */
 ol.feature.FeatureStyleFunction;

--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -1501,7 +1501,7 @@ ol.format.KML.prototype.readPlacemark_ = function(node, objectStack) {
   }
   feature.setProperties(object);
   if (this.extractStyles_) {
-    feature.setStyle(this.featureStyleFunction_);
+    feature.setStyle(goog.bind(this.featureStyleFunction_, feature));
   }
   return feature;
 };

--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -221,7 +221,7 @@ ol.renderer.canvas.VectorLayer.prototype.prepareFrame =
       function(feature) {
     var styles;
     if (goog.isDef(feature.getStyleFunction())) {
-      styles = feature.getStyleFunction().call(feature, resolution);
+      styles = feature.getStyleFunction()(resolution);
     } else if (goog.isDef(vectorLayer.getStyleFunction())) {
       styles = vectorLayer.getStyleFunction()(feature, resolution);
     }

--- a/src/ol/renderer/dom/domvectorlayerrenderer.js
+++ b/src/ol/renderer/dom/domvectorlayerrenderer.js
@@ -262,7 +262,7 @@ ol.renderer.dom.VectorLayer.prototype.prepareFrame =
       function(feature) {
     var styles;
     if (goog.isDef(feature.getStyleFunction())) {
-      styles = feature.getStyleFunction().call(feature, resolution);
+      styles = feature.getStyleFunction()(resolution);
     } else if (goog.isDef(vectorLayer.getStyleFunction())) {
       styles = vectorLayer.getStyleFunction()(feature, resolution);
     }

--- a/src/ol/renderer/webgl/webglvectorlayerrenderer.js
+++ b/src/ol/renderer/webgl/webglvectorlayerrenderer.js
@@ -179,7 +179,7 @@ ol.renderer.webgl.VectorLayer.prototype.prepareFrame =
       function(feature) {
     var styles;
     if (goog.isDef(feature.getStyleFunction())) {
-      styles = feature.getStyleFunction().call(feature, resolution);
+      styles = feature.getStyleFunction()(resolution);
     } else if (goog.isDef(vectorLayer.getStyleFunction())) {
       styles = vectorLayer.getStyleFunction()(feature, resolution);
     }

--- a/src/ol/source/imagevectorsource.js
+++ b/src/ol/source/imagevectorsource.js
@@ -260,7 +260,7 @@ ol.source.ImageVector.prototype.renderFeature_ =
     function(feature, resolution, pixelRatio, replayGroup) {
   var styles;
   if (goog.isDef(feature.getStyleFunction())) {
-    styles = feature.getStyleFunction().call(feature, resolution);
+    styles = feature.getStyleFunction()(resolution);
   } else if (goog.isDef(this.styleFunction_)) {
     styles = this.styleFunction_(feature, resolution);
   }


### PR DESCRIPTION
Following up on the discussion in #3010 this PR suggests not using `call` when calling the style function bound to a feature.

So with this the user needs to explicitly pre-binds his function to the feature to get the same behavior as before:

```js
var feature = new ol.Feature(geom);
feature.setStyle(function(resolution) {
  // "this" is a reference to the feature
  // …
}.bind(feature));
```

@tschaub, @ahocevar what do you think?