### PR TITLE
Move readProjectionFrom* functions to the base classes

### DIFF
--- a/src/ol/format/gpxformat.js
+++ b/src/ol/format/gpxformat.js
@@ -502,22 +502,6 @@ ol.format.GPX.prototype.readProjection;
 
 
 /**
- * @inheritDoc
- */
-ol.format.GPX.prototype.readProjectionFromDocument = function(doc) {
-  return this.defaultDataProjection;
-};
-
-
-/**
- * @inheritDoc
- */
-ol.format.GPX.prototype.readProjectionFromNode = function(node) {
-  return this.defaultDataProjection;
-};
-
-
-/**
  * @param {Node} node Node.
  * @param {string} value Value for the link's `href` attribute.
  * @param {Array.<*>} objectStack Node stack.

--- a/src/ol/format/igcformat.js
+++ b/src/ol/format/igcformat.js
@@ -218,11 +218,3 @@ ol.format.IGC.prototype.readFeaturesFromText = function(text, opt_options) {
  * @api
  */
 ol.format.IGC.prototype.readProjection;
-
-
-/**
- * @inheritDoc
- */
-ol.format.IGC.prototype.readProjectionFromText = function(text) {
-  return this.defaultDataProjection;
-};

--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -1722,22 +1722,6 @@ ol.format.KML.prototype.readProjection;
 
 
 /**
- * @inheritDoc
- */
-ol.format.KML.prototype.readProjectionFromDocument = function(doc) {
-  return this.defaultDataProjection;
-};
-
-
-/**
- * @inheritDoc
- */
-ol.format.KML.prototype.readProjectionFromNode = function(node) {
-  return this.defaultDataProjection;
-};
-
-
-/**
  * @param {Node} node Node to append a TextNode with the color to.
  * @param {ol.Color|string} color Color.
  * @private

--- a/src/ol/format/osmxmlformat.js
+++ b/src/ol/format/osmxmlformat.js
@@ -234,19 +234,3 @@ ol.format.OSMXML.prototype.readFeaturesFromNode = function(node, opt_options) {
  * @api stable
  */
 ol.format.OSMXML.prototype.readProjection;
-
-
-/**
- * @inheritDoc
- */
-ol.format.OSMXML.prototype.readProjectionFromDocument = function(doc) {
-  return this.defaultDataProjection;
-};
-
-
-/**
- * @inheritDoc
- */
-ol.format.OSMXML.prototype.readProjectionFromNode = function(node) {
-  return this.defaultDataProjection;
-};

--- a/src/ol/format/polylineformat.js
+++ b/src/ol/format/polylineformat.js
@@ -343,14 +343,6 @@ ol.format.Polyline.prototype.readProjection;
 /**
  * @inheritDoc
  */
