### PR TITLE
Add ol.source.Tile support for wrapping around the x-axis

### DIFF
--- a/examples/wms-tiled-wrap-180.html
+++ b/examples/wms-tiled-wrap-180.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <link rel="stylesheet" href="../css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap.min.css" type="text/css">
+    <link rel="stylesheet" href="../resources/layout.css" type="text/css">
+    <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap-responsive.min.css" type="text/css">
+    <title>Tiled WMS wrap 180° meridian example</title>
+  </head>
+  <body>
+
+    <div class="navbar navbar-inverse navbar-fixed-top">
+      <div class="navbar-inner">
+        <div class="container">
+          <a class="brand" href="./"><img src="../resources/logo.png"> OpenLayers 3 Examples</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="container-fluid">
+
+      <div class="row-fluid">
+        <div class="span12">
+          <div id="map" class="map"></div>
+        </div>
+      </div>
+
+      <div class="row-fluid">
+
+        <div class="span12">
+          <h4 id="title">Tiled WMS wrap 180° meridian example</h4>
+          <p id="shortdesc">Example of a tiled WMS layer that wraps across the 180° meridian.</p>
+          <div id="docs">
+            <p>See the <a href="wms-tiled-wrap-180.js" target="_blank">wms-tiled-wrap-180.js source</a> to see how this is done.</p>
+          </div>
+          <div id="tags">wms, tile, dateline, wrap, 180</div>
+        </div>
+
+      </div>
+
+    </div>
+
+    <script src="../resources/jquery.min.js" type="text/javascript"></script>
+    <script src="../resources/example-behaviour.js" type="text/javascript"></script>
+    <script src="loader.js?id=wms-tiled-wrap-180" type="text/javascript"></script>
+
+  </body>
+</html>

--- a/examples/wms-tiled-wrap-180.js
+++ b/examples/wms-tiled-wrap-180.js
@@ -1,0 +1,28 @@
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.layer.Tile');
+goog.require('ol.source.MapQuest');
+goog.require('ol.source.TileWMS');
+
+
+var layers = [
+  new ol.layer.Tile({
+    source: new ol.source.MapQuest({layer: 'sat'})
+  }),
+  new ol.layer.Tile({
+    source: new ol.source.TileWMS(/** @type {olx.source.TileWMSOptions} */ ({
+      url: 'http://demo.boundlessgeo.com/geoserver/ne/wms',
+      params: {'LAYERS': 'ne:ne_10m_admin_0_countries', 'TILED': true},
+      serverType: 'geoserver',
+      wrapX: true
+    }))
+  })
+];
+var map = new ol.Map({
+  layers: layers,
+  target: 'map',
+  view: new ol.View({
+    center: [0, 0],
+    zoom: 1
+  })
+});

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -3861,7 +3861,8 @@ olx.source.TileUTFGridOptions.prototype.url;
  *            tileGrid: (ol.tilegrid.TileGrid|undefined),
  *            tileLoadFunction: (ol.TileLoadFunctionType|undefined),
  *            tilePixelRatio: (number|undefined),
- *            tileUrlFunction: (ol.TileUrlFunctionType|undefined)}}
+ *            tileUrlFunction: (ol.TileUrlFunctionType|undefined),
+ *            wrapX: (boolean|undefined)}}
  * @api
  */
 olx.source.TileImageOptions;
@@ -3962,6 +3963,17 @@ olx.source.TileImageOptions.prototype.tilePixelRatio;
  * @api
  */
 olx.source.TileImageOptions.prototype.tileUrlFunction;
