### PR TITLE
Pixel manipulation with raster sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BUILD_HOSTED := build/hosted/$(BRANCH)
 BUILD_HOSTED_EXAMPLES := $(addprefix $(BUILD_HOSTED)/,$(EXAMPLES))
 BUILD_HOSTED_EXAMPLES_JS := $(addprefix $(BUILD_HOSTED)/,$(EXAMPLES_JS))
 
-UNPHANTOMABLE_EXAMPLES = examples/shaded-relief.html examples/raster.html
+UNPHANTOMABLE_EXAMPLES = examples/shaded-relief.html examples/raster.html examples/region-growing.html
 CHECK_EXAMPLE_TIMESTAMPS = $(patsubst examples/%.html,build/timestamps/check-%-timestamp,$(filter-out $(UNPHANTOMABLE_EXAMPLES),$(EXAMPLES_HTML)))
 
 TASKS_JS := $(shell find tasks -name '*.js')

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ BUILD_HOSTED := build/hosted/$(BRANCH)
 BUILD_HOSTED_EXAMPLES := $(addprefix $(BUILD_HOSTED)/,$(EXAMPLES))
 BUILD_HOSTED_EXAMPLES_JS := $(addprefix $(BUILD_HOSTED)/,$(EXAMPLES_JS))
 
-CHECK_EXAMPLE_TIMESTAMPS = $(patsubst examples/%.html,build/timestamps/check-%-timestamp,$(EXAMPLES_HTML))
+UNPHANTOMABLE_EXAMPLES = examples/shaded-relief.html examples/raster.html
+CHECK_EXAMPLE_TIMESTAMPS = $(patsubst examples/%.html,build/timestamps/check-%-timestamp,$(filter-out $(UNPHANTOMABLE_EXAMPLES),$(EXAMPLES_HTML)))
 
 TASKS_JS := $(shell find tasks -name '*.js')
 

--- a/examples/raster.css
+++ b/examples/raster.css
@@ -1,0 +1,31 @@
+.rel {
+  position: relative
+}
+
+#plot {
+  pointer-events: none;
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+}
+
+.bar {
+  pointer-events: auto;
+  fill: #AFAFB9;
+}
+
+.bar.selected {
+  fill: green;
+}
+
+.tip {
+  position: absolute;
+  background: black;
+  color: white;
+  padding: 6px;
+  font-size: 12px;
+  border-radius: 4px;
+  margin-bottom: 10px;
+  display: none;
+  opacity: 0;
+}

--- a/examples/raster.html
+++ b/examples/raster.html
@@ -19,9 +19,13 @@ docs: >
     threshold are green and those below are transparent).
   </p>
 tags: "raster, pixel"
+resources:
+  - http://d3js.org/d3.v3.min.js
+  - raster.css
 ---
 <div class="row-fluid">
-  <div class="span12">
+  <div class="span12 rel">
     <div id="map" class="map"></div>
+    <div id="plot"></div>
   </div>
 </div>

--- a/examples/raster.html
+++ b/examples/raster.html
@@ -12,8 +12,8 @@ docs: >
   </p>
   <p>
     In this case, a single tiled source of imagery is used as input.
-    For each pixel, the Triangular Greenness Index
-    (<a href="http://digitalcommons.unl.edu/cgi/viewcontent.cgi?article=2161&context=usdaarsfacpub">TGI</a>)
+    For each pixel, the Vegetaion Greenness Index
+    (<a href="http://www.tandfonline.com/doi/abs/10.1080/10106040108542184#.Vb90ITBViko">VGI</a>)
     is calculated from the input pixels.  A second operation colors
     those pixels based on a threshold value (values above the
     threshold are green and those below are transparent).

--- a/examples/raster.html
+++ b/examples/raster.html
@@ -3,7 +3,21 @@ template: example.html
 title: Raster Source
 shortdesc: Demonstrates pixelwise operations with a raster source.
 docs: >
-  A dynamically generated raster source.
+  <p>
+    This example uses a <code>ol.source.Raster</code> to generate data
+    based on another source.  The raster source accepts any number of
+    input sources (tile or image based) and runs a pipeline of
+    operations on the input pixels.  The return from the final
+    operation is used as the data for the output source.
+  </p>
+  <p>
+    In this case, a single tiled source of imagery is used as input.
+    For each pixel, the Triangular Greenness Index
+    (<a href="http://digitalcommons.unl.edu/cgi/viewcontent.cgi?article=2161&context=usdaarsfacpub">TGI</a>)
+    is calculated from the input pixels.  A second operation colors
+    those pixels based on a threshold value (values above the
+    threshold are green and those below are transparent).
+  </p>
 tags: "raster, pixel"
 ---
 <div class="row-fluid">

--- a/examples/raster.html
+++ b/examples/raster.html
@@ -1,0 +1,13 @@
+---
+template: example.html
+title: Raster Source
+shortdesc: Demonstrates pixelwise operations with a raster source.
+docs: >
+  A dynamically generated raster source.
+tags: "raster, pixel"
+---
+<div class="row-fluid">
+  <div class="span12">
+    <div id="map" class="map"></div>
+  </div>
+</div>

--- a/examples/raster.js
+++ b/examples/raster.js
@@ -1,0 +1,28 @@
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.layer.Image');
+goog.require('ol.source.OSM');
+goog.require('ol.source.Raster');
+
+
+var map = new ol.Map({
+  layers: [
+    new ol.layer.Image({
+      source: new ol.source.Raster({
+        sources: [new ol.source.OSM()],
+        operations: [function(pixels) {
+          var pixel = pixels[0];
+          var b = pixel[2];
+          pixel[2] = pixel[0];
+          pixel[0] = b;
+          return pixels;
+        }]
+      })
+    })
+  ],
+  target: 'map',
+  view: new ol.View({
+    center: [0, 0],
+    zoom: 2
+  })
+});

--- a/examples/raster.js
+++ b/examples/raster.js
@@ -1,3 +1,5 @@
+// NOCOMPILE
+// this example uses d3 for which we don't have an externs file.
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.layer.Image');
@@ -10,8 +12,16 @@ function tgi(pixels) {
   var r = pixel[0] / 255;
   var g = pixel[1] / 255;
   var b = pixel[2] / 255;
-  var index = (120 * (r - b) - (190 * (r - g))) / 2;
-  pixel[0] = index;
+  var value = (120 * (r - b) - (190 * (r - g))) / 2;
+  pixel[0] = value;
+  return pixels;
+}
+
+var counts = new Counts(0, 25);
+
+function summarize(pixels) {
+  var value = pixels[0][0];
+  counts.increment(value);
   return pixels;
 }
 
