### PR TITLE
maxZoom defined on ol.source.TileWMS but never used

### DIFF
--- a/src/ol/source/tilewmssource.js
+++ b/src/ol/source/tilewmssource.js
@@ -105,6 +105,12 @@ ol.source.TileWMS = function(opt_options) {
    */
   this.tmpExtent_ = ol.extent.createEmpty();
 
+  /**
+   * @private
+   * @type {number|undefined}
+   */
+  this.maxZoom_ = options.maxZoom;
+
   this.updateV13_();
 
 };
@@ -273,6 +279,19 @@ ol.source.TileWMS.prototype.getRequestUrl_ =
     url = urls[index];
   }
   return goog.uri.utils.appendParamsFromMap(url, params);
+};
+
+
+/**
+ * @param {ol.proj.Projection} projection Projection.
+ * @return {ol.tilegrid.TileGrid} Tile grid.
+ */
+ol.source.TileWMS.prototype.getTileGridForProjection = function(projection) {
+  if (goog.isNull(this.tileGrid)) {
+    return ol.tilegrid.getForProjection(projection, this.maxZoom_);
+  } else {
+    return this.tileGrid;
+  }
 };
 
 

--- a/src/ol/tilegrid/tilegrid.js
+++ b/src/ol/tilegrid/tilegrid.js
@@ -400,12 +400,14 @@ ol.tilegrid.TileGrid.prototype.getZForResolution = function(resolution) {
 
 /**
  * @param {ol.proj.Projection} projection Projection.
+ * @param {number=} opt_maxZoom Maximum zoom level (default is
+ *     ol.DEFAULT_MAX_ZOOM).
  * @return {ol.tilegrid.TileGrid} Default tile grid for the passed projection.
  */
-ol.tilegrid.getForProjection = function(projection) {
+ol.tilegrid.getForProjection = function(projection, opt_maxZoom) {
   var tileGrid = projection.getDefaultTileGrid();
   if (goog.isNull(tileGrid)) {
-    tileGrid = ol.tilegrid.createForProjection(projection);
+    tileGrid = ol.tilegrid.createForProjection(projection, opt_maxZoom);
     projection.setDefaultTileGrid(tileGrid);
   }
   return tileGrid;


### PR DESCRIPTION
There is a maxZoom constructor option for ```ol.source.TileWMS``` but it is never used

http://openlayers.org/en/v3.2.1/apidoc/ol.source.TileWMS.html?unstable=true