+
+
+/**
+ * Whether to wrap the world horizontally. The default, `undefined`, is to
+ * request out-of-bounds tiles from the server. When set to `false`, only one
+ * world will be rendered. When set to `true`, tiles will be requested for one
+ * world only, but they will be wrapped horizontally to render multiple worlds.
+ * @type {boolean|undefined}
+ * @api
+ */
+olx.source.TileImageOptions.prototype.wrapX;
 
 
 /**
@@ -5040,7 +5052,8 @@ olx.source.ServerVectorOptions.prototype.projection;
  *     projection: ol.proj.ProjectionLike,
  *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
  *     url: (string|undefined),
- *     urls: (Array.<string>|undefined)}}
+ *     urls: (Array.<string>|undefined),
+ *     wrapX: (boolean|undefined)}}
  * @api
  */
 olx.source.TileArcGISRestOptions;
@@ -5109,6 +5122,14 @@ olx.source.TileArcGISRestOptions.prototype.tileLoadFunction;
  * @api
  */
 olx.source.TileArcGISRestOptions.prototype.url;
+
+
+/**
+ * Whether to wrap the world horizontally. Default is `true`.
+ * @type {boolean|undefined}
+ * @api
+ */
+olx.source.TileArcGISRestOptions.prototype.wrapX;
 
 
 /**
@@ -5190,7 +5211,8 @@ olx.source.TileJSONOptions.prototype.wrapX;
  *     serverType: (ol.source.wms.ServerType|string|undefined),
  *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
  *     url: (string|undefined),
- *     urls: (Array.<string>|undefined)}}
+ *     urls: (Array.<string>|undefined),
+ *     wrapX: (boolean|undefined)}}
  * @api
  */
 olx.source.TileWMSOptions;
@@ -5318,6 +5340,18 @@ olx.source.TileWMSOptions.prototype.url;
  * @api stable
  */
 olx.source.TileWMSOptions.prototype.urls;
+
+
+/**
+ * Whether to wrap the world horizontally. The default, `undefined`, is to
+ * request out-of-bounds tiles from the server. This works well in e.g.
+ * GeoServer. When set to `false`, only one world will be rendered. When set to
+ * `true`, tiles will be requested for one world only, but they will be wrapped
+ * horizontally to render multiple worlds.
+ * @type {boolean|undefined}
+ * @api
+ */
+olx.source.TileWMSOptions.prototype.wrapX;
 
 
 /**

--- a/src/ol/source/bingmapssource.js
+++ b/src/ol/source/bingmapssource.js
@@ -33,7 +33,8 @@ ol.source.BingMaps = function(options) {
     opaque: true,
     projection: ol.proj.get('EPSG:3857'),
     state: ol.source.State.LOADING,
-    tileLoadFunction: options.tileLoadFunction
+    tileLoadFunction: options.tileLoadFunction,
+    wrapX: goog.isDef(options.wrapX) ? options.wrapX : true
   });
 
   /**
@@ -47,12 +48,6 @@ ol.source.BingMaps = function(options) {
    * @type {number}
    */
   this.maxZoom_ = goog.isDef(options.maxZoom) ? options.maxZoom : -1;
