### PR TITLE
Add spliceCoordinates method to LineString Geometry

### DIFF
--- a/examples/animate-linestring.html
+++ b/examples/animate-linestring.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <link rel="stylesheet" href="../css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap.min.css" type="text/css">
+    <link rel="stylesheet" href="../resources/layout.css" type="text/css">
+    <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap-responsive.min.css" type="text/css">
+    <title>LineString animation example</title>
+  </head>
+  <body>
+
+    <div class="navbar navbar-inverse navbar-fixed-top">
+      <div class="navbar-inner">
+        <div class="container">
+          <a class="brand" href="./"><img src="../resources/logo.png"> OpenLayers 3 Examples</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="container-fluid">
+      <h4 id="title">LineString Animation</h4>
+      <div id="map" class="map"></div>
+
+      <div class="row-fluid">
+        <p id="shortdesc">Example of animating a LineString</p>
+        <div id="docs">
+          <p>See the <a href="animate-linestring.js" target="_blank">animate-linestring.js source</a> to see how this is done.</p>
+        </div>
+        <div id="tags">linestring, geometry, animate</div>
+      </div>
+    </div>
+
+    <script src="../resources/jquery.min.js" type="text/javascript"></script>
+    <script src="../resources/example-behaviour.js" type="text/javascript"></script>
+    <script src="loader.js?id=animate-linestring" type="text/javascript"></script>
+
+  </body>
+</html>

--- a/examples/animate-linestring.js
+++ b/examples/animate-linestring.js
@@ -1,0 +1,79 @@
+goog.require('ol.Feature');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.geom.LineString');
+goog.require('ol.layer.Tile');
+goog.require('ol.layer.Vector');
+goog.require('ol.source.OSM');
+goog.require('ol.source.Vector');
+
+var stepSize = 1000,
+    stepDirection = 'N',
+    stepCount = 0,
+    head = [2952104.019976033, -3277504.823700756],
+    numCoordinates = 1;
+
+var takeStep = function(coordinate) {
+  var x = coordinate[0],
+      y = coordinate[1];
+  switch (stepDirection) {
+    case 'N': return [x, y + stepSize];
+    case 'S': return [x, y - stepSize];
+    case 'E': return [x + stepSize, y];
+    case 'W': return [x - stepSize, y];
+    default:
+      throw new Error('invalid direction: ' + stepDirection);
+  }
+};
+
+var nextDirection = function(direction) {
+  switch (direction) {
+    case 'N': return 'W';
+    case 'W': return 'S';
+    case 'S': return 'E';
+    case 'E': return 'N';
+  }
+};
+
+var nextStep = function(coordinate) {
+  stepCount++;
+  if (stepCount >= 20) {
+    stepCount = 0;
+    stepDirection = nextDirection(stepDirection);
+  }
+  return takeStep(coordinate);
+};
+
+var lineString = new ol.geom.LineString([head]);
+
+var map = new ol.Map({
+  layers: [
+    new ol.layer.Tile({
+      source: new ol.source.OSM()
+    }),
+    new ol.layer.Vector({
+      source: new ol.source.Vector({
+        features: [
+          new ol.Feature({ geometry: lineString })
+        ]
+      })
+    })
+  ],
+  target: 'map',
+  view: new ol.View({
+    center: head,
+    zoom: 10
+  })
+});
+
+var update = function() {
+  numCoordinates++;
+  head = nextStep(head);
+  lineString.appendCoordinate(head);
+  if (numCoordinates > 20) {
+    numCoordinates--;
+    lineString.spliceCoordinates(0, 1);
+  }
+};
+
+map.on('postrender', update);

--- a/src/ol/geom/flat/spliceflatgeom.js
+++ b/src/ol/geom/flat/spliceflatgeom.js
@@ -1,0 +1,26 @@
+goog.provide('ol.geom.flat.splice');
+
+goog.require('goog.array');
+goog.require('goog.asserts');
+goog.require('ol.geom.flat.deflate');
+
+
+/**
+ * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {number} stride Stride.
+ * @param {number} start Start.
+ * @param {number} deleteCount Delete Count.
+ * @param {Array.<ol.Coordinate>=} opt_coordinates Coordinates.
+ */
+ol.geom.flat.splice.coordinates =
+    function(flatCoordinates, stride, start, deleteCount, opt_coordinates) {
+  var newFlatCoordinates = [];
+  if (goog.isDef(opt_coordinates)) {
+    ol.geom.flat.deflate.coordinates(
+        newFlatCoordinates, 0, opt_coordinates, stride);
+    goog.asserts.assert(
+        newFlatCoordinates.length == opt_coordinates.length * stride);
+  }
+  goog.partial(goog.array.splice, flatCoordinates, start * stride,
+      deleteCount * stride).apply(null, newFlatCoordinates);
+};

--- a/src/ol/geom/linestring.js
+++ b/src/ol/geom/linestring.js
@@ -12,6 +12,7 @@ goog.require('ol.geom.flat.interpolate');
 goog.require('ol.geom.flat.intersectsextent');
 goog.require('ol.geom.flat.length');
 goog.require('ol.geom.flat.simplify');
+goog.require('ol.geom.flat.splice');
 
 
 
