### PR TITLE
Add wrapX option for ol.source.WMTS

### DIFF
--- a/examples/wmts-layer-from-capabilities.js
+++ b/examples/wmts-layer-from-capabilities.js
@@ -2,7 +2,6 @@ goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.format.WMTSCapabilities');
 goog.require('ol.layer.Tile');
-goog.require('ol.proj');
 goog.require('ol.source.OSM');
 goog.require('ol.source.WMTS');
 
@@ -14,8 +13,6 @@ $.ajax('data/WMTSCapabilities.xml').then(function(response) {
   var options = ol.source.WMTS.optionsFromCapabilities(result,
       {layer: 'layer-7328', matrixSet: 'EPSG:3857'});
 
-  var projection = ol.proj.get('EPSG:3857');
-  var projectionExtent = projection.getExtent();
   map = new ol.Map({
     layers: [
       new ol.layer.Tile({
@@ -24,7 +21,6 @@ $.ajax('data/WMTSCapabilities.xml').then(function(response) {
       }),
       new ol.layer.Tile({
         opacity: 1,
-        extent: projectionExtent,
         source: new ol.source.WMTS(options)
       })
     ],

--- a/examples/wmts.js
+++ b/examples/wmts.js
@@ -35,7 +35,6 @@ var map = new ol.Map({
     }),
     new ol.layer.Tile({
       opacity: 0.7,
-      extent: projectionExtent,
       source: new ol.source.WMTS({
         attributions: [attribution],
         url: 'http://services.arcgisonline.com/arcgis/rest/' +
@@ -49,7 +48,8 @@ var map = new ol.Map({
           resolutions: resolutions,
           matrixIds: matrixIds
         }),
-        style: 'default'
+        style: 'default',
+        wrapX: true
       })
     })
   ],

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -6503,8 +6503,8 @@ olx.tilegrid.TileGridOptions.prototype.origin;
 
 
 /**
- * Origins. If given, the array should match the `resolutions` array, i.e.
- * each resolution can have a different origin.
+ * Origins. If given, the array length should match the length of the
+ * `resolutions` array, i.e. each resolution can have a different origin.
  * @type {Array.<ol.Coordinate>|undefined}
  * @api stable
  */
@@ -6512,7 +6512,9 @@ olx.tilegrid.TileGridOptions.prototype.origins;
 
 
 /**
- * Resolutions.
+ * Resolutions. The array index of each resolution needs to match the zoom
+ * level. This means that even if a `minZoom` is configured, the resolutions
+ * array will have a length of `maxZoom + 1`.
  * @type {!Array.<number>}
  * @api stable
  */
@@ -6528,8 +6530,8 @@ olx.tilegrid.TileGridOptions.prototype.tileSize;
 
 
 /**
- * Tile sizes. If given, the array should match the `resolutions` array, i.e.
- * each resolution can have a different tile size.
+ * Tile sizes. If given, the array length should match the length of the
+ * `resolutions` array, i.e. each resolution can have a different tile size.
  * @type {Array.<number>|undefined}
  * @api stable
  */
@@ -6567,7 +6569,8 @@ olx.tilegrid.WMTSOptions.prototype.origin;
 
 
 /**
- * Origins.
+ * Origins. The length of this array needs to match the length of the
+ * `resolutions` array.
  * @type {Array.<ol.Coordinate>|undefined}
  * @api
  */
@@ -6575,7 +6578,9 @@ olx.tilegrid.WMTSOptions.prototype.origins;
 
 
 /**
- * Resolutions.
+ * Resolutions. The array index of each resolution needs to match the zoom
+ * level. This means that even if a `minZoom` is configured, the resolutions
+ * array will have a length of `maxZoom + 1`
  * @type {!Array.<number>}
  * @api
  */
@@ -6583,7 +6588,8 @@ olx.tilegrid.WMTSOptions.prototype.resolutions;
 
 
 /**
- * matrix IDs.
+ * matrix IDs. The length of this array needs to match the length of the
+ * `resolutions` array.
  * @type {!Array.<string>}
  * @api
  */
@@ -6599,7 +6605,8 @@ olx.tilegrid.WMTSOptions.prototype.tileSize;
 
 
 /**
- * Tile sizes.
+ * Tile sizes. The length of this array needs to match the length of the
+ * `resolutions` array.
  * @type {Array.<number>|undefined}
  * @api
  */

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -6479,7 +6479,8 @@ olx.tilegrid;
  *     origins: (Array.<ol.Coordinate>|undefined),
  *     resolutions: !Array.<number>,
  *     tileSize: (number|undefined),
- *     tileSizes: (Array.<number>|undefined)}}
+ *     tileSizes: (Array.<number>|undefined),
+ *     widths: (Array.<number>|undefined)}}
  * @api
  */
 olx.tilegrid.TileGridOptions;
@@ -6536,12 +6537,22 @@ olx.tilegrid.TileGridOptions.prototype.tileSizes;
 
 
 /**
+ * Widths in tiles. If given, the array length should match the length of the
+ * `resolutions` array, i.e. each resolution will have a number of tile columns.
+ * @type {Array.<number>|undefined}
+ * @api
+ */
+olx.tilegrid.TileGridOptions.prototype.widths;
+
+
+/**
  * @typedef {{origin: (ol.Coordinate|undefined),
  *     origins: (Array.<ol.Coordinate>|undefined),
  *     resolutions: !Array.<number>,
  *     matrixIds: !Array.<string>,
  *     tileSize: (number|undefined),
- *     tileSizes: (Array.<number>|undefined)}}
+ *     tileSizes: (Array.<number>|undefined),
+ *     widths: (Array.<number>|undefined)}}
  * @api
  */
 olx.tilegrid.WMTSOptions;
@@ -6593,6 +6604,15 @@ olx.tilegrid.WMTSOptions.prototype.tileSize;
  * @api
  */
 olx.tilegrid.WMTSOptions.prototype.tileSizes;
+
+
+/**
+ * Widths in tiles. If given, the array length should match the length of the
+ * `resolutions` array, i.e. each resolution will have a number of tile columns.
+ * @type {Array.<number>|undefined}
+ * @api
+ */
+olx.tilegrid.WMTSOptions.prototype.widths;
 
 
 /**

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -5530,7 +5530,8 @@ olx.source.StaticVectorOptions.prototype.urls;
  *     urls: (Array.<string>|undefined),
  *     tileClass: (function(new: ol.ImageTile, ol.TileCoord,
  *                          ol.TileState, string, ?string,
- *                          ol.TileLoadFunctionType)|undefined)}}
+ *                          ol.TileLoadFunctionType)|undefined),
+ *     wrapX: (boolean|undefined)}}
  * @api
  */
 olx.source.WMTSOptions;
@@ -5687,6 +5688,14 @@ olx.source.WMTSOptions.prototype.tileLoadFunction;
  * @api
  */
 olx.source.WMTSOptions.prototype.urls;
+
+
+/**
+ * Whether to wrap the world horizontally. Default is `false`.
+ * @type {boolean|undefined}
+ * @api
+ */
+olx.source.WMTSOptions.prototype.wrapX;
 
 
 /**

--- a/src/ol/attribution.js
+++ b/src/ol/attribution.js
@@ -77,8 +77,8 @@ ol.Attribution.prototype.intersectsAnyTileRange =
       if (testTileRange.intersects(tileRange)) {
         return true;
       }
-      var extentTileRange = tileGrid.getTileRangeForExtentAndZ(
-          ol.tilegrid.extentFromProjection(projection), parseInt(zKey, 10));
+      var extentTileRange = tileGrid.getTileRange(
+          parseInt(zKey, 10), projection);
       var width = extentTileRange.getWidth();
       if (tileRange.minX < extentTileRange.minX ||
           tileRange.maxX > extentTileRange.maxX) {

--- a/src/ol/source/tilesource.js
+++ b/src/ol/source/tilesource.js
@@ -224,12 +224,11 @@ ol.source.Tile.prototype.getWrapXTileCoord =
     function(tileCoord, opt_projection) {
   var projection = goog.isDef(opt_projection) ?
       opt_projection : this.getProjection();
-  if (goog.isDef(this.wrapX_) && projection.isGlobal()) {
-    var tileGrid = this.getTileGridForProjection(projection);
-    var extent = ol.tilegrid.extentFromProjection(projection);
+  var tileGrid = this.getTileGridForProjection(projection);
+  if (goog.isDef(this.wrapX_) && tileGrid.isGlobal(tileCoord[0], projection)) {
     return this.wrapX_ ?
-        ol.tilecoord.wrapX(tileCoord, tileGrid, extent) :
-        ol.tilecoord.clipX(tileCoord, tileGrid, extent);
+        ol.tilecoord.wrapX(tileCoord, tileGrid, projection) :
+        ol.tilecoord.clipX(tileCoord, tileGrid, projection);
   } else {
     return tileCoord;
   }

--- a/src/ol/tilecoord.js
+++ b/src/ol/tilecoord.js
@@ -143,15 +143,15 @@ ol.tilecoord.toString = function(tileCoord) {
 /**
  * @param {ol.TileCoord} tileCoord Tile coordinate.
  * @param {ol.tilegrid.TileGrid} tilegrid Tile grid.
- * @param {ol.Extent} extent Extent.
+ * @param {ol.proj.Projection} projection Projection.
  * @return {ol.TileCoord} Tile coordinate.
  */
 ol.tilecoord.wrapX = (function() {
   var tmpTileCoord = [0, 0, 0];
-  return function(tileCoord, tileGrid, extent) {
+  return function(tileCoord, tileGrid, projection) {
     var z = tileCoord[0];
     var x = tileCoord[1];
-    var tileRange = tileGrid.getTileRangeForExtentAndZ(extent, z);
+    var tileRange = tileGrid.getTileRange(z, projection);
     if (x < tileRange.minX || x > tileRange.maxX) {
       x = goog.math.modulo(x, tileRange.getWidth());
       return ol.tilecoord.createOrUpdate(z, x, tileCoord[2], tmpTileCoord);
@@ -164,11 +164,12 @@ ol.tilecoord.wrapX = (function() {
 /**
  * @param {ol.TileCoord} tileCoord Tile coordinate.
  * @param {ol.tilegrid.TileGrid} tileGrid Tile grid.
- * @param {ol.Extent} extent Extent.
+ * @param {ol.proj.Projection} projection Projection.
  * @return {ol.TileCoord} Tile coordinate.
  */
-ol.tilecoord.clipX = function(tileCoord, tileGrid, extent) {
+ol.tilecoord.clipX = function(tileCoord, tileGrid, projection) {
+  var z = tileCoord[0];
   var x = tileCoord[1];
-  var tileRange = tileGrid.getTileRangeForExtentAndZ(extent, tileCoord[0]);
+  var tileRange = tileGrid.getTileRange(z, projection);
   return (x < tileRange.minX || x > tileRange.maxX) ? null : tileCoord;
 };

--- a/src/ol/tilegrid/tilegrid.js
+++ b/src/ol/tilegrid/tilegrid.js
@@ -65,7 +65,7 @@ ol.tilegrid.TileGrid = function(options) {
   this.origins_ = null;
   if (goog.isDef(options.origins)) {
     this.origins_ = options.origins;
-    goog.asserts.assert(this.origins_.length == this.maxZoom + 1);
+    goog.asserts.assert(this.origins_.length == this.resolutions_.length);
   }
   goog.asserts.assert(
       (goog.isNull(this.origin_) && !goog.isNull(this.origins_)) ||
@@ -78,7 +78,7 @@ ol.tilegrid.TileGrid = function(options) {
   this.tileSizes_ = null;
   if (goog.isDef(options.tileSizes)) {
     this.tileSizes_ = options.tileSizes;
-    goog.asserts.assert(this.tileSizes_.length == this.maxZoom + 1);
+    goog.asserts.assert(this.tileSizes_.length == this.resolutions_.length);
   }
 
   /**

--- a/src/ol/tilegrid/wmtstilegrid.js
+++ b/src/ol/tilegrid/wmtstilegrid.js
@@ -34,7 +34,8 @@ ol.tilegrid.WMTS = function(options) {
     origins: options.origins,
     resolutions: options.resolutions,
     tileSize: options.tileSize,
-    tileSizes: options.tileSizes
+    tileSizes: options.tileSizes,
+    widths: options.widths
   });
 
 };
@@ -77,6 +78,8 @@ ol.tilegrid.WMTS.createFromCapabilitiesMatrixSet =
   var origins = [];
   /** @type {!Array.<number>} */
   var tileSizes = [];
+  /** @type {!Array.<number>} */
+  var widths = [];
 
   var supportedCRSPropName = 'SupportedCRS';
   var matrixIdsPropName = 'TileMatrix';
@@ -112,12 +115,14 @@ ol.tilegrid.WMTS.createFromCapabilitiesMatrixSet =
         var tileHeight = elt[tileHeightPropName];
         goog.asserts.assert(tileWidth == tileHeight);
         tileSizes.push(tileWidth);
+        widths.push(elt['MatrixWidth']);
       });
 
   return new ol.tilegrid.WMTS({
     origins: origins,
     resolutions: resolutions,
     matrixIds: matrixIds,
-    tileSizes: tileSizes
+    tileSizes: tileSizes,
+    widths: widths
   });
 };


### PR DESCRIPTION
This adds/fixes support for wrapping the date line for WMTS sources.

Fixes #3386.