### PR TITLE
Fix typos found by codespell

### DIFF
--- a/bin/BeautifulSoup.py
+++ b/bin/BeautifulSoup.py
@@ -1095,7 +1095,7 @@ class BeautifulStoneSoup(Tag, SGMLParser):
             p = self.tagStack[i]
             if (not p or p.name == name) and not isNestable:
                 #Non-nestable tags get popped to the top or to their
-                #last occurance.
+                #last occurrence.
                 popTo = name
                 break
             if (nestingResetTriggers != None
@@ -1242,14 +1242,14 @@ class BeautifulSoup(BeautifulStoneSoup):
 
     * Tag nesting rules:
 
-      Most tags can't be nested at all. For instance, the occurance of
+      Most tags can't be nested at all. For instance, the occurrence of
       a <p> tag should implicitly close the previous <p> tag.
 
        <p>Para1<p>Para2
         should be transformed into:
        <p>Para1</p><p>Para2
 
-      Some tags can be nested arbitrarily. For instance, the occurance
+      Some tags can be nested arbitrarily. For instance, the occurrence
       of a <blockquote> tag should _not_ implicitly close the previous
       <blockquote> tag.
 

--- a/bin/example-screenshot.js
+++ b/bin/example-screenshot.js
@@ -140,7 +140,7 @@
 
   console.log('Capturing ' + lenHtmlFiles + ' example screenshots.');
 
-  // The main interval function that is executed regularily and renders a
+  // The main interval function that is executed regularly and renders a
   // page to a file
   var interval = setInterval(function() {
     if (!loadInProgress && pageindex < lenHtmlFiles) {

--- a/build.py
+++ b/build.py
@@ -804,7 +804,7 @@ Other less frequently used targets are:
 If no target is given, the build-target will be executed.
 
 The above list is not complete, please see the source code for not-mentioned
-and only seldomly called targets.
+and only seldom called targets.
     '''
 
 if __name__ == '__main__':

--- a/src/ol/collection.js
+++ b/src/ol/collection.js
@@ -216,7 +216,7 @@ ol.Collection.prototype.push = function(elem) {
 
 
 /**
- * Removes the first occurence of elem from the collection.
+ * Removes the first occurrence of elem from the collection.
  * @param {T} elem Element.
  * @return {T|undefined} The removed element or undefined if elem was not found.
  * @api stable

--- a/src/ol/coordinate.js
+++ b/src/ol/coordinate.js
@@ -159,7 +159,7 @@ ol.coordinate.degreesToStringHDMS_ = function(degrees, hemispheres) {
  *     that will be replaced by first and second coordinate values.
  * @param {number=} opt_fractionDigits The number of digits to include
  *    after the decimal point. Default is `0`.
- * @return {string} Formated coordinate.
+ * @return {string} Formatted coordinate.
  * @api stable
  */
 ol.coordinate.format = function(coordinate, template, opt_fractionDigits) {

--- a/src/ol/deviceorientation.js
+++ b/src/ol/deviceorientation.js
@@ -28,7 +28,7 @@ ol.DeviceOrientationProperty = {
  *
  * Many new computers, and especially mobile phones
  * and tablets, provide hardware support for device orientation. Web
- * developers targetting mobile devices will be especially interested in this
+ * developers targeting mobile devices will be especially interested in this
  * class.
  *
  * Device orientation data are relative to a common starting point. For mobile

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -1,4 +1,4 @@
-// FIXME recheck layer/map projection compatability when projection changes
+// FIXME recheck layer/map projection compatibility when projection changes
 // FIXME layer renderers should skip when they can't reproject
 // FIXME add tilt and height?
 

--- a/src/ol/pointer/touchsource.js
+++ b/src/ol/pointer/touchsource.js
@@ -187,7 +187,7 @@ ol.pointer.TouchSource.prototype.touchToPointer_ =
   // Touch identifiers can start at 0.
   // Add 2 to the touch identifier for compatibility.
   e.pointerId = inTouch.identifier + 2;
-  // TODO: check if this is neccessary?
+  // TODO: check if this is necessary?
   //e.target = findTarget(e);
   e.bubbles = true;
   e.cancelable = true;

--- a/src/ol/sphere/sphere.js
+++ b/src/ol/sphere/sphere.js
@@ -2,7 +2,7 @@
  * @license
  * Latitude/longitude spherical geodesy formulae taken from
  * http://www.movable-type.co.uk/scripts/latlong.html
- * Licenced under CC-BY-3.0.
+ * Licensed under CC-BY-3.0.
  */
 
 // FIXME add intersection of two paths given start points and bearings

--- a/tasks/generate-exports.js
+++ b/tasks/generate-exports.js
@@ -72,7 +72,7 @@ function getSymbols(patterns, callback) {
 /**
  * Generate a list of symbol names given a list of patterns.  Patterns may
  * include a * wildcard at the end of the string, in which case all symbol names
- * that start with the preceeding string will be matched (e.g 'foo.Bar#*' will
+ * that start with the preceding string will be matched (e.g 'foo.Bar#*' will
  * match all symbol names that start with 'foo.Bar#').
  *
  * @param {Array.<string>} patterns A list of symbol names to match.  Wildcards

--- a/test/spec/ol/format/gpxformat.test.js
+++ b/test/spec/ol/format/gpxformat.test.js
@@ -220,7 +220,7 @@ describe('ol.format.GPX', function() {
         expect(serialized).to.xmleql(ol.xml.parse(text));
       });
 
-      it('can tranform, read and write a trk with a trkseg', function() {
+      it('can transform, read and write a trk with a trkseg', function() {
         var text =
             '<gpx xmlns="http://www.topografix.com/GPX/1/1">' +
             '  <trk>' +

--- a/test/spec/ol/format/kmlformat.test.js
+++ b/test/spec/ol/format/kmlformat.test.js
@@ -919,7 +919,7 @@ describe('ol.format.KML', function() {
         expect(g.getGeometries()).to.be.empty();
       });
 
-      it('can read heterogenous GeometryCollection geometries', function() {
+      it('can read heterogeneous GeometryCollection geometries', function() {
         var text =
             '<kml xmlns="http://earth.google.com/kml/2.2">' +
             '  <Placemark>' +
@@ -2407,7 +2407,7 @@ describe('ol.format.KML', function() {
       expect(features).to.have.length(50);
     });
 
-    it('creates features with heterogenous geometry collections', function() {
+    it('creates features with heterogeneous geometry collections', function() {
       // FIXME decide if we should instead create features with multiple geoms
       var feature = features[0];
       expect(feature).to.be.an(ol.Feature);

--- a/test/spec/ol/renderer/canvas/canvasreplay.test.js
+++ b/test/spec/ol/renderer/canvas/canvasreplay.test.js
@@ -82,7 +82,7 @@ describe('ol.render.canvas.LineStringReplay', function() {
 
   describe('#getBufferedMaxExtent()', function() {
 
-    it('buffers the max extent to accomodate stroke width', function() {
+    it('buffers the max extent to accommodate stroke width', function() {
       var tolerance = 1;
       var extent = [-180, -90, 180, 90];
       var resolution = 10;
@@ -104,7 +104,7 @@ describe('ol.render.canvas.PolygonReplay', function() {
 
   describe('#getBufferedMaxExtent()', function() {
 
-    it('buffers the max extent to accomodate stroke width', function() {
+    it('buffers the max extent to accommodate stroke width', function() {
       var tolerance = 1;
       var extent = [-180, -90, 180, 90];
       var resolution = 10;


### PR DESCRIPTION
Most of them are in comments, some in strings.

Signed-off-by: Stefan Weil <sw@weilnetz.de>