-ol.format.Polyline.prototype.readProjectionFromText = function(text) {
-  return this.defaultDataProjection;
-};
-
-
-/**
- * @inheritDoc
- */
 ol.format.Polyline.prototype.writeFeatureText = function(feature, opt_options) {
   var geometry = feature.getGeometry();
   if (goog.isDefAndNotNull(geometry)) {

--- a/src/ol/format/textfeatureformat.js
+++ b/src/ol/format/textfeatureformat.js
@@ -111,7 +111,9 @@ ol.format.TextFeature.prototype.readProjection = function(source) {
  * @protected
  * @return {ol.proj.Projection} Projection.
  */
-ol.format.TextFeature.prototype.readProjectionFromText = goog.abstractMethod;
+ol.format.TextFeature.prototype.readProjectionFromText = function(text) {
+  return this.defaultDataProjection;
+};
 
 
 /**

--- a/src/ol/format/wktformat.js
+++ b/src/ol/format/wktformat.js
@@ -292,14 +292,6 @@ ol.format.WKT.prototype.readGeometryFromText = function(text, opt_options) {
 
 
 /**
- * @inheritDoc
- */
-ol.format.WKT.prototype.readProjectionFromText = function(text) {
-  return null;
-};
-
-
-/**
  * Encode a feature as a WKT string.
  *
  * @function

--- a/src/ol/format/xmlfeatureformat.js
+++ b/src/ol/format/xmlfeatureformat.js
@@ -185,7 +185,9 @@ ol.format.XMLFeature.prototype.readProjection = function(source) {
  * @protected
  * @return {ol.proj.Projection} Projection.
  */
-ol.format.XMLFeature.prototype.readProjectionFromDocument = goog.abstractMethod;
+ol.format.XMLFeature.prototype.readProjectionFromDocument = function(doc) {
+  return this.defaultDataProjection;
+};
 
 
 /**
@@ -193,7 +195,9 @@ ol.format.XMLFeature.prototype.readProjectionFromDocument = goog.abstractMethod;
  * @protected
  * @return {ol.proj.Projection} Projection.
  */
-ol.format.XMLFeature.prototype.readProjectionFromNode = goog.abstractMethod;
+ol.format.XMLFeature.prototype.readProjectionFromNode = function(node) {
+  return this.defaultDataProjection;
+};
 
 
 /**

--- a/test/spec/ol/format/gpxformat.test.js
+++ b/test/spec/ol/format/gpxformat.test.js
@@ -7,6 +7,18 @@ describe('ol.format.GPX', function() {
     format = new ol.format.GPX();
   });
 
+  describe('#readProjection', function() {
+    it('returns the default projection from document', function() {
+      var projection = format.readProjectionFromDocument();
+      expect(projection).to.eql(ol.proj.get('EPSG:4326'));
+    });
+
+    it('returns the default projection from node', function() {
+      var projection = format.readProjectionFromNode();
+      expect(projection).to.eql(ol.proj.get('EPSG:4326'));
+    });
+  });
+
   describe('readFeatures', function() {
 
     describe('rte', function() {

--- a/test/spec/ol/format/igcformat.test.js
+++ b/test/spec/ol/format/igcformat.test.js
@@ -29,6 +29,13 @@ describe('ol.format.IGC', function() {
     format = new ol.format.IGC();
   });
 
+  describe('#readProjectionFromText', function() {
+    it('returns the default projection', function() {
+      var projection = format.readProjectionFromText(igc);
+      expect(projection).to.eql(ol.proj.get('EPSG:4326'));
+    });
+  });
+
   describe('#readFeature', function() {
     it('does not read invalid features', function() {
       expect(format.readFeature('invalid')).to.be(null);

--- a/test/spec/ol/format/kmlformat.test.js
+++ b/test/spec/ol/format/kmlformat.test.js
@@ -8,6 +8,18 @@ describe('ol.format.KML', function() {
     format = new ol.format.KML();
   });
 
+  describe('#readProjection', function() {
+    it('returns the default projection from document', function() {
+      var projection = format.readProjectionFromDocument();
+      expect(projection).to.eql(ol.proj.get('EPSG:4326'));
+    });
+
+    it('returns the default projection from node', function() {
+      var projection = format.readProjectionFromNode();
+      expect(projection).to.eql(ol.proj.get('EPSG:4326'));
+    });
+  });
+
   describe('#readFeatures', function() {
 
     describe('id', function() {

--- a/test/spec/ol/format/osmxmlformat.test.js
+++ b/test/spec/ol/format/osmxmlformat.test.js
@@ -8,6 +8,18 @@ describe('ol.format.OSMXML', function() {
     format = new ol.format.OSMXML();
   });
 
+  describe('#readProjection', function() {
+    it('returns the default projection from document', function() {
+      var projection = format.readProjectionFromDocument();
+      expect(projection).to.eql(ol.proj.get('EPSG:4326'));
+    });
+
+    it('returns the default projection from node', function() {
+      var projection = format.readProjectionFromNode();
+      expect(projection).to.eql(ol.proj.get('EPSG:4326'));
+    });
+  });
+
   describe('#readFeatures', function() {
 
     it('can read an empty document', function() {

--- a/test/spec/ol/format/polylineformat.test.js
+++ b/test/spec/ol/format/polylineformat.test.js
@@ -40,6 +40,12 @@ describe('ol.format.Polyline', function() {
   // Reset testing data
   beforeEach(resetTestingData);
 
+  describe('#readProjectionFromText', function() {
+    it('returns the default projection', function() {
+      var projection = format.readProjectionFromText(encodedFlatPoints);
+      expect(projection).to.eql(ol.proj.get('EPSG:4326'));
+    });
+  });
 
   describe('encodeDeltas', function() {
     it('returns expected value', function() {

--- a/test/spec/ol/format/wktformat.test.js
+++ b/test/spec/ol/format/wktformat.test.js
@@ -4,6 +4,13 @@ describe('ol.format.WKT', function() {
 
   var format = new ol.format.WKT();
 
+  describe('#readProjectionFromText', function() {
+    it('returns the default projection', function() {
+      var projection = format.readProjectionFromText('POINT(1 2)');
+      expect(projection).to.be(null);
+    });
+  });
+
   describe('#readGeometry()', function() {
 
     it('transforms with dataProjection and featureProjection', function() {


### PR DESCRIPTION
Simplify the code by moving identical functions to the base classes (`ol.format.TextFeature` and `ol.format.XMLFeature`)