### PR TITLE
Update closure-library and closure-util version

### DIFF
--- a/closure-util.json
+++ b/closure-util.json
@@ -1,3 +1,3 @@
 {
-  "library_url": "https://github.com/google/closure-library/archive/ad5e66c1e7d7829b0d77feae49aaf5f011265715.zip"
+  "library_url": "https://github.com/google/closure-library/archive/0011afd534469ba111786fe68300a634e08a4d80.zip"
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "async": "0.9.0",
-    "closure-util": "1.2.0",
+    "closure-util": "1.3.0",
     "fs-extra": "0.12.0",
     "graceful-fs": "3.0.2",
     "htmlparser2": "3.7.3",


### PR DESCRIPTION
Build size is reduced by ~ 2 kb (uncompressed)

master:
```
2015-01-19 16:02:43,887 build/ol.js: node tasks/build.js config/ol.json build/ol.js
info ol Parsing dependencies
info ol Compiling 362 sources
2015-01-19 16:03:22,263 build/ol.js: uncompressed:   450150 bytes
2015-01-19 16:03:22,264 build/ol.js:   compressed:   132346 bytes, (saved 70.60%)
```

this branch:
```
2015-01-19 16:04:20,723 build/ol.js: node tasks/build.js config/ol.json build/ol.js
info ol Parsing dependencies
info ol Compiling 362 sources
2015-01-19 16:04:38,965 build/ol.js: uncompressed:   448031 bytes
2015-01-19 16:04:38,965 build/ol.js:   compressed:   131608 bytes, (saved 70.63%)
```


