### PR TITLE
Listen on localhost to avoid phantomjs browsing 0.0.0.0

### DIFF
--- a/tasks/test.js
+++ b/tasks/test.js
@@ -31,7 +31,7 @@ function listen(min, max, server, callback) {
         callback(err);
       }
     });
-    server.listen(port, callback);
+    server.listen(port, '127.0.0.1', callback);
   }
   _listen(min);
 }


### PR DESCRIPTION
On some networks, making Node's HTTP Server listen on any IP address causes the IP address 0.0.0.0 to be returned, which makes Phantomjs fail on `npm test`.

This change makes it so the server listens on 127.0.0.1, which will ensure that a valid IP address is returned.