### PR TITLE
[docs] Stable Only unchecked by default

### DIFF
--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -74,7 +74,7 @@ $(function () {
     var stabilityToggle = $('#stability-toggle');
     stabilityToggle.change(function() {
         unstable.toggleClass('hidden', this.checked);
-        var search = this.checked ? '?stable=true' : '';
+        var search = this.checked ? '?stableonly=true' : '';
         links.each(function(i, el) {
             this.href = this.pathname + search + this.hash;
         });
@@ -88,6 +88,6 @@ $(function () {
     links.each(function(i, el) {
         this.href = this.pathname + search + this.hash;
     });
-    stabilityToggle.prop('checked', search === '?stable=true');
+    stabilityToggle.prop('checked', search === '?stableonly=true');
     unstable.toggleClass('hidden', stabilityToggle[0].checked);
 });

--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -74,7 +74,7 @@ $(function () {
     var stabilityToggle = $('#stability-toggle');
     stabilityToggle.change(function() {
         unstable.toggleClass('hidden', this.checked);
-        var search = this.checked ? '' : '?unstable=true';
+        var search = this.checked ? '?stable=true' : '';
         links.each(function(i, el) {
             this.href = this.pathname + search + this.hash;
         });
@@ -88,6 +88,6 @@ $(function () {
     links.each(function(i, el) {
         this.href = this.pathname + search + this.hash;
     });
-    stabilityToggle.prop('checked', search !== '?unstable=true');
+    stabilityToggle.prop('checked', search === '?stable=true');
     unstable.toggleClass('hidden', stabilityToggle[0].checked);
 });

--- a/config/jsdoc/api/template/tmpl/layout.tmpl
+++ b/config/jsdoc/api/template/tmpl/layout.tmpl
@@ -21,7 +21,7 @@
       <a class="brand" href="/"><img src="../resources/logo.png" width="40"> OpenLayers 3</a>
       <a class="brand" href="index.html">API Documentation</a>
       <label id="stability">
-        <input type="checkbox" id="stability-toggle" checked> Stable Only
+        <input type="checkbox" id="stability-toggle"> Stable Only
       </label>
     </div>
   </div>


### PR DESCRIPTION
Having it on by default makes it difficult for new users to find commonly used functionality.