### PR TITLE
Bugfix: "Cannot read property 'firstElementChild' of null" (WFS)

### DIFF
--- a/src/ol/format/wfsformat.js
+++ b/src/ol/format/wfsformat.js
@@ -747,8 +747,10 @@ ol.format.WFS.prototype.readProjectionFromDocument = function(doc) {
 ol.format.WFS.prototype.readProjectionFromNode = function(node) {
   goog.asserts.assert(node.nodeType == goog.dom.NodeType.ELEMENT);
   goog.asserts.assert(node.localName == 'FeatureCollection');
-  node = node.firstElementChild.firstElementChild;
-  if (goog.isDefAndNotNull(node)) {
+
+  if (goog.isDefAndNotNull(node.firstElementChild) &&
+      goog.isDefAndNotNull(node.firstElementChild.firstElementChild)) {
+    node = node.firstElementChild.firstElementChild;
     for (var n = node.firstElementChild; !goog.isNull(n);
         n = n.nextElementSibling) {
       if (!(n.childNodes.length === 0 ||
@@ -760,5 +762,6 @@ ol.format.WFS.prototype.readProjectionFromNode = function(node) {
       }
     }
   }
+
   return null;
 };

--- a/test/spec/ol/format/wfs/EmptyFeatureCollection.xml
+++ b/test/spec/ol/format/wfs/EmptyFeatureCollection.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding="ISO-8859-1" ?>
+<wfs:FeatureCollection
+   xmlns:rws="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:wfs="http://www.opengis.net/wfs"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://mapserver.gis.umn.edu/mapserver http://intranet.rijkswaterstaat.nl/services/geoservices/nwb_wegen?SERVICE=WFS&amp;VERSION=1.1.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=feature:AAA64&amp;OUTPUTFORMAT=text/xml; subtype=gml/3.1.1  http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd" numberOfFeatures="0">
+</wfs:FeatureCollection>

--- a/test/spec/ol/format/wfsformat.test.js
+++ b/test/spec/ol/format/wfsformat.test.js
@@ -90,6 +90,21 @@ describe('ol.format.WFS', function() {
   });
 
   describe('when parsing FeatureCollection', function() {
+    var xml;
+    before(function(done) {
+      afterLoadText('spec/ol/format/wfs/EmptyFeatureCollection.xml',
+          function(_xml) {
+            xml = _xml;
+            done();
+          });
+    });
+    it('returns an empty array of features when none exist', function() {
+      var result = new ol.format.WFS().readFeatures(xml);
+      expect(result).to.have.length(0);
+    });
+  });
+
+  describe('when parsing FeatureCollection', function() {
     var response;
     before(function(done) {
       afterLoadText('spec/ol/format/wfs/NumberOfFeatures.xml',


### PR DESCRIPTION
Occurs when the WFS FeatureCollection is empty.