### PR TITLE
Fix mouseMove event type comparison for IE10-11, pointermove

### DIFF
--- a/examples/select-features.html
+++ b/examples/select-features.html
@@ -41,7 +41,7 @@
                 <option value="none" selected>None</option>
                 <option value="singleclick">Single-click</option>
                 <option value="click">Click</option>
-                <option value="mousemove">Hover</option>
+                <option value="pointermove">Hover</option>
               </select>
           </form>
           <div id="docs">

--- a/examples/select-features.js
+++ b/examples/select-features.js
@@ -38,9 +38,9 @@ var selectClick = new ol.interaction.Select({
   condition: ol.events.condition.click
 });
 
-// select interaction working on "mousemove"
-var selectMouseMove = new ol.interaction.Select({
-  condition: ol.events.condition.mouseMove
+// select interaction working on "pointermove"
+var selectPointerMove = new ol.interaction.Select({
+  condition: ol.events.condition.pointerMove
 });
 
 var selectElement = document.getElementById('type');
@@ -54,8 +54,8 @@ var changeInteraction = function() {
     select = selectSingleClick;
   } else if (value == 'click') {
     select = selectClick;
-  } else if (value == 'mousemove') {
-    select = selectMouseMove;
+  } else if (value == 'pointermove') {
+    select = selectPointerMove;
   } else {
     select = null;
   }

--- a/src/ol/events/condition.js
+++ b/src/ol/events/condition.js
@@ -67,16 +67,6 @@ ol.events.condition.click = function(mapBrowserEvent) {
 
 
 /**
- * @param {ol.MapBrowserEvent} mapBrowserEvent Map browser event.
- * @return {boolean} True if the browser event is a `mousemove` event.
- * @api
- */
-ol.events.condition.mouseMove = function(mapBrowserEvent) {
-  return mapBrowserEvent.originalEvent.type == 'mousemove';
-};
-
-
-/**
  * Always false.
  * @param {ol.MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} False.
@@ -84,6 +74,16 @@ ol.events.condition.mouseMove = function(mapBrowserEvent) {
  * @api stable
  */
 ol.events.condition.never = goog.functions.FALSE;
+
+
+/**
+ * @param {ol.MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @return {boolean} True if the browser event is a `pointermove` event.
+ * @api
+ */
+ol.events.condition.pointerMove = function(mapBrowserEvent) {
+  return mapBrowserEvent.type == 'pointermove';
+};
 
 
 /**

--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -190,7 +190,7 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
     }
     features.extend(selected);
   }
-  return ol.events.condition.mouseMove(mapBrowserEvent);
+  return ol.events.condition.pointerMove(mapBrowserEvent);
 };
 
 


### PR DESCRIPTION
This PR fixes the issue raised in #3280.  Please, let me know if this fix is robust enough to be accepted / merged, otherwise a review would be welcome and I'll apply any modifications required.