### PR TITLE
Support multiple featureTpes in GML parser

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -1783,7 +1783,7 @@ olx.format.GPXOptions.prototype.readExtensions;
 
 /**
  * @typedef {{featureNS: string,
- *     featureType: string,
+ *     featureType: (Array.<string>|string|undefined),
  *     gmlFormat: (ol.format.GMLBase|undefined),
  *     schemaLocation: (string|undefined)}}
  * @api
@@ -1801,7 +1801,7 @@ olx.format.WFSOptions.prototype.featureNS;
 
 /**
  * The feature type to parse. Only used for read operations.
- * @type {string}
+ * @type {Array.<string>|string|undefined}
  * @api stable
  */
 olx.format.WFSOptions.prototype.featureType;

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -1693,7 +1693,13 @@ olx.format.GMLOptions;
 
 
 /**
- * Feature namespace. If not defined will be derived from GML.
+ * Feature namespace. If not defined will be derived from GML. If multiple
+ * feature types have been configured which come from different feature
+ * namespaces, this will be an object with the keys being the prefixes used
+ * in the entries of featureType array. The values of the object will be the
+ * feature namespaces themselves. So for instance there might be a featureType
+ * item `topp:states` in the `featureType` array and then there will be a key
+ * `topp` in the featureNS object with value `http://www.openplans.org/topp`.
  * @type {Object.<string, string>|string|undefined}
  * @api stable
  */
@@ -1701,7 +1707,13 @@ olx.format.GMLOptions.prototype.featureNS;
 
 
 /**
- * Feature type(s) to parse.
+ * Feature type(s) to parse. If multiple feature types need to be configured
+ * which come from different feature namespaces, `featureNS` will be an object
+ * with the keys being the prefixes used in the entries of featureType array.
+ * The values of the object will be the feature namespaces themselves.
+ * So for instance there might be a featureType item `topp:states` and then
+ * there will be a key named `topp` in the featureNS object with value
+ * `http://www.openplans.org/topp`.
  * @type {Array.<string>|string|undefined}
  * @api stable
  */

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -1679,8 +1679,8 @@ olx.format.KMLOptions.prototype.defaultStyle;
 
 
 /**
- * @typedef {{featureNS: string,
- *     featureType: string,
+ * @typedef {{featureNS: (string|undefined),
+ *     featureType: (Array.<string>|string|undefined),
  *     srsName: string,
  *     surface: (boolean|undefined),
  *     curve: (boolean|undefined),
@@ -1693,16 +1693,16 @@ olx.format.GMLOptions;
 
 
 /**
- * Feature namespace.
- * @type {string}
+ * Feature namespace. If not defined will be derived from GML.
+ * @type {string|undefined}
  * @api stable
  */
 olx.format.GMLOptions.prototype.featureNS;
 
 
 /**
- * Feature type to parse.
- * @type {string}
+ * Feature type(s) to parse.
+ * @type {Array.<string>|string|undefined}
  * @api stable
  */
 olx.format.GMLOptions.prototype.featureType;

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -1679,7 +1679,7 @@ olx.format.KMLOptions.prototype.defaultStyle;
 
 
 /**
- * @typedef {{featureNS: (string|undefined),
+ * @typedef {{featureNS: (Object.<string, string>|string|undefined),
  *     featureType: (Array.<string>|string|undefined),
  *     srsName: string,
  *     surface: (boolean|undefined),
@@ -1694,7 +1694,7 @@ olx.format.GMLOptions;
 
 /**
  * Feature namespace. If not defined will be derived from GML.
- * @type {string|undefined}
+ * @type {Object.<string, string>|string|undefined}
  * @api stable
  */
 olx.format.GMLOptions.prototype.featureNS;
@@ -1782,7 +1782,7 @@ olx.format.GPXOptions.prototype.readExtensions;
 
 
 /**
- * @typedef {{featureNS: string,
+ * @typedef {{featureNS: (Object.<string, string>|string|undefined),
  *     featureType: (Array.<string>|string|undefined),
  *     gmlFormat: (ol.format.GMLBase|undefined),
  *     schemaLocation: (string|undefined)}}
@@ -1793,7 +1793,7 @@ olx.format.WFSOptions;
 
 /**
  * The namespace URI used for features.
- * @type {string}
+ * @type {Object.<string, string>|string|undefined}
  * @api stable
  */
 olx.format.WFSOptions.prototype.featureNS;

