### PR TITLE
Added getter function to return the wrapped source within the cluster

### DIFF
--- a/src/ol/source/clustersource.js
+++ b/src/ol/source/clustersource.js
@@ -60,6 +60,7 @@ goog.inherits(ol.source.Cluster, ol.source.Vector);
 
 
 /**
+ * Get a reference to the wrapped source.
  * @return {ol.source.Vector} Source.
  * @api
  */

--- a/src/ol/source/clustersource.js
+++ b/src/ol/source/clustersource.js
@@ -60,6 +60,15 @@ goog.inherits(ol.source.Cluster, ol.source.Vector);
 
 
 /**
+ * @return {ol.source.Vector} Source.
+ * @api
+ */
+ol.source.Cluster.prototype.getSource = function() {
+  return this.source_;
+};
+
+
+/**
  * @inheritDoc
  */
 ol.source.Cluster.prototype.loadFeatures = function(extent, resolution,

--- a/src/ol/source/imagevectorsource.js
+++ b/src/ol/source/imagevectorsource.js
@@ -178,6 +178,7 @@ ol.source.ImageVector.prototype.forEachFeatureAtCoordinate = function(
 
 
 /**
+ * Get a reference to the wrapped source.
  * @return {ol.source.Vector} Source.
  * @api
  */


### PR DESCRIPTION
Added a `getSource()` method to return the wrapped source within the cluster, in the same way as `ol.source.ImageVector`.
See #3267 and https://groups.google.com/forum/#!topic/ol3-dev/EfYFeskOqyc