### PR TITLE
Add interface definition for ol.SelectEvent

### DIFF
--- a/externs/oli.js
+++ b/externs/oli.js
@@ -118,6 +118,25 @@ oli.MapEvent.prototype.frameState;
 
 
 /**
+ * @interface
+ */
+ oli.SelectEvent = function() {};
+
+
+ /**
+  * @type {Array.<ol.Feature>}
+  */
+oli.SelectEvent.prototype.deselected;
+
+
+ /**
+  * @type {Array.<ol.Feature>}
+  */
+oli.SelectEvent.prototype.selected;
+
+
+
+/**
  * @type {Object}
  */
 oli.control;

--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -36,6 +36,7 @@ ol.SelectEventType = {
  * @param {string} type The event type.
  * @param {Array.<ol.Feature>} selected Selected features.
  * @param {Array.<ol.Feature>} deselected Deselected features.
+ * @implements {oli.SelectEvent}
  * @extends {goog.events.Event}
  * @constructor
  */


### PR DESCRIPTION
Makes the new select events work with built versions of the library - currently http://openlayers.org/en/v3.3.0/examples/select-features.html` is partially broken, because it does not show how many features were selected/deselected.