### PR TITLE
retina issue on ArcGISREST sources

### DIFF
--- a/src/ol/source/tilearcgisrestsource.js
+++ b/src/ol/source/tilearcgisrestsource.js
@@ -168,6 +168,23 @@ ol.source.TileArcGISRest.prototype.setUrls = function(urls) {
 
 
 /**
+ * @param {number} z Z.
+ * @param {number} pixelRatio Pixel ratio.
+ * @param {ol.proj.Projection} projection Projection.
+ * @return {number} Size.
+ */
+ol.source.TileArcGISRest.prototype.getTilePixelSize =
+    function(z, pixelRatio, projection) {
+  var tileSize = goog.base(this, 'getTilePixelSize', z, pixelRatio, projection);
+  if (pixelRatio == 1) {
+    return tileSize;
+  } else {
+    return (tileSize * pixelRatio + 0.5) | 0;
+  }
+};
+
+
+/**
  * @param {ol.TileCoord} tileCoord Tile coordinate.
  * @param {number} pixelRatio Pixel ratio.
  * @param {ol.proj.Projection} projection Projection.


### PR DESCRIPTION
![b_r30hfwsaezszf png-large](https://cloud.githubusercontent.com/assets/319678/6492835/816046e6-c2b6-11e4-8117-9b2cc7d55fac.png)

Created a new ticket from the latest comments here: https://github.com/openlayers/ol3/pull/3263#issuecomment-77236815

I'm seeing the same thing on my iPad