@@ -19,8 +29,8 @@ var threshold = 10;
 
 function color(pixels) {
   var pixel = pixels[0];
-  var index = pixel[0];
-  if (index > threshold) {
+  var value = pixel[0];
+  if (value > threshold) {
     pixel[0] = 0;
     pixel[1] = 255;
     pixel[2] = 0;
@@ -36,19 +46,28 @@ var bing = new ol.source.BingMaps({
   imagerySet: 'Aerial'
 });
 
-var imagery = new ol.layer.Tile({
-  source: bing
+var raster = new ol.source.Raster({
+  sources: [bing],
+  operations: [tgi, summarize, color]
 });
 
-var greenness = new ol.layer.Image({
-  source: new ol.source.Raster({
-    sources: [bing],
-    operations: [tgi, color]
-  })
+raster.on('beforeoperations', function() {
+  counts.clear();
+});
+
+raster.on('afteroperations', function(event) {
+  schedulePlot(event.resolution);
 });
 
 var map = new ol.Map({
-  layers: [imagery, greenness],
+  layers: [
+    new ol.layer.Tile({
+      source: bing
+    }),
+    new ol.layer.Image({
+      source: raster
+    })
+  ],
   target: 'map',
   view: new ol.View({
     center: [-9651695.964309687, 4937351.719788862],
@@ -56,3 +75,117 @@ var map = new ol.Map({
     minZoom: 12
   })
 });
+
+
+
+/**
+ * Maintain counts of values between a min and max.
+ * @param {number} min The minimum value (inclusive).
+ * @param {[type]} max The maximum value (exclusive).
+ * @constructor
+ */
+function Counts(min, max) {
+  this.min = min;
+  this.max = max;
+  this.values = new Array(max - min);
+}
+
+
+/**
+ * Clear all counts.
+ */
+Counts.prototype.clear = function() {
+  for (var i = 0, ii = this.values.length; i < ii; ++i) {
+    this.values[i] = 0;
+  }
+};
+
+
+/**
+ * Increment the count for a value.
+ * @param {number} value The value.
+ */
+Counts.prototype.increment = function(value) {
+  value = Math.floor(value);
+  if (value >= this.min && value < this.max) {
+    this.values[value - this.min] += 1;
+  }
+};
+
+var timer = null;
+function schedulePlot(resolution) {
+  if (timer) {
+    clearTimeout(timer);
+    timer = null;
+  }
+  timer = setTimeout(plot.bind(null, resolution), 1000 / 60);
+}
+
+var barWidth = 15;
+var plotHeight = 150;
+var chart = d3.select('#plot').append('svg')
+    .attr('width', barWidth * counts.values.length)
+    .attr('height', plotHeight);
+
+var chartRect = chart[0][0].getBoundingClientRect();
+
+var tip = d3.select(document.body).append('div')
+    .attr('class', 'tip');
+
+function plot(resolution) {
+  var yScale = d3.scale.linear()
+      .domain([0, d3.max(counts.values)])
+      .range([0, plotHeight]);
+
+  var bar = chart.selectAll('rect').data(counts.values);
+
+  bar.enter().append('rect');
+
+  bar.attr('class', function(value, index) {
+    return 'bar' + (index - counts.min >= threshold ? ' selected' : '');
+  })
+  .attr('width', barWidth - 2);
+
+  bar.transition()
+      .attr('transform', function(value, index) {
+        return 'translate(' + (index * barWidth) + ', ' +
+            (plotHeight - yScale(value)) + ')';
+      })
+      .attr('height', yScale);
+
+  bar.on('mousemove', function() {
+    var old = threshold;
+    threshold = counts.min +
+        Math.floor((d3.event.pageX - chartRect.left) / barWidth);
+    if (old !== threshold) {
+      map.render();
+    }
+  });
+
+  bar.on('mouseover', function() {
+    var index = Math.floor((d3.event.pageX - chartRect.left) / barWidth);
+    var area = 0;
+    for (var i = counts.values.length - 1; i >= index; --i) {
+      area += resolution * resolution * counts.values[i];
+    }
+    tip.html(message(index + counts.min, area));
+    tip.style('display', 'block');
+    tip.transition().style({
+      left: (chartRect.left + (index * barWidth) + (barWidth / 2)) + 'px',
+      top: (d3.event.y - 60) + 'px',
+      opacity: 1
+    });
+  });
+
+  bar.on('mouseout', function() {
+    tip.transition().style('opacity', 0).each('end', function() {
+      tip.style('display', 'none');
+    });
+  });
+
+}
+
+function message(value, area) {
+  var acres = (area / 4046.86).toFixed(0).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  return acres + ' acres at<br>' + value + ' TGI or above';
+}

--- a/examples/raster.js
+++ b/examples/raster.js
@@ -1,28 +1,58 @@
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.layer.Image');
-goog.require('ol.source.OSM');
+goog.require('ol.layer.Tile');
+goog.require('ol.source.BingMaps');
 goog.require('ol.source.Raster');
 
+function tgi(pixels) {
+  var pixel = pixels[0];
+  var r = pixel[0] / 255;
+  var g = pixel[1] / 255;
+  var b = pixel[2] / 255;
+  var index = (120 * (r - b) - (190 * (r - g))) / 2;
+  pixel[0] = index;
+  return pixels;
+}
+
+var threshold = 10;
+
+function color(pixels) {
+  var pixel = pixels[0];
+  var index = pixel[0];
+  if (index > threshold) {
+    pixel[0] = 0;
+    pixel[1] = 255;
+    pixel[2] = 0;
+    pixel[3] = 255;
+  } else {
+    pixel[3] = 0;
+  }
+  return pixels;
+}
+
+var bing = new ol.source.BingMaps({
+  key: 'Ak-dzM4wZjSqTlzveKz5u0d4IQ4bRzVI309GxmkgSVr1ewS6iPSrOvOKhA-CJlm3',
+  imagerySet: 'Aerial'
+});
+
+var imagery = new ol.layer.Tile({
+  source: bing
+});
+
+var greenness = new ol.layer.Image({
+  source: new ol.source.Raster({
+    sources: [bing],
+    operations: [tgi, color]
+  })
+});
 
 var map = new ol.Map({
-  layers: [
-    new ol.layer.Image({
-      source: new ol.source.Raster({
-        sources: [new ol.source.OSM()],
-        operations: [function(pixels) {
-          var pixel = pixels[0];
-          var b = pixel[2];
-          pixel[2] = pixel[0];
-          pixel[0] = b;
-          return pixels;
-        }]
-      })
-    })
-  ],
+  layers: [imagery, greenness],
   target: 'map',
   view: new ol.View({
-    center: [0, 0],
-    zoom: 2
+    center: [-9651695.964309687, 4937351.719788862],
+    zoom: 13,
+    minZoom: 12
   })
 });

--- a/examples/raster.js
+++ b/examples/raster.js
@@ -34,7 +34,7 @@ function color(pixels) {
     pixel[0] = 0;
     pixel[1] = 255;
     pixel[2] = 0;
-    pixel[3] = 255;
+    pixel[3] = 128;
   } else {
     pixel[3] = 0;
   }
@@ -70,9 +70,10 @@ var map = new ol.Map({
   ],
   target: 'map',
   view: new ol.View({
-    center: [-9651695.964309687, 4937351.719788862],
+    center: [-9651695, 4937351],
     zoom: 13,
-    minZoom: 12
+    minZoom: 12,
+    maxZoom: 19
   })
 });
 

--- a/examples/region-growing.css
+++ b/examples/region-growing.css
@@ -1,0 +1,4 @@
+table.controls td {
+  min-width: 110px;
+  padding: 2px 5px;
+}

--- a/examples/region-growing.html
+++ b/examples/region-growing.html
@@ -28,16 +28,11 @@ tags: "raster, region growing"
 <div class="row-fluid">
   <div class="span12">
     <div id="map" class="map" style="cursor: pointer"></div>
-  </div>
-</div>
-<div class="row">
-  <div class="col-md-1">
-    Threshold:
-  </div>
-  <div class="col-md-2">
-    <input id="threshold" type="range" min="1" max="50" value="20"/>
-  </div>
-  <div class="col-md-1">
-    <span id="threshold-value"></span>
+    <table class="controls">
+      <tr>
+        <td>Threshold: <span id="threshold-value"></span></td>
+        <td><input id="threshold" type="range" min="1" max="50" value="20"></td>
+      </tr>
+    </table>
   </div>
 </div>

--- a/examples/region-growing.html
+++ b/examples/region-growing.html
@@ -27,7 +27,7 @@ tags: "raster, region growing"
 ---
 <div class="row-fluid">
   <div class="span12">
-    <div id="map" class="map"></div>
+    <div id="map" class="map" style="cursor: pointer"></div>
   </div>
 </div>
 <div class="row">

--- a/examples/region-growing.html
+++ b/examples/region-growing.html
@@ -1,0 +1,43 @@
+---
+template: example.html
+title: Region Growing
+shortdesc: Grow a region from a seed pixel
+docs: >
+  <p>Click a region on the map. The computed region will be red.</p>
+  <p>
+    This example uses a <code>ol.source.Raster</code> to generate data
+    based on another source.  The raster source accepts any number of
+    input sources (tile or image based) and runs a pipeline of
+    operations on the input data.  The return from the final
+    operation is used as the data for the output source.
+  </p>
+  <p>
+    In this case, a single tiled source of imagery data is used as input.
+    The region is calculated in a single "image" operation using the "seed"
+    pixel provided by the user clicking on the map. The "threshold" value
+    determines whether a given contiguous pixel belongs to the "region" - the
+    difference between a candidate pixel's RGB values and the seed values must
+    be below the threshold.
+  </p>
+  <p>
+    This example also shows how an additional function can be made available
+    to the operation.
+  </p>
+tags: "raster, region growing"
+---
+<div class="row-fluid">
+  <div class="span12">
+    <div id="map" class="map"></div>
+  </div>
+</div>
+<div class="row">
+  <div class="col-md-1">
+    Threshold:
+  </div>
+  <div class="col-md-2">
+    <input id="threshold" type="range" min="1" max="50" value="20"/>
+  </div>
+  <div class="col-md-1">
+    <span id="threshold-value"></span>
+  </div>
+</div>

--- a/examples/region-growing.js
+++ b/examples/region-growing.js
@@ -12,7 +12,7 @@ function growRegion(inputs, data) {
   var seed = data.pixel;
   var delta = parseInt(data.delta);
   if (!seed) {
-    return [image];
+    return image;
   }
 
   seed = seed.map(Math.round);
@@ -59,7 +59,7 @@ function growRegion(inputs, data) {
     }
     edge = newedge;
   }
-  return [new ImageData(outputData, width, height)];
+  return new ImageData(outputData, width, height);
 }
 
 function next4Edges(edge) {
@@ -81,8 +81,8 @@ var imagery = new ol.layer.Tile({
 var raster = new ol.source.Raster({
   sources: [imagery.getSource()],
   operationType: 'image',
-  operations: [growRegion],
-  // the contents of `lib` option will be available to the operation(s) run in
+  operation: growRegion,
+  // Functions in the `lib` object will be available to the operation run in
   // the web worker.
   lib: {
     nextEdges: next4Edges
@@ -90,7 +90,7 @@ var raster = new ol.source.Raster({
 });
 
 var rasterImage = new ol.layer.Image({
-  opacity: 0.8,
+  opacity: 0.7,
   source: raster
 });
 
@@ -98,8 +98,8 @@ var map = new ol.Map({
   layers: [imagery, rasterImage],
   target: 'map',
   view: new ol.View({
-    center: ol.proj.fromLonLat([-120, 50]),
-    zoom: 6
+    center: ol.proj.fromLonLat([-119.07, 47.65]),
+    zoom: 11
   })
 });
 

--- a/examples/region-growing.js
+++ b/examples/region-growing.js
@@ -103,14 +103,10 @@ var map = new ol.Map({
   })
 });
 
-var pixel;
+var coordinate;
 
-map.getView().on('change', function() {
-  pixel = null;
-});
-
-map.on('click', function(ev) {
-  pixel = map.getPixelFromCoordinate(ev.coordinate);
+map.on('click', function(event) {
+  coordinate = event.coordinate;
   raster.changed();
 });
 
@@ -118,7 +114,9 @@ raster.on('beforeoperations', function(event) {
   // the event.data object will be passed to operations
   var data = event.data;
   data.delta = thresholdControl.value;
-  data.pixel = pixel;
+  if (coordinate) {
+    data.pixel = map.getPixelFromCoordinate(coordinate);
+  }
 });
 
 var thresholdControl = document.getElementById('threshold');

--- a/examples/region-growing.js
+++ b/examples/region-growing.js
@@ -1,0 +1,134 @@
+// NOCOMPILE
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.layer.Image');
+goog.require('ol.layer.Tile');
+goog.require('ol.proj');
+goog.require('ol.source.BingMaps');
+goog.require('ol.source.Raster');
+
+function growRegion(inputs, data) {
+  var image = inputs[0];
+  var seed = data.pixel;
+  var delta = parseInt(data.delta);
+  if (!seed) {
+    return [image];
+  }
+
+  seed = seed.map(Math.round);
+  var width = image.width;
+  var height = image.height;
+  var inputData = image.data;
+  var outputData = new Uint8ClampedArray(inputData);
+  var seedIdx = (seed[1] * width + seed[0]) * 4;
+  var seedR = inputData[seedIdx];
+  var seedG = inputData[seedIdx + 1];
+  var seedB = inputData[seedIdx + 2];
+  var edge = [seed];
+  while (edge.length) {
+    var newedge = [];
+    for (var i = 0, ii = edge.length; i < ii; i++) {
+      // As noted in the Raster source constructor, this function is provided
+      // using the `lib` option. Other functions will NOT be visible unless
+      // provided using the `lib` option.
+      var next = nextEdges(edge[i]);
+      for (var j = 0, jj = next.length; j < jj; j++) {
+        var s = next[j][0], t = next[j][1];
+        if (s >= 0 && s < width && t >= 0 && t < height) {
+          var ci = (t * width + s) * 4;
+          var cr = inputData[ci];
+          var cg = inputData[ci + 1];
+          var cb = inputData[ci + 2];
+          var ca = inputData[ci + 3];
+          // if alpha is zero, carry on
+          if (ca === 0) {
+            continue;
+          }
+          if (Math.abs(seedR - cr) < delta && Math.abs(seedG - cg) < delta &&
+              Math.abs(seedB - cb) < delta) {
+            outputData[ci] = 255;
+            outputData[ci + 1] = 0;
+            outputData[ci + 2] = 0;
+            outputData[ci + 3] = 255;
+            newedge.push([s, t]);
+          }
+          // mark as visited
+          inputData[ci + 3] = 0;
+        }
+      }
+    }
+    edge = newedge;
+  }
+  return [new ImageData(outputData, width, height)];
+}
+
+function next4Edges(edge) {
+  var x = edge[0], y = edge[1];
+  return [
+    [x + 1, y],
+    [x - 1, y],
+    [x, y + 1],
+    [x, y - 1]
+  ];
+}
+
+var key = 'Ak-dzM4wZjSqTlzveKz5u0d4IQ4bRzVI309GxmkgSVr1ewS6iPSrOvOKhA-CJlm3';
+
+var imagery = new ol.layer.Tile({
+  source: new ol.source.BingMaps({key: key, imagerySet: 'Aerial'})
+});
+
+var raster = new ol.source.Raster({
+  sources: [imagery.getSource()],
+  operationType: 'image',
+  operations: [growRegion],
+  // the contents of `lib` option will be available to the operation(s) run in
+  // the web worker.
+  lib: {
+    nextEdges: next4Edges
+  }
+});
+
+var rasterImage = new ol.layer.Image({
+  opacity: 0.8,
+  source: raster
+});
+
+var map = new ol.Map({
+  layers: [imagery, rasterImage],
+  target: 'map',
+  view: new ol.View({
+    center: ol.proj.fromLonLat([-120, 50]),
+    zoom: 6
+  })
+});
+
+var pixel;
+
+map.getView().on('change', function() {
+  pixel = null;
+});
+
+map.on('click', function(ev) {
+  pixel = map.getPixelFromCoordinate(ev.coordinate);
+  raster.changed();
+});
+
+raster.on('beforeoperations', function(event) {
+  // the event.data object will be passed to operations
+  var data = event.data;
+  data.delta = thresholdControl.value;
+  data.pixel = pixel;
+});
+
+var thresholdControl = document.getElementById('threshold');
+
+function updateControlValue() {
+  document.getElementById('threshold-value').innerText = thresholdControl.value;
+}
+updateControlValue();
+
+thresholdControl.addEventListener('input', function() {
+  updateControlValue();
+  raster.changed();
+});

--- a/examples/shaded-relief.css
+++ b/examples/shaded-relief.css
@@ -1,0 +1,4 @@
+table.controls td {
+  text-align: center;
+  padding: 2px 5px;
+}

--- a/examples/shaded-relief.html
+++ b/examples/shaded-relief.html
@@ -1,0 +1,19 @@
+---
+template: example.html
+title: Shaded Relief
+shortdesc: Calculate shaded relief from elevation data
+docs: >
+  With a `ol.source.Raster`, it is possible to run operations on input data from other sources.
+tags: "raster"
+---
+<div class="row-fluid">
+  <div class="span12">
+    <div id="map" class="map"></div>
+    <div id="controls">
+      <label for="sun-el">sun elevation</label>
+      <input id="sun-el" type="range" min="0" max="90" value="45"/>
+      <label for="sun-az">sun azimuth</label>
+      <input id="sun-az" type="range" min="0" max="360" value="45"/>
+    </div>
+  </div>
+</div>

--- a/examples/shaded-relief.html
+++ b/examples/shaded-relief.html
@@ -28,11 +28,19 @@ tags: "raster, shaded relief"
 <div class="row-fluid">
   <div class="span12">
     <div id="map" class="map"></div>
-    <div id="controls">
-      <label for="sun-el">sun elevation</label>
-      <input id="sun-el" type="range" min="0" max="90" value="45"/>
-      <label for="sun-az">sun azimuth</label>
-      <input id="sun-az" type="range" min="0" max="360" value="45"/>
-    </div>
+    <table class="controls">
+      <tr>
+        <td>vertical exaggeration: <span id="vertOut"></span>x</td>
+        <td><input id="vert" type="range" min="1" max="5" value="1"/></td>
+      </tr>
+      <tr>
+        <td>sun elevation: <span id="sunElOut"></span>°</td>
+        <td><input id="sunEl" type="range" min="0" max="90" value="45"/></td>
+      </tr>
+      <tr>
+        <td>sun azimuth: <span id="sunAzOut"></span>°</td>
+        <td><input id="sunAz" type="range" min="0" max="360" value="45"/></td>
+      </tr>
+    </table>
   </div>
 </div>

--- a/examples/shaded-relief.html
+++ b/examples/shaded-relief.html
@@ -3,8 +3,27 @@ template: example.html
 title: Shaded Relief
 shortdesc: Calculate shaded relief from elevation data
 docs: >
-  With a `ol.source.Raster`, it is possible to run operations on input data from other sources.
-tags: "raster"
+  <p>
+    This example uses a <code>ol.source.Raster</code> to generate data
+    based on another source.  The raster source accepts any number of
+    input sources (tile or image based) and runs a pipeline of
+    operations on the input data.  The return from the final
+    operation is used as the data for the output source.
+  </p>
+  <p>
+    In this case, a single tiled source of elevation data is used as input.
+    The shaded relief is calculated in a single "image" operation.  By setting
+    <code>operationType: 'image'</code> on the raster source, operations are
+    called with an <code>ImageData</code> object for each of the input sources.
+    Operations are also called with a general purpose <code>data</code> object.
+    In this example, the sun elevation and azimuth data from the inputs above
+    are assigned to this <code>data</code> object and accessed in the shading
+    operation.  The shading operation returns an array of <code>ImageData</code>
+    objects.  When the raster source is used by an image layer, the first
+    <code>ImageData</code> object returned by the last operation in the pipeline
+    is used for rendering.
+  </p>
+tags: "raster, shaded relief"
 ---
 <div class="row-fluid">
   <div class="span12">

--- a/examples/shaded-relief.js
+++ b/examples/shaded-relief.js
@@ -1,0 +1,183 @@
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.layer.Tile');
+goog.require('ol.source.Raster');
+goog.require('ol.source.TileWMS');
+
+
+function read3x3(imageData, callback) {
+  var size = 3;
+  var mid = 1;
+  var width = imageData.width;
+  var height = imageData.height;
+  var data = imageData.data;
+  var kernel = new Array(size * size);
+  for (var n = 0, nn = kernel.length; n < nn; ++n) {
+    kernel[n] = [0, 0, 0, 0];
+  }
+  var offsetMin = (1 - size) / 2;
+  for (var pixelY = 0; pixelY < height; ++j) {
+    for (var pixelX = 0; pixelX < width; ++i) {
+      for (var kernelY = 0; kernelY < size; ++kernelY) {
+        var neighborY = Math.max(pixelY - (kernelY - mix), 0);
+        for (var kernelX = 0; kernelX < size; ++kernelX) {
+          var neighborX = Math.max(pixelX - (kernelX - mid), 0);
+          var kernelIndex = kernelX + kernelY * size;
+          var dataIndex = 4 * (neighborY * width + neighborX);
+          kernel[kernelIndex][0] = data[dataIndex];
+          kernel[kernelIndex][1] = data[dataIndex + 1];
+          kernel[kernelIndex][2] = data[dataIndex + 2];
+          kernel[kernelIndex][3] = data[dataIndex + 3];
+        }
+      }
+      callback(kernel, pixelX, pixelY);
+    }
+  }
+}
+
+/**
+ * The NED dataset is symbolized by a color ramp that maps the following
+ * elevations to corresponding RGB values.  This operation is used to
+ * invert the mapping - returning elevations in meters for a pixel RGB array.
+ *
+ *  -20m : 0, 0, 0
+ *  400m : 0, 0, 255
+ *  820m : 0, 255, 255
+ * 1240m : 255, 255, 255
+ *
+ */
+function getElevation(pixel) {
+  return (420 * (pixel[0] + pixel[1] + pixel[2]) / 255) - 20;
+}
+
+/**
+ * Generates a shaded relief image given elevation data.  Uses a 3x3
+ * neighborhood for determining slope and aspect.
+ * @param {Array.<ImageData>} inputs Array of input images.
+ * @param {Object} data Data with resolution property.
+ * @return {Array.<ImageData>} Output images (only the first is rendered).
+ */
+function shade(inputs, data) {
+  var elevationImage = inputs[0];
+  var width = elevationImage.width;
+  var height = elevationImage.height;
+  var elevationData = elevationImage.data;
+  var shadeData = new Uint8ClampedArray(elevationData.length);
+  var dx = dy = data.resolution * 2;
+  var maxX = width - 1;
+  var maxY = height - 1;
+  var pixel = [0, 0, 0, 0];
+  var offset, z0, z1, dzdx, dzdy, slope, aspect, scaled;
+  for (var pixelY = 0; pixelY <= maxY; ++pixelY) {
+    var y0 = pixelY === 0 ? 0 : pixelY - 1;
+    var y1 = pixelY === maxY ? maxY : pixelY + 1;
+    for (var pixelX = 0; pixelX <= maxX; ++pixelX) {
+      var x0 = pixelX === 0 ? 0 : pixelX - 1;
+      var x1 = pixelX === maxX ? maxX : pixelX + 1;
+
+      // determine x0, pixelY elevation
+      offset = (pixelY * width + x0) * 4;
+      pixel[0] = elevationData[offset];
+      pixel[1] = elevationData[offset + 1];
+      pixel[2] = elevationData[offset + 2];
+      pixel[3] = elevationData[offset + 3];
+      z0 = getElevation(pixel);
+
+      // determine x1, pixelY elevation
+      offset = (pixelY * width + x1) * 4;
+      pixel[0] = elevationData[offset];
+      pixel[1] = elevationData[offset + 1];
+      pixel[2] = elevationData[offset + 2];
+      pixel[3] = elevationData[offset + 3];
+      z1 = getElevation(pixel);
+
+      dzdx = (z1 - z0) / dx;
+
+      // determine pixelX, y0 elevation
+      offset = (y0 * width + pixelX) * 4;
+      pixel[0] = elevationData[offset];
+      pixel[1] = elevationData[offset + 1];
+      pixel[2] = elevationData[offset + 2];
+      pixel[3] = elevationData[offset + 3];
+      z0 = getElevation(pixel);
+
+      // determine pixelX, y1 elevation
+      offset = (y1 * width + pixelX) * 4;
+      pixel[0] = elevationData[offset];
+      pixel[1] = elevationData[offset + 1];
+      pixel[2] = elevationData[offset + 2];
+      pixel[3] = elevationData[offset + 3];
+      z1 = getElevation(pixel);
+
+      dzdy = (z1 - z0) / dy;
+
+      slope = Math.atan(Math.sqrt(dzdx * dzdx + dzdy * dzdy));
+      aspect = Math.atan2(dzdy, -dzdx);
+      if (aspect < 0) {
+        aspect = (Math.PI / 2) - aspect;
+      } else if (aspect > Math.PI / 2) {
+        aspect = (2 * Math.PI) - aspect + (Math.PI / 2);
+      } else {
+        aspect = Math.PI / 2 - aspect;
+      }
+
+      cosIncidence = Math.sin(data.sunEl) * Math.cos(slope) +
+        Math.cos(data.sunEl) * Math.sin(slope) * Math.cos(data.sunAz - aspect);
+
+
+      scaled = 255 * cosIncidence;
+
+      offset = (pixelY * width + pixelX) * 4;
+      shadeData[offset] = scaled;
+      shadeData[offset + 1] = scaled;
+      shadeData[offset + 2] = scaled;
+      shadeData[offset + 3] = elevationData[offset + 3];
+    }
+  }
+
+  return [new ImageData(shadeData, width, height)];
+}
+
+var elevation = new ol.source.TileWMS({
+  url: 'http://demo.opengeo.org/geoserver/wms',
+  params: {'LAYERS': 'usgs:ned', 'TILED': true, 'FORMAT': 'image/png'},
+  crossOrigin: 'anonymous',
+  serverType: 'geoserver'
+});
+
+var raster = new ol.source.Raster({
+  sources: [elevation],
+  operationType: 'image',
+  operations: [shade]
+});
+
+var sunElevationInput = document.getElementById('sun-el');
+var sunAzimuthInput = document.getElementById('sun-az');
+
+sunElevationInput.addEventListener('input', function() {
+  raster.changed();
+});
+
+sunAzimuthInput.addEventListener('input', function() {
+  raster.changed();
+});
+
+raster.on('beforeoperations', function(event) {
+  // the event.data object will be passed to operations
+  event.data.resolution = event.resolution;
+  event.data.sunEl = Math.PI * sunElevationInput.value / 180;
+  event.data.sunAz = Math.PI * sunAzimuthInput.value / 180;
+});
+
+var map = new ol.Map({
+  target: 'map',
+  layers: [
+    new ol.layer.Image({
+      source: raster
+    })
+  ],
+  view: new ol.View({
+    center: [-8610263, 4747090],
+    zoom: 10
+  })
+});

--- a/examples/shaded-relief.js
+++ b/examples/shaded-relief.js
@@ -81,7 +81,7 @@ function shade(inputs, data) {
       aspect = Math.atan2(dzdy, -dzdx);
       if (aspect < 0) {
         aspect = halfPi - aspect;
-      } else if (aspect > Math.PI / 2) {
+      } else if (aspect > halfPi) {
         aspect = twoPi - aspect + halfPi;
       } else {
         aspect = halfPi - aspect;
@@ -99,7 +99,7 @@ function shade(inputs, data) {
     }
   }
 
-  return [new ImageData(shadeData, width, height)];
+  return new ImageData(shadeData, width, height);
 }
 
 var elevation = new ol.source.XYZ({
@@ -110,7 +110,7 @@ var elevation = new ol.source.XYZ({
 var raster = new ol.source.Raster({
   sources: [elevation],
   operationType: 'image',
-  operations: [shade]
+  operation: shade
 });
 
 var map = new ol.Map({

--- a/examples/shaded-relief.js
+++ b/examples/shaded-relief.js
@@ -1,8 +1,9 @@
 goog.require('ol.Map');
 goog.require('ol.View');
+goog.require('ol.layer.Image');
 goog.require('ol.layer.Tile');
-goog.require('ol.source.TileJSON');
 goog.require('ol.source.Raster');
+goog.require('ol.source.TileJSON');
 goog.require('ol.source.XYZ');
 
 
@@ -10,7 +11,7 @@ goog.require('ol.source.XYZ');
  * Generates a shaded relief image given elevation data.  Uses a 3x3
  * neighborhood for determining slope and aspect.
  * @param {Array.<ImageData>} inputs Array of input images.
- * @param {Object} data Data with resolution property.
+ * @param {Object} data Data added in the "beforeoperations" event.
  * @return {Array.<ImageData>} Output images (only the first is rendered).
  */
 function shade(inputs, data) {
@@ -19,14 +20,16 @@ function shade(inputs, data) {
   var height = elevationImage.height;
   var elevationData = elevationImage.data;
   var shadeData = new Uint8ClampedArray(elevationData.length);
-  var dx = dy = data.resolution * 2;
+  var dp = data.resolution * 2;
   var maxX = width - 1;
   var maxY = height - 1;
   var pixel = [0, 0, 0, 0];
   var twoPi = 2 * Math.PI;
   var halfPi = Math.PI / 2;
-  var cosSunEl = Math.cos(data.sunEl);
-  var sinSunEl = Math.sin(data.sunEl);
+  var sunEl = Math.PI * data.sunEl / 180;
+  var sunAz = Math.PI * data.sunAz / 180;
+  var cosSunEl = Math.cos(sunEl);
+  var sinSunEl = Math.sin(sunEl);
   var pixelX, pixelY, x0, x1, y0, y1, offset,
       z0, z1, dzdx, dzdy, slope, aspect, cosIncidence, scaled;
   for (pixelY = 0; pixelY <= maxY; ++pixelY) {
@@ -42,7 +45,7 @@ function shade(inputs, data) {
       pixel[1] = elevationData[offset + 1];
       pixel[2] = elevationData[offset + 2];
       pixel[3] = elevationData[offset + 3];
-      z0 = pixel[0] + pixel[1] * 2 + pixel[2] * 3;
+      z0 = data.vert * (pixel[0] + pixel[1] * 2 + pixel[2] * 3);
 
       // determine elevation for (x1, pixelY)
       offset = (pixelY * width + x1) * 4;
@@ -50,9 +53,9 @@ function shade(inputs, data) {
       pixel[1] = elevationData[offset + 1];
       pixel[2] = elevationData[offset + 2];
       pixel[3] = elevationData[offset + 3];
-      z1 = pixel[0] + pixel[1] * 2 + pixel[2] * 3;
+      z1 = data.vert * (pixel[0] + pixel[1] * 2 + pixel[2] * 3);
 
-      dzdx = (z1 - z0) / dx;
+      dzdx = (z1 - z0) / dp;
 
       // determine elevation for (pixelX, y0)
       offset = (y0 * width + pixelX) * 4;
@@ -60,7 +63,7 @@ function shade(inputs, data) {
       pixel[1] = elevationData[offset + 1];
       pixel[2] = elevationData[offset + 2];
       pixel[3] = elevationData[offset + 3];
-      z0 = pixel[0] + pixel[1] * 2 + pixel[2] * 3;
+      z0 = data.vert * (pixel[0] + pixel[1] * 2 + pixel[2] * 3);
 
       // determine elevation for (pixelX, y1)
       offset = (y1 * width + pixelX) * 4;
@@ -68,9 +71,9 @@ function shade(inputs, data) {
       pixel[1] = elevationData[offset + 1];
       pixel[2] = elevationData[offset + 2];
       pixel[3] = elevationData[offset + 3];
-      z1 = pixel[0] + pixel[1] * 2 + pixel[2] * 3;
+      z1 = data.vert * (pixel[0] + pixel[1] * 2 + pixel[2] * 3);
 
-      dzdy = (z1 - z0) / dy;
+      dzdy = (z1 - z0) / dp;
 
       slope = Math.atan(Math.sqrt(dzdx * dzdx + dzdy * dzdy));
 
@@ -84,7 +87,7 @@ function shade(inputs, data) {
       }
 
       cosIncidence = sinSunEl * Math.cos(slope) +
-          cosSunEl * Math.sin(slope) * Math.cos(data.sunAz - aspect);
+          cosSunEl * Math.sin(slope) * Math.cos(sunAz - aspect);
 
       offset = (pixelY * width + pixelX) * 4;
       scaled = 255 * cosIncidence;
@@ -124,27 +127,31 @@ var map = new ol.Map({
   ],
   view: new ol.View({
     extent: [-13675026, 4439648, -13580856, 4580292],
-    center: [-13606539, 4492849],
+    center: [-13615645, 4497969],
     minZoom: 10,
     maxZoom: 16,
-    zoom: 12
+    zoom: 13
   })
 });
 
-var sunElevationInput = document.getElementById('sun-el');
-var sunAzimuthInput = document.getElementById('sun-az');
-
-sunElevationInput.addEventListener('input', function() {
-  raster.changed();
-});
-
-sunAzimuthInput.addEventListener('input', function() {
-  raster.changed();
+var controlIds = ['vert', 'sunEl', 'sunAz'];
+var controls = {};
+controlIds.forEach(function(id) {
+  var control = document.getElementById(id);
+  var output = document.getElementById(id + 'Out');
+  control.addEventListener('input', function() {
+    output.innerText = control.value;
+    raster.changed();
+  });
+  output.innerText = control.value;
+  controls[id] = control;
 });
 
 raster.on('beforeoperations', function(event) {
   // the event.data object will be passed to operations
-  event.data.resolution = event.resolution;
-  event.data.sunEl = Math.PI * sunElevationInput.value / 180;
-  event.data.sunAz = Math.PI * sunAzimuthInput.value / 180;
+  var data = event.data;
+  data.resolution = event.resolution;
+  for (var id in controls) {
+    data[id] = Number(controls[id].value);
+  }
 });

--- a/examples/shaded-relief.js
+++ b/examples/shaded-relief.js
@@ -1,3 +1,4 @@
+// NOCOMPILE
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.layer.Image');

--- a/externs/oli.js
+++ b/externs/oli.js
@@ -285,6 +285,12 @@ oli.source.RasterEvent.prototype.resolution;
 
 
 /**
+ * @type {Object}
+ */
+oli.source.RasterEvent.prototype.data;
+
+
+/**
  * @interface
  */
 oli.source.TileEvent = function() {};

--- a/externs/oli.js
+++ b/externs/oli.js
@@ -273,6 +273,12 @@ oli.source.RasterEvent = function() {};
 
 
 /**
+ * @type {ol.Extent}
+ */
+oli.source.RasterEvent.prototype.extent;
+
+
+/**
  * @type {number}
  */
 oli.source.RasterEvent.prototype.resolution;

--- a/externs/oli.js
+++ b/externs/oli.js
@@ -269,6 +269,18 @@ oli.source.ImageEvent.prototype.image;
 /**
  * @interface
  */
+oli.source.RasterEvent = function() {};
+
+
+/**
+ * @type {number}
+ */
+oli.source.RasterEvent.prototype.resolution;
+
+
+/**
+ * @interface
+ */
 oli.source.TileEvent = function() {};
 
 

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -4500,7 +4500,7 @@ olx.source.ImageVectorOptions.prototype.style;
 
 /**
  * @typedef {{sources: Array.<ol.source.Source>,
- *     operations: (Array.<ol.raster.Operation>|undefined),
+ *     operation: (ol.raster.Operation|undefined),
  *     lib: (Object|undefined),
  *     threads: (number|undefined),
  *     operationType: (ol.raster.OperationType|undefined)}}
@@ -4518,12 +4518,12 @@ olx.source.RasterOptions.prototype.sources;
 
 
 /**
- * Pixel operations.  Operations will be called with data from input sources
- * and the final output will be assigned to the raster source.
- * @type {Array.<ol.raster.Operation>|undefined}
+ * Raster operation.  The operation will be called with data from input sources
+ * and the output will be assigned to the raster source.
+ * @type {ol.raster.Operation|undefined}
  * @api
  */
-olx.source.RasterOptions.prototype.operations;
+olx.source.RasterOptions.prototype.operation;
 
 
 /**

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -4500,7 +4500,8 @@ olx.source.ImageVectorOptions.prototype.style;
 
 /**
  * @typedef {{sources: Array.<ol.source.Source>,
- *     operations: (Array.<ol.raster.Operation>|undefined)}}
+ *     operations: (Array.<ol.raster.Operation>|undefined),
+ *     operationType: (ol.raster.OperationType|undefined)}}
  * @api
  */
 olx.source.RasterOptions;
@@ -4515,12 +4516,23 @@ olx.source.RasterOptions.prototype.sources;
 
 
 /**
- * Pixel operations.  Operations will be called with pixels from input sources
+ * Pixel operations.  Operations will be called with data from input sources
  * and the final output will be assigned to the raster source.
  * @type {Array.<ol.raster.Operation>|undefined}
  * @api
  */
 olx.source.RasterOptions.prototype.operations;
+
+
+/**
+ * Operation type.  Supported values are `'pixel'` and `'image'`.  By default,
+ * `'pixel'` operations are assumed, and operations will be called with an
+ * array of pixels from input sources.  If set to `'image'`, operations will
+ * be called with an array of ImageData objects from input sources.
+ * @type {ol.raster.OperationType|undefined}
+ * @api
+ */
+olx.source.RasterOptions.prototype.operationType;
 
 
 /**

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -4537,8 +4537,8 @@ olx.source.RasterOptions.prototype.lib;
 /**
  * By default, operations will be run in a single worker thread.  To avoid using
  * workers altogether, set `threads: 0`.  For pixel operations, operations can
- * be run in multiple worker threads.  Note that there some additional overhead
- * in transferring data to multiple workers, and that depending on the user's
+ * be run in multiple worker threads.  Note that there is additional overhead in
+ * transferring data to multiple workers, and that depending on the user's
  * system, it may not be possible to parallelize the work.
  * @type {number|undefined}
  * @api

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -4499,6 +4499,31 @@ olx.source.ImageVectorOptions.prototype.style;
 
 
 /**
+ * @typedef {{sources: Array.<ol.source.Source>,
+ *     operations: (Array.<ol.raster.Operation>|undefined)}}
+ * @api
+ */
+olx.source.RasterOptions;
+
+
+/**
+ * Input sources.
+ * @type {Array.<ol.source.Source>}
+ * @api
+ */
+olx.source.RasterOptions.prototype.sources;
+
+
+/**
+ * Pixel operations.  Operations will be called with pixels from input sources
+ * and the final output will be assigned to the raster source.
+ * @type {Array.<ol.raster.Operation>|undefined}
+ * @api
+ */
+olx.source.RasterOptions.prototype.operations;
+
+
+/**
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
  *     crossOrigin: (null|string|undefined),
  *     hidpi: (boolean|undefined),

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -4501,6 +4501,8 @@ olx.source.ImageVectorOptions.prototype.style;
 /**
  * @typedef {{sources: Array.<ol.source.Source>,
  *     operations: (Array.<ol.raster.Operation>|undefined),
+ *     lib: (Object|undefined),
+ *     threads: (number|undefined),
  *     operationType: (ol.raster.OperationType|undefined)}}
  * @api
  */
@@ -4522,6 +4524,26 @@ olx.source.RasterOptions.prototype.sources;
  * @api
  */
 olx.source.RasterOptions.prototype.operations;
+
+
+/**
+ * Functions that will be made available to operations run in a worker.
+ * @type {Object|undefined}
+ * @api
+ */
+olx.source.RasterOptions.prototype.lib;
+
+
+/**
+ * By default, operations will be run in a single worker thread.  To avoid using
+ * workers altogether, set `threads: 0`.  For pixel operations, operations can
+ * be run in multiple worker threads.  Note that there some additional overhead
+ * in transferring data to multiple workers, and that depending on the user's
+ * system, it may not be possible to parallelize the work.
+ * @type {number|undefined}
+ * @api
+ */
+olx.source.RasterOptions.prototype.threads;
 
 
 /**

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "metalsmith": "1.6.0",
     "metalsmith-templates": "0.7.0",
     "nomnom": "1.8.0",
-    "pixelworks": "^0.8.0",
+    "pixelworks": "^0.9.0",
     "rbush": "1.3.5",
     "temp": "0.8.1",
     "walk": "2.3.4",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "async": "0.9.0",
+    "browserify": "9.0.3",
     "closure-util": "1.5.0",
     "fs-extra": "0.12.0",
     "glob": "5.0.3",
@@ -37,11 +38,11 @@
     "metalsmith": "1.6.0",
     "metalsmith-templates": "0.7.0",
     "nomnom": "1.8.0",
+    "pixelworks": "^0.8.0",
     "rbush": "1.3.5",
     "temp": "0.8.1",
     "walk": "2.3.4",
-    "wrench": "1.5.8",
-    "browserify": "9.0.3"
+    "wrench": "1.5.8"
   },
   "devDependencies": {
     "clean-css": "2.2.16",
@@ -61,6 +62,7 @@
     "slimerjs-edge": "0.10.0-pre-2"
   },
   "ext": [
-    "rbush"
+    "rbush",
+    {"module": "pixelworks", "browserify": true}
   ]
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "metalsmith": "1.6.0",
     "metalsmith-templates": "0.7.0",
     "nomnom": "1.8.0",
-    "pixelworks": "^0.10.1",
+    "pixelworks": "^0.11.0",
     "rbush": "1.3.5",
     "temp": "0.8.1",
     "walk": "2.3.4",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "metalsmith": "1.6.0",
     "metalsmith-templates": "0.7.0",
     "nomnom": "1.8.0",
-    "pixelworks": "^0.11.0",
+    "pixelworks": "1.0.0",
     "rbush": "1.3.5",
     "temp": "0.8.1",
     "walk": "2.3.4",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "metalsmith": "1.6.0",
     "metalsmith-templates": "0.7.0",
     "nomnom": "1.8.0",
-    "pixelworks": "^0.9.0",
+    "pixelworks": "^0.10.1",
     "rbush": "1.3.5",
     "temp": "0.8.1",
     "walk": "2.3.4",

--- a/src/ol/imagecanvas.js
+++ b/src/ol/imagecanvas.js
@@ -1,5 +1,6 @@
 goog.provide('ol.ImageCanvas');
 
+goog.require('goog.asserts');
 goog.require('ol.ImageBase');
 goog.require('ol.ImageState');
 
@@ -13,12 +14,23 @@ goog.require('ol.ImageState');
  * @param {number} pixelRatio Pixel ratio.
  * @param {Array.<ol.Attribution>} attributions Attributions.
  * @param {HTMLCanvasElement} canvas Canvas.
+ * @param {ol.ImageCanvasLoader=} opt_loader Optional loader function to
+ *     support asynchronous canvas drawing.
  */
 ol.ImageCanvas = function(extent, resolution, pixelRatio, attributions,
-    canvas) {
+    canvas, opt_loader) {
 
-  goog.base(this, extent, resolution, pixelRatio, ol.ImageState.LOADED,
-      attributions);
+  /**
+   * Optional canvas loader function.
+   * @type {?ol.ImageCanvasLoader}
+   * @private
+   */
+  this.loader_ = goog.isDef(opt_loader) ? opt_loader : null;
+
+  var state = goog.isDef(opt_loader) ?
+      ol.ImageState.IDLE : ol.ImageState.LOADED;
+
+  goog.base(this, extent, resolution, pixelRatio, state, attributions);
 
   /**
    * @private
@@ -26,8 +38,52 @@ ol.ImageCanvas = function(extent, resolution, pixelRatio, attributions,
    */
   this.canvas_ = canvas;
 
+  /**
+   * @private
+   * @type {Error}
+   */
+  this.error_ = null;
+
 };
 goog.inherits(ol.ImageCanvas, ol.ImageBase);
+
+
+/**
+ * Get any error associated with asynchronous rendering.
+ * @return {Error} Any error that occurred during rendering.
+ */
+ol.ImageCanvas.prototype.getError = function() {
+  return this.error_;
+};
+
+
+/**
+ * Handle async drawing complete.
+ * @param {Error} err Any error during drawing.
+ * @private
+ */
+ol.ImageCanvas.prototype.handleLoad_ = function(err) {
+  if (err) {
+    this.error_ = err;
+    this.state = ol.ImageState.ERROR;
+  } else {
+    this.state = ol.ImageState.LOADED;
+  }
+  this.changed();
+};
+
+
+/**
+ * Trigger drawing on canvas.
+ */
+ol.ImageCanvas.prototype.load = function() {
+  if (this.state == ol.ImageState.IDLE) {
+    goog.asserts.assert(!goog.isNull(this.loader_));
+    this.state = ol.ImageState.LOADING;
+    this.changed();
+    this.loader_(goog.bind(this.handleLoad_, this));
+  }
+};
 
 
 /**
@@ -36,3 +92,14 @@ goog.inherits(ol.ImageCanvas, ol.ImageBase);
 ol.ImageCanvas.prototype.getImage = function(opt_context) {
   return this.canvas_;
 };
+
+
+/**
+ * A function that is called to trigger asynchronous canvas drawing.  It is
+ * called with a "done" callback that should be called when drawing is done.
+ * If any error occurs during drawing, the "done" callback should be called with
+ * that error.
+ *
+ * @typedef {function(function(Error))}
+ */
+ol.ImageCanvasLoader;

--- a/src/ol/raster/operation.js
+++ b/src/ol/raster/operation.js
@@ -1,0 +1,24 @@
+goog.provide('ol.raster.IdentityOp');
+goog.provide('ol.raster.Operation');
+
+
+/**
+ * A function that takes an array of {@link ol.raster.Pixel} as inputs, performs
+ * some operation on them, and returns an array of {@link ol.raster.Pixel} as
+ * outputs.
+ *
+ * @typedef {function(Array.<ol.raster.Pixel>): Array.<ol.raster.Pixel>}
+ * @api
+ */
+ol.raster.Operation;
+
+
+/**
+ * The identity operation for pixels.  Returns the supplied input pixels as
+ * outputs.
+ * @param {Array.<ol.raster.Pixel>} inputs Input pixels.
+ * @return {Array.<ol.raster.Pixel>} The input pixels as output.
+ */
+ol.raster.IdentityOp = function(inputs) {
+  return inputs;
+};

--- a/src/ol/raster/operation.js
+++ b/src/ol/raster/operation.js
@@ -21,9 +21,12 @@ ol.raster.OperationType = {
  * return an array of the same.  For `'image'` type operations, functions will
  * be called with an array of {@link ImageData
  * https://developer.mozilla.org/en-US/docs/Web/API/ImageData} and should return
- * an array of the same.
+ * an array of the same.  The operations are called with a second "data"
+ * argument, which can be used for storage.  The data object is accessible
+ * from raster events, where it can be initialized in "beforeoperations" and
+ * accessed again in "afteroperations."
  *
- * @typedef {function((Array.<ol.raster.Pixel>|Array.<ImageData>)):
+ * @typedef {function((Array.<ol.raster.Pixel>|Array.<ImageData>), Object):
  *     (Array.<ol.raster.Pixel>|Array.<ImageData>)}
  * @api
  */

--- a/src/ol/raster/operation.js
+++ b/src/ol/raster/operation.js
@@ -1,4 +1,3 @@
-goog.provide('ol.raster.IdentityOp');
 goog.provide('ol.raster.Operation');
 goog.provide('ol.raster.OperationType');
 
@@ -31,13 +30,3 @@ ol.raster.OperationType = {
  * @api
  */
 ol.raster.Operation;
-
-
-/**
- * The identity operation.  Returns the supplied input data as output.
- * @param {(Array.<ol.raster.Pixel>|Array.<ImageData>)} inputs Input data.
- * @return {(Array.<ol.raster.Pixel>|Array.<ImageData>)} The output data.
- */
-ol.raster.IdentityOp = function(inputs) {
-  return inputs;
-};

--- a/src/ol/raster/operation.js
+++ b/src/ol/raster/operation.js
@@ -1,23 +1,39 @@
 goog.provide('ol.raster.IdentityOp');
 goog.provide('ol.raster.Operation');
+goog.provide('ol.raster.OperationType');
 
 
 /**
- * A function that takes an array of {@link ol.raster.Pixel} as inputs, performs
- * some operation on them, and returns an array of {@link ol.raster.Pixel} as
- * outputs.
+ * Raster operation type. Supported values are `'pixel'` and `'image'`.
+ * @enum {string}
+ * @api
+ */
+ol.raster.OperationType = {
+  PIXEL: 'pixel',
+  IMAGE: 'image'
+};
+
+
+/**
+ * A function that takes an array of input data, performs some operation, and
+ * returns an array of ouput data.  For `'pixel'` type operations, functions
+ * will be called with an array of {@link ol.raster.Pixel} data and should
+ * return an array of the same.  For `'image'` type operations, functions will
+ * be called with an array of {@link ImageData
+ * https://developer.mozilla.org/en-US/docs/Web/API/ImageData} and should return
+ * an array of the same.
  *
- * @typedef {function(Array.<ol.raster.Pixel>): Array.<ol.raster.Pixel>}
+ * @typedef {function((Array.<ol.raster.Pixel>|Array.<ImageData>)):
+ *     (Array.<ol.raster.Pixel>|Array.<ImageData>)}
  * @api
  */
 ol.raster.Operation;
 
 
 /**
- * The identity operation for pixels.  Returns the supplied input pixels as
- * outputs.
- * @param {Array.<ol.raster.Pixel>} inputs Input pixels.
- * @return {Array.<ol.raster.Pixel>} The input pixels as output.
+ * The identity operation.  Returns the supplied input data as output.
+ * @param {(Array.<ol.raster.Pixel>|Array.<ImageData>)} inputs Input data.
+ * @return {(Array.<ol.raster.Pixel>|Array.<ImageData>)} The output data.
  */
 ol.raster.IdentityOp = function(inputs) {
   return inputs;

--- a/src/ol/raster/operation.js
+++ b/src/ol/raster/operation.js
@@ -24,7 +24,7 @@ ol.raster.OperationType = {
  * an array of the same.  The operations are called with a second "data"
  * argument, which can be used for storage.  The data object is accessible
  * from raster events, where it can be initialized in "beforeoperations" and
- * accessed again in "afteroperations."
+ * accessed again in "afteroperations".
  *
  * @typedef {function((Array.<ol.raster.Pixel>|Array.<ImageData>), Object):
  *     (Array.<ol.raster.Pixel>|Array.<ImageData>)}

--- a/src/ol/raster/pixel.js
+++ b/src/ol/raster/pixel.js
@@ -1,0 +1,9 @@
+goog.provide('ol.raster.Pixel');
+
+
+/**
+ * An array of numbers representing pixel values.
+ * @typedef {Array.<number>} ol.raster.Pixel
+ * @api
+ */
+ol.raster.Pixel;

--- a/src/ol/renderer/layerrenderer.js
+++ b/src/ol/renderer/layerrenderer.js
@@ -113,7 +113,6 @@ ol.renderer.Layer.prototype.createLoadedTileFinder = function(source, tiles) {
 
 
 /**
- * @protected
  * @return {ol.layer.Layer} Layer.
  */
 ol.renderer.Layer.prototype.getLayer = function() {

--- a/src/ol/source/rastersource.js
+++ b/src/ol/source/rastersource.js
@@ -105,6 +105,15 @@ goog.inherits(ol.source.Raster, ol.source.Image);
 
 
 /**
+ * Reset the operations.
+ * @param {Array.<ol.raster.Operation>} operations New operations.
+ */
+ol.source.Raster.prototype.setOperations = function(operations) {
+  this.operations_ = operations;
+};
+
+
+/**
  * Update the stored frame state.
  * @param {ol.Extent} extent The view extent (in map units).
  * @param {number} resolution The view resolution.
@@ -199,8 +208,7 @@ ol.source.Raster.prototype.composeFrame_ = function(frameState) {
       pixel[2] = source[j + 2];
       pixel[3] = source[j + 3];
     }
-    this.runOperations_(pixels);
-    pixel = pixels[0];
+    pixel = this.runOperations_(pixels)[0];
     target[j] = pixel[0];
     target[j + 1] = pixel[1];
     target[j + 2] = pixel[2];

--- a/src/ol/source/rastersource.js
+++ b/src/ol/source/rastersource.js
@@ -28,9 +28,9 @@ goog.require('ol.source.Tile');
 
 /**
  * @classdesc
- * An source that transforms data from any number of input sources source using
- * an array of {@link ol.raster.Operation} functions to transform input pixel
- * values into output pixel values.
+ * A source that transforms data from any number of input sources using an array
+ * of {@link ol.raster.Operation} functions to transform input pixel values into
+ * output pixel values.
  *
  * @constructor
  * @extends {ol.source.Image}

--- a/src/ol/source/rastersource.js
+++ b/src/ol/source/rastersource.js
@@ -223,9 +223,8 @@ ol.source.Raster.prototype.composeFrame_ = function(frameState) {
         this.renderers_[i], frameState, frameState.layerStatesArray[i]);
   }
 
-  var resolution = frameState.viewState.resolution / frameState.pixelRatio;
   this.dispatchEvent(new ol.source.RasterEvent(
-      ol.source.RasterEventType.BEFOREOPERATIONS, resolution));
+      ol.source.RasterEventType.BEFOREOPERATIONS, frameState));
 
   var targetImageData = null;
   if (this.operationType_ === ol.raster.OperationType.PIXEL) {
@@ -256,7 +255,7 @@ ol.source.Raster.prototype.composeFrame_ = function(frameState) {
   }
 
   this.dispatchEvent(new ol.source.RasterEvent(
-      ol.source.RasterEventType.AFTEROPERATIONS, resolution));
+      ol.source.RasterEventType.AFTEROPERATIONS, frameState));
 
   context.putImageData(targetImageData, 0, 0);
 
@@ -396,17 +395,24 @@ ol.source.Raster.createTileRenderer_ = function(source) {
  * @extends {goog.events.Event}
  * @implements {oli.source.RasterEvent}
  * @param {string} type Type.
- * @param {number} resolution Map units per pixel.
+ * @param {olx.FrameState} frameState The frame state.
  */
-ol.source.RasterEvent = function(type, resolution) {
+ol.source.RasterEvent = function(type, frameState) {
   goog.base(this, type);
 
   /**
-   * Map units per pixel.
+   * The raster extent.
+   * @type {ol.Extent}
+   * @api
+   */
+  this.extent = frameState.extent;
+
+  /**
+   * The pixel resolution (map units per pixel).
    * @type {number}
    * @api
    */
-  this.resolution = resolution;
+  this.resolution = frameState.viewState.resolution / frameState.pixelRatio;
 
 };
 goog.inherits(ol.source.RasterEvent, goog.events.Event);

--- a/src/ol/source/rastersource.js
+++ b/src/ol/source/rastersource.js
@@ -223,8 +223,9 @@ ol.source.Raster.prototype.composeFrame_ = function(frameState) {
         this.renderers_[i], frameState, frameState.layerStatesArray[i]);
   }
 
+  var data = {};
   this.dispatchEvent(new ol.source.RasterEvent(
-      ol.source.RasterEventType.BEFOREOPERATIONS, frameState));
+      ol.source.RasterEventType.BEFOREOPERATIONS, frameState, data));
 
   var targetImageData = null;
   if (this.operationType_ === ol.raster.OperationType.PIXEL) {
@@ -242,20 +243,20 @@ ol.source.Raster.prototype.composeFrame_ = function(frameState) {
         pixel[2] = source[j + 2];
         pixel[3] = source[j + 3];
       }
-      pixel = this.runPixelOperations_(pixels)[0];
+      pixel = this.runPixelOperations_(pixels, data)[0];
       target[j] = pixel[0];
       target[j + 1] = pixel[1];
       target[j + 2] = pixel[2];
       target[j + 3] = pixel[3];
     }
   } else if (this.operationType_ === ol.raster.OperationType.IMAGE) {
-    targetImageData = this.runImageOperations_(imageDatas)[0];
+    targetImageData = this.runImageOperations_(imageDatas, data)[0];
   } else {
     goog.asserts.fail('unsupported operation type: ' + this.operationType_);
   }
 
   this.dispatchEvent(new ol.source.RasterEvent(
-      ol.source.RasterEventType.AFTEROPERATIONS, frameState));
+      ol.source.RasterEventType.AFTEROPERATIONS, frameState, data));
 
   context.putImageData(targetImageData, 0, 0);
 
@@ -266,12 +267,13 @@ ol.source.Raster.prototype.composeFrame_ = function(frameState) {
 /**
  * Run pixel-wise operations to transform pixels.
  * @param {Array.<ol.raster.Pixel>} pixels The input pixels.
+ * @param {Object} data User storage.
  * @return {Array.<ol.raster.Pixel>} The modified pixels.
  * @private
  */
-ol.source.Raster.prototype.runPixelOperations_ = function(pixels) {
+ol.source.Raster.prototype.runPixelOperations_ = function(pixels, data) {
   for (var i = 0, ii = this.operations_.length; i < ii; ++i) {
-    pixels = this.operations_[i](pixels);
+    pixels = this.operations_[i](pixels, data);
   }
   return pixels;
 };
@@ -280,12 +282,13 @@ ol.source.Raster.prototype.runPixelOperations_ = function(pixels) {
 /**
  * Run image operations.
  * @param {Array.<ImageData>} imageDatas The input image data.
+ * @param {Object} data User storage.
  * @return {Array.<ImageData>} The output image data.
  * @private
  */
-ol.source.Raster.prototype.runImageOperations_ = function(imageDatas) {
+ol.source.Raster.prototype.runImageOperations_ = function(imageDatas, data) {
   for (var i = 0, ii = this.operations_.length; i < ii; ++i) {
-    imageDatas = this.operations_[i](imageDatas);
+    imageDatas = this.operations_[i](imageDatas, data);
   }
   return imageDatas;
 };
@@ -396,8 +399,9 @@ ol.source.Raster.createTileRenderer_ = function(source) {
  * @implements {oli.source.RasterEvent}
  * @param {string} type Type.
  * @param {olx.FrameState} frameState The frame state.
+ * @param {Object} data An object made available to operations.
  */
-ol.source.RasterEvent = function(type, frameState) {
+ol.source.RasterEvent = function(type, frameState, data) {
   goog.base(this, type);
 
   /**
@@ -413,6 +417,14 @@ ol.source.RasterEvent = function(type, frameState) {
    * @api
    */
   this.resolution = frameState.viewState.resolution / frameState.pixelRatio;
+
+  /**
+   * An object made available to all operations.  This can be used by operations
+   * as a storage object (e.g. for calculating statistics).
+   * @type {Object}
+   * @api
+   */
+  this.data = data;
 
 };
 goog.inherits(ol.source.RasterEvent, goog.events.Event);

--- a/src/ol/source/rastersource.js
+++ b/src/ol/source/rastersource.js
@@ -46,8 +46,8 @@ ol.source.Raster = function(options) {
   this.operationType_ = goog.isDef(options.operationType) ?
       options.operationType : ol.raster.OperationType.PIXEL;
 
-  var operations = goog.isDef(options.operations) ?
-      options.operations : [ol.raster.IdentityOp];
+  var operation = goog.isDef(options.operation) ?
+      options.operation : ol.raster.IdentityOp;
 
   /**
    * @private
@@ -59,7 +59,7 @@ ol.source.Raster = function(options) {
    * @private
    * @type {*}
    */
-  this.worker_ = this.createWorker_(operations, options.lib, this.threads_);
+  this.worker_ = this.createWorker_(operation, options.lib, this.threads_);
 
   /**
    * @private
@@ -146,16 +146,16 @@ goog.inherits(ol.source.Raster, ol.source.Image);
 
 /**
  * Create a worker.
- * @param {Array.<ol.raster.Operation>} operations The operations.
+ * @param {ol.raster.Operation} operation The operation.
  * @param {Object=} opt_lib Optional lib functions.
  * @param {number=} opt_threads Number of threads.
  * @return {*} The worker.
  * @private
  */
 ol.source.Raster.prototype.createWorker_ =
-    function(operations, opt_lib, opt_threads) {
+    function(operation, opt_lib, opt_threads) {
   return new ol.ext.pixelworks.Processor({
-    operations: operations,
+    operation: operation,
     imageOps: this.operationType_ === ol.raster.OperationType.IMAGE,
     queue: 1,
     lib: opt_lib,
@@ -165,14 +165,14 @@ ol.source.Raster.prototype.createWorker_ =
 
 
 /**
- * Reset the operations.
- * @param {Array.<ol.raster.Operation>} operations New operations.
+ * Reset the operation.
+ * @param {ol.raster.Operation} operation New operation.
  * @param {Object=} opt_lib Functions that will be available to operations run
  *     in a worker.
  * @api
  */
-ol.source.Raster.prototype.setOperations = function(operations, opt_lib) {
-  this.worker_ = this.createWorker_(operations, opt_lib, this.threads_);
+ol.source.Raster.prototype.setOperation = function(operation, opt_lib) {
+  this.worker_ = this.createWorker_(operation, opt_lib, this.threads_);
   this.changed();
 };
 

--- a/src/ol/source/rastersource.js
+++ b/src/ol/source/rastersource.js
@@ -117,8 +117,8 @@ ol.source.Raster.prototype.updateFrameState_ =
   var frameState = this.frameState_;
 
   var center = ol.extent.getCenter(extent);
-  var width = ol.extent.getWidth(extent) / resolution;
-  var height = ol.extent.getHeight(extent) / resolution;
+  var width = Math.round(ol.extent.getWidth(extent) / resolution);
+  var height = Math.round(ol.extent.getHeight(extent) / resolution);
 
   frameState.extent = extent;
   frameState.focus = ol.extent.getCenter(extent);
@@ -142,8 +142,8 @@ ol.source.Raster.prototype.getImage =
   var context = this.canvasContext_;
   var canvas = context.canvas;
 
-  var width = ol.extent.getWidth(extent) / resolution;
-  var height = ol.extent.getHeight(extent) / resolution;
+  var width = Math.round(ol.extent.getWidth(extent) / resolution);
+  var height = Math.round(ol.extent.getHeight(extent) / resolution);
 
   if (width !== canvas.width ||
       height !== canvas.height) {
@@ -178,8 +178,7 @@ ol.source.Raster.prototype.composeFrame_ = function(frameState) {
   for (var i = 0; i < len; ++i) {
     pixels[i] = [0, 0, 0, 0];
     imageDatas[i] = ol.source.Raster.getImageData_(
-        this.renderers_[i], canvas.width, canvas.height,
-        frameState, frameState.layerStatesArray[i]);
+        this.renderers_[i], frameState, frameState.layerStatesArray[i]);
   }
 
   var targetImageData = context.getImageData(0, 0, canvas.width, canvas.height);
@@ -234,15 +233,12 @@ ol.source.Raster.prototype.runOperations_ = function(pixels) {
 /**
  * Get image data from a renderer.
  * @param {ol.renderer.canvas.Layer} renderer Layer renderer.
- * @param {number} width Data width.
- * @param {number} height Data height.
  * @param {olx.FrameState} frameState The frame state.
  * @param {ol.layer.LayerState} layerState The layer state.
  * @return {ImageData} The image data.
  * @private
  */
-ol.source.Raster.getImageData_ =
-    function(renderer, width, height, frameState, layerState) {
+ol.source.Raster.getImageData_ = function(renderer, frameState, layerState) {
   renderer.prepareFrame(frameState, layerState);
   var canvas = renderer.getImage();
   var imageTransform = renderer.getImageTransform();
@@ -250,7 +246,7 @@ ol.source.Raster.getImageData_ =
   var dy = goog.vec.Mat4.getElement(imageTransform, 1, 3);
   return canvas.getContext('2d').getImageData(
       Math.round(-dx), Math.round(-dy),
-      width, height);
+      frameState.size[0], frameState.size[1]);
 };
 
 

--- a/src/ol/source/rastersource.js
+++ b/src/ol/source/rastersource.js
@@ -318,7 +318,10 @@ ol.source.Raster.prototype.onWorkerComplete_ =
   this.dispatchEvent(new ol.source.RasterEvent(
       ol.source.RasterEventType.AFTEROPERATIONS, frameState, data));
 
-  this.canvasContext_.putImageData(output, 0, 0);
+  var resolution = frameState.viewState.resolution / frameState.pixelRatio;
+  if (!this.isDirty_(frameState.extent, resolution)) {
+    this.canvasContext_.putImageData(output, 0, 0);
+  }
 
   callback(null);
 };

--- a/src/ol/source/rastersource.js
+++ b/src/ol/source/rastersource.js
@@ -16,6 +16,7 @@ goog.require('ol.raster.IdentityOp');
 goog.require('ol.renderer.canvas.ImageLayer');
 goog.require('ol.renderer.canvas.TileLayer');
 goog.require('ol.source.Image');
+goog.require('ol.source.State');
 goog.require('ol.source.Tile');
 
 
@@ -173,12 +174,34 @@ ol.source.Raster.prototype.getImage =
 
 
 /**
+ * Determine if all sources are ready.
+ * @return {boolean} All sources are ready.
+ * @private
+ */
+ol.source.Raster.prototype.allSourcesReady_ = function() {
+  var ready = true;
+  var source;
+  for (var i = 0, ii = this.renderers_.length; i < ii; ++i) {
+    source = this.renderers_[i].getLayer().getSource();
+    if (source.getState() !== ol.source.State.READY) {
+      ready = false;
+      break;
+    }
+  }
+  return ready;
+};
+
+
+/**
  * Compose the frame.  This renders data from all sources, runs pixel-wise
  * operations, and renders the result to the stored canvas context.
  * @param {olx.FrameState} frameState The frame state.
  * @private
  */
 ol.source.Raster.prototype.composeFrame_ = function(frameState) {
+  if (!this.allSourcesReady_()) {
+    return;
+  }
   var len = this.renderers_.length;
   var imageDatas = new Array(len);
   var pixels = new Array(len);

--- a/src/ol/source/rastersource.js
+++ b/src/ol/source/rastersource.js
@@ -269,21 +269,21 @@ ol.source.Raster.prototype.composeFrame_ = function(frameState, callback) {
       ol.source.RasterEventType.BEFOREOPERATIONS, frameState, data));
 
   this.worker_.process(imageDatas, data,
-      this.onWorkerComplete_.bind(this, frameState, data, callback));
+      this.onWorkerComplete_.bind(this, frameState, callback));
 };
 
 
 /**
  * Called when pixel processing is complete.
  * @param {olx.FrameState} frameState The frame state.
- * @param {Object} data The user data.
  * @param {function(Error)} callback Called when rendering is complete.
  * @param {Error} err Any error during processing.
  * @param {ImageData} output The output image data.
+ * @param {Object} data The user data.
  * @private
  */
 ol.source.Raster.prototype.onWorkerComplete_ =
-    function(frameState, data, callback, err, output) {
+    function(frameState, callback, err, output, data) {
   if (err) {
     callback(err);
     return;

--- a/src/ol/source/rastersource.js
+++ b/src/ol/source/rastersource.js
@@ -37,14 +37,21 @@ goog.require('ol.source.Tile');
  */
 ol.source.Raster = function(options) {
 
+  /**
+   * @private
+   * @type {ol.raster.OperationType}
+   */
+  this.operationType_ = goog.isDef(options.operationType) ?
+      options.operationType : ol.raster.OperationType.PIXEL;
+
   var operations = goog.isDef(options.operations) ?
       options.operations : [ol.raster.IdentityOp];
 
-  this.worker_ = new ol.ext.pixelworks.Processor({
-    operations: operations,
-    imageOps: options.operationType === ol.raster.OperationType.IMAGE,
-    queue: 1
-  });
+  /**
+   * @private
+   * @type {*}
+   */
+  this.worker_ = this.createWorker_(operations);
 
   /**
    * @private
@@ -125,12 +132,27 @@ goog.inherits(ol.source.Raster, ol.source.Image);
 
 
 /**
+ * Create a worker.
+ * @param {Array.<ol.raster.Operation>} operations The operations.
+ * @return {*} The worker.
+ * @private
+ */
+ol.source.Raster.prototype.createWorker_ = function(operations) {
+  return new ol.ext.pixelworks.Processor({
+    operations: operations,
+    imageOps: this.operationType_ === ol.raster.OperationType.IMAGE,
+    queue: 1
+  });
+};
+
+
+/**
  * Reset the operations.
  * @param {Array.<ol.raster.Operation>} operations New operations.
  * @api
  */
 ol.source.Raster.prototype.setOperations = function(operations) {
-  this.worker_.setOperations(operations);
+  this.worker_ = this.createWorker_(operations);
   this.changed();
 };
 

--- a/src/ol/source/rastersource.js
+++ b/src/ol/source/rastersource.js
@@ -107,9 +107,11 @@ goog.inherits(ol.source.Raster, ol.source.Image);
 /**
  * Reset the operations.
  * @param {Array.<ol.raster.Operation>} operations New operations.
+ * @api
  */
 ol.source.Raster.prototype.setOperations = function(operations) {
   this.operations_ = operations;
+  this.changed();
 };
 
 

--- a/src/ol/source/rastersource.js
+++ b/src/ol/source/rastersource.js
@@ -1,0 +1,316 @@
+goog.provide('ol.source.Raster');
+
+goog.require('goog.asserts');
+goog.require('goog.functions');
+goog.require('goog.vec.Mat4');
+goog.require('ol.ImageCanvas');
+goog.require('ol.TileQueue');
+goog.require('ol.dom');
+goog.require('ol.extent');
+goog.require('ol.layer.Image');
+goog.require('ol.layer.Tile');
+goog.require('ol.raster.IdentityOp');
+goog.require('ol.renderer.canvas.ImageLayer');
+goog.require('ol.renderer.canvas.TileLayer');
+goog.require('ol.source.Image');
+goog.require('ol.source.Tile');
+
+
+
+/**
+ * @classdesc
+ * An source that transforms data from any number of input sources source using
+ * an array of {@link ol.raster.Operation} functions to transform input pixel
+ * values into output pixel values.
+ *
+ * @constructor
+ * @extends {ol.source.Image}
+ * @param {olx.source.RasterOptions} options Options.
+ * @api
+ */
+ol.source.Raster = function(options) {
+
+  /**
+   * @private
+   * @type {Array.<ol.raster.Operation>}
+   */
+  this.operations_ = goog.isDef(options.operations) ?
+      options.operations : [ol.raster.IdentityOp];
+
+  /**
+   * @private
+   * @type {Array.<ol.renderer.canvas.Layer>}
+   */
+  this.renderers_ = ol.source.Raster.createRenderers_(options.sources);
+
+  /**
+   * @private
+   * @type {CanvasRenderingContext2D}
+   */
+  this.canvasContext_ = ol.dom.createCanvasContext2D();
+
+  /**
+   * @private
+   * @type {ol.TileQueue}
+   */
+  this.tileQueue_ = new ol.TileQueue(
+      goog.functions.constant(1),
+      goog.bind(this.changed, this));
+
+  var layerStatesArray = ol.source.Raster.getLayerStatesArray_(this.renderers_);
+  var layerStates = {};
+  for (var i = 0, ii = layerStatesArray.length; i < ii; ++i) {
+    layerStates[goog.getUid(layerStatesArray[i].layer)] = layerStatesArray[i];
+  }
+
+  /**
+   * @private
+   * @type {olx.FrameState}
+   */
+  this.frameState_ = {
+    animate: false,
+    attributions: {},
+    coordinateToPixelMatrix: goog.vec.Mat4.createNumber(),
+    extent: null,
+    focus: null,
+    index: 0,
+    layerStates: layerStates,
+    layerStatesArray: layerStatesArray,
+    logos: {},
+    pixelRatio: 1,
+    pixelToCoordinateMatrix: goog.vec.Mat4.createNumber(),
+    postRenderFunctions: [],
+    size: [0, 0],
+    skippedFeatureUids: {},
+    tileQueue: this.tileQueue_,
+    time: Date.now(),
+    usedTiles: {},
+    viewState: /** @type {olx.ViewState} */ ({
+      rotation: 0
+    }),
+    viewHints: [],
+    wantedTiles: {}
+  };
+
+  goog.base(this, {
+    // TODO: pass along any relevant options
+  });
+
+
+};
+goog.inherits(ol.source.Raster, ol.source.Image);
+
+
+/**
+ * Update the stored frame state.
+ * @param {ol.Extent} extent The view extent (in map units).
+ * @param {number} resolution The view resolution.
+ * @param {ol.proj.Projection} projection The view projection.
+ * @return {olx.FrameState} The updated frame state.
+ * @private
+ */
+ol.source.Raster.prototype.updateFrameState_ =
+    function(extent, resolution, projection) {
+  var frameState = this.frameState_;
+
+  var center = ol.extent.getCenter(extent);
+  var width = ol.extent.getWidth(extent) / resolution;
+  var height = ol.extent.getHeight(extent) / resolution;
+
+  frameState.extent = extent;
+  frameState.focus = ol.extent.getCenter(extent);
+  frameState.size[0] = width;
+  frameState.size[1] = height;
+
+  var viewState = frameState.viewState;
+  viewState.center = center;
+  viewState.projection = projection;
+  viewState.resolution = resolution;
+  return frameState;
+};
+
+
+/**
+ * @inheritDoc
+ */
+ol.source.Raster.prototype.getImage =
+    function(extent, resolution, pixelRatio, projection) {
+
+  var context = this.canvasContext_;
+  var canvas = context.canvas;
+
+  var width = ol.extent.getWidth(extent) / resolution;
+  var height = ol.extent.getHeight(extent) / resolution;
+
+  if (width !== canvas.width ||
+      height !== canvas.height) {
+    canvas.width = width;
+    canvas.height = height;
+  }
+
+  var frameState = this.updateFrameState_(extent, resolution, projection);
+  this.composeFrame_(frameState);
+
+  var imageCanvas = new ol.ImageCanvas(extent, resolution, 1,
+      this.getAttributions(), canvas);
+
+  return imageCanvas;
+};
+
+
+/**
+ * Compose the frame.  This renders data from all sources, runs pixel-wise
+ * operations, and renders the result to the stored canvas context.
+ * @param {olx.FrameState} frameState The frame state.
+ * @private
+ */
+ol.source.Raster.prototype.composeFrame_ = function(frameState) {
+  var len = this.renderers_.length;
+  var imageDatas = new Array(len);
+  var pixels = new Array(len);
+
+  var context = this.canvasContext_;
+  var canvas = context.canvas;
+
+  for (var i = 0; i < len; ++i) {
+    pixels[i] = [0, 0, 0, 0];
+    imageDatas[i] = ol.source.Raster.getImageData_(
+        this.renderers_[i], canvas.width, canvas.height,
+        frameState, frameState.layerStatesArray[i]);
+  }
+
+  var targetImageData = context.getImageData(0, 0, canvas.width, canvas.height);
+  var target = targetImageData.data;
+
+  var source, pixel;
+  for (var j = 0, jj = target.length; j < jj; j += 4) {
+    for (var k = 0; k < len; ++k) {
+      source = imageDatas[k].data;
+      pixel = pixels[k];
+      pixel[0] = source[j];
+      pixel[1] = source[j + 1];
+      pixel[2] = source[j + 2];
+      pixel[3] = source[j + 3];
+    }
+    this.transformPixels_(pixels);
+    pixel = pixels[0];
+    target[j] = pixel[0];
+    target[j + 1] = pixel[1];
+    target[j + 2] = pixel[2];
+    target[j + 3] = pixel[3];
+  }
+  context.putImageData(targetImageData, 0, 0);
+
+  frameState.tileQueue.loadMoreTiles(16, 16);
+};
+
+
+/**
+ * Run pixel-wise operations to transform pixels.
+ * @param {Array.<ol.raster.Pixel>} pixels The input pixels.
+ * @return {Array.<ol.raster.Pixel>} The modified pixels.
+ * @private
+ */
+ol.source.Raster.prototype.transformPixels_ = function(pixels) {
+  for (var i = 0, ii = this.operations_.length; i < ii; ++i) {
+    pixels = this.operations_[i](pixels);
+  }
+  return pixels;
+};
+
+
+/**
+ * Get image data from a renderer.
+ * @param {ol.renderer.canvas.Layer} renderer Layer renderer.
+ * @param {number} width Data width.
+ * @param {number} height Data height.
+ * @param {olx.FrameState} frameState The frame state.
+ * @param {ol.layer.LayerState} layerState The layer state.
+ * @return {ImageData} The image data.
+ * @private
+ */
+ol.source.Raster.getImageData_ =
+    function(renderer, width, height, frameState, layerState) {
+  renderer.prepareFrame(frameState, layerState);
+  var canvas = renderer.getImage();
+  var imageTransform = renderer.getImageTransform();
+  var dx = goog.vec.Mat4.getElement(imageTransform, 0, 3);
+  var dy = goog.vec.Mat4.getElement(imageTransform, 1, 3);
+  return canvas.getContext('2d').getImageData(
+      Math.round(-dx), Math.round(-dy),
+      width, height);
+};
+
+
+/**
+ * Get a list of layer states from a list of renderers.
+ * @param {Array.<ol.renderer.canvas.Layer>} renderers Layer renderers.
+ * @return {Array.<ol.layer.LayerState>} The layer states.
+ * @private
+ */
+ol.source.Raster.getLayerStatesArray_ = function(renderers) {
+  return renderers.map(function(renderer) {
+    return renderer.getLayer().getLayerState();
+  });
+};
+
+
+/**
+ * Create renderers for all sources.
+ * @param {Array.<ol.source.Source>} sources The sources.
+ * @return {Array.<ol.renderer.canvas.Layer>} Array of layer renderers.
+ * @private
+ */
+ol.source.Raster.createRenderers_ = function(sources) {
+  var len = sources.length;
+  var renderers = new Array(len);
+  for (var i = 0; i < len; ++i) {
+    renderers[i] = ol.source.Raster.createRenderer_(sources[i]);
+  }
+  return renderers;
+};
+
+
+/**
+ * Create a renderer for the provided source.
+ * @param {ol.source.Source} source The source.
+ * @return {ol.renderer.canvas.Layer} The renderer.
+ * @private
+ */
+ol.source.Raster.createRenderer_ = function(source) {
+  var renderer = null;
+  if (source instanceof ol.source.Tile) {
+    renderer = ol.source.Raster.createTileRenderer_(
+        /** @type {ol.source.Tile} */ (source));
+  } else if (source instanceof ol.source.Image) {
+    renderer = ol.source.Raster.createImageRenderer_(
+        /** @type {ol.source.Image} */ (source));
+  } else {
+    goog.asserts.fail('Unsupported source type: ' + source);
+  }
+  return renderer;
+};
+
+
+/**
+ * Create an image renderer for the provided source.
+ * @param {ol.source.Image} source The source.
+ * @return {ol.renderer.canvas.Layer} The renderer.
+ * @private
+ */
+ol.source.Raster.createImageRenderer_ = function(source) {
+  var layer = new ol.layer.Image({source: source});
+  return new ol.renderer.canvas.ImageLayer(layer);
+};
+
+
+/**
+ * Create a tile renderer for the provided source.
+ * @param {ol.source.Tile} source The source.
+ * @return {ol.renderer.canvas.Layer} The renderer.
+ * @private
+ */
+ol.source.Raster.createTileRenderer_ = function(source) {
+  var layer = new ol.layer.Tile({source: source});
+  return new ol.renderer.canvas.TileLayer(layer);
+};

--- a/test/spec/ol/source/rastersource.test.js
+++ b/test/spec/ol/source/rastersource.test.js
@@ -52,9 +52,9 @@ describe('ol.source.Raster', function() {
     raster = new ol.source.Raster({
       threads: 0,
       sources: [redSource, greenSource, blueSource],
-      operations: [function(inputs) {
-        return inputs;
-      }]
+      operation: function(inputs) {
+        return inputs[0];
+      }
     });
 
     map = new ol.Map({
@@ -91,17 +91,17 @@ describe('ol.source.Raster', function() {
       expect(source).to.be.a(ol.source.Raster);
     });
 
-    itNoPhantom('defaults to "pixel" operations', function(done) {
+    itNoPhantom('defaults to "pixel" operation', function(done) {
 
       var log = [];
 
       raster = new ol.source.Raster({
         threads: 0,
         sources: [redSource, greenSource, blueSource],
-        operations: [function(inputs) {
+        operation: function(inputs) {
           log.push(inputs);
-          return inputs;
-        }]
+          return inputs[0];
+        }
       });
 
       raster.on('afteroperations', function() {
@@ -127,10 +127,10 @@ describe('ol.source.Raster', function() {
         operationType: ol.raster.OperationType.IMAGE,
         threads: 0,
         sources: [redSource, greenSource, blueSource],
-        operations: [function(inputs) {
+        operation: function(inputs) {
           log.push(inputs);
-          return inputs;
-        }]
+          return inputs[0];
+        }
       });
 
       raster.on('afteroperations', function() {
@@ -149,12 +149,12 @@ describe('ol.source.Raster', function() {
 
   });
 
-  describe('#setOperations()', function() {
+  describe('#setOperation()', function() {
 
-    itNoPhantom('allows operations to be set', function(done) {
+    itNoPhantom('allows operation to be set', function(done) {
 
       var count = 0;
-      raster.setOperations([function(pixels) {
+      raster.setOperation(function(pixels) {
         ++count;
         var redPixel = pixels[0];
         var greenPixel = pixels[1];
@@ -162,8 +162,8 @@ describe('ol.source.Raster', function() {
         expect(redPixel).to.eql([255, 0, 0, 255]);
         expect(greenPixel).to.eql([0, 255, 0, 255]);
         expect(bluePixel).to.eql([0, 0, 255, 255]);
-        return pixels;
-      }]);
+        return pixels[0];
+      });
 
       var view = map.getView();
       view.setCenter([0, 0]);
@@ -176,7 +176,7 @@ describe('ol.source.Raster', function() {
 
     });
 
-    itNoPhantom('updates and re-runs the operations', function(done) {
+    itNoPhantom('updates and re-runs the operation', function(done) {
 
       var view = map.getView();
       view.setCenter([0, 0]);
@@ -186,9 +186,9 @@ describe('ol.source.Raster', function() {
       raster.on('afteroperations', function(event) {
         ++count;
         if (count === 1) {
-          raster.setOperations([function(inputs) {
-            return inputs;
-          }]);
+          raster.setOperation(function(inputs) {
+            return inputs[0];
+          });
         } else {
           done();
         }
@@ -203,10 +203,10 @@ describe('ol.source.Raster', function() {
     itNoPhantom('gets called before operations are run', function(done) {
 
       var count = 0;
-      raster.setOperations([function(inputs) {
+      raster.setOperation(function(inputs) {
         ++count;
-        return inputs;
-      }]);
+        return inputs[0];
+      });
 
       raster.on('beforeoperations', function(event) {
         expect(count).to.equal(0);
@@ -224,12 +224,12 @@ describe('ol.source.Raster', function() {
     });
 
 
-    itNoPhantom('allows data to be set for the operations', function(done) {
+    itNoPhantom('allows data to be set for the operation', function(done) {
 
-      raster.setOperations([function(inputs, data) {
+      raster.setOperation(function(inputs, data) {
         ++data.count;
-        return inputs;
-      }]);
+        return inputs[0];
+      });
 
       raster.on('beforeoperations', function(event) {
         event.data.count = 0;
@@ -253,10 +253,10 @@ describe('ol.source.Raster', function() {
     itNoPhantom('gets called after operations are run', function(done) {
 
       var count = 0;
-      raster.setOperations([function(inputs) {
+      raster.setOperation(function(inputs) {
         ++count;
-        return inputs;
-      }]);
+        return inputs[0];
+      });
 
       raster.on('afteroperations', function(event) {
         expect(count).to.equal(4);
@@ -273,12 +273,12 @@ describe('ol.source.Raster', function() {
 
     });
 
-    itNoPhantom('receives data set by the operations', function(done) {
+    itNoPhantom('receives data set by the operation', function(done) {
 
-      raster.setOperations([function(inputs, data) {
+      raster.setOperation(function(inputs, data) {
         data.message = 'hello world';
-        return inputs;
-      }]);
+        return inputs[0];
+      });
 
       raster.on('afteroperations', function(event) {
         expect(event.data.message).to.equal('hello world');

--- a/test/spec/ol/source/rastersource.test.js
+++ b/test/spec/ol/source/rastersource.test.js
@@ -1,0 +1,307 @@
+goog.provide('ol.test.source.RasterSource');
+
+var red = 'data:image/gif;base64,R0lGODlhAQABAPAAAP8AAP///yH5BAAAAAAALAAAAAA' +
+    'BAAEAAAICRAEAOw==';
+
+var green = 'data:image/gif;base64,R0lGODlhAQABAPAAAAD/AP///yH5BAAAAAAALAAAA' +
+    'AABAAEAAAICRAEAOw==';
+
+var blue = 'data:image/gif;base64,R0lGODlhAQABAPAAAAAA/////yH5BAAAAAAALAAAAA' +
+    'ABAAEAAAICRAEAOw==';
+
+function itNoPhantom() {
+  if (window.mochaPhantomJS) {
+    return xit.apply(this, arguments);
+  } else {
+    return it.apply(this, arguments);
+  }
+}
+
+describe('ol.source.Raster', function() {
+
+  var target, map, redSource, greenSource, blueSource;
+
+  beforeEach(function() {
+    target = document.createElement('div');
+
+    var style = target.style;
+    style.position = 'absolute';
+    style.left = '-1000px';
+    style.top = '-1000px';
+    style.width = '2px';
+    style.height = '2px';
+    document.body.appendChild(target);
+
+    var extent = [-1, -1, 1, 1];
+
+    redSource = new ol.source.ImageStatic({
+      url: red,
+      imageExtent: extent
+    });
+
+    greenSource = new ol.source.ImageStatic({
+      url: green,
+      imageExtent: extent
+    });
+
+    blueSource = new ol.source.ImageStatic({
+      url: blue,
+      imageExtent: extent
+    });
+
+    raster = new ol.source.Raster({
+      threads: 0,
+      sources: [redSource, greenSource, blueSource],
+      operations: [function(inputs) {
+        return inputs;
+      }]
+    });
+
+    map = new ol.Map({
+      target: target,
+      view: new ol.View({
+        resolutions: [1],
+        projection: new ol.proj.Projection({
+          code: 'image',
+          units: 'pixels',
+          extent: extent
+        })
+      }),
+      layers: [
+        new ol.layer.Image({
+          source: raster
+        })
+      ]
+    });
+  });
+
+  afterEach(function() {
+    goog.dispose(map);
+    document.body.removeChild(target);
+  });
+
+  describe('constructor', function() {
+
+    it('returns a tile source', function() {
+      var source = new ol.source.Raster({
+        threads: 0,
+        sources: [new ol.source.Tile({})]
+      });
+      expect(source).to.be.a(ol.source.Source);
+      expect(source).to.be.a(ol.source.Raster);
+    });
+
+    itNoPhantom('defaults to "pixel" operations', function(done) {
+
+      var log = [];
+
+      raster = new ol.source.Raster({
+        threads: 0,
+        sources: [redSource, greenSource, blueSource],
+        operations: [function(inputs) {
+          log.push(inputs);
+          return inputs;
+        }]
+      });
+
+      raster.on('afteroperations', function() {
+        expect(log.length).to.equal(4);
+        var inputs = log[0];
+        var pixel = inputs[0];
+        expect(pixel).to.be.an('array');
+        done();
+      });
+
+      map.getLayers().item(0).setSource(raster);
+      var view = map.getView();
+      view.setCenter([0, 0]);
+      view.setZoom(0);
+
+    });
+
+    itNoPhantom('allows operation type to be set to "image"', function(done) {
+
+      var log = [];
+
+      raster = new ol.source.Raster({
+        operationType: ol.raster.OperationType.IMAGE,
+        threads: 0,
+        sources: [redSource, greenSource, blueSource],
+        operations: [function(inputs) {
+          log.push(inputs);
+          return inputs;
+        }]
+      });
+
+      raster.on('afteroperations', function() {
+        expect(log.length).to.equal(1);
+        var inputs = log[0];
+        expect(inputs[0]).to.be.an(ImageData);
+        done();
+      });
+
+      map.getLayers().item(0).setSource(raster);
+      var view = map.getView();
+      view.setCenter([0, 0]);
+      view.setZoom(0);
+
+    });
+
+  });
+
+  describe('#setOperations()', function() {
+
+    itNoPhantom('allows operations to be set', function(done) {
+
+      var count = 0;
+      raster.setOperations([function(pixels) {
+        ++count;
+        var redPixel = pixels[0];
+        var greenPixel = pixels[1];
+        var bluePixel = pixels[2];
+        expect(redPixel).to.eql([255, 0, 0, 255]);
+        expect(greenPixel).to.eql([0, 255, 0, 255]);
+        expect(bluePixel).to.eql([0, 0, 255, 255]);
+        return pixels;
+      }]);
+
+      var view = map.getView();
+      view.setCenter([0, 0]);
+      view.setZoom(0);
+
+      raster.on('afteroperations', function(event) {
+        expect(count).to.equal(4);
+        done();
+      });
+
+    });
+
+    itNoPhantom('updates and re-runs the operations', function(done) {
+
+      var view = map.getView();
+      view.setCenter([0, 0]);
+      view.setZoom(0);
+
+      var count = 0;
+      raster.on('afteroperations', function(event) {
+        ++count;
+        if (count === 1) {
+          raster.setOperations([function(inputs) {
+            return inputs;
+          }]);
+        } else {
+          done();
+        }
+      });
+
+    });
+
+  });
+
+  describe('beforeoperations', function() {
+
+    itNoPhantom('gets called before operations are run', function(done) {
+
+      var count = 0;
+      raster.setOperations([function(inputs) {
+        ++count;
+        return inputs;
+      }]);
+
+      raster.on('beforeoperations', function(event) {
+        expect(count).to.equal(0);
+        expect(!!event).to.be(true);
+        expect(event.extent).to.be.an('array');
+        expect(event.resolution).to.be.a('number');
+        expect(event.data).to.be.an('object');
+        done();
+      });
+
+      var view = map.getView();
+      view.setCenter([0, 0]);
+      view.setZoom(0);
+
+    });
+
+
+    itNoPhantom('allows data to be set for the operations', function(done) {
+
+      raster.setOperations([function(inputs, data) {
+        ++data.count;
+        return inputs;
+      }]);
+
+      raster.on('beforeoperations', function(event) {
+        event.data.count = 0;
+      });
+
+      raster.on('afteroperations', function(event) {
+        expect(event.data.count).to.equal(4);
+        done();
+      });
+
+      var view = map.getView();
+      view.setCenter([0, 0]);
+      view.setZoom(0);
+
+    });
+
+  });
+
+  describe('afteroperations', function() {
+
+    itNoPhantom('gets called after operations are run', function(done) {
+
+      var count = 0;
+      raster.setOperations([function(inputs) {
+        ++count;
+        return inputs;
+      }]);
+
+      raster.on('afteroperations', function(event) {
+        expect(count).to.equal(4);
+        expect(!!event).to.be(true);
+        expect(event.extent).to.be.an('array');
+        expect(event.resolution).to.be.a('number');
+        expect(event.data).to.be.an('object');
+        done();
+      });
+
+      var view = map.getView();
+      view.setCenter([0, 0]);
+      view.setZoom(0);
+
+    });
+
+    itNoPhantom('receives data set by the operations', function(done) {
+
+      raster.setOperations([function(inputs, data) {
+        data.message = 'hello world';
+        return inputs;
+      }]);
+
+      raster.on('afteroperations', function(event) {
+        expect(event.data.message).to.equal('hello world');
+        done();
+      });
+
+      var view = map.getView();
+      view.setCenter([0, 0]);
+      view.setZoom(0);
+
+    });
+
+  });
+
+});
+
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.layer.Image');
+goog.require('ol.proj.Projection');
+goog.require('ol.raster.OperationType');
+goog.require('ol.source.Image');
+goog.require('ol.source.ImageStatic');
+goog.require('ol.source.Raster');
+goog.require('ol.source.Source');
+goog.require('ol.source.Tile');


### PR DESCRIPTION
This adds an `ol.source.Raster` that takes any number of input sources (image or tile based) and runs a pipeline of operations.  The return from the final operation is used as the data for the output source.  This source can then in turn be used in an image layer.

Operations can either be pixel based or image based.  By default, operations are called for each pixel in the input sources.  By setting `operationType: 'image'` on the raster source, operations are called with an array of `ImageData` objects (one for each input source).  Operations return the same type that they are called with (an array of pixels for pixel-wise operations or an array of `ImageData` for image operations).

Examples:

 * pixel-wise operations: http://tschaub.net/ol-raster/examples/raster.html
 * image operations: http://tschaub.net/ol-raster/examples/shaded-relief.html

Caveats:

 * The device pixel ratio is ignored.  This is a simplification and optimization.
 * Operations are run in a [`Worker`](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers).  This means that they can only use the data they are called with.  `ImageData` is transferred with [structured cloning](https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/The_structured_clone_algorithm) and should be efficient.  The second `data` argument is available in the `beforeoperations` event where an application can provide additional data to the operations.  All properties assigned to `data` must be serializable.
 * The [underlying library](https://github.com/tschaub/pixelworks) that runs the operations allows the main UI thread to be used as well.  We could give the raster source an additional option that avoids using workers (for fast operations, this may be more efficient than transferring data to the worker).