### PR TITLE
Avoid creating unnecessary images in tile layers

### DIFF
--- a/src/ol/renderer/canvas/canvastilelayerrenderer.js
+++ b/src/ol/renderer/canvas/canvastilelayerrenderer.js
@@ -287,11 +287,7 @@ ol.renderer.canvas.TileLayer.prototype.prepareFrame =
   /** @type {Array.<ol.Tile>} */
   var tilesToClear = [];
 
-  var getTileIfLoaded = this.createGetTileIfLoadedFunction(function(tile) {
-    return !goog.isNull(tile) && tile.getState() == ol.TileState.LOADED;
-  }, tileSource, pixelRatio, projection);
-  var findLoadedTiles = goog.bind(tileSource.findLoadedTiles, tileSource,
-      tilesToDrawByZ, getTileIfLoaded);
+  var findLoadedTiles = this.createLoadedTileFinder(tileSource, tilesToDrawByZ);
 
   var useInterimTilesOnError = tileLayer.getUseInterimTilesOnError();
 

--- a/src/ol/renderer/dom/domtilelayerrenderer.js
+++ b/src/ol/renderer/dom/domtilelayerrenderer.js
@@ -128,11 +128,7 @@ ol.renderer.dom.TileLayer.prototype.prepareFrame =
   var tilesToDrawByZ = {};
   tilesToDrawByZ[z] = {};
 
-  var getTileIfLoaded = this.createGetTileIfLoadedFunction(function(tile) {
-    return !goog.isNull(tile) && tile.getState() == ol.TileState.LOADED;
-  }, tileSource, pixelRatio, projection);
-  var findLoadedTiles = goog.bind(tileSource.findLoadedTiles, tileSource,
-      tilesToDrawByZ, getTileIfLoaded);
+  var findLoadedTiles = this.createLoadedTileFinder(tileSource, tilesToDrawByZ);
 
   var useInterimTilesOnError = tileLayer.getUseInterimTilesOnError();
 

--- a/src/ol/renderer/layerrenderer.js
+++ b/src/ol/renderer/layerrenderer.js
@@ -86,6 +86,33 @@ ol.renderer.Layer.prototype.hasFeatureAtCoordinate = goog.functions.FALSE;
 
 
 /**
+ * Create a function that adds loaded tiles to the tile lookup.
+ * @param {ol.source.Tile} source Tile source.
+ * @param {Object.<number, Object.<string, ol.Tile>>} tiles Lookup of loaded
+ *     tiles by zoom level.
+ * @return {function(number, ol.TileRange):boolean} A function that can be
+ *     called with a zoom level and a tile range to add loaded tiles to the
+ *     lookup.
+ * @protected
+ */
+ol.renderer.Layer.prototype.createLoadedTileFinder = function(source, tiles) {
+  /**
+   * @param {number} zoom Zoom level.
+   * @param {ol.TileRange} tileRange Tile range.
+   * @return {boolean} The tile range is fully loaded.
+   */
+  return function(zoom, tileRange) {
+    return source.forEachLoadedTile(zoom, tileRange, function(tile) {
+      if (!tiles[zoom]) {
+        tiles[zoom] = {};
+      }
+      tiles[zoom][tile.tileCoord.toString()] = tile;
+    });
+  };
+};
+
+
+/**
  * @protected
  * @return {ol.layer.Layer} Layer.
  */

--- a/src/ol/source/tiledebugsource.js
+++ b/src/ol/source/tiledebugsource.js
@@ -1,7 +1,6 @@
 goog.provide('ol.source.TileDebug');
 
 goog.require('ol.Tile');
-goog.require('ol.TileCache');
 goog.require('ol.TileCoord');
 goog.require('ol.TileState');
 goog.require('ol.dom');
@@ -89,12 +88,6 @@ ol.source.TileDebug = function(options) {
     tileGrid: options.tileGrid
   });
 
-  /**
-   * @private
-   * @type {ol.TileCache}
-   */
-  this.tileCache_ = new ol.TileCache();
-
 };
 goog.inherits(ol.source.TileDebug, ol.source.Tile);
 
@@ -102,29 +95,13 @@ goog.inherits(ol.source.TileDebug, ol.source.Tile);
 /**
  * @inheritDoc
  */
