### PR TITLE
tilegrid is recreated often in ol.source.TileWMS

### DIFF
--- a/src/ol/source/tilesource.js
+++ b/src/ol/source/tilesource.js
@@ -179,10 +179,9 @@ ol.source.Tile.prototype.getTileGrid = function() {
  */
 ol.source.Tile.prototype.getTileGridForProjection = function(projection) {
   if (goog.isNull(this.tileGrid)) {
-    return ol.tilegrid.getForProjection(projection);
-  } else {
-    return this.tileGrid;
+    this.tileGrid = ol.tilegrid.getForProjection(projection);
   }
+  return this.tileGrid;
 };
 
 


### PR DESCRIPTION
why is the tile grid recreated all the time in ```ol.source.TileWMS```? Why is the result of ```ol.tilegrid.getForProjection``` not cached as ```this.tileGrid```?

https://github.com/openlayers/ol3/blob/master/src/ol/source/tilesource.js#L181:L185