### PR TITLE
Add new geometry layout option for polyline format

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -1618,7 +1618,8 @@ olx.format.GeoJSONOptions.prototype.geometryName;
 
 
 /**
- * @typedef {{factor: (number|undefined)}}
+ * @typedef {{factor: (number|undefined),
+ *     geometryLayout: (ol.geom.GeometryLayout|undefined)}}
  * @api
  */
 olx.format.PolylineOptions;
@@ -1631,6 +1632,15 @@ olx.format.PolylineOptions;
  * @api stable
  */
 olx.format.PolylineOptions.prototype.factor;
+
+
+/**
+ * Layout of the feature geometries created by the format reader.
+ * Default is `ol.geom.GeometryLayout.XY`.
+ * @type {ol.geom.GeometryLayout|undefined}
+ * @api
+ */
+olx.format.PolylineOptions.prototype.geometryLayout;
 
 
 /**

--- a/src/ol/format/polylineformat.js
+++ b/src/ol/format/polylineformat.js
@@ -5,6 +5,7 @@ goog.require('ol.Feature');
 goog.require('ol.format.Feature');
 goog.require('ol.format.TextFeature');
 goog.require('ol.geom.LineString');
+goog.require('ol.geom.SimpleGeometry');
 goog.require('ol.geom.flat.flip');
 goog.require('ol.geom.flat.inflate');
 goog.require('ol.proj');
@@ -38,6 +39,13 @@ ol.format.Polyline = function(opt_options) {
    * @type {number}
    */
   this.factor_ = goog.isDef(options.factor) ? options.factor : 1e5;
+
+  /**
+   * @private
+   * @type {ol.geom.GeometryLayout}
+   */
+  this.geometryLayout_ = goog.isDef(options.geometryLayout) ?
+      options.geometryLayout : ol.geom.GeometryLayout.XY;
 };
 goog.inherits(ol.format.Polyline, ol.format.TextFeature);
 
@@ -316,15 +324,17 @@ ol.format.Polyline.prototype.readGeometry;
  */
 ol.format.Polyline.prototype.readGeometryFromText =
     function(text, opt_options) {
-  var flatCoordinates = ol.format.Polyline.decodeDeltas(text, 2, this.factor_);
+  var stride = ol.geom.SimpleGeometry.getStrideForLayout(this.geometryLayout_);
+  var flatCoordinates = ol.format.Polyline.decodeDeltas(
+      text, stride, this.factor_);
   ol.geom.flat.flip.flipXY(
-      flatCoordinates, 0, flatCoordinates.length, 2, flatCoordinates);
+      flatCoordinates, 0, flatCoordinates.length, stride, flatCoordinates);
   var coordinates = ol.geom.flat.inflate.coordinates(
-      flatCoordinates, 0, flatCoordinates.length, 2);
+      flatCoordinates, 0, flatCoordinates.length, stride);
 
   return /** @type {ol.geom.Geometry} */ (
       ol.format.Feature.transformWithOptions(
-          new ol.geom.LineString(coordinates), false,
+          new ol.geom.LineString(coordinates, this.geometryLayout_), false,
           this.adaptOptions(opt_options)));
 };
 

--- a/src/ol/geom/simplegeometry.js
+++ b/src/ol/geom/simplegeometry.js
@@ -64,10 +64,9 @@ ol.geom.SimpleGeometry.getLayoutForStride_ = function(stride) {
 
 /**
  * @param {ol.geom.GeometryLayout} layout Layout.
- * @private
  * @return {number} Stride.
  */
-ol.geom.SimpleGeometry.getStrideForLayout_ = function(layout) {
+ol.geom.SimpleGeometry.getStrideForLayout = function(layout) {
   if (layout == ol.geom.GeometryLayout.XY) {
     return 2;
   } else if (layout == ol.geom.GeometryLayout.XYZ) {
@@ -200,7 +199,7 @@ ol.geom.SimpleGeometry.prototype.getStride = function() {
  */
 ol.geom.SimpleGeometry.prototype.setFlatCoordinatesInternal =
     function(layout, flatCoordinates) {
-  this.stride = ol.geom.SimpleGeometry.getStrideForLayout_(layout);
+  this.stride = ol.geom.SimpleGeometry.getStrideForLayout(layout);
   this.layout = layout;
   this.flatCoordinates = flatCoordinates;
 };
@@ -217,7 +216,7 @@ ol.geom.SimpleGeometry.prototype.setLayout =
   /** @type {number} */
   var stride;
   if (goog.isDef(layout)) {
-    stride = ol.geom.SimpleGeometry.getStrideForLayout_(layout);
+    stride = ol.geom.SimpleGeometry.getStrideForLayout(layout);
   } else {
     var i;
     for (i = 0; i < nesting; ++i) {

--- a/test/spec/ol/format/polylineformat.test.js
+++ b/test/spec/ol/format/polylineformat.test.js
@@ -314,6 +314,25 @@ describe('ol.format.Polyline', function() {
       expect(geometry.getFlatCoordinates()).to.eql(flatPoints);
     });
 
+    it('parses XYZ linestring', function() {
+      var xyz = ol.format.Polyline.encodeDeltas([
+        38.500, -120.200, 100,
+        40.700, -120.950, 200,
+        43.252, -126.453, 20
+      ], 3);
+      var format = new ol.format.Polyline({
+        geometryLayout: ol.geom.GeometryLayout.XYZ
+      });
+
+      var geometry = format.readGeometry(xyz);
+      expect(geometry.getLayout()).to.eql(ol.geom.GeometryLayout.XYZ);
+      expect(geometry.getCoordinates()).to.eql([
+        [-120.200, 38.500, 100],
+        [-120.950, 40.700, 200],
+        [-126.453, 43.252, 20]
+      ]);
+    });
+
     it('transforms and returns the expected geometry', function() {
       var geometry = format.readGeometry(encodedFlatPoints, {
         featureProjection: 'EPSG:3857'


### PR DESCRIPTION
To be able to choose the geometry layout of the feature geometries created by the format reader.

Default is `ol.geom.GeometryLayout.XY`