### PR TITLE
Exclude source files from docs

### DIFF
--- a/config/jsdoc/api/conf.json
+++ b/config/jsdoc/api/conf.json
@@ -34,7 +34,7 @@
         "cleverLinks": true,
         "monospaceLinks": true,
         "default": {
-            "outputSourceFiles": true
+            "outputSourceFiles": false
         },
         "applicationName": "OpenLayers 3"
     },


### PR DESCRIPTION
Including the source files in the API doc adds ~80MB to the (uncompressed) release distribution.  While I think there is some value in linking to the source, an alternative would be to customize the template to link to the sources on GitHub rather than include them in HTML form in the distribution.

I'm open to other opinions on this.  In general, I'm looking for a ways to reduce the size of the release archive (see #3078).