### PR TITLE
assertion errors when reading OGR GML with ol.format.GML

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -1726,7 +1726,7 @@ olx.format.GPXOptions.prototype.readExtensions;
 
 /**
  * @typedef {{featureNS: string,
- *     featureType: string,
+ *     featureType: (Array.<string>|string|undefined),
  *     gmlFormat: (ol.format.GMLBase|undefined),
  *     schemaLocation: (string|undefined)}}
  * @api
@@ -1744,7 +1744,7 @@ olx.format.WFSOptions.prototype.featureNS;
 
 /**
  * The feature type to parse. Only used for read operations.
- * @type {string}
+ * @type {Array.<string>|string|undefined}
  * @api stable
  */
 olx.format.WFSOptions.prototype.featureType;

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -1622,8 +1622,8 @@ olx.format.KMLOptions.prototype.defaultStyle;
 
 
 /**
- * @typedef {{featureNS: string,
- *     featureType: string,
+ * @typedef {{featureNS: (string|undefined),
+ *     featureType: (Array.<string>|string|undefined),
  *     srsName: string,
  *     surface: (boolean|undefined),
  *     curve: (boolean|undefined),
@@ -1636,16 +1636,16 @@ olx.format.GMLOptions;
 
 
 /**
- * Feature namespace.
- * @type {string}
+ * Feature namespace. If not defined will be derived from GML.
+ * @type {string|undefined}
  * @api stable
  */
 olx.format.GMLOptions.prototype.featureNS;
 
 
 /**
- * Feature type to parse.
- * @type {string}
+ * Feature type(s) to parse.
+ * @type {Array.<string>|string|undefined}
  * @api stable
  */
 olx.format.GMLOptions.prototype.featureType;

--- a/src/ol/format/gml/gmlbaseformat.js
+++ b/src/ol/format/gml/gmlbaseformat.js
@@ -46,13 +46,13 @@ ol.format.GMLBase = function(opt_options) {
 
   /**
    * @protected
-   * @type {string}
+   * @type {Array.<string>|string|undefined}
    */
   this.featureType = options.featureType;
 
   /**
    * @protected
-   * @type {string}
+   * @type {string|undefined}
    */
   this.featureNS = options.featureNS;
 
@@ -99,9 +99,12 @@ ol.format.GMLBase.prototype.readFeatures_ = function(node, objectStack) {
     }
     var parsers = {};
     var parsersNS = {};
-    parsers[featureType] = (localName == 'featureMembers') ?
-        ol.xml.makeArrayPusher(this.readFeatureElement, this) :
-        ol.xml.makeReplacer(this.readFeatureElement, this);
+    var featureTypes = goog.isArray(featureType) ? featureType : [featureType];
+    for (var i = 0, ii = featureTypes.length; i < ii; ++i) {
+      parsers[featureTypes[i]] = (localName == 'featureMembers') ?
+          ol.xml.makeArrayPusher(this.readFeatureElement, this) :
+          ol.xml.makeReplacer(this.readFeatureElement, this);
+    }
     parsersNS[goog.object.get(context, 'featureNS')] = parsers;
     features = ol.xml.pushParseAndPop([], parsersNS, node, objectStack);
   }

