### PR TITLE
Allow other params than 'mode' in example page query string.

### DIFF
--- a/resources/example-behaviour.js
+++ b/resources/example-behaviour.js
@@ -29,11 +29,13 @@
         pairs = [],
         i,
         pair,
-        adjusted;
+        adjusted,
+        modeFound = false;
     for (i = chunks.length - 1; i >= 0; --i) {
       pair = chunks[i].split('=');
       if (pair[0].toLowerCase() === 'mode') {
         pair[1] = newMode;
+        modeFound = true;
       }
       adjusted = encodeURIComponent(pair[0]);
       if (typeof pair[1] !== undefined) {
@@ -41,8 +43,8 @@
       }
       pairs.push(adjusted);
     }
-    if (pairs.length === 0) {
-      pairs[0] = 'mode=' + encodeURIComponent(newMode);
+    if (!modeFound) {
+      pairs.push('mode=' + encodeURIComponent(newMode));
     }
     location.href = baseUrl + '?' + pairs.join('&');
   };


### PR DESCRIPTION
Possible fix to #3184
Other fix: #3182 
Currently, if other params are present at the beginning of the query string of an example page, the mode switcher will not work.

This situation can occur when a search criteria was entered in the examples
index page. That criteria will be passed along to the example page via a query
param.

Eg: http://openlayers.org/en/v3.1.1/examples/simple.html?q=simpl