### PR TITLE
Add missing ol.style.AtlasManager goog.require

### DIFF
--- a/src/ol/style/regularshapestyle.js
+++ b/src/ol/style/regularshapestyle.js
@@ -7,6 +7,7 @@ goog.require('ol.color');
 goog.require('ol.has');
 goog.require('ol.render.canvas');
 goog.require('ol.structs.IHasChecksum');
+goog.require('ol.style.AtlasManager');
 goog.require('ol.style.Fill');
 goog.require('ol.style.Image');
 goog.require('ol.style.ImageState');


### PR DESCRIPTION
Without it, I've the following error:
```
mkdir -p schweizmobil/static/build/
node tasks/build.js build.json schweizmobil/static/build/build.js
info schweizmobil Parsing dependencies
info schweizmobil Compiling 426 sources
ERR! compile /xxx/node_modules/openlayers/src/ol/style/regularshapestyle.js:384: ERROR - Property hitImage never defined on info
ERR! compile       this.hitDetectionCanvas_ = info.hitImage;
ERR! compile                                       ^
ERR! compile
ERR! compile /xxx/node_modules/openlayers/src/ol/style/regularshapestyle.js:386: ERROR - Property hitImage never defined on info
ERR! compile           [info.hitImage.width, info.hitImage.height];
ERR! compile                 ^
ERR! compile
ERR! compile /xxx/node_modules/openlayers/src/ol/style/regularshapestyle.js:386: ERROR - Property hitImage never defined on info
ERR! compile           [info.hitImage.width, info.hitImage.height];
ERR! compile                                      ^
ERR! compile
ERR! compile
ERR! compile 3 error(s), 0 warning(s),
ERR! compile 96.7% typed
ERR! compile
ERR! Process exited with non-zero status, see log for more detail: 3
```