### PR TITLE
Add support for generic external modules with Browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "rbush": "1.3.5",
     "temp": "0.8.1",
     "walk": "2.3.4",
-    "wrench": "1.5.8"
+    "wrench": "1.5.8",
+    "browserify": "9.0.3"
   },
   "devDependencies": {
     "clean-css": "2.2.16",


### PR DESCRIPTION
Right now, our only external library rbush consists of a single file which we [wrap](https://github.com/openlayers/ol3/blob/c6b172aef2b10a8a7c04a53b182db2ed2d8d689b/tasks/build-ext.js#L27) into a Closure module. But this only works because rbush is a single file. We can not use libraries consiting of multiple files (e.g. like [vector-tile-js](https://github.com/mapbox/vector-tile-js/blob/master/index.js)).

This PR uses Browserify to bundles external libraries into a single file so that they can be used as Closure module. This allows configurations like the following:

    "ext": [
      "rbush",
      {
        "module": "vector-tile",
        "name": "vectortile",
        "browserify": true
      },
      {
        "module": "pbf",
        "browserify": true
      }
    ]