### PR TITLE
Don't pass renderBuffer option to the parent constructor

### DIFF
--- a/src/ol/layer/vectorlayer.js
+++ b/src/ol/layer/vectorlayer.js
@@ -35,6 +35,7 @@ ol.layer.Vector = function(opt_options) {
   var baseOptions = goog.object.clone(options);
 
   delete baseOptions.style;
+  delete baseOptions.renderBuffer;
   goog.base(this, /** @type {olx.layer.LayerOptions} */ (baseOptions));
 
   /**


### PR DESCRIPTION
Otherwise, an `ol.Object` property is created.