### PR TITLE
[wip] Export isEmpty and getTilesLoading functions from ol.TileQueue

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -6550,6 +6550,13 @@ olx.FrameState.prototype.pixelRatio;
 
 
 /**
+ * @type {ol.TileQueue}
+ * @api
+ */
+olx.FrameState.prototype.tileQueue;
+
+
+/**
  * @type {number}
  * @api
  */

--- a/src/ol/structs/priorityqueue.js
+++ b/src/ol/structs/priorityqueue.js
@@ -184,6 +184,7 @@ ol.structs.PriorityQueue.prototype.heapify_ = function() {
 
 /**
  * @return {boolean} Is empty.
+ * @api
  */
 ol.structs.PriorityQueue.prototype.isEmpty = function() {
   return this.elements_.length === 0;

--- a/src/ol/tilequeue.js
+++ b/src/ol/tilequeue.js
@@ -60,6 +60,7 @@ goog.inherits(ol.TileQueue, ol.structs.PriorityQueue);
 
 /**
  * @return {number} Number of tiles loading.
+ * @api
  */
 ol.TileQueue.prototype.getTilesLoading = function() {
   return this.tilesLoading_;


### PR DESCRIPTION
To be able to determine when all the tiles are loaded. Example:
```javascript
map.on('postcompose', function(event) {
  var tileQueue = event.frameState.tileQueue;
  if (tileQueue.isEmpty() && tileQueue.getTilesLoading() == 0) {
    // all tiles loaded
  }
});
```

Comments welcome.