### PR TITLE
Add new use_strict option to the build config

### DIFF
--- a/config/ol.json
+++ b/config/ol.json
@@ -1,6 +1,7 @@
 {
   "exports": ["*"],
   "umd": true,
+  "use_strict": true,
   "compile": {
     "externs": [
       "externs/bingmaps.js",

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -20,9 +20,9 @@ var umdWrapper = '(function (root, factory) {\n' +
     '  if (typeof define === "function" && define.amd) {\n' +
     '    define([], factory);\n' +
     '  } else if (typeof exports === "object") {\n' +
-    '    module.exports = factory();\n' +
+    '    module.exports = factory.call(root);\n' +
     '  } else {\n' +
-    '    root.ol = factory();\n' +
+    '    root.ol = factory.call(root);\n' +
     '  }\n' +
     '}(this, function () {\n' +
     '  var OPENLAYERS = {};\n' +
@@ -63,6 +63,8 @@ function assertValidConfig(config, callback) {
       if (config.compile) {
         config.compile.output_wrapper = umdWrapper;
       }
+    } else {
+      config.compile.output_wrapper = '(function() { %output% }).call(this);';
     }
     callback(null);
   });
@@ -214,6 +216,20 @@ function build(config, paths, callback) {
 
 
 /**
+ * Optionally adds the `"use strict";` flag before the compiled source.
+ * @param {string} compiledSource The compiled library.
+ * @param {function(Error, string)} callback Called with the output
+ *     ready to be written into a file, or any error.
+ */
+function addStrictMode(config, compiledSource, callback) {
+  if (config.use_strict) {
+    compiledSource = '"use strict";\n' + compiledSource;
+  }
+  callback(null, compiledSource);
+}
+
+
+/**
  * Adds a file header with the most recent Git tag.
  * @param {string} compiledSource The compiled library.
  * @param {function(Error, string)} callback Called with the output
@@ -245,6 +261,7 @@ function main(config, callback) {
     generateExports.bind(null, config),
     getDependencies.bind(null, config),
     build.bind(null, config),
+    addStrictMode.bind(null, config),
     addHeader
   ], callback);
 }

--- a/tasks/readme.md
+++ b/tasks/readme.md
@@ -26,6 +26,8 @@ Build configuration files are JSON files that are used to determine what should 
 
     If the **compile** object is not provided, the build task will generate a "debug" build of the library without any variable naming or other minification.  This is suitable for development or debugging purposes, but should not be used in production.
 
+  * **use_strict** - `boolean` Optional flag to create an ECMAScript 5's strict mode build. Default is false.
+
   * **umd** - `boolean` Optional flag to wrap the build in [UMD syntax](https://github.com/umdjs/umd).  If set to `true`, the build output can be used with a CommonJS module loader (e.g. [Browserify](http://browserify.org/)), an AMD script loader (e.g. [RequireJS](http://requirejs.org/)), or just loaded with a `<script>` tag.  If this option is specified, the **namespace** and any **compile.output_wrapper** options will be ignored.
 
   * **src** - `Array.<string>` Optional array of [path patterns](https://github.com/isaacs/minimatch/blob/master/README.md) for source files, that is, those that provide the symbols/names included in `exports`.  By default, all of the library source files will be included (`'src/**/*.js'`).  If you want to provide additional source files to be configured together with the library, you need to provide path patterns to your source files *and* the library source files.  Note that these patterns are `/` delimited even on Windows.  There is a bit of special handling with the `src` config.


### PR DESCRIPTION
Optional flag to create an ECMAScript 5's strict mode build. Default is false.
