### PR TITLE
Use array.length = 0 instead of goog.array.clear

### DIFF
--- a/src/ol/source/clustersource.js
+++ b/src/ol/source/clustersource.js
@@ -93,7 +93,7 @@ ol.source.Cluster.prototype.cluster_ = function() {
   if (!goog.isDef(this.resolution_)) {
     return;
   }
-  goog.array.clear(this.features_);
+  this.features_.length = 0;
   var extent = ol.extent.createEmpty();
   var mapDistance = this.distance_ * this.resolution_;
   var features = this.source_.getFeatures();


### PR DESCRIPTION
And `goog.object.clear(obj)` should probably changed to `obj = {}`