### PR TITLE
Wmts getFeatureInfo with REST functionality

### DIFF
--- a/examples/wmtsgetfeatureinfo-rest.html
+++ b/examples/wmtsgetfeatureinfo-rest.html
@@ -1,0 +1,21 @@
+---
+template: example.html
+title: WMTS GetFeatureInfo REST example
+shortdesc: This example shows how to trigger WMTS GetFeatureInfo requests on click for a WMTS image layer with a REST endpoint.
+docs: >
+  This example shows how to trigger WMTS GetFeatureInfo requests on click for a WMTS image layer with a REST endpoint. The [WMTS GetFeatureInfo example](wmtsgetfeatureinfo.html) shows how to create GetFeatureInfo requests using a KVP endpoint.
+tags: "wmts, getfeatureinfo"
+---
+<div class="row-fluid">
+  <div class="span12">
+    <div id="map" class="map"></div>
+  </div>
+</div>
+
+<div class="row-fluid">
+  <div class="span12">
+    <div id="info" class="alert alert-success">
+      &nbsp;
+    </div>
+  </div>
+</div>

--- a/examples/wmtsgetfeatureinfo-rest.js
+++ b/examples/wmtsgetfeatureinfo-rest.js
@@ -1,16 +1,11 @@
 goog.require('ol.Attribution');
 goog.require('ol.Map');
 goog.require('ol.View');
-goog.require('ol.extent');
 goog.require('ol.layer.Tile');
 goog.require('ol.proj');
 goog.require('ol.source.OSM');
 goog.require('ol.source.WMTS');
 goog.require('ol.tilegrid.WMTS');