--- a/src/ol/format/gml/gmlbaseformat.js
+++ b/src/ol/format/gml/gmlbaseformat.js
@@ -45,13 +45,13 @@ ol.format.GMLBase = function(opt_options) {
 
   /**
    * @protected
-   * @type {string}
+   * @type {Array.<string>|string|undefined}
    */
   this.featureType = options.featureType;
 
   /**
    * @protected
-   * @type {string}
+   * @type {string|undefined}
    */
   this.featureNS = options.featureNS;
 
@@ -115,10 +115,13 @@ ol.format.GMLBase.prototype.readFeaturesInternal = function(node, objectStack) {
     }
     var parsers = {};
     var parsersNS = {};
-    parsers[featureType] = (localName == 'featureMembers') ?
-        ol.xml.makeArrayPusher(this.readFeatureElement, this) :
-        ol.xml.makeReplacer(this.readFeatureElement, this);
-    parsersNS[context['featureNS']] = parsers;
+    var featureTypes = goog.isArray(featureType) ? featureType : [featureType];
+    for (var i = 0, ii = featureTypes.length; i < ii; ++i) {
+      parsers[featureTypes[i]] = (localName == 'featureMembers') ?
+          ol.xml.makeArrayPusher(this.readFeatureElement, this) :
+          ol.xml.makeReplacer(this.readFeatureElement, this);
+    }
+    parsersNS[goog.object.get(context, 'featureNS')] = parsers;
     features = ol.xml.pushParseAndPop([], parsersNS, node, objectStack);
   }
   if (!goog.isDef(features)) {

--- a/src/ol/format/gml/gmlbaseformat.js
+++ b/src/ol/format/gml/gmlbaseformat.js
@@ -106,7 +106,7 @@ ol.format.GMLBase.prototype.readFeaturesInternal = function(node, objectStack) {
   } else if (localName == 'featureMembers' || localName == 'featureMember') {
     var context = objectStack[0];
     goog.asserts.assert(goog.isObject(context));
-    var featureType = goog.object.get(context, 'featureType');
+    var featureType = context['featureType'];
     var i, ii, featureNS;
     if (!goog.isDef(featureType) && goog.isDefAndNotNull(node.childNodes)) {
       featureType = [];
@@ -133,7 +133,7 @@ ol.format.GMLBase.prototype.readFeaturesInternal = function(node, objectStack) {
           ol.xml.makeArrayPusher(this.readFeatureElement, this) :
           ol.xml.makeReplacer(this.readFeatureElement, this);
     }
-    parsersNS[goog.object.get(context, 'featureNS')] = parsers;
+    parsersNS[context['featureNS']] = parsers;
     features = ol.xml.pushParseAndPop([], parsersNS, node, objectStack);
   }
   if (!goog.isDef(features)) {

--- a/src/ol/format/gml/gmlbaseformat.js
+++ b/src/ol/format/gml/gmlbaseformat.js
@@ -106,17 +106,29 @@ ol.format.GMLBase.prototype.readFeaturesInternal = function(node, objectStack) {
   } else if (localName == 'featureMembers' || localName == 'featureMember') {
     var context = objectStack[0];
     goog.asserts.assert(goog.isObject(context));
-    var featureType = context['featureType'];
-    if (!goog.isDef(featureType) && !goog.isNull(node.firstElementChild)) {
-      var member = node.firstElementChild;
-      featureType = member.nodeName.split(':').pop();
+    var featureType = goog.object.get(context, 'featureType');
+    var i, ii, featureNS;
+    if (!goog.isDef(featureType) && goog.isDefAndNotNull(node.childNodes)) {
+      featureType = [];
+      for (i = 0, ii = node.childNodes.length; i < ii; ++i) {
+        var child = node.childNodes[i];
+        if (child.nodeType === 1) {
+          var ft = child.nodeName.split(':').pop();
+          if (goog.array.indexOf(featureType, ft) === -1) {
+            featureType.push(ft);
+            if (!goog.isDef(featureNS)) {
+              featureNS = child.namespaceURI;
+            }
+          }
+        }
+      }
       context['featureType'] = featureType;
-      context['featureNS'] = member.namespaceURI;
+      context['featureNS'] = featureNS;
     }
     var parsers = {};
     var parsersNS = {};
     var featureTypes = goog.isArray(featureType) ? featureType : [featureType];
-    for (var i = 0, ii = featureTypes.length; i < ii; ++i) {
+    for (i = 0, ii = featureTypes.length; i < ii; ++i) {
       parsers[featureTypes[i]] = (localName == 'featureMembers') ?
           ol.xml.makeArrayPusher(this.readFeatureElement, this) :
           ol.xml.makeReplacer(this.readFeatureElement, this);

--- a/src/ol/format/gml/gmlbaseformat.js
+++ b/src/ol/format/gml/gmlbaseformat.js
@@ -51,7 +51,7 @@ ol.format.GMLBase = function(opt_options) {
 
   /**
    * @protected
-   * @type {string|undefined}
+   * @type {Object.<string, string>|string|undefined}
    */
   this.featureNS = options.featureNS;
 
@@ -107,33 +107,52 @@ ol.format.GMLBase.prototype.readFeaturesInternal = function(node, objectStack) {
     var context = objectStack[0];
     goog.asserts.assert(goog.isObject(context));
     var featureType = context['featureType'];
-    var i, ii, featureNS;
+    var featureNS = context['featureNS'];
+    var i, ii, prefix = 'p', defaultPrefix = 'p0';
     if (!goog.isDef(featureType) && goog.isDefAndNotNull(node.childNodes)) {
-      featureType = [];
+      featureType = [], featureNS = {};
       for (i = 0, ii = node.childNodes.length; i < ii; ++i) {
         var child = node.childNodes[i];
         if (child.nodeType === 1) {
           var ft = child.nodeName.split(':').pop();
           if (goog.array.indexOf(featureType, ft) === -1) {
-            featureType.push(ft);
-            if (!goog.isDef(featureNS)) {
-              featureNS = child.namespaceURI;
+            var key;
+            if (!goog.object.contains(featureNS, child.namespaceURI)) {
+              key = prefix + goog.object.getCount(featureNS);
+              featureNS[key] = child.namespaceURI;
+            } else {
+              key = goog.object.findKey(featureNS, function(value) {
+                return value === child.namespaceURI;
+              });
             }
+            featureType.push(key + ':' + ft);
           }
         }
       }
       context['featureType'] = featureType;
       context['featureNS'] = featureNS;
     }
-    var parsers = {};
+    if (goog.isString(featureNS)) {
+      var ns = featureNS;
+      featureNS = {};
+      featureNS[defaultPrefix] = ns;
+    }
     var parsersNS = {};
     var featureTypes = goog.isArray(featureType) ? featureType : [featureType];
-    for (i = 0, ii = featureTypes.length; i < ii; ++i) {
-      parsers[featureTypes[i]] = (localName == 'featureMembers') ?
-          ol.xml.makeArrayPusher(this.readFeatureElement, this) :
-          ol.xml.makeReplacer(this.readFeatureElement, this);
+    for (var p in featureNS) {
+      var parsers = {};
+      for (i = 0, ii = featureTypes.length; i < ii; ++i) {
+        var featurePrefix = featureTypes[i].indexOf(':') === -1 ?
+            defaultPrefix : featureTypes[i].split(':')[0];
+        if (featurePrefix === p) {
+          parsers[featureTypes[i].split(':').pop()] =
+              (localName == 'featureMembers') ?
+              ol.xml.makeArrayPusher(this.readFeatureElement, this) :
+              ol.xml.makeReplacer(this.readFeatureElement, this);
+        }
+      }
+      parsersNS[featureNS[p]] = parsers;
     }
-    parsersNS[context['featureNS']] = parsers;
     features = ol.xml.pushParseAndPop([], parsersNS, node, objectStack);
   }
   if (!goog.isDef(features)) {

--- a/src/ol/format/wfsformat.js
+++ b/src/ol/format/wfsformat.js
@@ -37,7 +37,7 @@ ol.format.WFS = function(opt_options) {
 
   /**
    * @private
-   * @type {string}
+   * @type {Object.<string, string>|string|undefined}
    */
   this.featureNS_ = options.featureNS;
 

--- a/src/ol/format/wfsformat.js
+++ b/src/ol/format/wfsformat.js
@@ -31,7 +31,7 @@ ol.format.WFS = function(opt_options) {
 
   /**
    * @private
-   * @type {string}
+   * @type {Array.<string>|string|undefined}
    */
   this.featureType_ = options.featureType;
 

--- a/test/spec/ol/format/gml/multiple-typenames-ns.xml
+++ b/test/spec/ol/format/gml/multiple-typenames-ns.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wfs:FeatureCollection xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:it.geosolutions="http://www.geo-solutions.it"
+    xmlns:cite="http://www.opengeospatial.net/cite" xmlns:ogc="http://www.opengis.net/ogc"
+    xmlns:tiger="http://www.census.gov" xmlns:sde="http://geoserver.sf.net"
+    xmlns:topp="http://www.openplans.org/topp" xmlns:wfs="http://www.opengis.net/wfs"
+    xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:sf="http://www.openplans.org/spearfish" xmlns:gml="http://www.opengis.net/gml"
+    xmlns:nurc="http://www.nurc.nato.int" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    numberOfFeatures="874" timeStamp="2015-03-04T09:53:58.763Z"
+    xsi:schemaLocation="http://www.openplans.org/topp http://localhost:8080/geoserver/wfs?service=WFS&amp;version=1.1.0&amp;request=DescribeFeatureType&amp;typeName=topp%3Astates http://www.openplans.org/spearfish http://localhost:8080/geoserver/wfs?service=WFS&amp;version=1.1.0&amp;request=DescribeFeatureType&amp;typeName=sf%3Aroads http://www.opengis.net/wfs http://localhost:8080/geoserver/schemas/wfs/1.1.0/wfs.xsd">
+    <gml:featureMembers>
+        <topp:states gml:id="states.1">
+            <topp:the_geom>
+                <gml:MultiSurface srsDimension="2" srsName="EPSG:4326">
+                    <gml:surfaceMember>
+                        <gml:Polygon srsDimension="2">
+                            <gml:exterior>
+                                <gml:LinearRing srsDimension="2">
+                                    <gml:posList>37.51099000000001 -88.071564 37.476273000000006
+                                        -88.087883 37.442852 -88.311707 37.40930899999999 -88.359177
+                                        37.51099000000001 -88.071564</gml:posList>
+                                </gml:LinearRing>
+                            </gml:exterior>
+                        </gml:Polygon>
+                    </gml:surfaceMember>
+                </gml:MultiSurface>
+            </topp:the_geom>
+            <topp:STATE_NAME>Illinois</topp:STATE_NAME>
+            <topp:STATE_FIPS>17</topp:STATE_FIPS>
+            <topp:SUB_REGION>E N Cen</topp:SUB_REGION>
+            <topp:STATE_ABBR>IL</topp:STATE_ABBR>
+            <topp:LAND_KM>143986.61</topp:LAND_KM>
+            <topp:WATER_KM>1993.335</topp:WATER_KM>
+            <topp:PERSONS>1.1430602E7</topp:PERSONS>
+            <topp:FAMILIES>2924880.0</topp:FAMILIES>
+            <topp:HOUSHOLD>4202240.0</topp:HOUSHOLD>
+            <topp:MALE>5552233.0</topp:MALE>
+            <topp:FEMALE>5878369.0</topp:FEMALE>
+            <topp:WORKERS>4199206.0</topp:WORKERS>
+            <topp:DRVALONE>3741715.0</topp:DRVALONE>
+            <topp:CARPOOL>652603.0</topp:CARPOOL>
+            <topp:PUBTRANS>538071.0</topp:PUBTRANS>
+            <topp:EMPLOYED>5417967.0</topp:EMPLOYED>
+            <topp:UNEMPLOY>385040.0</topp:UNEMPLOY>
+            <topp:SERVICE>1360159.0</topp:SERVICE>
+            <topp:MANUAL>828906.0</topp:MANUAL>
+            <topp:P_MALE>0.486</topp:P_MALE>
+            <topp:P_FEMALE>0.514</topp:P_FEMALE>
+            <topp:SAMP_POP>1747776.0</topp:SAMP_POP>
+        </topp:states>
+        <sf:roads gml:id="roads.1">
+            <sf:the_geom>
+                <gml:MultiLineString srsDimension="2" srsName="EPSG:4326">
+                    <gml:lineStringMember>
+                        <gml:LineString srsDimension="2">
+                            <gml:posList>37.51099000000001 -88.071564 37.476273000000006
+                                -88.087883 37.442852 -88.311707 37.40930899999999 -88.359177
+                                37.51099000000001 -88.071564</gml:posList>
+                        </gml:LineString>
+                    </gml:lineStringMember>
+                </gml:MultiLineString>
+            </sf:the_geom>
+            <sf:cat>5</sf:cat>
+            <sf:label>unimproved road</sf:label>
+        </sf:roads>
+    </gml:featureMembers>
+</wfs:FeatureCollection>

--- a/test/spec/ol/format/gml/multiple-typenames.xml
+++ b/test/spec/ol/format/gml/multiple-typenames.xml
@@ -1,0 +1,44 @@
+<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:gml="http://www.opengis.net/gml"
+    xmlns:official="http://localhost:8080/official" xmlns:ogc="http://www.opengis.net/ogc"
+    xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" numberOfFeatures="12"
+    timeStamp="2014-11-03T21:04:28.345Z">
+    <gml:featureMembers>
+        <official:planet_osm_line gml:id="planet_osm_line.fid-53719711_14976c6c1aa_6795">
+            <official:osm_id>3822829</official:osm_id>
+        </official:planet_osm_line>
+        <official:planet_osm_line gml:id="planet_osm_line.fid-53719711_14976c6c1aa_6796">
+            <official:osm_id>3820888</official:osm_id>
+        </official:planet_osm_line>
+        <official:planet_osm_line gml:id="planet_osm_line.fid-53719711_14976c6c1aa_6797">
+            <official:osm_id>296916318</official:osm_id>
+        </official:planet_osm_line>
+        <official:planet_osm_polygon gml:id="planet_osm_polygon.fid-53719711_14976c6c1aa_6798">
+            <official:osm_id>37244</official:osm_id>
+        </official:planet_osm_polygon>
+        <official:planet_osm_polygon gml:id="planet_osm_polygon.fid-53719711_14976c6c1aa_6799">
+            <official:osm_id>1641478</official:osm_id>
+        </official:planet_osm_polygon>
+        <official:planet_osm_polygon gml:id="planet_osm_polygon.fid-53719711_14976c6c1aa_679a">
+            <official:osm_id>1244004</official:osm_id>
+        </official:planet_osm_polygon>
+        <official:planet_osm_polygon gml:id="planet_osm_polygon.fid-53719711_14976c6c1aa_679b">
+            <official:osm_id>22259</official:osm_id>
+        </official:planet_osm_polygon>
+        <official:planet_osm_polygon gml:id="planet_osm_polygon.fid-53719711_14976c6c1aa_679c">
+            <official:osm_id>1606103</official:osm_id>
+        </official:planet_osm_polygon>
+        <official:planet_osm_polygon gml:id="planet_osm_polygon.fid-53719711_14976c6c1aa_679d">
+            <official:osm_id>3217145</official:osm_id>
+        </official:planet_osm_polygon>
+        <official:planet_osm_polygon gml:id="planet_osm_polygon.fid-53719711_14976c6c1aa_679e">
+            <official:osm_id>3228576</official:osm_id>
+        </official:planet_osm_polygon>
+        <official:planet_osm_polygon gml:id="planet_osm_polygon.fid-53719711_14976c6c1aa_679f">
+            <official:osm_id>936994</official:osm_id>
+        </official:planet_osm_polygon>
+        <official:planet_osm_polygon gml:id="planet_osm_polygon.fid-53719711_14976c6c1aa_67a0">
+            <official:osm_id>936990</official:osm_id>
+        </official:planet_osm_polygon>
+    </gml:featureMembers>
+</wfs:FeatureCollection>

--- a/test/spec/ol/format/gmlformat.test.js
+++ b/test/spec/ol/format/gmlformat.test.js
@@ -1107,6 +1107,49 @@ describe('ol.format.GML3', function() {
 
   });
 
+  describe('when parsing multiple feature types', function() {
+
+    var features;
+    before(function(done) {
+      afterLoadText('spec/ol/format/gml/multiple-typenames.xml', function(xml) {
+        try {
+          features = new ol.format.GML({
+            featureNS: 'http://localhost:8080/official',
+            featureType: ['planet_osm_polygon', 'planet_osm_line']
+          }).readFeatures(xml);
+        } catch (e) {
+          done(e);
+        }
+        done();
+      });
+    });
+
+    it('reads all features', function() {
+      expect(features.length).to.be(12);
+    });
+
+  });
+
+  describe('when parsing multiple feature types', function() {
+
+    var features;
+    before(function(done) {
+      afterLoadText('spec/ol/format/gml/multiple-typenames.xml', function(xml) {
+        try {
+          features = new ol.format.GML().readFeatures(xml);
+        } catch (e) {
+          done(e);
+        }
+        done();
+      });
+    });
+
+    it('reads all features with autoconfigure', function() {
+      expect(features.length).to.be(12);
+    });
+
+  });
+
 });
 
 

--- a/test/spec/ol/format/gmlformat.test.js
+++ b/test/spec/ol/format/gmlformat.test.js
@@ -1150,6 +1150,54 @@ describe('ol.format.GML3', function() {
 
   });
 
+  describe('when parsing multiple feature types / namespaces', function() {
+
+    var features;
+    before(function(done) {
+      var url = 'spec/ol/format/gml/multiple-typenames-ns.xml';
+      afterLoadText(url, function(xml) {
+        try {
+          features = new ol.format.GML({
+            featureNS: {
+              'topp': 'http://www.openplans.org/topp',
+              'sf': 'http://www.openplans.org/spearfish'
+            },
+            featureType: ['topp:states', 'sf:roads']
+          }).readFeatures(xml);
+        } catch (e) {
+          done(e);
+        }
+        done();
+      });
+    });
+
+    it('reads all features', function() {
+      expect(features.length).to.be(2);
+    });
+
+  });
+
+  describe('when parsing multiple feature types / namespaces', function() {
+
+    var features;
+    before(function(done) {
+      var url = 'spec/ol/format/gml/multiple-typenames-ns.xml';
+      afterLoadText(url, function(xml) {
+        try {
+          features = new ol.format.GML().readFeatures(xml);
+        } catch (e) {
+          done(e);
+        }
+        done();
+      });
+    });
+
+    it('reads all features with autoconfigure', function() {
+      expect(features.length).to.be(2);
+    });
+
+  });
+
 });
 
 

--- a/test/spec/ol/format/wfsformat.test.js
+++ b/test/spec/ol/format/wfsformat.test.js
@@ -448,6 +448,49 @@ describe('ol.format.WFS', function() {
 
   });
 
+  describe('when parsing multiple feature types', function() {
+
+    var features;
+    before(function(done) {
+      afterLoadText('spec/ol/format/gml/multiple-typenames.xml', function(xml) {
+        try {
+          features = new ol.format.WFS({
+            featureNS: 'http://localhost:8080/official',
+            featureType: ['planet_osm_polygon', 'planet_osm_line']
+          }).readFeatures(xml);
+        } catch (e) {
+          done(e);
+        }
+        done();
+      });
+    });
+
+    it('reads all features', function() {
+      expect(features.length).to.be(12);
+    });
+
+  });
+
+  describe('when parsing multiple feature types', function() {
+
+    var features;
+    before(function(done) {
+      afterLoadText('spec/ol/format/gml/multiple-typenames.xml', function(xml) {
+        try {
+          features = new ol.format.WFS().readFeatures(xml);
+        } catch (e) {
+          done(e);
+        }
+        done();
+      });
+    });
+
+    it('reads all features with autoconfigure', function() {
+      expect(features.length).to.be(12);
+    });
+
+  });
+
 });
 
 


### PR DESCRIPTION
Details and previous discussions are here: 
https://groups.google.com/forum/#!topic/ol3-dev/g0Ka2f96cD0
A simple WFS GetFeature response in GML3 from two layers with only osm_id as useful data:
http://pastebin.com/FfnfCeeK

<bountysource-plugin>

---
Want to back this issue? **[Place a bounty on it!](https://www.bountysource.com/issues/5742071-gml-parser?utm_campaign=plugin&utm_content=tracker%2F79013&utm_medium=issues&utm_source=github)** We accept bounties via [Bountysource](https://www.bountysource.com/?utm_campaign=plugin&utm_content=tracker%2F79013&utm_medium=issues&utm_source=github).
</bountysource-plugin>