### PR TITLE
Fix select event always reporting as multi select

### DIFF
--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -198,7 +198,8 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
          */
         function(feature, layer) {
           selected.push(feature);
-        }, undefined, this.layerFilter_);
+          return !this.multi_;
+        }, this, this.layerFilter_);
     if (selected.length > 0 && features.getLength() == 1 &&
         features.item(0) == selected[0]) {
       // No change
@@ -208,11 +209,7 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
         deselected = Array.prototype.concat(features.getArray());
         features.clear();
       }
-      if (this.multi_) {
-        features.extend(selected);
-      } else if (selected.length > 0) {
-        features.push(selected[0]);
-      }
+      features.extend(selected);
     }
   } else {
     // Modify the currently selected feature(s).

--- a/test/spec/ol/interaction/selectinteraction.test.js
+++ b/test/spec/ol/interaction/selectinteraction.test.js
@@ -89,7 +89,14 @@ describe('ol.interaction.Select', function() {
     });
 
     it('select with single-click', function() {
+      var listenerSpy = sinon.spy(function(e) {
+        expect(e.selected).to.have.length(1);
+      });
+      select.on('select', listenerSpy);
+
       simulateEvent(ol.MapBrowserEvent.EventType.SINGLECLICK, 10, -20);
+
+      expect(listenerSpy.callCount).to.be(1);
 
       var features = select.getFeatures();
       expect(features.getLength()).to.equal(1);
@@ -107,7 +114,14 @@ describe('ol.interaction.Select', function() {
     });
 
     it('select with single-click', function() {
+      var listenerSpy = sinon.spy(function(e) {
+        expect(e.selected).to.have.length(2);
+      });
+      select.on('select', listenerSpy);
+
       simulateEvent(ol.MapBrowserEvent.EventType.SINGLECLICK, 10, -20);
+
+      expect(listenerSpy.callCount).to.be(1);
 
       var features = select.getFeatures();
       expect(features.getLength()).to.equal(2);


### PR DESCRIPTION
The selected property of SelectEvent always contained all features at clicked position, regardless of multi setting.