--- a/src/ol/format/gml/gmlbaseformat.js
+++ b/src/ol/format/gml/gmlbaseformat.js
@@ -91,16 +91,28 @@ ol.format.GMLBase.prototype.readFeatures_ = function(node, objectStack) {
     var context = objectStack[0];
     goog.asserts.assert(goog.isObject(context));
     var featureType = goog.object.get(context, 'featureType');
-    if (!goog.isDef(featureType) && !goog.isNull(node.firstElementChild)) {
-      var member = node.firstElementChild;
-      featureType = member.nodeName.split(':').pop();
+    var i, ii, featureNS;
+    if (!goog.isDef(featureType) && goog.isDefAndNotNull(node.childNodes)) {
+      featureType = [];
+      for (i = 0, ii = node.childNodes.length; i < ii; ++i) {
+        var child = node.childNodes[i];
+        if (child.nodeType === 1) {
+          var ft = child.nodeName.split(':').pop();
+          if (goog.array.indexOf(featureType, ft) === -1) {
+            featureType.push(ft);
+            if (!goog.isDef(featureNS)) {
+              featureNS = child.namespaceURI;
+            }
+          }
+        }
+      }
       goog.object.set(context, 'featureType', featureType);
-      goog.object.set(context, 'featureNS', member.namespaceURI);
+      goog.object.set(context, 'featureNS', featureNS);
     }
     var parsers = {};
     var parsersNS = {};
     var featureTypes = goog.isArray(featureType) ? featureType : [featureType];
-    for (var i = 0, ii = featureTypes.length; i < ii; ++i) {
+    for (i = 0, ii = featureTypes.length; i < ii; ++i) {
       parsers[featureTypes[i]] = (localName == 'featureMembers') ?
           ol.xml.makeArrayPusher(this.readFeatureElement, this) :
           ol.xml.makeReplacer(this.readFeatureElement, this);

--- a/src/ol/format/gml/gmlbaseformat.js
+++ b/src/ol/format/gml/gmlbaseformat.js
@@ -111,6 +111,11 @@ ol.format.GMLBase.prototype.readFeatures_ = function(node, objectStack) {
     }
     var parsers = {};
     var parsersNS = {};
+    if (goog.object.get(context, 'useArrayPusher') === true) {
+      var ns = 'http://www.opengis.net/gml';
+      goog.object.set(this.FEATURE_COLLECTION_PARSERS[ns], 'featureMember',
+          ol.xml.makeArrayPusher(ol.format.GMLBase.prototype.readFeatures_));
+    }
     var featureTypes = goog.isArray(featureType) ? featureType : [featureType];
     for (i = 0, ii = featureTypes.length; i < ii; ++i) {
       parsers[featureTypes[i]] = (localName == 'featureMembers') ?
@@ -132,7 +137,7 @@ ol.format.GMLBase.prototype.readFeatures_ = function(node, objectStack) {
  */
 ol.format.GMLBase.prototype.FEATURE_COLLECTION_PARSERS = Object({
   'http://www.opengis.net/gml': {
-    'featureMember': ol.xml.makeArrayPusher(
+    'featureMember': ol.xml.makeReplacer/*ArrayPusher*/(
         ol.format.GMLBase.prototype.readFeatures_),
     'featureMembers': ol.xml.makeReplacer(
         ol.format.GMLBase.prototype.readFeatures_)

--- a/src/ol/format/wfsformat.js
+++ b/src/ol/format/wfsformat.js
@@ -31,7 +31,7 @@ ol.format.WFS = function(opt_options) {
 
   /**
    * @private
-   * @type {string}
+   * @type {Array.<string>|string|undefined}
    */
   this.featureType_ = options.featureType;
 

--- a/src/ol/format/wfsformat.js
+++ b/src/ol/format/wfsformat.js
@@ -120,7 +120,8 @@ ol.format.WFS.prototype.readFeatures;
 ol.format.WFS.prototype.readFeaturesFromNode = function(node, opt_options) {
   var context = {
     'featureType': this.featureType_,
-    'featureNS': this.featureNS_
+    'featureNS': this.featureNS_,
+    'useArrayPusher': true
   };
   goog.object.extend(context, this.getReadOptions(node,
       goog.isDef(opt_options) ? opt_options : {}));

--- a/test/spec/ol/format/gml/multiple-typenames.xml
+++ b/test/spec/ol/format/gml/multiple-typenames.xml
@@ -1,0 +1,44 @@
+<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:gml="http://www.opengis.net/gml"
+    xmlns:official="http://localhost:8080/official" xmlns:ogc="http://www.opengis.net/ogc"
+    xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" numberOfFeatures="12"
+    timeStamp="2014-11-03T21:04:28.345Z">
+    <gml:featureMembers>
+        <official:planet_osm_line gml:id="planet_osm_line.fid-53719711_14976c6c1aa_6795">
+            <official:osm_id>3822829</official:osm_id>
+        </official:planet_osm_line>
+        <official:planet_osm_line gml:id="planet_osm_line.fid-53719711_14976c6c1aa_6796">
+            <official:osm_id>3820888</official:osm_id>
+        </official:planet_osm_line>
+        <official:planet_osm_line gml:id="planet_osm_line.fid-53719711_14976c6c1aa_6797">
+            <official:osm_id>296916318</official:osm_id>
+        </official:planet_osm_line>
+        <official:planet_osm_polygon gml:id="planet_osm_polygon.fid-53719711_14976c6c1aa_6798">
+            <official:osm_id>37244</official:osm_id>
+        </official:planet_osm_polygon>
+        <official:planet_osm_polygon gml:id="planet_osm_polygon.fid-53719711_14976c6c1aa_6799">
+            <official:osm_id>1641478</official:osm_id>
+        </official:planet_osm_polygon>
+        <official:planet_osm_polygon gml:id="planet_osm_polygon.fid-53719711_14976c6c1aa_679a">
+            <official:osm_id>1244004</official:osm_id>
+        </official:planet_osm_polygon>
+        <official:planet_osm_polygon gml:id="planet_osm_polygon.fid-53719711_14976c6c1aa_679b">
+            <official:osm_id>22259</official:osm_id>
+        </official:planet_osm_polygon>
+        <official:planet_osm_polygon gml:id="planet_osm_polygon.fid-53719711_14976c6c1aa_679c">
+            <official:osm_id>1606103</official:osm_id>
+        </official:planet_osm_polygon>
+        <official:planet_osm_polygon gml:id="planet_osm_polygon.fid-53719711_14976c6c1aa_679d">
+            <official:osm_id>3217145</official:osm_id>
+        </official:planet_osm_polygon>
+        <official:planet_osm_polygon gml:id="planet_osm_polygon.fid-53719711_14976c6c1aa_679e">
+            <official:osm_id>3228576</official:osm_id>
+        </official:planet_osm_polygon>
+        <official:planet_osm_polygon gml:id="planet_osm_polygon.fid-53719711_14976c6c1aa_679f">
+            <official:osm_id>936994</official:osm_id>
+        </official:planet_osm_polygon>
+        <official:planet_osm_polygon gml:id="planet_osm_polygon.fid-53719711_14976c6c1aa_67a0">
+            <official:osm_id>936990</official:osm_id>
+        </official:planet_osm_polygon>
+    </gml:featureMembers>
+</wfs:FeatureCollection>

--- a/test/spec/ol/format/gml/ogr.xml
+++ b/test/spec/ol/format/gml/ogr.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<wfs:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	 xmlns:wfs="http://www.opengis.net/wfs"
+     xsi:schemaLocation="http://ogr.maptools.org/ test.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+
+                                                                                                                       
+  <gml:featureMember>
+    <ogr:Plaatsbepalingspunt fid="Plaatsbepalingspunt.0">
+		<ogr:geometryProperty>
+			<gml:Point>
+				<gml:pos srsDimension="2">115512.666 479836.28</gml:pos>
+			</gml:Point>
+		</ogr:geometryProperty>
+		<ogr:gml_id>x2</ogr:gml_id>
+		<ogr:namespace>NL.IMGEO</ogr:namespace>
+		<ogr:lokaalID>L0001.A3C177B4105A4FFD82EB80084C8CA732</ogr:lokaalID>
+		<ogr:nauwkeurigheid>60</ogr:nauwkeurigheid>
+		<ogr:datumInwinning>2014-02-14</ogr:datumInwinning>
+		<ogr:inwinnendeInstantie>L0001</ogr:inwinnendeInstantie>
+		<ogr:inwinningsmethode>fotogrammetrisch</ogr:inwinningsmethode>
+    </ogr:Plaatsbepalingspunt>
+  </gml:featureMember>
+</wfs:FeatureCollection>

--- a/test/spec/ol/format/gmlformat.test.js
+++ b/test/spec/ol/format/gmlformat.test.js
@@ -1110,6 +1110,26 @@ describe('ol.format.GML3', function() {
 
   });
 
+  describe('when parsing multiple feature types', function() {
+
+    var features;
+    before(function(done) {
+      afterLoadText('spec/ol/format/gml/multiple-typenames.xml', function(xml) {
+        try {
+          features = new ol.format.GML().readFeatures(xml);
+        } catch (e) {
+          done(e);
+        }
+        done();
+      });
+    });
+
+    it('reads all features with autoconfigure', function() {
+      expect(features.length).to.be(12);
+    });
+
+  });
+
 });
 
 

--- a/test/spec/ol/format/gmlformat.test.js
+++ b/test/spec/ol/format/gmlformat.test.js
@@ -1087,6 +1087,29 @@ describe('ol.format.GML3', function() {
 
   });
 
+  describe('when parsing multiple feature types', function() {
+
+    var features;
+    before(function(done) {
+      afterLoadText('spec/ol/format/gml/multiple-typenames.xml', function(xml) {
+        try {
+          features = new ol.format.GML({
+            featureNS: 'http://localhost:8080/official',
+            featureType: ['planet_osm_polygon', 'planet_osm_line']
+          }).readFeatures(xml);
+        } catch (e) {
+          done(e);
+        }
+        done();
+      });
+    });
+
+    it('reads all features', function() {
+      expect(features.length).to.be(12);
+    });
+
+  });
+
 });
 
 

--- a/test/spec/ol/format/gmlformat.test.js
+++ b/test/spec/ol/format/gmlformat.test.js
@@ -1130,6 +1130,26 @@ describe('ol.format.GML3', function() {
 
   });
 
+  describe('when parsing from OGR', function() {
+
+    var features;
+    before(function(done) {
+      afterLoadText('spec/ol/format/gml/ogr.xml', function(xml) {
+        try {
+          features = new ol.format.GML().readFeatures(xml);
+        } catch (e) {
+          done(e);
+        }
+        done();
+      });
+    });
+
+    it('reads all features', function() {
+      expect(features.length).to.be(1);
+    });
+
+  });
+
 });
 
 

--- a/test/spec/ol/format/wfsformat.test.js
+++ b/test/spec/ol/format/wfsformat.test.js
@@ -433,6 +433,49 @@ describe('ol.format.WFS', function() {
 
   });
 
+  describe('when parsing multiple feature types', function() {
+
+    var features;
+    before(function(done) {
+      afterLoadText('spec/ol/format/gml/multiple-typenames.xml', function(xml) {
+        try {
+          features = new ol.format.WFS({
+            featureNS: 'http://localhost:8080/official',
+            featureType: ['planet_osm_polygon', 'planet_osm_line']
+          }).readFeatures(xml);
+        } catch (e) {
+          done(e);
+        }
+        done();
+      });
+    });
+
+    it('reads all features', function() {
+      expect(features.length).to.be(12);
+    });
+
+  });
+
+  describe('when parsing multiple feature types', function() {
+
+    var features;
+    before(function(done) {
+      afterLoadText('spec/ol/format/gml/multiple-typenames.xml', function(xml) {
+        try {
+          features = new ol.format.WFS().readFeatures(xml);
+        } catch (e) {
+          done(e);
+        }
+        done();
+      });
+    });
+
+    it('reads all features with autoconfigure', function() {
+      expect(features.length).to.be(12);
+    });
+
+  });
+
 });
 
 


### PR DESCRIPTION
Example GML:

```
<?xml version="1.0" encoding="utf-8" ?>
<wfs:FeatureCollection
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
	 xmlns:wfs="http://www.opengis.net/wfs"
     xsi:schemaLocation="http://ogr.maptools.org/ test.xsd"
     xmlns:ogr="http://ogr.maptools.org/"
     xmlns:gml="http://www.opengis.net/gml">

                                                                                                                       
  <gml:featureMember>
    <ogr:Plaatsbepalingspunt fid="Plaatsbepalingspunt.0">
		<ogr:geometryProperty>
			<gml:Point>
				<gml:pos srsDimension="2">115512.666 479836.28</gml:pos>
			</gml:Point>
		</ogr:geometryProperty>
		<ogr:gml_id>x2</ogr:gml_id>
		<ogr:namespace>NL.IMGEO</ogr:namespace>
		<ogr:lokaalID>L0001.A3C177B4105A4FFD82EB80084C8CA732</ogr:lokaalID>
		<ogr:nauwkeurigheid>60</ogr:nauwkeurigheid>
		<ogr:datumInwinning>2014-02-14</ogr:datumInwinning>
		<ogr:inwinnendeInstantie>L0001</ogr:inwinnendeInstantie>
		<ogr:inwinningsmethode>fotogrammetrisch</ogr:inwinningsmethode>
    </ogr:Plaatsbepalingspunt>
  </gml:featureMember>
</wfs:FeatureCollection>
```

If featureMembers instead of featureMember parsing is okay. Also using ol.format.WFS parsing is okay. Will investigate deeper.