-
-var projection = ol.proj.get('EPSG:3857');
-var projectionExtent = projection.getExtent();
-var size = ol.extent.getWidth(projectionExtent) / 256;
 
 var attribution = new ol.Attribution({
   html: 'Tiles &copy; <a href="https://labs.koordinates.com/">Koordinates</a>'
@@ -18,19 +13,23 @@ var attribution = new ol.Attribution({
 
 var wmtsSource = new ol.source.WMTS({
   attributions: [attribution],
-  extent: projectionExtent,
   layer: 'layer-7328',
   matrixSet: 'EPSG:3857',
   format: 'image/png',
-  projection: projection,
-  requestEncoding: 'REST',
+  projection: 'EPSG:3857',
   style: 'style=39',
+  requestEncoding: 'REST',
   getFeatureInfoOptions: {
     url: 'https://labs.koordinates.com/services;' +
-        'key=d740ea02e0c44cafb70dce31a774ca10/wmts/',
-    requestEncoding: 'KVP',
+        'key=d740ea02e0c44cafb70dce31a774ca10/wmts/1.0.0/layer/7328/' +
+        'featureinfo/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}/' +
+        '{I}/{J}.json',
+    requestEncoding: 'REST',
     infoFormat: 'application/json'
   },
+  url: 'https://koordinates-tiles-a.global.ssl.fastly.net/' +
+      'services;key=d740ea02e0c44cafb70dce31a774ca10/tiles/v4/layer=7328,' +
+      '{style}/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png',
   tileGrid: new ol.tilegrid.WMTS({
     origin: [-20037508.3428, 20037508.3428],
     resolutions: [
@@ -58,10 +57,7 @@ var wmtsSource = new ol.source.WMTS({
     matrixIds: [
       0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19
     ]
-  }),
-  url: 'https://koordinates-tiles-a.global.ssl.fastly.net/services;' +
-      'key=d740ea02e0c44cafb70dce31a774ca10/tiles/v4/layer=7328,{style}/' +
-      '{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png'
+  })
 });
 
 
@@ -97,6 +93,6 @@ map.on('singleclick', function(evt) {
       evt.coordinate, viewResolution, viewProjection);
   if (url) {
     document.getElementById('info').innerHTML =
-        '<iframe seamless src="' + url + '"></iframe>';
+        '<iframe seamless frameBorder="0" src="' + url + '"></iframe>';
   }
 });

--- a/examples/wmtsgetfeatureinfo.html
+++ b/examples/wmtsgetfeatureinfo.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <link rel="stylesheet" href="../css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap.min.css" type="text/css">
+    <link rel="stylesheet" href="../resources/layout.css" type="text/css">
+    <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap-responsive.min.css" type="text/css">
+    <title>WMTS Get feature info example</title>
+  </head>
+  <body>
+
+    <div class="navbar navbar-inverse navbar-fixed-top">
+      <div class="navbar-inner">
+        <div class="container">
+          <a class="brand" href="./"><img src="../resources/logo.png"> OpenLayers 3 Examples</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="container-fluid">
+
+      <div class="row-fluid">
+        <div class="span12">
+          <div id="map" class="map"></div>
+        </div>
+      </div>
+
+      <div class="row-fluid">
+
+        <div class="span4">
+          <h4 id="title">WMTS GetFeatureInfo example</h4>
+          <p id="shortdesc">This example shows how to trigger WMTS GetFeatureInfo requests on click for a WMTS image layer.</p>
+          <div id="docs">
+            <p>See the <a href="getfeatureinfo.js" target="_blank">wmtsgetfeatureinfo.js source</a> to see how this is done.</p>
+          </div>
+          <div id="tags">getfeatureinfo</div>
+        </div>
+        <div class="span4 offset4">
+          <div id="info" class="alert alert-success">
+            &nbsp;
+          </div>
+        </div>
+
+      </div>
+
+    </div>
+
+    <script src="jquery.min.js" type="text/javascript"></script>
+    <script src="../resources/example-behaviour.js" type="text/javascript"></script>
+    <script src="loader.js?id=wmtsgetfeatureinfo" type="text/javascript"></script>
+
+  </body>
+</html>

--- a/examples/wmtsgetfeatureinfo.html
+++ b/examples/wmtsgetfeatureinfo.html
@@ -1,57 +1,23 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
-    <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
-    <link rel="stylesheet" href="../css/ol.css" type="text/css">
-    <link rel="stylesheet" href="../css/ol.css" type="text/css">
-    <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap.min.css" type="text/css">
-    <link rel="stylesheet" href="../resources/layout.css" type="text/css">
-    <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap-responsive.min.css" type="text/css">
-    <title>WMTS Get feature info example</title>
-  </head>
-  <body>
+---
+template: example.html
+title: WMTS GetFeatureInfo example
+shortdesc: This example shows how to trigger WMTS GetFeatureInfo requests on click for a WMTS image layer.
+docs: >
+  This example shows how to trigger WMTS GetFeatureInfo requests on click for a WMTS image layer with a KVP endpoint. The [WMTS GetFeatureInfo REST example](wmtsgetfeatureinfo-rest.html) shows how to create GetFeatureInfo requests using a REST endpoint.
+tags: "wmts, getfeatureinfo"
+---
+<div class="row-fluid">
+  <div class="span12">
+    <div id="map" class="map"></div>
+  </div>
+</div>
 
-    <div class="navbar navbar-inverse navbar-fixed-top">
-      <div class="navbar-inner">
-        <div class="container">
-          <a class="brand" href="./"><img src="../resources/logo.png"> OpenLayers 3 Examples</a>
-        </div>
-      </div>
+<div class="row-fluid">
+  <div class="span12">
+    <div id="info" class="alert alert-success">
+      &nbsp;
     </div>
+  </div>
+</div>
 
-    <div class="container-fluid">
 
-      <div class="row-fluid">
-        <div class="span12">
-          <div id="map" class="map"></div>
-        </div>
-      </div>
-
-      <div class="row-fluid">
-
-        <div class="span4">
-          <h4 id="title">WMTS GetFeatureInfo example</h4>
-          <p id="shortdesc">This example shows how to trigger WMTS GetFeatureInfo requests on click for a WMTS image layer.</p>
-          <div id="docs">
-            <p>See the <a href="getfeatureinfo.js" target="_blank">wmtsgetfeatureinfo.js source</a> to see how this is done.</p>
-          </div>
-          <div id="tags">getfeatureinfo</div>
-        </div>
-        <div class="span4 offset4">
-          <div id="info" class="alert alert-success">
-            &nbsp;
-          </div>
-        </div>
-
-      </div>
-
-    </div>
-
-    <script src="jquery.min.js" type="text/javascript"></script>
-    <script src="../resources/example-behaviour.js" type="text/javascript"></script>
-    <script src="loader.js?id=wmtsgetfeatureinfo" type="text/javascript"></script>
-
-  </body>
-</html>

--- a/examples/wmtsgetfeatureinfo.js
+++ b/examples/wmtsgetfeatureinfo.js
@@ -1,0 +1,72 @@
+goog.require('ol.Attribution');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.extent');
+goog.require('ol.layer.Tile');
+goog.require('ol.proj');
+goog.require('ol.source.WMTS');
+goog.require('ol.tilegrid.WMTS');
+
+var projection = ol.proj.get('EPSG:900913');
+var projectionExtent = projection.getExtent();
+var size = ol.extent.getWidth(projectionExtent) / 256;
+var resolutions = new Array(14);
+var matrixIds = new Array(14);
+for (var z = 0; z < 14; ++z) {
+  // generate resolutions and matrixIds arrays for this WMTS
+  resolutions[z] = size / Math.pow(2, z);
+  matrixIds[z] = 'EPSG:900913:' + z;
+}
+
+var attribution = new ol.Attribution({
+  html: 'Tiles &copy; <a href="http://maps.opengeo.org/geowebcache/' +
+      'service/wmts">opengeo</a>'
+});
+
+var wmtsSource = new ol.source.WMTS({
+  attributions: [attribution],
+  extent: projectionExtent,
+  layer: 'graphite',
+  matrixSet: 'EPSG:900913',
+  format: 'image/png',
+  projection: projection,
+  style: '_null',
+  tileGrid: new ol.tilegrid.WMTS({
+    origin: ol.extent.getTopLeft(projectionExtent),
+    resolutions: resolutions,
+    matrixIds: matrixIds
+  }),
+  url: 'http://maps.opengeo.org/geowebcache/service/wmts'
+});
+
+
+var wmtsLayer = new ol.layer.Tile({
+  source: wmtsSource
+});
+
+
+var view = new ol.View({
+  center: [0, 0],
+  zoom: 2
+});
+
+var viewProjection = /** @type {ol.proj.Projection} */
+    (view.getProjection());
+
+var map = new ol.Map({
+  layers: [wmtsLayer],
+  target: 'map',
+  view: view
+});
+
+map.on('singleclick', function(evt) {
+  document.getElementById('info').innerHTML = '';
+  var viewResolution = /** @type {number} */ (view.getResolution());
+  var url = wmtsSource.getGetFeatureInfoUrl(
+      evt.coordinate, viewResolution, viewProjection,
+      {'INFOFORMAT': 'text/html'});
+  if (url) {
+    document.getElementById('info').innerHTML =
+        '<iframe seamless src="' + url + '"></iframe>';
+  }
+});

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -5041,6 +5041,42 @@ olx.source.VectorOptions.prototype.wrapX;
 
 
 /**
+ * Options for the WMTS GetFeatureInfo URL
+ * @typedef {{url: (string|undefined),
+ *     requestEncoding: (ol.source.WMTSRequestEncoding|string|undefined),
+ *     infoFormat: (string|undefined)}}
+ * @api
+ */
+olx.source.WMTSGetFeatureInfoOptions;
+
+
+/**
+ * A URL for the GetFeatureInfo service.  For the RESTful request encoding, this is a URL
+ * template.  For KVP encoding, it is normal URL. Default is the WMTS source url
+ * @type {string|undefined}
+ * @api
+ */
+olx.source.WMTSGetFeatureInfoOptions.prototype.url;
+
+
+/**
+ * Request encoding. Default is `KVP`.
+ * @type {ol.source.WMTSRequestEncoding|string|undefined}
+ * @api
+ */
+olx.source.WMTSGetFeatureInfoOptions.prototype.requestEncoding;
+
+
+/**
+ * The format to retrieve the information from the GetFeatureInfo service in. This can 
+ * also be specified in the getGetFeatureInfoUrl call
+ * @type {string|undefined}
+ * @api
+ */
+olx.source.WMTSGetFeatureInfoOptions.prototype.infoFormat;
+
+
+/**
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
  *     crossOrigin: (string|null|undefined),
  *     logo: (string|olx.LogoOptions|undefined),
@@ -5061,7 +5097,8 @@ olx.source.VectorOptions.prototype.wrapX;
  *     tileClass: (function(new: ol.ImageTile, ol.TileCoord,
  *                          ol.TileState, string, ?string,
  *                          ol.TileLoadFunctionType)|undefined),
- *     wrapX: (boolean|undefined)}}
+ *     wrapX: (boolean|undefined),
+ *     getFeatureInfoOptions: (olx.source.WMTSGetFeatureInfoOptions|undefined)}}
  * @api
  */
 olx.source.WMTSOptions;
@@ -5229,6 +5266,12 @@ olx.source.WMTSOptions.prototype.urls;
  */
 olx.source.WMTSOptions.prototype.wrapX;
 
+/**
+ * Options for the WMTS GetFeatureInfo URL
+ * @type {olx.source.WMTSGetFeatureInfoOptions|undefined}
+ * @api
+ */
+olx.source.WMTSOptions.prototype.getFeatureInfoOptions;
 
 /**
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),

--- a/test/spec/ol/source/wmtssource.test.js
+++ b/test/spec/ol/source/wmtssource.test.js
@@ -76,6 +76,46 @@ describe('ol.source.WMTS', function() {
           expect(options.dimensions).to.eql({});
 
         });
+
+    it('can create getFeatureInfoOptions from ' +
+        'spec/ol/format/wmts/ogcsample.xml', function() {
+          var options;
+          options = ol.source.WMTS.optionsFromCapabilities(
+              capabilities,
+              { layer: 'BlueMarbleNextGeneration', matrixSet: 'google3857' });
+
+          expect(options.urls).to.be.an('array');
+          expect(options.urls).to.have.length(1);
+          expect(options.urls[0]).to.be.eql(
+              'http://www.maps.bob/cgi-bin/MiraMon5_0.cgi?');
+
+          expect(options.layer).to.be.eql('BlueMarbleNextGeneration');
+
+          expect(options.matrixSet).to.be.eql('google3857');
+
+          expect(options.format).to.be.eql('image/jpeg');
+
+          expect(options.projection).to.be.a(ol.proj.Projection);
+          expect(options.projection).to.be.eql(ol.proj.get('EPSG:3857'));
+
+          expect(options.requestEncoding).to.be.eql('KVP');
+
+          expect(options.getFeatureInfoOptions).to.be.an('object');
+          expect(options.getFeatureInfoOptions.url).to.be.eql(
+              'http://www.example.com/wmts/coastlines/{TileMatrixSet}/' +
+              '{TileMatrix}/{TileRow}/{TileCol}/{J}/{I}.xml');
+          expect(options.getFeatureInfoOptions.requestEncoding).to.be.eql(
+              'REST');
+          expect(options.getFeatureInfoOptions.infoFormat).to.be.eql(
+              'application/gml+xml; version=3.1');
+
+          expect(options.tileGrid).to.be.a(ol.tilegrid.WMTS);
+
+          expect(options.style).to.be.eql('DarkBlue');
+
+          expect(options.dimensions).to.eql({});
+
+        });
   });
 
   describe('when creating tileUrlFunction', function() {
@@ -233,6 +273,142 @@ describe('ol.source.WMTS', function() {
       expect(requestEncoding).to.be.eql('REST');
     });
 
+  });
+
+  describe('when retrieving GetFeatureInfo url', function() {
+    it('can get url without defining getFeatureInfoOptions',
+        function() {
+          var source = new ol.source.WMTS({
+            layer: 'layer',
+            style: 'default',
+            urls: ['http://www.example.com/wmts/coastlines'],
+            matrixSet: 'EPSG:3857',
+            tileGrid: new ol.tilegrid.WMTS({
+              origin: [-20037508.342789244, 20037508.342789244],
+              resolutions: [559082264.029 * 0.28E-3,
+                279541132.015 * 0.28E-3,
+                139770566.007 * 0.28E-3],
+              matrixIds: [0, 1, 2]
+            })
+          });
+
+          var url = source.getGetFeatureInfoUrl([1, -2], 78271.516,
+             ol.proj.get('EPSG:3857'), 'text/html');
+          expect(url).to.be.eql('http://www.example.com/wmts/coastlines' +
+             '?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetFeatureInfo&LAYER=layer' +
+             '&STYLE=default&FORMAT=image%2Fjpeg&TileCol=1&TileRow=1' +
+             '&TileMatrix=1&TileMatrixSet=EPSG%3A3857&' +
+             'INFOFORMAT=text%2Fhtml&I=0&J=0');
+        });
+
+    it('can get url without defining request encoding in getFeatureInfoOptions',
+        function() {
+          var source = new ol.source.WMTS({
+            layer: 'layer',
+            style: 'default',
+            urls: ['http://www.example.com/wmts/coastlines'],
+            matrixSet: 'EPSG:3857',
+            getFeatureInfoOptions: {
+              url: 'http://www.example.com/wmts/coastlines/featureinfo/',
+              infoFormat: 'text/html'
+            },
+            tileGrid: new ol.tilegrid.WMTS({
+              origin: [-20037508.342789244, 20037508.342789244],
+              resolutions: [559082264.029 * 0.28E-3,
+                279541132.015 * 0.28E-3,
+                139770566.007 * 0.28E-3],
+              matrixIds: [0, 1, 2]
+            })
+          });
+
+          var url = source.getGetFeatureInfoUrl([1, -2], 78271.516,
+             ol.proj.get('EPSG:3857'));
+          expect(url).to.be.eql('http://www.example.com/wmts/coastlines/' +
+             'featureinfo/?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetFeatureInfo' +
+             '&LAYER=layer&STYLE=default&FORMAT=image%2Fjpeg&TileCol=1' +
+             '&TileRow=1&TileMatrix=1&TileMatrixSet=EPSG%3A3857' +
+             '&INFOFORMAT=text%2Fhtml&I=0&J=0');
+        });
+
+    it('can get KVP url from getFeatureInfoOptions',
+        function() {
+          var source = new ol.source.WMTS({
+            layer: 'layer',
+            style: 'default',
+            urls: ['http://www.example.com/wmts/coastlines'],
+            matrixSet: 'EPSG:3857',
+            getFeatureInfoOptions: {
+              url: 'http://www.example.com/wmts/coastlines/featureinfo/',
+              requestEncoding: 'KVP',
+              infoFormat: 'text/html'
+            },
+            tileGrid: new ol.tilegrid.WMTS({
+              origin: [-20037508.342789244, 20037508.342789244],
+              resolutions: [559082264.029 * 0.28E-3,
+                279541132.015 * 0.28E-3,
+                139770566.007 * 0.28E-3],
+              matrixIds: [0, 1, 2]
+            })
+          });
+
+          var url = source.getGetFeatureInfoUrl([1, -2], 78271.516,
+             ol.proj.get('EPSG:3857'));
+          expect(url).to.be.eql('http://www.example.com/wmts/coastlines/' +
+             'featureinfo/?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetFeatureInfo' +
+             '&LAYER=layer&STYLE=default&FORMAT=image%2Fjpeg&TileCol=1' +
+             '&TileRow=1&TileMatrix=1&TileMatrixSet=EPSG%3A3857' +
+             '&INFOFORMAT=text%2Fhtml&I=0&J=0');
+        });
+
+    it('can get REST url from getFeatureInfoOptions',
+        function() {
+          var source = new ol.source.WMTS({
+            layer: 'layer',
+            style: 'default',
+            urls: ['http://www.example.com/wmts/coastlines'],
+            matrixSet: 'EPSG:3857',
+            getFeatureInfoOptions: {
+              url: 'http://www.example.com/wmts/coastlines/featureinfo/' +
+                 '{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}/{I}/{J}.html',
+              requestEncoding: 'REST',
+              infoFormat: 'text/html'
+            },
+            tileGrid: new ol.tilegrid.WMTS({
+              origin: [-20037508.342789244, 20037508.342789244],
+              resolutions: [559082264.029 * 0.28E-3,
+                279541132.015 * 0.28E-3,
+                139770566.007 * 0.28E-3],
+              matrixIds: [0, 1, 2]
+            })
+          });
+
+          var url = source.getGetFeatureInfoUrl([1, -2], 78271.516,
+             ol.proj.get('EPSG:3857'));
+          expect(url).to.be.eql('http://www.example.com/wmts/coastlines/' +
+              'featureinfo/EPSG:3857/1/1/1/0/0.html');
+        });
+
+    it('throws an exception when infoFormat is not defined',
+        function() {
+          var source = new ol.source.WMTS({
+            layer: 'layer',
+            style: 'default',
+            urls: ['http://www.example.com/wmts/coastlines'],
+            matrixSet: 'EPSG:3857',
+            tileGrid: new ol.tilegrid.WMTS({
+              origin: [-20037508.342789244, 20037508.342789244],
+              resolutions: [559082264.029 * 0.28E-3,
+                279541132.015 * 0.28E-3,
+                139770566.007 * 0.28E-3],
+              matrixIds: [0, 1, 2]
+            })
+          });
+
+          expect(function() {
+            source.getGetFeatureInfoUrl([1, -2], 78271.516,
+               ol.proj.get('EPSG:3857'));
+          }).to.throwException();
+        });
   });
 
 });


### PR DESCRIPTION
This is based on #3142, it builds on #3026 and #2373 which address issues #2721 and #2368 and adds functionality to allow for REST encoded WMTS getFeatureInfo requests and creating these from the capabilities document. 

It adds a getFeatureInfoOptions object to the WMTS source constructor which allows the preferred request encoding, info format and url to be set.     