### PR TITLE
Only update the rbush item if the extent has changed

### DIFF
--- a/src/ol/structs/rbush.js
+++ b/src/ol/structs/rbush.js
@@ -4,6 +4,7 @@ goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.object');
 goog.require('ol.ext.rbush');
+goog.require('ol.extent');
 
 
 
@@ -123,8 +124,17 @@ ol.structs.RBush.prototype.remove = function(value) {
  * @param {T} value Value.
  */
 ol.structs.RBush.prototype.update = function(extent, value) {
-  this.remove(value);
-  this.insert(extent, value);
+  var uid = goog.getUid(value);
+  goog.asserts.assert(goog.object.containsKey(this.items_, uid));
+
+  var item = this.items_[uid];
+  if (!ol.extent.equals(item.slice(0, 4), extent)) {
+    if (goog.DEBUG && this.readers_) {
+      throw new Error('Can not update extent while reading');
+    }
+    this.remove(value);
+    this.insert(extent, value);
+  }
 };
 
 

--- a/test/spec/ol/structs/rbush.test.js
+++ b/test/spec/ol/structs/rbush.test.js
@@ -44,6 +44,14 @@ describe('ol.structs.RBush', function() {
       expect(rBush.getInExtent([2, 2, 3, 3])).to.eql([obj]);
     });
 
+    it('don\'t throws an exception if the extent is not modified', function() {
+      expect(function() {
+        rBush.forEach(function(value) {
+          rBush.update([0, 0, 1, 1], obj);
+        });
+      }).not.to.throwException();
+    });
+
   });
 
   describe('with a few objects', function() {


### PR DESCRIPTION
To be able to update a feature property while iterating. Example:
```javascript
source.forEachFeature(function(feature) {
  feature.set('foo', 'bar');
});
```
The feature was lost during the migration to CommonJS style modules in #2867.

See also #2219