### PR TITLE
Add missing GeoJSONFeature#bbox property

### DIFF
--- a/externs/geojson.js
+++ b/externs/geojson.js
@@ -111,6 +111,12 @@ var GeoJSONFeature = function() {};
 
 
 /**
+ * @type {!Array.<number>|undefined}
+ */
+GeoJSONFeature.prototype.bbox;
+
+
+/**
  * @type {GeoJSONGeometry}
  */
 GeoJSONFeature.prototype.geometry;


### PR DESCRIPTION
See http://geojson.org/geojson-spec.html#bounding-boxes

This property is not (yet) used by `ol.format.GeoJSON`