### PR TITLE
Set the 'properties' member to null if the feature has not properties

### DIFF
--- a/src/ol/format/geojsonformat.js
+++ b/src/ol/format/geojsonformat.js
@@ -516,6 +516,8 @@ ol.format.GeoJSON.prototype.writeFeatureObject = function(
   goog.object.remove(properties, feature.getGeometryName());
   if (!goog.object.isEmpty(properties)) {
     object['properties'] = properties;
+  } else {
+    object['properties'] = null;
   }
   return object;
 };

--- a/test/spec/ol/format/geojsonformat.test.js
+++ b/test/spec/ol/format/geojsonformat.test.js
@@ -507,6 +507,12 @@ describe('ol.format.GeoJSON', function() {
           expect(geojson.features[0].properties.mygeom).to.eql(undefined);
         });
 
+    it('writes out a feature without properties correctly', function() {
+      var feature = new ol.Feature(new ol.geom.Point([5, 10]));
+      var geojson = format.writeFeatureObject(feature);
+      expect(geojson.properties).to.eql(null);
+    });
+
   });
 
   describe('#writeGeometry', function() {


### PR DESCRIPTION
Fixes #3345 