-ol.source.TileDebug.prototype.canExpireCache = function() {
-  return this.tileCache_.canExpireCache();
-};
-
-
-/**
- * @inheritDoc
- */
-ol.source.TileDebug.prototype.expireCache = function(usedTiles) {
-  this.tileCache_.expireCache(usedTiles);
-};
-
-
-/**
- * @inheritDoc
- */
 ol.source.TileDebug.prototype.getTile = function(z, x, y) {
   var tileCoordKey = this.getKeyZXY(z, x, y);
-  if (this.tileCache_.containsKey(tileCoordKey)) {
-    return /** @type {!ol.DebugTile_} */ (this.tileCache_.get(tileCoordKey));
+  if (this.tileCache.containsKey(tileCoordKey)) {
+    return /** @type {!ol.DebugTile_} */ (this.tileCache.get(tileCoordKey));
   } else {
     var tile = new ol.DebugTile_([z, x, y], this.tileGrid);
-    this.tileCache_.set(tileCoordKey, tile);
+    this.tileCache.set(tileCoordKey, tile);
     return tile;
   }
 };

--- a/src/ol/source/tileimagesource.js
+++ b/src/ol/source/tileimagesource.js
@@ -2,7 +2,6 @@ goog.provide('ol.source.TileImage');
 
 goog.require('goog.asserts');
 goog.require('ol.ImageTile');
-goog.require('ol.TileCache');
 goog.require('ol.TileCoord');
 goog.require('ol.TileLoadFunctionType');
 goog.require('ol.TileState');
@@ -52,12 +51,6 @@ ol.source.TileImage = function(options) {
 
   /**
    * @protected
-   * @type {ol.TileCache}
-   */
-  this.tileCache = new ol.TileCache();
-
-  /**
-   * @protected
    * @type {ol.TileLoadFunctionType}
    */
   this.tileLoadFunction = goog.isDef(options.tileLoadFunction) ?
@@ -81,22 +74,6 @@ goog.inherits(ol.source.TileImage, ol.source.Tile);
  */
 ol.source.TileImage.defaultTileLoadFunction = function(imageTile, src) {
   imageTile.getImage().src = src;
-};
-
-
-/**
- * @inheritDoc
- */
-ol.source.TileImage.prototype.canExpireCache = function() {
-  return this.tileCache.canExpireCache();
-};
-
-
-/**
- * @inheritDoc
- */
-ol.source.TileImage.prototype.expireCache = function(usedTiles) {
-  this.tileCache.expireCache(usedTiles);
 };
 
 

--- a/src/ol/source/tilesource.js
+++ b/src/ol/source/tilesource.js
@@ -4,6 +4,7 @@ goog.provide('ol.source.TileOptions');
 goog.require('goog.functions');
 goog.require('ol.Attribution');
 goog.require('ol.Extent');
+goog.require('ol.TileCache');
 goog.require('ol.TileRange');
 goog.require('ol.source.Source');
 goog.require('ol.tilecoord');
@@ -64,6 +65,12 @@ ol.source.Tile = function(options) {
    */
   this.tileGrid = goog.isDef(options.tileGrid) ? options.tileGrid : null;
 
+  /**
+   * @protected
+   * @type {ol.TileCache}
+   */
+  this.tileCache = new ol.TileCache();
+
 };
 goog.inherits(ol.source.Tile, ol.source.Source);
 
@@ -71,13 +78,17 @@ goog.inherits(ol.source.Tile, ol.source.Source);
 /**
  * @return {boolean} Can expire cache.
  */
-ol.source.Tile.prototype.canExpireCache = goog.functions.FALSE;
+ol.source.Tile.prototype.canExpireCache = function() {
+  return this.tileCache.canExpireCache();
+};
 
 
 /**
  * @param {Object.<string, ol.TileRange>} usedTiles Used tiles.
  */
-ol.source.Tile.prototype.expireCache = goog.abstractMethod;
+ol.source.Tile.prototype.expireCache = function(usedTiles) {
+  this.tileCache.expireCache(usedTiles);
+};
 
 
 /**

--- a/src/ol/source/tileutfgridsource.js
+++ b/src/ol/source/tileutfgridsource.js
@@ -7,7 +7,6 @@ goog.require('goog.events.EventType');
 goog.require('goog.net.Jsonp');
 goog.require('ol.Attribution');
 goog.require('ol.Tile');
-goog.require('ol.TileCache');
 goog.require('ol.TileState');
 goog.require('ol.TileUrlFunction');
 goog.require('ol.extent');
@@ -48,12 +47,6 @@ ol.source.TileUTFGrid = function(options) {
 
   /**
    * @private
-   * @type {!ol.TileCache}
-   */
-  this.tileCache_ = new ol.TileCache();
-
-  /**
-   * @private
    * @type {string|undefined}
    */
   this.template_ = undefined;
@@ -62,22 +55,6 @@ ol.source.TileUTFGrid = function(options) {
   request.send(undefined, goog.bind(this.handleTileJSONResponse, this));
 };
 goog.inherits(ol.source.TileUTFGrid, ol.source.Tile);
-
-
-/**
- * @inheritDoc
- */
-ol.source.TileUTFGrid.prototype.canExpireCache = function() {
-  return this.tileCache_.canExpireCache();
-};
-
-
-/**
- * @inheritDoc
- */
-ol.source.TileUTFGrid.prototype.expireCache = function(usedTiles) {
-  this.tileCache_.expireCache(usedTiles);
-};
 
 
 /**
@@ -195,8 +172,8 @@ ol.source.TileUTFGrid.prototype.handleTileJSONResponse = function(tileJSON) {
 ol.source.TileUTFGrid.prototype.getTile =
     function(z, x, y, pixelRatio, projection) {
   var tileCoordKey = this.getKeyZXY(z, x, y);
-  if (this.tileCache_.containsKey(tileCoordKey)) {
-    return /** @type {!ol.Tile} */ (this.tileCache_.get(tileCoordKey));
+  if (this.tileCache.containsKey(tileCoordKey)) {
+    return /** @type {!ol.Tile} */ (this.tileCache.get(tileCoordKey));
   } else {
     goog.asserts.assert(projection);
     var tileCoord = [z, x, y];
@@ -207,7 +184,7 @@ ol.source.TileUTFGrid.prototype.getTile =
         goog.isDef(tileUrl) ? tileUrl : '',
         this.tileGrid.getTileCoordExtent(tileCoord),
         this.preemptive_);
-    this.tileCache_.set(tileCoordKey, tile);
+    this.tileCache.set(tileCoordKey, tile);
     return tile;
   }
 };
