### PR TITLE
Add tooltip to show measure + help message while drawing

### DIFF
--- a/examples/measure.html
+++ b/examples/measure.html
@@ -9,6 +9,40 @@
     <link rel="stylesheet" href="../resources/layout.css" type="text/css">
     <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap-responsive.min.css" type="text/css">
     <title>Measure example</title>
+    <style>
+      .tooltip {
+        position: relative;
+        background: rgba(0, 0, 0, 0.5);
+        border-radius: 4px;
+        color: white;
+        padding: 4px 8px;
+        opacity: 0.7;
+        white-space: nowrap;
+      }
+      .tooltip-measure {
+        opacity: 1;
+        font-weight: bold;
+      }
+      .tooltip-static {
+        background-color: #ffcc33;
+        color: black;
+        border: 1px solid white;
+      }
+      .tooltip-measure:before,
+      .tooltip-static:before {
+        border-top: 6px solid rgba(0, 0, 0, 0.5);
+        border-right: 6px solid transparent;
+        border-left: 6px solid transparent;
+        content: "";
+        position: absolute;
+        bottom: -6px;
+        margin-left: -7px;
+        left: 50%;
+      }
+      .tooltip-static:before {
+        border-top-color: #ffcc33;
+      }
+    </style>
   </head>
   <body>
 
@@ -42,8 +76,6 @@
                 <option value="area">Area</option>
               </select>
           </form>
-
-          <ol id="measureOutput" reversed></ol>
 
           <div id="docs">
               <p><i>NOTE: Measure is done in simple way on projected plane. Earth

--- a/examples/measure.js
+++ b/examples/measure.js
@@ -141,7 +141,26 @@ function addInteraction() {
   var type = (typeSelect.value == 'area' ? 'Polygon' : 'LineString');
   draw = new ol.interaction.Draw({
     source: source,
-    type: /** @type {ol.geom.GeometryType} */ (type)
+    type: /** @type {ol.geom.GeometryType} */ (type),
+    style: new ol.style.Style({
+      fill: new ol.style.Fill({
+        color: 'rgba(255, 255, 255, 0.2)'
+      }),
+      stroke: new ol.style.Stroke({
+        color: 'rgba(0, 0, 0, 0.5)',
+        lineDash: [10, 10],
+        width: 2
+      }),
+      image: new ol.style.Circle({
+        radius: 5,
+        stroke: new ol.style.Stroke({
+          color: 'rgba(0, 0, 0, 0.7)'
+        }),
+        fill: new ol.style.Fill({
+          color: 'rgba(255, 255, 255, 0.2)'
+        })
+      })
+    })
   });
   map.addInteraction(draw);
 


### PR DESCRIPTION
The goal of this pull request is to update the measure example to show how to show the measurement while drawing. It relies on `ol.Overlay`.

Here's how it looks:
![ol3_measure_tooltip](https://cloud.githubusercontent.com/assets/319774/6044255/60f6dd46-ac92-11e4-86b7-96fa0bc36b4e.gif)

Please review.