@@ -199,6 +200,39 @@ ol.geom.LineString.prototype.intersectsExtent = function(extent) {
   return ol.geom.flat.intersectsextent.lineString(
       this.flatCoordinates, 0, this.flatCoordinates.length, this.stride,
       extent);
+};
+
+
+/**
+ * Modifies the geometry's coordinates in place.
+ *
+ * ```js
+ * var lineString = new ol.geom.LineString(coords);
+ *
+ * // to add coordinates at index, do:
+ * lineString.spliceCoordinates(index, 0, [newCoord]);
+ *
+ * // to delete coordinate at index, do:
+ * lineString.spliceCoordinates(index, 1);
+ *
+ * // to replace coordinate at index, do:
+ * lineString.spliceCoordinates(index, 1, [newCoord]);
+ * ```
+ *
+ * @param {number} start Index at which to start changing the coordinates.
+ * @param {number} deleteCount Delete An integer indicating the number of old
+ *    coordinates to remove. If `deleteCount` is `0`, no elements are removed.
+ *    In this case, you should specify at least one new element.
+ * @param {Array.<ol.Coordinate>=} opt_coordinates The coordinates to add.
+ *    If you don't specify any elements, `spliceCoordinates()` will only remove
+ *    elements.
+ * @api
+ */
+ol.geom.LineString.prototype.spliceCoordinates =
+    function(start, deleteCount, opt_coordinates) {
+  ol.geom.flat.splice.coordinates(this.flatCoordinates,
+      this.stride, start, deleteCount, opt_coordinates);
+  this.changed();
 };
 
 

--- a/test/spec/ol/geom/flat/spliceflatgeom.test.js
+++ b/test/spec/ol/geom/flat/spliceflatgeom.test.js
@@ -1,0 +1,74 @@
+goog.provide('ol.test.geom.flat.splice');
+
+describe('ol.geom.flat.splice', function() {
+
+  describe('ol.geom.flat.splice.coordinates', function() {
+
+    describe('with stride 2', function() {
+
+      it('can replace coordinates', function() {
+        var flatCoordinates = [1, 2, 3, 4];
+        ol.geom.flat.splice.coordinates(
+            flatCoordinates, 2, 0, 2, [[5, 6]]);
+        expect(flatCoordinates).to.eql([5, 6]);
+      });
+
+      it('can insert coordinates', function() {
+        var flatCoordinates = [1, 2, 7, 8];
+        ol.geom.flat.splice.coordinates(
+            flatCoordinates, 2, 1, 0, [[3, 4], [5, 6]]);
+        expect(flatCoordinates).to.eql([1, 2, 3, 4, 5, 6, 7, 8]);
+      });
+
+      it('can prepend coordinates', function() {
+        var flatCoordinates = [3, 4];
+        ol.geom.flat.splice.coordinates(
+            flatCoordinates, 2, 0, 0, [[1, 2]]);
+        expect(flatCoordinates).to.eql([1, 2, 3, 4]);
+      });
+
+      it('can append coordinates', function() {
+        var flatCoordinates = [1, 2];
+        ol.geom.flat.splice.coordinates(
+            flatCoordinates, 2, 2, 0, [[3, 4]]);
+        expect(flatCoordinates).to.eql([1, 2, 3, 4]);
+      });
+
+    });
+
+    describe('with stride 3', function() {
+
+      it('can replace coordinates', function() {
+        var flatCoordinates = [1, 2, 3, 4, 5, 6];
+        ol.geom.flat.splice.coordinates(
+            flatCoordinates, 3, 0, 2, [[7, 8, 9]]);
+        expect(flatCoordinates).to.eql([7, 8, 9]);
+      });
+
+      it('can insert coordinates', function() {
+        var flatCoordinates = [1, 2, 3, 10, 11, 12];
+        ol.geom.flat.splice.coordinates(
+            flatCoordinates, 3, 1, 0, [[4, 5, 6], [7, 8, 9]]);
+        expect(flatCoordinates).to.eql([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+      });
+
+      it('can prepend coordinates', function() {
+        var flatCoordinates = [4, 5, 6];
+        ol.geom.flat.splice.coordinates(
+            flatCoordinates, 3, 0, 0, [[1, 2, 3]]);
+        expect(flatCoordinates).to.eql([1, 2, 3, 4, 5, 6]);
+      });
+
+      it('can append coordinates', function() {
+        var flatCoordinates = [1, 2, 3];
+        ol.geom.flat.splice.coordinates(
+            flatCoordinates, 3, 2, 0, [[4, 5, 6]]);
+        expect(flatCoordinates).to.eql([1, 2, 3, 4, 5, 6]);
+      });
+    });
+
+  });
+
+});
+
+goog.require('ol.geom.flat.splice');

--- a/test/spec/ol/geom/linestring.test.js
+++ b/test/spec/ol/geom/linestring.test.js
@@ -44,6 +44,13 @@ describe('ol.geom.LineString', function() {
       expect(lineString.getCoordinates()).to.eql([[1, 2], [3, 4]]);
     });
 
+    it('can splice coordinates', function() {
+      lineString.spliceCoordinates(0, 0, [[1, 2]]);
+      expect(lineString.getCoordinates()).to.eql([[1, 2]]);
+      lineString.spliceCoordinates(0, 1);
+      expect(lineString.getCoordinates()).to.be.empty();
+    });
+
   });
 
   describe('construct with 2D coordinates', function() {


### PR DESCRIPTION
I'm animating a `ol.geom.LineString` and need to modify the coordinates. Using `getCoordinates` and `setCoordinates` isn't efficient enough because the coordinates are converted back and forth from the flat representation.

**edit:**

I'm not sure if replaceCoordinatesis the appropriate name, but I think this covers most use cases that involve mutating the coordinates in place. Let me know if more tests are required.