### PR TITLE
Update canvastilelayerrenderer.js

### DIFF
--- a/src/ol/renderer/canvas/canvastilelayerrenderer.js
+++ b/src/ol/renderer/canvas/canvastilelayerrenderer.js
@@ -230,8 +230,8 @@ ol.renderer.canvas.TileLayer.prototype.prepareFrame =
     context = this.context_;
     if (this.canvasSize_[0] < canvasWidth ||
         this.canvasSize_[1] < canvasHeight ||
-        this.canvasSize_[0] % tilePixelSize != 0 ||
-        this.canvasSize_[1] % tilePixelSize != 0 ||
+        this.canvasSize_[0] % tilePixelSize !== 0 ||
+        this.canvasSize_[1] % tilePixelSize !== 0 ||
         (this.canvasTooBig_ && (this.canvasSize_[0] > canvasWidth ||
         this.canvasSize_[1] > canvasHeight))) {
       // Canvas is too small or not a multiple of tileSize, resize it.

--- a/src/ol/renderer/canvas/canvastilelayerrenderer.js
+++ b/src/ol/renderer/canvas/canvastilelayerrenderer.js
@@ -71,7 +71,7 @@ ol.renderer.canvas.TileLayer = function(mapRenderer, tileLayer) {
    * @type {number}
    */
   this.renderedCanvasZ_ = NaN;
-  
+
   /**
    * @private
    * @type {number}

--- a/src/ol/renderer/canvas/canvastilelayerrenderer.js
+++ b/src/ol/renderer/canvas/canvastilelayerrenderer.js
@@ -234,7 +234,7 @@ ol.renderer.canvas.TileLayer.prototype.prepareFrame =
         this.canvasSize_[1] % tilePixelSize != 0 ||
         (this.canvasTooBig_ && (this.canvasSize_[0] > canvasWidth ||
         this.canvasSize_[1] > canvasHeight))) {
-      // Canvas is too small or not a multiple of tileSize, resize it. 
+      // Canvas is too small or not a multiple of tileSize, resize it.
       // We never shrink the canvas, unless
       // we know that the current canvas size exceeds the maximum size
       canvas.width = canvasWidth;

--- a/src/ol/renderer/canvas/canvastilelayerrenderer.js
+++ b/src/ol/renderer/canvas/canvastilelayerrenderer.js
@@ -230,9 +230,12 @@ ol.renderer.canvas.TileLayer.prototype.prepareFrame =
     context = this.context_;
     if (this.canvasSize_[0] < canvasWidth ||
         this.canvasSize_[1] < canvasHeight ||
+        this.canvasSize_[0] % tilePixelSize != 0 ||
+        this.canvasSize_[1] % tilePixelSize != 0 ||
         (this.canvasTooBig_ && (this.canvasSize_[0] > canvasWidth ||
         this.canvasSize_[1] > canvasHeight))) {
-      // Canvas is too small, resize it. We never shrink the canvas, unless
+      // Canvas is too small or not a multiple of tileSize, resize it. 
+      // We never shrink the canvas, unless
       // we know that the current canvas size exceeds the maximum size
       canvas.width = canvasWidth;
       canvas.height = canvasHeight;

--- a/src/ol/renderer/canvas/canvastilelayerrenderer.js
+++ b/src/ol/renderer/canvas/canvastilelayerrenderer.js
@@ -71,6 +71,12 @@ ol.renderer.canvas.TileLayer = function(mapRenderer, tileLayer) {
    * @type {number}
    */
   this.renderedCanvasZ_ = NaN;
+  
+  /**
+   * @private
+   * @type {number}
+   */
+  this.renderedTileSize_ = NaN;
 
   /**
    * @private
@@ -230,11 +236,10 @@ ol.renderer.canvas.TileLayer.prototype.prepareFrame =
     context = this.context_;
     if (this.canvasSize_[0] < canvasWidth ||
         this.canvasSize_[1] < canvasHeight ||
-        this.canvasSize_[0] % tilePixelSize !== 0 ||
-        this.canvasSize_[1] % tilePixelSize !== 0 ||
+        this.renderedTileSize_ !== tilePixelSize ||
         (this.canvasTooBig_ && (this.canvasSize_[0] > canvasWidth ||
         this.canvasSize_[1] > canvasHeight))) {
-      // Canvas is too small or not a multiple of tileSize, resize it.
+      // Canvas is too small or tileSize has changed, resize it.
       // We never shrink the canvas, unless
       // we know that the current canvas size exceeds the maximum size
       canvas.width = canvasWidth;
@@ -262,6 +267,7 @@ ol.renderer.canvas.TileLayer.prototype.prepareFrame =
     minY = tileRange.minY -
         Math.floor((canvasTileRangeHeight - tileRange.getHeight()) / 2);
     this.renderedCanvasZ_ = z;
+    this.renderedTileSize_ = tilePixelSize;
     this.renderedCanvasTileRange_ = new ol.TileRange(
         minX, minX + canvasTileRangeWidth - 1,
         minY, minY + canvasTileRangeHeight - 1);


### PR DESCRIPTION
Fix for Issue 2314#
This fixes canvas tile rendering when tileSize changes with zoom (by using a tileSizes array with a TileGrid)