### PR TITLE
Add "url" option to ol.source.MapQuest

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -4301,7 +4301,8 @@ olx.source.KMLOptions.prototype.urls;
 
 /**
  * @typedef {{layer: string,
- *     tileLoadFunction: (ol.TileLoadFunctionType|undefined)}}
+ *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
+ *     url: (string|undefined)}}
  * @api
  */
 olx.source.MapQuestOptions;
@@ -4321,6 +4322,14 @@ olx.source.MapQuestOptions.prototype.layer;
  * @api
  */
 olx.source.MapQuestOptions.prototype.tileLoadFunction;
+
+
+/**
+ * URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
+ * @type {string|undefined}
+ * @api
+ */
+olx.source.MapQuestOptions.prototype.url;
 
 
 /**

--- a/src/ol/source/mapquestsource.js
+++ b/src/ol/source/mapquestsource.js
@@ -25,7 +25,8 @@ ol.source.MapQuest = function(opt_options) {
   var layerConfig = ol.source.MapQuestConfig[options.layer];
 
   var protocol = ol.IS_HTTPS ? 'https:' : 'http:';
-  var url = protocol + '//otile{1-4}-s.mqcdn.com/tiles/1.0.0/' +
+  var url = goog.isDef(options.url) ? options.url :
+      protocol + '//otile{1-4}-s.mqcdn.com/tiles/1.0.0/' +
       options.layer + '/{z}/{x}/{y}.jpg';
 
   goog.base(this, {


### PR DESCRIPTION
We already have that option for other tile sources like OSM and Stamen so it makes sense to have it for MapQuest as well.