### PR TITLE
Do not include query string in example link

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -159,9 +159,6 @@
       }
 
       window.onload = function() {
-        for (var i = 0; i < info.examples.length; ++i) {
-          info.examples[i].link += window.location.search;
-        }
         // document.getElementById('keywords').focus();
         template = new jugl.Template("template");
         target = document.getElementById("examples");


### PR DESCRIPTION
Possible fix to #3184
Other fix: #3183 
When a user perform a search and hit 'Enter', the term is append as a query param to the URL. This query param is then passed to whatever example is opened. The example page does not need this param but more importantly, it causes issues with the development/production select switcher that no longer works.