### PR TITLE
Add ol.control.Control#setTarget

### DIFF
--- a/src/ol/control/control.js
+++ b/src/ol/control/control.js
@@ -51,8 +51,7 @@ ol.control.Control = function(options) {
    * @private
    * @type {Element}
    */
-  this.target_ = goog.isDef(options.target) ?
-      goog.dom.getElement(options.target) : null;
+  this.target_ = null;
 
   /**
    * @private
@@ -70,6 +69,10 @@ ol.control.Control = function(options) {
    * @type {function(ol.MapEvent)}
    */
   this.render = goog.isDef(options.render) ? options.render : goog.nullFunction;
+
+  if (goog.isDef(options.target)) {
+    this.setTarget(options.target);
+  }
 
 };
 goog.inherits(ol.control.Control, ol.Object);
@@ -120,4 +123,18 @@ ol.control.Control.prototype.setMap = function(map) {
     }
     map.render();
   }
+};
+
+
+/**
+ * This function is used to set a target element for the control. It has no
+ * effect if it is called after the control has been added to the map (i.e.
+ * after `setMap` is called on the control). If no `target` is set in the
+ * options passed to the control constructor and if `setTarget` is not called
+ * then the control is added to the map's overlay container.
+ * @param {Element|string} target Target.
+ * @api
+ */
+ol.control.Control.prototype.setTarget = function(target) {
+  this.target_ = goog.dom.getElement(target);
 };


### PR DESCRIPTION
This commit adds a `setTarget` method to `ol.control.Control`. This function can be used in cases where the target cannot be set at control construction time.

For example, with Angular, it makes sense to create the control instance in an Angular controller, and have a "control" directive insert the control into the DOM.