### PR TITLE
Add parameter on interectSelect to trigger event even if no change detec...

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -2650,6 +2650,15 @@ olx.interaction.SelectOptions.prototype.toggleCondition;
  */
 olx.interaction.SelectOptions.prototype.multi;
 
+/**
+ * A boolean that determines if the default behaviour should trigger event
+ * even if there is no change detected
+ * position. Default is false i.e trigger only if change detected
+ * @type {boolean|undefined}
+ * @api
+ */
+olx.interaction.SelectOptions.prototype.triggerNoChange;
+
 
 /**
  * Namespace.

--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -119,7 +119,8 @@ ol.interaction.Select = function(opt_options) {
    * @private
    * @type {boolean}
    */
-  this.triggerNoChange_ = goog.isDef(options.triggerNoChange) ? options.triggerNoChange : false;
+  this.triggerNoChange_ = goog.isDef(options.triggerNoChange) ?
+      options.triggerNoChange : false;
 
   var layerFilter;
   if (goog.isDef(options.layers)) {

--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -115,6 +115,12 @@ ol.interaction.Select = function(opt_options) {
    */
   this.multi_ = goog.isDef(options.multi) ? options.multi : false;
 
+  /**
+   * @private
+   * @type {boolean}
+   */
+  this.triggerNoChange_ = goog.isDef(options.triggerNoChange) ? options.triggerNoChange : false;
+
   var layerFilter;
   if (goog.isDef(options.layers)) {
     if (goog.isFunction(options.layers)) {
@@ -240,7 +246,7 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
       change = true;
     }
   }
-  if (change) {
+  if (this.triggerNoChange_ || change) {
     this.dispatchEvent(
         new ol.SelectEvent(ol.SelectEventType.SELECT, selected, deselected));
   }


### PR DESCRIPTION
Hi,

I propose a new parameter on ol.interaction.Select to trigger the event even if there is no changed detected.
I use it to show a popup with ol.Overlay on a feature and hide it when there is a click outside of features.

	
		var selectClick = new ol.interaction.Select({
		  triggerNoChange: true
		});
		selectClick.on('select', function(event, selected, deselected)
		{
			if(typeof event.selected !== 'undefined' && event.selected.length > 0)
			{
			  var coordinate = event.selected[0].getGeometry().getCoordinates();
			  overlay.setPosition(coordinate);
		  	  $('#ol-popup').show();
			}
		});
		
		Map.map.on('singleclick', function(evt) {
			$('#ol-popup').hide();
			overlay.setPosition();
		});
		
		Map.map.addInteraction(selectClick);