### PR TITLE
Add an inline sourcemap to uncompiled builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "clean-css": "2.2.16",
     "expect.js": "0.3.1",
+    "inline-source-map": "^0.3.0",
     "jquery": "2.1.1",
     "jshint": "2.5.6",
     "mocha": "1.21.5",


### PR DESCRIPTION
This adds an inline sourcemap to concatenated builds (those without `compile` options).  The benefit of an inline sourcemap is that only a single file has to be hosted (as opposed to all ol and Closure Library sources).  The drawback is that the single file is massive.  This bumps the `ol-debug.js` size from 3.4MB (already unwieldy) to 8.9MB.