-
-  /**
-   * @private
-   * @type {boolean}
-   */
-  this.wrapX_ = goog.isDef(options.wrapX) ? options.wrapX : true;
 
   var protocol = ol.IS_HTTPS ? 'https:' : 'http:';
   var uri = new goog.Uri(
@@ -117,7 +112,7 @@ ol.source.BingMaps.prototype.handleImageryMetadataResponse =
 
   var culture = this.culture_;
   this.tileUrlFunction = ol.TileUrlFunction.withTileCoordTransform(
-      tileGrid.createTileCoordTransform({wrapX: this.wrapX_}),
+      tileGrid.createTileCoordTransform(),
       ol.TileUrlFunction.createFromTileUrlFunctions(
           goog.array.map(
               resource.imageUrlSubdomains,

--- a/src/ol/source/tilearcgisrestsource.js
+++ b/src/ol/source/tilearcgisrestsource.js
@@ -42,7 +42,8 @@ ol.source.TileArcGISRest = function(opt_options) {
     projection: options.projection,
     tileGrid: options.tileGrid,
     tileLoadFunction: options.tileLoadFunction,
-    tileUrlFunction: goog.bind(this.tileUrlFunction_, this)
+    tileUrlFunction: goog.bind(this.tileUrlFunction_, this),
+    wrapX: goog.isDef(options.wrapX) ? options.wrapX : true
   });
 
   var urls = options.urls;

--- a/src/ol/source/tileimagesource.js
+++ b/src/ol/source/tileimagesource.js
@@ -34,7 +34,8 @@ ol.source.TileImage = function(options) {
     state: goog.isDef(options.state) ?
         /** @type {ol.source.State} */ (options.state) : undefined,
     tileGrid: options.tileGrid,
-    tilePixelRatio: options.tilePixelRatio
+    tilePixelRatio: options.tilePixelRatio,
+    wrapX: options.wrapX
   });
 
   /**
@@ -91,7 +92,9 @@ ol.source.TileImage.prototype.getTile =
   } else {
     goog.asserts.assert(projection);
     var tileCoord = [z, x, y];
-    var tileUrl = this.tileUrlFunction(tileCoord, pixelRatio, projection);
+    var urlTileCoord = this.getWrapXTileCoord(tileCoord, projection);
+    var tileUrl = goog.isNull(urlTileCoord) ? undefined :
+        this.tileUrlFunction(urlTileCoord, pixelRatio, projection);
     var tile = new this.tileClass(
         tileCoord,
         goog.isDef(tileUrl) ? ol.TileState.IDLE : ol.TileState.EMPTY,

--- a/src/ol/source/tilejsonsource.js
+++ b/src/ol/source/tilejsonsource.js
@@ -37,14 +37,9 @@ ol.source.TileJSON = function(options) {
     crossOrigin: options.crossOrigin,
     projection: ol.proj.get('EPSG:3857'),
     state: ol.source.State.LOADING,
-    tileLoadFunction: options.tileLoadFunction
+    tileLoadFunction: options.tileLoadFunction,
+    wrapX: goog.isDef(options.wrapX) ? options.wrapX : true
   });
-
-  /**
-   * @type {boolean|undefined}
-   * @private
-   */
-  this.wrapX_ = options.wrapX;
 
   var request = new goog.net.Jsonp(options.url);
   request.send(undefined, goog.bind(this.handleTileJSONResponse, this));
@@ -82,10 +77,7 @@ ol.source.TileJSON.prototype.handleTileJSONResponse = function(tileJSON) {
   this.tileGrid = tileGrid;
 
   this.tileUrlFunction = ol.TileUrlFunction.withTileCoordTransform(
-      tileGrid.createTileCoordTransform({
-        extent: extent,
-        wrapX: this.wrapX_
-      }),
+      tileGrid.createTileCoordTransform({extent: extent}),
       ol.TileUrlFunction.createFromTemplates(tileJSON.tiles));
 
   if (goog.isDef(tileJSON.attribution) &&

--- a/src/ol/source/tilewmssource.js
+++ b/src/ol/source/tilewmssource.js
@@ -47,7 +47,8 @@ ol.source.TileWMS = function(opt_options) {
     projection: options.projection,
     tileGrid: options.tileGrid,
     tileLoadFunction: options.tileLoadFunction,
-    tileUrlFunction: goog.bind(this.tileUrlFunction_, this)
+    tileUrlFunction: goog.bind(this.tileUrlFunction_, this),
+    wrapX: options.wrapX
   });
 
   var urls = options.urls;

--- a/src/ol/source/xyzsource.js
+++ b/src/ol/source/xyzsource.js
@@ -34,16 +34,15 @@ ol.source.XYZ = function(options) {
     tileGrid: tileGrid,
     tileLoadFunction: options.tileLoadFunction,
     tilePixelRatio: options.tilePixelRatio,
-    tileUrlFunction: ol.TileUrlFunction.nullTileUrlFunction
+    tileUrlFunction: ol.TileUrlFunction.nullTileUrlFunction,
+    wrapX: goog.isDef(options.wrapX) ? options.wrapX : true
   });
 
   /**
    * @private
    * @type {ol.TileCoordTransformType}
    */
-  this.tileCoordTransform_ = tileGrid.createTileCoordTransform({
-    wrapX: options.wrapX
-  });
+  this.tileCoordTransform_ = tileGrid.createTileCoordTransform();
 
   if (goog.isDef(options.tileUrlFunction)) {
     this.setTileUrlFunction(options.tileUrlFunction);

--- a/src/ol/tilecoord.js
+++ b/src/ol/tilecoord.js
@@ -3,6 +3,7 @@ goog.provide('ol.tilecoord');
 
 goog.require('goog.array');
 goog.require('goog.asserts');
+goog.require('goog.math');
 
 
 /**
@@ -136,4 +137,38 @@ ol.tilecoord.quadKey = function(tileCoord) {
  */
 ol.tilecoord.toString = function(tileCoord) {
   return ol.tilecoord.getKeyZXY(tileCoord[0], tileCoord[1], tileCoord[2]);
+};
+
+
+/**
+ * @param {ol.TileCoord} tileCoord Tile coordinate.
+ * @param {ol.tilegrid.TileGrid} tilegrid Tile grid.
+ * @param {ol.Extent} extent Extent.
+ * @return {ol.TileCoord} Tile coordinate.
+ */
+ol.tilecoord.wrapX = (function() {
+  var tmpTileCoord = [0, 0, 0];
+  return function(tileCoord, tileGrid, extent) {
+    var z = tileCoord[0];
+    var x = tileCoord[1];
+    var tileRange = tileGrid.getTileRangeForExtentAndZ(extent, z);
+    if (x < tileRange.minX || x > tileRange.maxX) {
+      x = goog.math.modulo(x, tileRange.getWidth());
+      return ol.tilecoord.createOrUpdate(z, x, tileCoord[2], tmpTileCoord);
+    }
+    return tileCoord;
+  };
+})();
+
+
+/**
+ * @param {ol.TileCoord} tileCoord Tile coordinate.
+ * @param {ol.tilegrid.TileGrid} tileGrid Tile grid.
+ * @param {ol.Extent} extent Extent.
+ * @return {ol.TileCoord} Tile coordinate.
+ */
+ol.tilecoord.clipX = function(tileCoord, tileGrid, extent) {
+  var x = tileCoord[1];
+  var tileRange = tileGrid.getTileRangeForExtentAndZ(extent, tileCoord[0]);
+  return (x < tileRange.minX || x > tileRange.maxX) ? null : tileCoord;
 };

--- a/src/ol/tilegrid/tilegrid.js
+++ b/src/ol/tilegrid/tilegrid.js
@@ -103,8 +103,7 @@ ol.tilegrid.TileGrid.tmpTileCoord_ = [0, 0, 0];
 
 /**
  * Returns the identity function. May be overridden in subclasses.
- * @param {{extent: (ol.Extent|undefined),
- *          wrapX: (boolean|undefined)}=} opt_options Options.
+ * @param {{extent: (ol.Extent|undefined)}=} opt_options Options.
  * @return {function(ol.TileCoord, ol.proj.Projection, ol.TileCoord=):
  *     ol.TileCoord} Tile coordinate transform.
  */

--- a/src/ol/tilegrid/xyztilegrid.js
+++ b/src/ol/tilegrid/xyztilegrid.js
@@ -47,7 +47,6 @@ ol.tilegrid.XYZ.prototype.createTileCoordTransform = function(opt_options) {
   var options = goog.isDef(opt_options) ? opt_options : {};
   var minZ = this.minZoom;
   var maxZ = this.maxZoom;
-  var wrapX = goog.isDef(options.wrapX) ? options.wrapX : true;
   /** @type {Array.<ol.TileRange>} */
   var tileRangeByZ = null;
   if (goog.isDef(options.extent)) {
@@ -75,11 +74,6 @@ ol.tilegrid.XYZ.prototype.createTileCoordTransform = function(opt_options) {
         }
         var n = Math.pow(2, z);
         var x = tileCoord[1];
-        if (wrapX) {
-          x = goog.math.modulo(x, n);
-        } else if (x < 0 || n <= x) {
-          return null;
-        }
         var y = tileCoord[2];
         if (y < -n || -1 < y) {
           return null;

--- a/test/spec/ol/source/tilesource.test.js
+++ b/test/spec/ol/source/tilesource.test.js
@@ -115,6 +115,56 @@ describe('ol.source.Tile', function() {
 
   });
 
+  describe('#getWrapXTileCoord()', function() {
+
+    it('returns the expected tile coordinate - {wrapX: undefined}', function() {
+      var tileSource = new ol.source.Tile({
+        projection: 'EPSG:3857'
+      });
+
+      var tileCoord = tileSource.getWrapXTileCoord([6, -31, 22]);
+      expect(tileCoord).to.eql([6, -31, 22]);
+
+      tileCoord = tileSource.getWrapXTileCoord([6, 33, 22]);
+      expect(tileCoord).to.eql([6, 33, 22]);
+
+      tileCoord = tileSource.getWrapXTileCoord([6, 97, 22]);
+      expect(tileCoord).to.eql([6, 97, 22]);
+    });
+
+    it('returns the expected tile coordinate - {wrapX: true}', function() {
+      var tileSource = new ol.source.Tile({
+        projection: 'EPSG:3857',
+        wrapX: true
+      });
+
+      var tileCoord = tileSource.getWrapXTileCoord([6, -31, 22]);
+      expect(tileCoord).to.eql([6, 33, 22]);
+
+      tileCoord = tileSource.getWrapXTileCoord([6, 33, 22]);
+      expect(tileCoord).to.eql([6, 33, 22]);
+
+      tileCoord = tileSource.getWrapXTileCoord([6, 97, 22]);
+      expect(tileCoord).to.eql([6, 33, 22]);
+    });
+
+    it('returns the expected tile coordinate - {wrapX: false}', function() {
+      var tileSource = new ol.source.Tile({
+        projection: 'EPSG:3857',
+        wrapX: false
+      });
+
+      var tileCoord = tileSource.getWrapXTileCoord([6, -31, 22]);
+      expect(tileCoord).to.eql(null);
+
+      tileCoord = tileSource.getWrapXTileCoord([6, 33, 22]);
+      expect(tileCoord).to.eql([6, 33, 22]);
+
+      tileCoord = tileSource.getWrapXTileCoord([6, 97, 22]);
+      expect(tileCoord).to.eql(null);
+    });
+  });
+
 });
 
 

--- a/test/spec/ol/source/xyzsource.test.js
+++ b/test/spec/ol/source/xyzsource.test.js
@@ -64,14 +64,17 @@ describe('ol.source.XYZ', function() {
     describe('wrap x', function() {
 
       it('returns the expected URL', function() {
+        var projection = xyzTileSource.getProjection();
         var tileUrl = xyzTileSource.tileUrlFunction(
-            [6, -31, -23]);
+            xyzTileSource.getWrapXTileCoord([6, -31, -23], projection));
         expect(tileUrl).to.eql('6/33/22');
 
-        tileUrl = xyzTileSource.tileUrlFunction([6, 33, -23]);
+        tileUrl = xyzTileSource.tileUrlFunction(
+            xyzTileSource.getWrapXTileCoord([6, 33, -23], projection));
         expect(tileUrl).to.eql('6/33/22');
 
-        tileUrl = xyzTileSource.tileUrlFunction([6, 97, -23]);
+        tileUrl = xyzTileSource.tileUrlFunction(
+            xyzTileSource.getWrapXTileCoord([6, 97, -23], projection));
         expect(tileUrl).to.eql('6/33/22');
       });
 


### PR DESCRIPTION
This pull request adds general support for wrapping around the 180° meridian to tile sources and adds a `wrapX` option to WMS and ArcGISRest tile sources.

Fixes #2712.