@@ -218,8 +195,8 @@ ol.source.TileUTFGrid.prototype.getTile =
  */
 ol.source.TileUTFGrid.prototype.useTile = function(z, x, y) {
   var tileCoordKey = this.getKeyZXY(z, x, y);
-  if (this.tileCache_.containsKey(tileCoordKey)) {
-    this.tileCache_.get(tileCoordKey);
+  if (this.tileCache.containsKey(tileCoordKey)) {
+    this.tileCache.get(tileCoordKey);
   }
 };
 

--- a/test/spec/ol/source/tilesource.test.js
+++ b/test/spec/ol/source/tilesource.test.js
@@ -12,176 +12,105 @@ describe('ol.source.Tile', function() {
     });
   });
 
-  describe('#findLoadedTiles()', function() {
+  describe('#forEachLoadedTile()', function() {
 
-    it('adds no tiles if none are already loaded', function() {
-      // a source with no loaded tiles
+    var callback;
+    beforeEach(function() {
+      callback = sinon.spy();
+    });
+
+    it('does not call the callback if no tiles are loaded', function() {
       var source = new ol.test.source.TileMock({});
-
-      var loadedTilesByZ = {};
       var grid = source.getTileGrid();
       var extent = [-180, -180, 180, 180];
-      var range = grid.getTileRangeForExtentAndZ(extent, 3);
+      var zoom = 3;
+      var range = grid.getTileRangeForExtentAndZ(extent, zoom);
 
-      function getTileIfLoaded(z, x, y) {
-        var tile = source.getTile(z, x, y);
-        return (!goog.isNull(tile) && tile.getState() === ol.TileState.LOADED) ?
-            tile : null;
-      }
-      source.findLoadedTiles(loadedTilesByZ, getTileIfLoaded, 3, range);
-
-      var keys = goog.object.getKeys(loadedTilesByZ);
-      expect(keys.length).to.be(0);
+      source.forEachLoadedTile(zoom, range, callback);
+      expect(callback.callCount).to.be(0);
     });
 
-    it('adds loaded tiles to the lookup (z: 0)', function() {
-      // a source with no loaded tiles
-      var source = new ol.test.source.TileMock({
-        '0/0/0': true,
-        '1/0/0': true
-      });
-
-      var loadedTilesByZ = {};
-      var grid = source.getTileGrid();
-      var extent = [-180, -180, 180, 180];
-      var range = grid.getTileRangeForExtentAndZ(extent, 0);
-
-      function getTileIfLoaded(z, x, y) {
-        var tile = source.getTile(z, x, y);
-        return (!goog.isNull(tile) && tile.getState() === ol.TileState.LOADED) ?
-            tile : null;
-      }
-      source.findLoadedTiles(loadedTilesByZ, getTileIfLoaded, 0, range);
-      var keys = goog.object.getKeys(loadedTilesByZ);
-      expect(keys.length).to.be(1);
-      var tile = loadedTilesByZ['0']['0/0/0'];
-      expect(tile).to.be.a(ol.Tile);
-      expect(tile.state).to.be(ol.TileState.LOADED);
-    });
-
-    it('adds loaded tiles to the lookup (z: 1)', function() {
-      // a source with no loaded tiles
-      var source = new ol.test.source.TileMock({
-        '0/0/0': true,
-        '1/0/0': true
-      });
-
-      var loadedTilesByZ = {};
-      var grid = source.getTileGrid();
-      var extent = [-180, -180, 180, 180];
-      var range = grid.getTileRangeForExtentAndZ(extent, 1);
-
-      function getTileIfLoaded(z, x, y) {
-        var tile = source.getTile(z, x, y);
-        return (!goog.isNull(tile) && tile.getState() === ol.TileState.LOADED) ?
-            tile : null;
-      }
-      source.findLoadedTiles(loadedTilesByZ, getTileIfLoaded, 1, range);
-      var keys = goog.object.getKeys(loadedTilesByZ);
-      expect(keys.length).to.be(1);
-      var tile = loadedTilesByZ['1']['1/0/0'];
-      expect(tile).to.be.a(ol.Tile);
-      expect(tile.state).to.be(ol.TileState.LOADED);
-    });
-
-    it('returns true when all tiles are already loaded', function() {
-      // a source with no loaded tiles
-      var source = new ol.test.source.TileMock({
-        '1/0/0': true,
-        '1/0/1': true,
-        '1/1/0': true,
-        '1/1/1': true
-      });
-
-      var loadedTilesByZ = {};
-      var grid = source.getTileGrid();
-      var extent = [-180, -180, 180, 180];
-      var range = grid.getTileRangeForExtentAndZ(extent, 1);
-      function getTileIfLoaded(z, x, y) {
-        var tile = source.getTile(z, x, y);
-        return (!goog.isNull(tile) && tile.getState() === ol.TileState.LOADED) ?
-            tile : null;
-      }
-      var loaded = source.findLoadedTiles(
-          loadedTilesByZ, getTileIfLoaded, 1, range);
-      expect(loaded).to.be(true);
-    });
-
-    it('returns true when all tiles are already loaded (part 2)', function() {
-      // a source with no loaded tiles
+    it('does not call getTile() if no tiles are loaded', function() {
       var source = new ol.test.source.TileMock({});
-
-      var loadedTilesByZ = {
-        '1': {
-          '1/0/0': true,
-          '1/0/1': true,
-          '1/1/0': true,
-          '1/1/1': true,
-          '1/1/2': true
-        }
-      };
+      sinon.spy(source, 'getTile');
       var grid = source.getTileGrid();
       var extent = [-180, -180, 180, 180];
-      var range = grid.getTileRangeForExtentAndZ(extent, 1);
+      var zoom = 3;
+      var range = grid.getTileRangeForExtentAndZ(extent, zoom);
 
-      function getTileIfLoaded(z, x, y) {
-        var tile = source.getTile(z, x, y);
-        return (!goog.isNull(tile) && tile.getState() === ol.TileState.LOADED) ?
-            tile : null;
-      }
-      var loaded = source.findLoadedTiles(
-          loadedTilesByZ, getTileIfLoaded, 1, range);
-      expect(loaded).to.be(true);
+      source.forEachLoadedTile(zoom, range, callback);
+      expect(source.getTile.callCount).to.be(0);
+      source.getTile.restore();
     });
 
-    it('returns false when all tiles are already loaded', function() {
-      // a source with no loaded tiles
+
+    it('calls callback for each loaded tile', function() {
       var source = new ol.test.source.TileMock({
-        '1/0/0': true,
-        '1/0/1': true,
-        '1/1/0': true,
-        '1/1/1': false
+        '1/0/0': ol.TileState.LOADED,
+        '1/0/1': ol.TileState.LOADED,
+        '1/1/0': ol.TileState.LOADING,
+        '1/1/1': ol.TileState.LOADED
       });
 
-      var loadedTilesByZ = {};
-      var grid = source.getTileGrid();
-      var extent = [-180, -180, 180, 180];
-      var range = grid.getTileRangeForExtentAndZ(extent, 1);
+      var zoom = 1;
+      var range = new ol.TileRange(0, 1, 0, 1);
 
-      function getTileIfLoaded(z, x, y) {
-        var tile = source.getTile(z, x, y);
-        return (!goog.isNull(tile) && tile.getState() === ol.TileState.LOADED) ?
-            tile : null;
-      }
-      var loaded = source.findLoadedTiles(
-          loadedTilesByZ, getTileIfLoaded, 1, range);
-      expect(loaded).to.be(false);
+      source.forEachLoadedTile(zoom, range, callback);
+      expect(callback.callCount).to.be(3);
     });
 
-    it('returns false when all tiles are already loaded (part 2)', function() {
+    it('returns true if range is fully loaded', function() {
       // a source with no loaded tiles
-      var source = new ol.test.source.TileMock({});
+      var source = new ol.test.source.TileMock({
+        '1/0/0': ol.TileState.LOADED,
+        '1/0/1': ol.TileState.LOADED,
+        '1/1/0': ol.TileState.LOADED,
+        '1/1/1': ol.TileState.LOADED
+      });
 
-      var loadedTilesByZ = {
-        '1': {
-          '1/0/0': true,
-          '1/0/1': true,
-          '1/1/0': true,
-          '1/1/1': false
-        }
-      };
-      var grid = source.getTileGrid();
-      var extent = [-180, -180, 180, 180];
-      var range = grid.getTileRangeForExtentAndZ(extent, 1);
+      var zoom = 1;
+      var range = new ol.TileRange(0, 1, 0, 1);
 
-      function getTileIfLoaded(z, x, y) {
-        var tile = source.getTile(z, x, y);
-        return (!goog.isNull(tile) && tile.getState() === ol.TileState.LOADED) ?
-            tile : null;
-      }
-      var loaded = source.findLoadedTiles(
-          loadedTilesByZ, getTileIfLoaded, 1, range);
-      expect(loaded).to.be(false);
+      var covered = source.forEachLoadedTile(zoom, range, function() {
+        return true;
+      });
+      expect(covered).to.be(true);
+    });
+
+    it('returns false if range is not fully loaded', function() {
+      // a source with no loaded tiles
+      var source = new ol.test.source.TileMock({
+        '1/0/0': ol.TileState.LOADED,
+        '1/0/1': ol.TileState.LOADED,
+        '1/1/0': ol.TileState.LOADING,
+        '1/1/1': ol.TileState.LOADED
+      });
+
+      var zoom = 1;
+      var range = new ol.TileRange(0, 1, 0, 1);
+
+      var covered = source.forEachLoadedTile(zoom, range, function() {
+        return true;
+      });
+      expect(covered).to.be(false);
+    });
+
+    it('allows callback to override loaded check', function() {
+      // a source with no loaded tiles
+      var source = new ol.test.source.TileMock({
+        '1/0/0': ol.TileState.LOADED,
+        '1/0/1': ol.TileState.LOADED,
+        '1/1/0': ol.TileState.LOADED,
+        '1/1/1': ol.TileState.LOADED
+      });
+
+      var zoom = 1;
+      var range = new ol.TileRange(0, 1, 0, 1);
+
+      var covered = source.forEachLoadedTile(zoom, range, function() {
+        return false;
+      });
+      expect(covered).to.be(false);
     });
 
   });
@@ -196,9 +125,10 @@ describe('ol.source.Tile', function() {
  *
  * @constructor
  * @extends {ol.source.Tile}
- * @param {Object.<string, boolean>} loaded Lookup of already loaded tiles.
+ * @param {Object.<string, ol.TileState>} tileStates Lookup of tile key to
+ *     tile state.
  */
-ol.test.source.TileMock = function(loaded) {
+ol.test.source.TileMock = function(tileStates) {
   var tileGrid = new ol.tilegrid.TileGrid({
     resolutions: [360 / 256, 180 / 256, 90 / 256, 45 / 256],
     origin: [-180, -180],
@@ -210,11 +140,9 @@ ol.test.source.TileMock = function(loaded) {
     tileGrid: tileGrid
   });
 
-  /**
-   * @type {Object.<string, boolean>}
-   * @private
-   */
-  this.loaded_ = loaded;
+  for (var key in tileStates) {
+    this.tileCache.set(key, new ol.Tile(key.split('/'), tileStates[key]));
+  }
 
 };
 goog.inherits(ol.test.source.TileMock, ol.source.Tile);
@@ -224,9 +152,14 @@ goog.inherits(ol.test.source.TileMock, ol.source.Tile);
  * @inheritDoc
  */
 ol.test.source.TileMock.prototype.getTile = function(z, x, y) {
-  var key = ol.tilecoord.getKeyZXY(z, x, y);
-  var tileState = this.loaded_[key] ? ol.TileState.LOADED : ol.TileState.IDLE;
-  return new ol.Tile([z, x, y], tileState);
+  var key = this.getKeyZXY(z, x, y);
+  if (this.tileCache.containsKey(key)) {
+    return /** @type {!ol.Tile} */ (this.tileCache.get(key));
+  } else {
+    var tile = new ol.Tile(key, ol.TileState.IDLE);
+    this.tileCache.set(key, tile);
+    return tile;
+  }
 };
 
 
@@ -243,8 +176,8 @@ describe('ol.test.source.TileMock', function() {
   describe('#getTile()', function() {
     it('returns a tile with state based on constructor arg', function() {
       var source = new ol.test.source.TileMock({
-        '0/0/0': true,
-        '1/0/0': true
+        '0/0/0': ol.TileState.LOADED,
+        '1/0/0': ol.TileState.LOADED
       });
       var tile;
 
@@ -270,9 +203,9 @@ describe('ol.test.source.TileMock', function() {
 
 goog.require('goog.object');
 goog.require('ol.Tile');
+goog.require('ol.TileRange');
 goog.require('ol.TileState');
 goog.require('ol.proj');
 goog.require('ol.source.Source');
 goog.require('ol.source.Tile');
-goog.require('ol.tilecoord');
 goog.require('ol.tilegrid.TileGrid');


### PR DESCRIPTION
When rendering tiled layers, we call `source.getTile()` many times while looking for loaded images at alternate zoom levels.  For image tile layers, calls to `getTile` create `Image` elements.  When we only need to check if a tile is loaded, it is unnecessary to create a new tile with an unused `Image`.

Since all of the `ol.source.Tile` types create a tile cache in the same way and have the same implementation of `canExpireCache` and `expireCache`, we can move the repeated code to the `ol.source.Tile` base class (see 2cf1fe555222a1df820c88716b7600bec3114fd8).

Then, since an image cannot already have the loaded state if it is not in the cache, the check for loaded images can avoid calling `getTile` and instead check the cache (see e5432f7cb5885dc476647b83b51532e25fb86184).  The DOM and Canvas tile layer renderers can share the same implementation of `createLoadedTileFinder` function.  The WebGL renderer needs a custom implementation since it also checks with the map renderer to see if the tile texture is loaded.

Without these changes, the first rendering of the full screen example (not in full screen mode) fills the cache with 80 images though only 12 are used (on my current screen width).  And these extra cached images are *not* used as you zoom out.  By the time I zoom out to level one, about 1350 `Image` elements have been created.  On this branch, the same sequence (zooming one step at a time to level 1) creates 350 `Image` elements.
