### PR TITLE
Fix fullscreen pseudo CSS class name

### DIFF
--- a/examples/full-screen-drag-rotate-and-zoom.html
+++ b/examples/full-screen-drag-rotate-and-zoom.html
@@ -15,7 +15,7 @@
       .map:-webkit-full-screen {
         height: 100%;
       }
-      .map:full-screen {
+      .map:fullscreen {
         height: 100%;
       }
     </style>

--- a/examples/full-screen.html
+++ b/examples/full-screen.html
@@ -18,7 +18,7 @@
       .map:-ms-fullscreen {
         height: 100%;
       }
-      .map:full-screen {
+      .map:fullscreen {
         height: 100%;
       }
       .ol-rotate {


### PR DESCRIPTION
Change from `:full-screen` to `:fullscreen`.
See https://fullscreen.spec.whatwg.org/#:fullscreen-pseudo-class