### PR TITLE
Add a getMap function to ol.FeatureOverlay

### DIFF
--- a/src/ol/featureoverlay.js
+++ b/src/ol/featureoverlay.js
@@ -113,6 +113,15 @@ ol.FeatureOverlay.prototype.getFeatures = function() {
 
 
 /**
+ * @return {?ol.Map} The map with which this feature overlay is associated.
+ * @api
+ */
+ol.FeatureOverlay.prototype.getMap = function() {
+  return this.map_;
+};
+
+
+/**
  * @private
  */
 ol.FeatureOverlay.prototype.handleFeatureChange_ = function() {

--- a/test/spec/ol/featureoverlay.test.js
+++ b/test/spec/ol/featureoverlay.test.js
@@ -25,10 +25,18 @@ describe('ol.FeatureOverlay', function() {
       expect(featureOverlay.getStyleFunction()()).to.eql(style);
     });
 
+    it('takes a map', function() {
+      var map = new ol.Map({});
+      var featureOverlay = new ol.FeatureOverlay({
+        map: map
+      });
+      expect(featureOverlay.getMap()).to.eql(map);
+    });
   });
 });
 
 goog.require('ol.Feature');
 goog.require('ol.FeatureOverlay');
+goog.require('ol.Map');
 goog.require('ol.geom.Point');
 goog.require('ol.style.Style');


### PR DESCRIPTION
Currently there is no way to get to the map from a feature overlay. There is a getter for style and features though.