### PR TITLE
Publish to bower repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /examples/example-list.xml
 /node_modules/
 /dist/
+/tmp/

--- a/tasks/publish.sh
+++ b/tasks/publish.sh
@@ -19,9 +19,19 @@ PROFILES="ol ol-debug"
 BUILDS=dist
 
 #
+# Temporary directory
+#
+TMP=tmp
+
+#
 # URL for canonical repo.
 #
 REMOTE=https://github.com/openlayers/ol3.git
+
+#
+# Name of bower repo
+#
+BOWER=bower-ol3
 
 #
 # Display usage and exit.
@@ -81,6 +91,25 @@ checkout_tag() {
 }
 
 #
+# Publishes to bower repo.
+#
+bower_publish() {
+  rm -rf $TMP/$BOWER
+
+  git clone git@github.com:openlayers/$BOWER $TMP/$BOWER
+
+  cp $BUILDS/* $TMP/$BOWER/
+  cp css/* $TMP/$BOWER/
+
+  pushd $TMP/$BOWER
+  git add -A
+  git ci -m "v${1}"
+  bower version ${1}
+  git push origin
+  popd
+}
+
+#
 # Build all profiles and publish.
 #
 main() {
@@ -92,6 +121,7 @@ main() {
   rm -rf ${BUILDS}
   build_profiles ${PROFILES}
   npm publish
+  bower_publish ${1}
 }
 
 if test ${#} -ne 1; then

--- a/tasks/publish.sh
+++ b/tasks/publish.sh
@@ -106,6 +106,7 @@ bower_publish() {
   git ci -m "v${1}"
   bower version ${1}
   git push origin
+  git push origin --tags
   popd
 }
 


### PR DESCRIPTION
Regarding #3119

Added a sub-task to publish.sh that publishes to a specified bower repo.

With this in place would still need a few things for ol3 to be published to bower:
- Create `openlayers/bower-ol3` with a bower.json similar to that seen at malaretv/bower-ol3
- Register package with bower using `bower register` (see http://bower.io/docs/creating-packages/#register)

Note that this currently depends on bower being install globally via npm. If that is not acceptable bower could be added as dev dependency or the `bower version` task can be done manually by updating the json and adding the correct tag.

