### PR TITLE
Fix autoPan in examples with ol.Overlay on hover

### DIFF
--- a/examples/measure.js
+++ b/examples/measure.js
@@ -204,7 +204,8 @@ function createHelpTooltip() {
   helpTooltip = new ol.Overlay({
     element: helpTooltipElement,
     offset: [15, 0],
-    positioning: 'center-left'
+    positioning: 'center-left',
+    autoPan: false
   });
   map.addOverlay(helpTooltip);
 }
@@ -222,7 +223,8 @@ function createMeasureTooltip() {
   measureTooltip = new ol.Overlay({
     element: measureTooltipElement,
     offset: [0, -15],
-    positioning: 'bottom-center'
+    positioning: 'bottom-center',
+    autoPan: false
   });
   map.addOverlay(measureTooltip);
 }

--- a/examples/tileutfgrid.js
+++ b/examples/tileutfgrid.js
@@ -36,7 +36,8 @@ var nameElement = document.getElementById('country-name');
 var infoOverlay = new ol.Overlay({
   element: infoElement,
   offset: [15, 15],
-  stopEvent: false
+  stopEvent: false,
+  autoPan: false
 });
 map.addOverlay(infoOverlay);
 


### PR DESCRIPTION
#3256 enabled `autoPan` by default which made the map pan uncontrollable in examples where an overlay is shown on mouse hover. 

This PR disables `autoPan` for the example `measure` and `tileutfgrid`.