### PR TITLE
Introduce `dragging` flag for MapBrowserEvent

### DIFF
--- a/examples/drag-and-drop-image-vector.js
+++ b/examples/drag-and-drop-image-vector.js
@@ -145,7 +145,10 @@ var displayFeatureInfo = function(pixel) {
   }
 };
 
-$(map.getViewport()).on('mousemove', function(evt) {
+map.on('pointermove', function(evt) {
+  if (evt.dragging) {
+    return;
+  }
   var pixel = map.getEventPixel(evt.originalEvent);
   displayFeatureInfo(pixel);
 });

--- a/examples/drag-and-drop.js
+++ b/examples/drag-and-drop.js
@@ -141,7 +141,10 @@ var displayFeatureInfo = function(pixel) {
   }
 };
 
-$(map.getViewport()).on('mousemove', function(evt) {
+map.on('pointermove', function(evt) {
+  if (evt.dragging) {
+    return;
+  }
   var pixel = map.getEventPixel(evt.originalEvent);
   displayFeatureInfo(pixel);
 });

--- a/examples/gpx.js
+++ b/examples/gpx.js
@@ -85,7 +85,10 @@ var displayFeatureInfo = function(pixel) {
   }
 };
 
-$(map.getViewport()).on('mousemove', function(evt) {
+map.on('pointermove', function(evt) {
+  if (evt.dragging) {
+    return;
+  }
   var pixel = map.getEventPixel(evt.originalEvent);
   displayFeatureInfo(pixel);
 });

--- a/examples/icon-sprite-webgl.js
+++ b/examples/icon-sprite-webgl.js
@@ -132,7 +132,10 @@ map.on('click', function(evt) {
   }, 1);
 });
 
-$(map.getViewport()).on('mousemove', function(evt) {
+map.on('pointermove', function(evt) {
+  if (evt.dragging) {
+    return;
+  }
   var pixel = map.getEventPixel(evt.originalEvent);
   var hit = map.hasFeatureAtPixel(pixel);
   map.getTarget().style.cursor = hit ? 'pointer' : '';

--- a/examples/icon.js
+++ b/examples/icon.js
@@ -86,7 +86,11 @@ map.on('click', function(evt) {
 });
 
 // change mouse cursor when over marker
-$(map.getViewport()).on('mousemove', function(e) {
+map.on('pointermove', function(e) {
+  if (e.dragging) {
+    $(element).popover('destroy');
+    return;
+  }
   var pixel = map.getEventPixel(e.originalEvent);
   var hit = map.hasFeatureAtPixel(pixel);
   map.getTarget().style.cursor = hit ? 'pointer' : '';

--- a/examples/igc.js
+++ b/examples/igc.js
@@ -126,7 +126,10 @@ var displaySnap = function(coordinate) {
   map.render();
 };
 
-$(map.getViewport()).on('mousemove', function(evt) {
+map.on('pointermove', function(evt) {
+  if (evt.dragging) {
+    return;
+  }
   var coordinate = map.getEventCoordinate(evt.originalEvent);
   displaySnap(coordinate);
 });

--- a/examples/image-vector-layer.js
+++ b/examples/image-vector-layer.js
@@ -80,7 +80,10 @@ var displayFeatureInfo = function(pixel) {
 
 };
 
-$(map.getViewport()).on('mousemove', function(evt) {
+map.on('pointermove', function(evt) {
+  if (evt.dragging) {
+    return;
+  }
   var pixel = map.getEventPixel(evt.originalEvent);
   displayFeatureInfo(pixel);
 });

--- a/examples/kml-earthquakes.js
+++ b/examples/kml-earthquakes.js
@@ -85,7 +85,11 @@ var displayFeatureInfo = function(pixel) {
   }
 };
 
-$(map.getViewport()).on('mousemove', function(evt) {
+map.on('pointermove', function(evt) {
+  if (evt.dragging) {
+    info.tooltip('hide');
+    return;
+  }
   displayFeatureInfo(map.getEventPixel(evt.originalEvent));
 });
 

--- a/examples/kml-timezones.js
+++ b/examples/kml-timezones.js
@@ -92,7 +92,11 @@ var displayFeatureInfo = function(pixel) {
   }
 };
 
-$(map.getViewport()).on('mousemove', function(evt) {
+map.on('pointermove', function(evt) {
+  if (evt.dragging) {
+    info.tooltip('hide');
+    return;
+  }
   displayFeatureInfo(map.getEventPixel(evt.originalEvent));
 });
 

--- a/examples/kml.js
+++ b/examples/kml.js
@@ -52,7 +52,10 @@ var displayFeatureInfo = function(pixel) {
   }
 };
 
-$(map.getViewport()).on('mousemove', function(evt) {
+map.on('pointermove', function(evt) {
+  if (evt.dragging) {
+    return;
+  }
   var pixel = map.getEventPixel(evt.originalEvent);
   displayFeatureInfo(pixel);
 });

--- a/examples/measure.js
+++ b/examples/measure.js
@@ -57,7 +57,10 @@ var sketchElement;
  * handle pointer move
  * @param {Event} evt
  */
-var mouseMoveHandler = function(evt) {
+var pointerMoveHandler = function(evt) {
+  if (evt.dragging) {
+    return;
+  }
   if (sketch) {
     var output;
     var geom = (sketch.getGeometry());
@@ -81,7 +84,7 @@ var map = new ol.Map({
   })
 });
 
-$(map.getViewport()).on('mousemove', mouseMoveHandler);
+map.on('pointermove', pointerMoveHandler);
 
 var typeSelect = document.getElementById('type');
 

--- a/examples/synthetic-points.js
+++ b/examples/synthetic-points.js
@@ -83,7 +83,10 @@ var displaySnap = function(coordinate) {
   map.render();
 };
 
-$(map.getViewport()).on('mousemove', function(evt) {
+map.on('pointermove', function(evt) {
+  if (evt.dragging) {
+    return;
+  }
   var coordinate = map.getEventCoordinate(evt.originalEvent);
   displaySnap(coordinate);
 });
@@ -116,13 +119,12 @@ map.on('postcompose', function(evt) {
   }
 });
 
-$(map.getViewport()).on('mousemove', function(e) {
-  var pixel = map.getEventPixel(e.originalEvent);
-
-  var hit = map.forEachFeatureAtPixel(pixel, function(feature, layer) {
-    return true;
-  });
-
+map.on('pointermove', function(evt) {
+  if (evt.dragging) {
+    return;
+  }
+  var pixel = map.getEventPixel(evt.originalEvent);
+  var hit = map.hasFeatureAtPixel(pixel);
   if (hit) {
     map.getTarget().style.cursor = 'pointer';
   } else {

--- a/examples/tileutfgrid.js
+++ b/examples/tileutfgrid.js
@@ -58,7 +58,10 @@ var displayCountryInfo = function(coordinate) {
       });
 };
 
-$(map.getViewport()).on('mousemove', function(evt) {
+map.on('pointermove', function(evt) {
+  if (evt.dragging) {
+    return;
+  }
   var coordinate = map.getEventCoordinate(evt.originalEvent);
   displayCountryInfo(coordinate);
 });

--- a/examples/vector-layer.js
+++ b/examples/vector-layer.js
@@ -114,7 +114,10 @@ var displayFeatureInfo = function(pixel) {
 
 };
 
-$(map.getViewport()).on('mousemove', function(evt) {
+map.on('pointermove', function(evt) {
+  if (evt.dragging) {
+    return;
+  }
   var pixel = map.getEventPixel(evt.originalEvent);
   displayFeatureInfo(pixel);
 });

--- a/externs/oli.js
+++ b/externs/oli.js
@@ -92,6 +92,12 @@ oli.MapBrowserEvent.prototype.originalEvent;
 oli.MapBrowserEvent.prototype.pixel;
 
 
+/**
+ * @type {boolean}
+ */
+oli.MapBrowserEvent.prototype.dragging;
+
+
 
 /**
  * @interface

--- a/src/ol/mapbrowserevent.js
+++ b/src/ol/mapbrowserevent.js
@@ -64,6 +64,9 @@ ol.MapBrowserEvent = function(type, map, browserEvent, opt_dragging,
   this.coordinate = map.getCoordinateFromPixel(this.pixel);
 
   /**
+   * Indicates if the map is currently being dragged. Only set for
+   * `POINTERDRAG` and `POINTERMOVE` events. Default is `false`.
+   *
    * @type {boolean}
    * @api stable
    */
@@ -173,6 +176,8 @@ ol.MapBrowserEventHandler = function(map) {
   }
 
   /**
+   * The most recent "down" type event (or null if none have occurred).
+   * Set on pointerdown.
    * @type {ol.pointer.PointerEvent}
    * @private
    */
@@ -231,16 +236,6 @@ ol.MapBrowserEventHandler = function(map) {
 
 };
 goog.inherits(ol.MapBrowserEventHandler, goog.events.EventTarget);
-
-
-/**
- * Get the last "down" type event. This will be set on pointerdown.
- * @return {ol.pointer.PointerEvent} The most recent "down" type event (or null
- * if none have occurred).
- */
-ol.MapBrowserEventHandler.prototype.getDown = function() {
-  return this.down_;
-};
 
 
 /**

--- a/test/spec/ol/mapbrowserevent.test.js
+++ b/test/spec/ol/mapbrowserevent.test.js
@@ -96,22 +96,22 @@ describe('ol.MapBrowserEventHandler', function() {
 
   });
 
-  describe('#getDown()', function() {
+  describe('#down_', function() {
 
     var handler;
     beforeEach(function() {
       handler = new ol.MapBrowserEventHandler(new ol.Map({}));
     });
 
-    it('returns null if no "down" type event has been handled', function() {
-      expect(handler.getDown()).to.be(null);
+    it('is null if no "down" type event has been handled', function() {
+      expect(handler.down_).to.be(null);
     });
 
-    it('returns an event after handlePointerDown_ has been called', function() {
+    it('is an event after handlePointerDown_ has been called', function() {
       var event = new ol.pointer.PointerEvent('pointerdown',
           new goog.events.BrowserEvent({}));
       handler.handlePointerDown_(event);
-      expect(handler.getDown()).to.be(event);
+      expect(handler.down_).to.be(event);
     });
 
   });


### PR DESCRIPTION
So far, when listening to `mousemove`, there is no way to know if the map is currently being dragged. For example in the code below, `hasFeatureAtPixel` is always executed. Also when the map is being dragged, which slows down the performance.

```js
    $(map.getViewport()).on('mousemove', function(evt) {
      var pixel = map.getEventPixel(evt.originalEvent);
      var hit = map.hasFeatureAtPixel(pixel);
      map.getTarget().style.cursor = hit ? 'pointer' : '';
    });
```

This PR adds a flag `dragging` to `MapBrowserEvent`. With this, the above code can be changed to:

```js
    map.on('pointermove', function(evt) {
      if (evt.dragging) return;

      var pixel = map.getEventPixel(evt.originalEvent);
      var hit = map.hasFeatureAtPixel(pixel);
      map.getTarget().style.cursor = hit ? 'pointer' : '';
    });
```
