### PR TITLE
Only create one template TileCoord

### DIFF
--- a/src/ol/tilecoord.js
+++ b/src/ol/tilecoord.js
@@ -142,23 +142,21 @@ ol.tilecoord.toString = function(tileCoord) {
 
 /**
  * @param {ol.TileCoord} tileCoord Tile coordinate.
- * @param {ol.tilegrid.TileGrid} tilegrid Tile grid.
+ * @param {ol.tilegrid.TileGrid} tileGrid Tile grid.
  * @param {ol.proj.Projection} projection Projection.
  * @return {ol.TileCoord} Tile coordinate.
  */
-ol.tilecoord.wrapX = (function() {
-  var tmpTileCoord = [0, 0, 0];
-  return function(tileCoord, tileGrid, projection) {
-    var z = tileCoord[0];
-    var x = tileCoord[1];
-    var tileRange = tileGrid.getTileRange(z, projection);
-    if (x < tileRange.minX || x > tileRange.maxX) {
-      x = goog.math.modulo(x, tileRange.getWidth());
-      return ol.tilecoord.createOrUpdate(z, x, tileCoord[2], tmpTileCoord);
-    }
-    return tileCoord;
-  };
-})();
+ol.tilecoord.wrapX = function(tileCoord, tileGrid, projection) {
+  var z = tileCoord[0];
+  var x = tileCoord[1];
+  var tileRange = tileGrid.getTileRange(z, projection);
+  if (x < tileRange.minX || x > tileRange.maxX) {
+    x = goog.math.modulo(x, tileRange.getWidth());
+    return ol.tilecoord.createOrUpdate(z, x, tileCoord[2],
+        ol.tilecoord.tileCoord);
+  }
+  return tileCoord;
+};
 
 
 /**
@@ -173,3 +171,9 @@ ol.tilecoord.clipX = function(tileCoord, tileGrid, projection) {
   var tileRange = tileGrid.getTileRange(z, projection);
   return (x < tileRange.minX || x > tileRange.maxX) ? null : tileCoord;
 };
+
+
+/**
+ * @type {ol.TileCoord}
+ */
+ol.tilecoord.tileCoord = [0, 0, 0];

--- a/src/ol/tilegrid/tilegrid.js
+++ b/src/ol/tilegrid/tilegrid.js
@@ -106,13 +106,6 @@ ol.tilegrid.TileGrid = function(options) {
 
 
 /**
- * @private
- * @type {ol.TileCoord}
- */
-ol.tilegrid.TileGrid.tmpTileCoord_ = [0, 0, 0];
-
-
-/**
  * Returns the identity function. May be overridden in subclasses.
  * @param {{extent: (ol.Extent|undefined)}=} opt_options Options.
  * @return {function(ol.TileCoord, ol.proj.Projection, ol.TileCoord=):
@@ -247,7 +240,7 @@ ol.tilegrid.TileGrid.prototype.getTileRangeExtent =
  */
 ol.tilegrid.TileGrid.prototype.getTileRangeForExtentAndResolution =
     function(extent, resolution, opt_tileRange) {
-  var tileCoord = ol.tilegrid.TileGrid.tmpTileCoord_;
+  var tileCoord = ol.tilecoord.tileCoord;
   this.getTileCoordForXYAndResolution_(
       extent[0], extent[1], resolution, false, tileCoord);
   var minX = tileCoord[1];

--- a/src/ol/tileurlfunction.js
+++ b/src/ol/tileurlfunction.js
@@ -115,7 +115,6 @@ ol.TileUrlFunction.nullTileUrlFunction =
  */
 ol.TileUrlFunction.withTileCoordTransform =
     function(transformFn, tileUrlFunction) {
-  var tmpTileCoord = [0, 0, 0];
   return (
       /**
        * @param {ol.TileCoord} tileCoord Tile Coordinate.
@@ -128,7 +127,7 @@ ol.TileUrlFunction.withTileCoordTransform =
           return undefined;
         } else {
           return tileUrlFunction(
-              transformFn(tileCoord, projection, tmpTileCoord),
+              transformFn(tileCoord, projection, ol.tilecoord.tileCoord),
               pixelRatio,
               projection);
         }


### PR DESCRIPTION
Saves memory and library bytes.