### PR TITLE
Allow rendering of feature when download of icon failed

### DIFF
--- a/src/ol/render/vector.js
+++ b/src/ol/render/vector.js
@@ -88,18 +88,11 @@ ol.renderer.vector.renderFeature = function(
   var loading = false;
   var imageStyle, imageState;
   imageStyle = style.getImage();
-  if (goog.isNull(imageStyle)) {
-    ol.renderer.vector.renderFeature_(
-        replayGroup, feature, style, squaredTolerance);
-  } else {
+  if (!goog.isNull(imageStyle)) {
     imageState = imageStyle.getImageState();
     if (imageState == ol.style.ImageState.LOADED ||
         imageState == ol.style.ImageState.ERROR) {
       imageStyle.unlistenImageChange(listener, thisArg);
-      if (imageState == ol.style.ImageState.LOADED) {
-        ol.renderer.vector.renderFeature_(
-            replayGroup, feature, style, squaredTolerance);
-      }
     } else {
       if (imageState == ol.style.ImageState.IDLE) {
         imageStyle.load();
@@ -110,6 +103,8 @@ ol.renderer.vector.renderFeature = function(
       loading = true;
     }
   }
+  ol.renderer.vector.renderFeature_(replayGroup, feature, style,
+      squaredTolerance);
   return loading;
 };
 
@@ -254,6 +249,9 @@ ol.renderer.vector.renderPointGeometry_ =
   goog.asserts.assertInstanceof(geometry, ol.geom.Point);
   var imageStyle = style.getImage();
   if (!goog.isNull(imageStyle)) {
+    if (imageStyle.getImageState() != ol.style.ImageState.LOADED) {
+      return;
+    }
     var imageReplay = replayGroup.getReplay(
         style.getZIndex(), ol.render.ReplayType.IMAGE);
     imageReplay.setImageStyle(imageStyle);
@@ -281,6 +279,9 @@ ol.renderer.vector.renderMultiPointGeometry_ =
   goog.asserts.assertInstanceof(geometry, ol.geom.MultiPoint);
   var imageStyle = style.getImage();
   if (!goog.isNull(imageStyle)) {
+    if (imageStyle.getImageState() != ol.style.ImageState.LOADED) {
+      return;
+    }
     var imageReplay = replayGroup.getReplay(
         style.getZIndex(), ol.render.ReplayType.IMAGE);
     imageReplay.setImageStyle(imageStyle);

--- a/test/spec/ol/render/vector.test.js
+++ b/test/spec/ol/render/vector.test.js
@@ -3,37 +3,40 @@ goog.provide('ol.test.renderer.vector');
 describe('ol.renderer.vector', function() {
   describe('#renderFeature', function() {
     var replayGroup;
+    var feature, iconStyle, style, squaredTolerance, listener, listenerThis;
+    var iconStyleLoadSpy;
 
     beforeEach(function() {
       replayGroup = new ol.render.canvas.ReplayGroup(1);
+      feature = new ol.Feature();
+      iconStyle = new ol.style.Icon({
+        src: 'http://example.com/icon.png'
+      });
+      style = new ol.style.Style({
+        image: iconStyle,
+        fill: new ol.style.Fill({}),
+        stroke: new ol.style.Stroke({})
+      });
+      squaredTolerance = 1;
+      listener = function() {};
+      listenerThis = {};
+      iconStyleLoadSpy = sinon.stub(iconStyle, 'load', function() {
+        iconStyle.iconImage_.imageState_ = ol.style.ImageState.LOADING;
+      });
+    });
+
+    afterEach(function() {
+      iconStyleLoadSpy.restore();
     });
 
     describe('call multiple times', function() {
 
       it('does not set multiple listeners', function() {
-        var iconStyle = new ol.style.Icon({
-          src: 'http://example.com/icon.png'
-        });
-
-        var iconImage = iconStyle.iconImage_;
-
-        var iconStyleLoadSpy = sinon.stub(iconStyle, 'load', function() {
-          iconImage.imageState_ = ol.style.ImageState.LOADING;
-        });
-
-        var style = new ol.style.Style({
-          image: iconStyle
-        });
-
-        var feature = new ol.Feature();
-
-        var listener = function() {};
-        var listenerThis = {};
         var listeners;
 
         // call #1
         ol.renderer.vector.renderFeature(replayGroup, feature,
-            style, 1, listener, listenerThis);
+            style, squaredTolerance, listener, listenerThis);
 
         expect(iconStyleLoadSpy.calledOnce).to.be.ok();
         listeners = goog.events.getListeners(
@@ -42,7 +45,7 @@ describe('ol.renderer.vector', function() {
 
         // call #2
         ol.renderer.vector.renderFeature(replayGroup, feature,
-            style, 1, listener, listenerThis);
+            style, squaredTolerance, listener, listenerThis);
 
         expect(iconStyleLoadSpy.calledOnce).to.be.ok();
         listeners = goog.events.getListeners(
@@ -52,14 +55,119 @@ describe('ol.renderer.vector', function() {
 
     });
 
+    describe('call renderFeature with a loading icon', function() {
+
+      it('does not render the point', function() {
+        feature.setGeometry(new ol.geom.Point([0, 0]));
+        var imageReplay = replayGroup.getReplay(
+            style.getZIndex(), ol.render.ReplayType.IMAGE);
+        var setImageStyleSpy = sinon.spy(imageReplay, 'setImageStyle');
+        var drawPointGeometrySpy = sinon.stub(imageReplay,
+            'drawPointGeometry', goog.nullFunction);
+        ol.renderer.vector.renderFeature(replayGroup, feature,
+            style, squaredTolerance, listener, listenerThis);
+        expect(setImageStyleSpy.called).to.be(false);
+        setImageStyleSpy.restore();
+        drawPointGeometrySpy.restore();
+      });
+
+      it('does not render the multipoint', function() {
+        feature.setGeometry(new ol.geom.MultiPoint([[0, 0], [1, 1]]));
+        var imageReplay = replayGroup.getReplay(
+            style.getZIndex(), ol.render.ReplayType.IMAGE);
+        var setImageStyleSpy = sinon.spy(imageReplay, 'setImageStyle');
+        var drawMultiPointGeometrySpy = sinon.stub(imageReplay,
+            'drawMultiPointGeometry', goog.nullFunction);
+        ol.renderer.vector.renderFeature(replayGroup, feature,
+            style, squaredTolerance, listener, listenerThis);
+        expect(setImageStyleSpy.called).to.be(false);
+        setImageStyleSpy.restore();
+        drawMultiPointGeometrySpy.restore();
+      });
+
+      it('does render the linestring', function() {
+        feature.setGeometry(new ol.geom.LineString([[0, 0], [1, 1]]));
+        var lineStringReplay = replayGroup.getReplay(
+            style.getZIndex(), ol.render.ReplayType.LINE_STRING);
+        var setFillStrokeStyleSpy = sinon.spy(lineStringReplay,
+            'setFillStrokeStyle');
+        var drawLineStringGeometrySpy = sinon.stub(lineStringReplay,
+            'drawLineStringGeometry', goog.nullFunction);
+        ol.renderer.vector.renderFeature(replayGroup, feature,
+            style, squaredTolerance, listener, listenerThis);
+        expect(setFillStrokeStyleSpy.called).to.be(true);
+        expect(drawLineStringGeometrySpy.called).to.be(true);
+        setFillStrokeStyleSpy.restore();
+        drawLineStringGeometrySpy.restore();
+      });
+
+      it('does render the multilinestring', function() {
+        feature.setGeometry(new ol.geom.MultiLineString([[[0, 0], [1, 1]]]));
+        var lineStringReplay = replayGroup.getReplay(
+            style.getZIndex(), ol.render.ReplayType.LINE_STRING);
+        var setFillStrokeStyleSpy = sinon.spy(lineStringReplay,
+            'setFillStrokeStyle');
+        var drawMultiLineStringGeometrySpy = sinon.stub(lineStringReplay,
+            'drawMultiLineStringGeometry', goog.nullFunction);
+        ol.renderer.vector.renderFeature(replayGroup, feature,
+            style, squaredTolerance, listener, listenerThis);
+        expect(setFillStrokeStyleSpy.called).to.be(true);
+        expect(drawMultiLineStringGeometrySpy.called).to.be(true);
+        setFillStrokeStyleSpy.restore();
+        drawMultiLineStringGeometrySpy.restore();
+      });
+
+      it('does render the polygon', function() {
+        feature.setGeometry(new ol.geom.Polygon(
+            [[[0, 0], [1, 1], [1, 0], [0, 0]]]));
+        var polygonReplay = replayGroup.getReplay(
+            style.getZIndex(), ol.render.ReplayType.POLYGON);
+        var setFillStrokeStyleSpy = sinon.spy(polygonReplay,
+            'setFillStrokeStyle');
+        var drawPolygonGeometrySpy = sinon.stub(polygonReplay,
+            'drawPolygonGeometry', goog.nullFunction);
+        ol.renderer.vector.renderFeature(replayGroup, feature,
+            style, squaredTolerance, listener, listenerThis);
+        expect(setFillStrokeStyleSpy.called).to.be(true);
+        expect(drawPolygonGeometrySpy.called).to.be(true);
+        setFillStrokeStyleSpy.restore();
+        drawPolygonGeometrySpy.restore();
+      });
+
+      it('does render the multipolygon', function() {
+        feature.setGeometry(new ol.geom.MultiPolygon(
+            [[[[0, 0], [1, 1], [1, 0], [0, 0]]]]));
+        var polygonReplay = replayGroup.getReplay(
+            style.getZIndex(), ol.render.ReplayType.POLYGON);
+        var setFillStrokeStyleSpy = sinon.spy(polygonReplay,
+            'setFillStrokeStyle');
+        var drawMultiPolygonGeometrySpy = sinon.stub(polygonReplay,
+            'drawMultiPolygonGeometry', goog.nullFunction);
+        ol.renderer.vector.renderFeature(replayGroup, feature,
+            style, squaredTolerance, listener, listenerThis);
+        expect(setFillStrokeStyleSpy.called).to.be(true);
+        expect(drawMultiPolygonGeometrySpy.called).to.be(true);
+        setFillStrokeStyleSpy.restore();
+        drawMultiPolygonGeometrySpy.restore();
+      });
+    });
+
   });
 });
 
 goog.require('goog.events');
 goog.require('goog.events.EventType');
+goog.require('ol.geom.LineString');
+goog.require('ol.geom.Point');
+goog.require('ol.geom.Polygon');
+goog.require('ol.geom.MultiLineString');
+goog.require('ol.geom.MultiPoint');
+goog.require('ol.geom.MultiPolygon');
 goog.require('ol.render.canvas.ReplayGroup');
 goog.require('ol.renderer.vector');
+goog.require('ol.style.Fill');
 goog.require('ol.style.Icon');
 goog.require('ol.style.ImageState');
+goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
 goog.require('ol.Feature');


### PR DESCRIPTION
Currently a feature is not rendered when the download of icon, defined in an image style, failed (bad link, offline mode). 
That makes sense only for `ol.geom.Point` and `ol.geom.MultiPoint ` . The others types of geometry don't use the image style, so this PR allows rendering of feature when the download of an icon failed.


Any opinions?