### PR TITLE
Optimize ol.structs.RBush#getAll function

### DIFF
--- a/src/ol/structs/rbush.js
+++ b/src/ol/structs/rbush.js
@@ -129,10 +129,12 @@ ol.structs.RBush.prototype.update = function(extent, value) {
  * @return {Array.<T>} All.
  */
 ol.structs.RBush.prototype.getAll = function() {
-  var items = this.rbush_.all();
-  return goog.array.map(items, function(item) {
-    return item[4];
-  });
+  var items = [];
+  var i = 0;
+  for (var item in this.items_) {
+    items[i++] = this.items_[item][4];
+  }
+  return items;
 };
 
 

--- a/src/ol/structs/rbush.js
+++ b/src/ol/structs/rbush.js
@@ -27,7 +27,7 @@ ol.structs.RBush = function(opt_maxEntries) {
    * A mapping between the objects added to this rbush wrapper
    * and the objects that are actually added to the internal rbush.
    * @private
-   * @type {Object.<number, Object>}
+   * @type {Object.<string, Object>}
    */
   this.items_ = {};
 


### PR DESCRIPTION
Instead of calling `this.rbush_.all()` use `this.items_` variable.

Work in progress; benchmarks needed