### PR TITLE
Pass on opt_fast to parent clear function in ol.source.ServerVector

### DIFF
--- a/src/ol/source/servervectorsource.js
+++ b/src/ol/source/servervectorsource.js
@@ -82,11 +82,12 @@ ol.source.ServerVector.prototype.addFeaturesInternal = function(features) {
 
 /**
  * @inheritDoc
+ * @api stable
  */
-ol.source.ServerVector.prototype.clear = function() {
+ol.source.ServerVector.prototype.clear = function(opt_fast) {
   goog.object.clear(this.loadedFeatures_);
   this.loadedExtents_.clear();
-  goog.base(this, 'clear');
+  goog.base(this, 'clear', opt_fast);
 };
 
 


### PR DESCRIPTION
Currently the opt_fast argument is not available for ```ol.source.ServerVector``` but it should be since this class calls the parent method.