### PR TITLE
Add stroke to default editing style for geometry collections

### DIFF
--- a/src/ol/style/style.js
+++ b/src/ol/style/style.js
@@ -347,6 +347,7 @@ ol.style.createDefaultEditingStyles = function() {
 
   styles[ol.geom.GeometryType.GEOMETRY_COLLECTION] =
       styles[ol.geom.GeometryType.POLYGON].concat(
+          styles[ol.geom.GeometryType.LINE_STRING],
           styles[ol.geom.GeometryType.POINT]
       );
 


### PR DESCRIPTION
If one creates a default editing style and uses if for features with a geometry of `GeometryCollection` type, they will appear without any stroke. Lines within a collection will even be invisible.
This pull request fixes this.
Please review.