### PR TITLE
Optimize canvas hit detection by rendering features in a limited extent

### DIFF
--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -207,7 +207,7 @@ ol.renderer.canvas.VectorLayer.prototype.prepareFrame =
   var replayGroup =
       new ol.render.canvas.ReplayGroup(
           ol.renderer.vector.getTolerance(resolution, pixelRatio), extent,
-          resolution);
+          resolution, vectorLayer.getRenderBuffer());
   vectorSource.loadFeatures(extent, resolution, projection);
   var renderFeature =
       /**

--- a/src/ol/renderer/dom/domvectorlayerrenderer.js
+++ b/src/ol/renderer/dom/domvectorlayerrenderer.js
@@ -247,7 +247,7 @@ ol.renderer.dom.VectorLayer.prototype.prepareFrame =
   var replayGroup =
       new ol.render.canvas.ReplayGroup(
           ol.renderer.vector.getTolerance(resolution, pixelRatio), extent,
-          resolution);
+          resolution, vectorLayer.getRenderBuffer());
   vectorSource.loadFeatures(extent, resolution, projection);
   var renderFeature =
       /**


### PR DESCRIPTION
Inspired by @tsauerwein's work in #3065, this adds an optimization for hit detection with the Canvas renderer.  Features are only considered for hit checking if their extent intersects a buffered extent around the provided coordinate - using the buffer from the new `renderBuffer` property for vector layers (see #3061).

In some unscientific benchmarking, it looks like this cuts the hit detection time by up to 50% (~2.3ms v. ~4.9ms in the vector layer example and ~9ms v. ~16ms in the synthetic points example in worst case scenarios).
