### PR TITLE
Make source map usable by default

### DIFF
--- a/config/ol.json
+++ b/config/ol.json
@@ -63,6 +63,7 @@
     "use_types_for_optimization": true,
     "manage_closure_dependencies": true,
     "create_source_map": "build/ol.js.map",
-    "source_map_format": "V3"
+    "source_map_format": "V3",
+    "source_map_location_mapping": ".."
   }
 }


### PR DESCRIPTION
Currently there's a source map generated for `ol.js` but it can't be
used easily. With tweaking the build system, the source files are now
expected to be in a directory called `src` which is on the same level
as the `build` directory where the `ol.js` resides.

This makes local development easier. You can have a local server pointing
to an OpenLayers checkout and you just need to include the `build/ol.js`
file in your project and it will automatically pick up the source map.