### PR TITLE
Parse extrude and altitude mode

### DIFF
--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -897,14 +897,17 @@ ol.format.KML.readMultiGeometry_ = function(node, objectStack) {
       }
       var multiPoint = new ol.geom.MultiPoint(null);
       multiPoint.setFlatCoordinates(layout, flatCoordinates);
+      ol.format.KML.setCommonGeometryProperties_(multiPoint, geometries);
       return multiPoint;
     } else if (type == ol.geom.GeometryType.LINE_STRING) {
       var multiLineString = new ol.geom.MultiLineString(null);
       multiLineString.setLineStrings(geometries);
+      ol.format.KML.setCommonGeometryProperties_(multiLineString, geometries);
       return multiLineString;
     } else if (type == ol.geom.GeometryType.POLYGON) {
       var multiPolygon = new ol.geom.MultiPolygon(null);
       multiPolygon.setPolygons(geometries);
+      ol.format.KML.setCommonGeometryProperties_(multiPolygon, geometries);
       return multiPolygon;
     } else if (type == ol.geom.GeometryType.GEOMETRY_COLLECTION) {
       return new ol.geom.GeometryCollection(geometries);
@@ -1023,6 +1026,37 @@ ol.format.KML.readStyle_ = function(node, objectStack) {
     text: textStyle,
     zIndex: undefined // FIXME
   })];
+};
+
+
+/**
+ * Reads an array of geometries and creates arrays for common geometry
+ * properties. Then sets them to the multi geometry.
+ * @param {ol.geom.MultiPoint|ol.geom.MultiLineString|ol.geom.MultiPolygon}
+ * multiGeometry
+ * @param {Array.<ol.geom.Geometry>} geometries
+ * @private
+ */
+ol.format.KML.setCommonGeometryProperties_ = function(multiGeometry,
+    geometries) {
+  var ii = geometries.length;
+  var extrudes = new Array(geometries.length);
+  var altitudeModes = new Array(geometries.length);
+  var geometry, i, hasExtrude, hasAltitudeMode;
+  hasExtrude = hasAltitudeMode = false;
+  for (i = 0; i < ii; ++i) {
+    geometry = geometries[i];
+    extrudes[i] = geometry.get('extrude');
+    altitudeModes[i] = geometry.get('altitudeMode');
+    hasExtrude = hasExtrude || goog.isDef(extrudes[i]);
+    hasAltitudeMode = hasAltitudeMode || goog.isDef(altitudeModes[i]);
+  }
+  if (hasExtrude) {
+    multiGeometry.set('extrude', extrudes);
+  }
+  if (hasAltitudeMode) {
+    multiGeometry.set('altitudeMode', altitudeModes);
+  }
 };
 
 

--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -802,11 +802,15 @@ ol.format.KML.readLineString_ = function(node, objectStack) {
       'node.nodeType should be ELEMENT');
   goog.asserts.assert(node.localName == 'LineString',
       'localName should be LineString');
+  var properties = ol.xml.pushParseAndPop(/** @type {Object<string,*>} */ ({}),
+      ol.format.KML.EXTRUDE_AND_ALTITUDE_MODE_PARSERS_, node,
+      objectStack);
   var flatCoordinates =
       ol.format.KML.readFlatCoordinatesFromNode_(node, objectStack);
   if (goog.isDef(flatCoordinates)) {
     var lineString = new ol.geom.LineString(null);
     lineString.setFlatCoordinates(ol.geom.GeometryLayout.XYZ, flatCoordinates);
+    lineString.setProperties(properties);
     return lineString;
   } else {
     return undefined;
@@ -825,12 +829,16 @@ ol.format.KML.readLinearRing_ = function(node, objectStack) {
       'node.nodeType should be ELEMENT');
   goog.asserts.assert(node.localName == 'LinearRing',
       'localName should be LinearRing');
+  var properties = ol.xml.pushParseAndPop(/** @type {Object<string,*>} */ ({}),
+      ol.format.KML.EXTRUDE_AND_ALTITUDE_MODE_PARSERS_, node,
+      objectStack);
   var flatCoordinates =
       ol.format.KML.readFlatCoordinatesFromNode_(node, objectStack);
   if (goog.isDef(flatCoordinates)) {
     var polygon = new ol.geom.Polygon(null);
     polygon.setFlatCoordinates(ol.geom.GeometryLayout.XYZ, flatCoordinates,
         [flatCoordinates.length]);
+    polygon.setProperties(properties);
     return polygon;
   } else {
     return undefined;
@@ -920,6 +928,9 @@ ol.format.KML.readPoint_ = function(node, objectStack) {
   goog.asserts.assert(node.nodeType == goog.dom.NodeType.ELEMENT,
       'node.nodeType should be ELEMENT');
   goog.asserts.assert(node.localName == 'Point', 'localName should be Point');
+  var properties = ol.xml.pushParseAndPop(/** @type {Object<string,*>} */ ({}),
+      ol.format.KML.EXTRUDE_AND_ALTITUDE_MODE_PARSERS_, node,
+      objectStack);
   var flatCoordinates =
       ol.format.KML.readFlatCoordinatesFromNode_(node, objectStack);
   if (goog.isDefAndNotNull(flatCoordinates)) {
@@ -927,6 +938,7 @@ ol.format.KML.readPoint_ = function(node, objectStack) {
     goog.asserts.assert(flatCoordinates.length == 3,
         'flatCoordinates should have a length of 3');
     point.setFlatCoordinates(ol.geom.GeometryLayout.XYZ, flatCoordinates);
+    point.setProperties(properties);
     return point;
   } else {
     return undefined;
@@ -945,6 +957,9 @@ ol.format.KML.readPolygon_ = function(node, objectStack) {
       'node.nodeType should be ELEMENT');
   goog.asserts.assert(node.localName == 'Polygon',
       'localName should be Polygon');
+  var properties = ol.xml.pushParseAndPop(/** @type {Object<string,*>} */ ({}),
+      ol.format.KML.EXTRUDE_AND_ALTITUDE_MODE_PARSERS_, node,
+      objectStack);
   var flatLinearRings = ol.xml.pushParseAndPop(
       /** @type {Array.<Array.<number>>} */ ([null]),
       ol.format.KML.FLAT_LINEAR_RINGS_PARSERS_, node, objectStack);
@@ -960,6 +975,7 @@ ol.format.KML.readPolygon_ = function(node, objectStack) {
     }
     polygon.setFlatCoordinates(
         ol.geom.GeometryLayout.XYZ, flatCoordinates, ends);
+    polygon.setProperties(properties);
     return polygon;
   } else {
     return undefined;
@@ -1263,6 +1279,18 @@ ol.format.KML.EXTENDED_DATA_PARSERS_ = ol.xml.makeParsersNS(
     ol.format.KML.NAMESPACE_URIS_, {
       'Data': ol.format.KML.DataParser_,
       'SchemaData': ol.format.KML.SchemaDataParser_
+    });
+
+
+/**
+ * @const
+ * @type {Object.<string, Object.<string, ol.xml.Parser>>}
+ * @private
+ */
+ol.format.KML.EXTRUDE_AND_ALTITUDE_MODE_PARSERS_ = ol.xml.makeParsersNS(
+    ol.format.KML.NAMESPACE_URIS_, {
+      'extrude': ol.xml.makeObjectPropertySetter(ol.format.XSD.readBoolean),
+      'altitudeMode': ol.xml.makeObjectPropertySetter(ol.format.XSD.readString)
     });
 
 

--- a/src/ol/geom/geometry.js
+++ b/src/ol/geom/geometry.js
@@ -2,7 +2,7 @@ goog.provide('ol.geom.Geometry');
 goog.provide('ol.geom.GeometryType');
 
 goog.require('goog.functions');
-goog.require('ol.Observable');
+goog.require('ol.Object');
 goog.require('ol.extent');
 goog.require('ol.proj');
 
@@ -50,7 +50,7 @@ ol.geom.GeometryLayout = {
  * Base class for vector geometries.
  *
  * @constructor
- * @extends {ol.Observable}
+ * @extends {ol.Object}
  * @fires change Triggered when the geometry changes.
  * @api stable
  */
@@ -89,7 +89,7 @@ ol.geom.Geometry = function() {
   this.simplifiedGeometryRevision = 0;
 
 };
-goog.inherits(ol.geom.Geometry, ol.Observable);
+goog.inherits(ol.geom.Geometry, ol.Object);
 
 
 /**

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -679,7 +679,7 @@ ol.xml.parseNode = function(parsersNS, node, objectStack, opt_this) {
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
  * @param {*=} opt_this The object to use as `this`.
- * @return {T|undefined} Object.
+ * @return {T} Object.
  * @template T
  */
 ol.xml.pushParseAndPop = function(

--- a/test/spec/ol/format/kmlformat.test.js
+++ b/test/spec/ol/format/kmlformat.test.js
@@ -754,9 +754,13 @@ describe('ol.format.KML', function() {
             '    <MultiGeometry>' +
             '      <Point>' +
             '        <coordinates>1,2,3</coordinates>' +
+            '        <extrude>0</extrude>' +
+            '        <altitudeMode>absolute</altitudeMode>' +
             '      </Point>' +
             '      <Point>' +
             '        <coordinates>4,5,6</coordinates>' +
+            '        <extrude>1</extrude>' +
+            '        <altitudeMode>clampToGround</altitudeMode>' +
             '      </Point>' +
             '    </MultiGeometry>' +
             '  </Placemark>' +
@@ -768,6 +772,14 @@ describe('ol.format.KML', function() {
         var g = f.getGeometry();
         expect(g).to.be.an(ol.geom.MultiPoint);
         expect(g.getCoordinates()).to.eql([[1, 2, 3], [4, 5, 6]]);
+        expect(g.get('extrude')).to.be.an('array');
+        expect(g.get('extrude')).to.have.length(2);
+        expect(g.get('extrude')[0]).to.be(false);
+        expect(g.get('extrude')[1]).to.be(true);
+        expect(g.get('altitudeMode')).to.be.an('array');
+        expect(g.get('altitudeMode')).to.have.length(2);
+        expect(g.get('altitudeMode')[0]).to.be('absolute');
+        expect(g.get('altitudeMode')[1]).to.be('clampToGround');
       });
 
       it('can write MultiPoint geometries', function() {
@@ -802,6 +814,8 @@ describe('ol.format.KML', function() {
             '  <Placemark>' +
             '    <MultiGeometry>' +
             '      <LineString>' +
+            '        <extrude>0</extrude>' +
+            '        <altitudeMode>absolute</altitudeMode>' +
             '        <coordinates>1,2,3 4,5,6</coordinates>' +
             '      </LineString>' +
             '      <LineString>' +
@@ -818,6 +832,14 @@ describe('ol.format.KML', function() {
         expect(g).to.be.an(ol.geom.MultiLineString);
         expect(g.getCoordinates()).to.eql(
             [[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]);
+        expect(g.get('extrude')).to.be.an('array');
+        expect(g.get('extrude')).to.have.length(2);
+        expect(g.get('extrude')[0]).to.be(false);
+        expect(g.get('extrude')[1]).to.be(undefined);
+        expect(g.get('altitudeMode')).to.be.an('array');
+        expect(g.get('altitudeMode')).to.have.length(2);
+        expect(g.get('altitudeMode')[0]).to.be('absolute');
+        expect(g.get('altitudeMode')[1]).to.be(undefined);
       });
 
       it('can write MultiLineString geometries', function() {
@@ -852,6 +874,8 @@ describe('ol.format.KML', function() {
             '  <Placemark>' +
             '    <MultiGeometry>' +
             '      <Polygon>' +
+            '        <extrude>0</extrude>' +
+            '        <altitudeMode>absolute</altitudeMode>' +
             '        <outerBoundaryIs>' +
             '          <LinearRing>' +
             '            <coordinates>0,0,0 0,1,0 1,1,0 1,0,0</coordinates>' +
@@ -877,6 +901,14 @@ describe('ol.format.KML', function() {
         expect(g.getCoordinates()).to.eql(
             [[[[0, 0, 0], [0, 1, 0], [1, 1, 0], [1, 0, 0]]],
              [[[3, 0, 0], [3, 1, 0], [4, 1, 0], [4, 0, 0]]]]);
+        expect(g.get('extrude')).to.be.an('array');
+        expect(g.get('extrude')).to.have.length(2);
+        expect(g.get('extrude')[0]).to.be(false);
+        expect(g.get('extrude')[1]).to.be(undefined);
+        expect(g.get('altitudeMode')).to.be.an('array');
+        expect(g.get('altitudeMode')).to.have.length(2);
+        expect(g.get('altitudeMode')[0]).to.be('absolute');
+        expect(g.get('altitudeMode')[1]).to.be(undefined);
       });
 
       it('can write MultiPolygon geometries', function() {

--- a/test/spec/ol/format/kmlformat.test.js
+++ b/test/spec/ol/format/kmlformat.test.js
@@ -133,6 +133,8 @@ describe('ol.format.KML', function() {
             '  <Placemark>' +
             '    <Point>' +
             '      <coordinates>1,2,3</coordinates>' +
+            '      <extrude>0</extrude>' +
+            '      <altitudeMode>absolute</altitudeMode>' +
             '    </Point>' +
             '  </Placemark>' +
             '</kml>';
@@ -143,6 +145,8 @@ describe('ol.format.KML', function() {
         var g = f.getGeometry();
         expect(g).to.be.an(ol.geom.Point);
         expect(g.getCoordinates()).to.eql([1, 2, 3]);
+        expect(g.get('extrude')).to.be(false);
+        expect(g.get('altitudeMode')).to.be('absolute');
       });
 
       it('can transform and read Point geometries', function() {
@@ -338,6 +342,8 @@ describe('ol.format.KML', function() {
             '  <Placemark>' +
             '    <LineString>' +
             '      <coordinates>1,2,3 4,5,6</coordinates>' +
+            '      <extrude>0</extrude>' +
+            '      <altitudeMode>absolute</altitudeMode>' +
             '    </LineString>' +
             '  </Placemark>' +
             '</kml>';
@@ -348,6 +354,8 @@ describe('ol.format.KML', function() {
         var g = f.getGeometry();
         expect(g).to.be.an(ol.geom.LineString);
         expect(g.getCoordinates()).to.eql([[1, 2, 3], [4, 5, 6]]);
+        expect(g.get('extrude')).to.be(false);
+        expect(g.get('altitudeMode')).to.be('absolute');
       });
 
       it('can write XY LineString geometries', function() {
@@ -540,6 +548,8 @@ describe('ol.format.KML', function() {
             '<kml xmlns="http://earth.google.com/kml/2.2">' +
             '  <Placemark>' +
             '    <Polygon>' +
+            '      <extrude>0</extrude>' +
+            '      <altitudeMode>absolute</altitudeMode>' +
             '      <outerBoundaryIs>' +
             '        <LinearRing>' +
             '          <coordinates>0,0,1 0,5,1 5,5,2 5,0,3</coordinates>' +
@@ -556,6 +566,8 @@ describe('ol.format.KML', function() {
         expect(g).to.be.an(ol.geom.Polygon);
         expect(g.getCoordinates()).to.eql(
             [[[0, 0, 1], [0, 5, 1], [5, 5, 2], [5, 0, 3]]]);
+        expect(g.get('extrude')).to.be(false);
+        expect(g.get('altitudeMode')).to.be('absolute');
       });
 
       it('can write XY Polygon geometries', function() {


### PR DESCRIPTION
For simple geometries, set `extrude` and `altitudeMode` properties.
For multi-geometries, set `extrude` and `altitudeMode` array properties.
Properties of `Polygon` are handled, but not the ones of `LinearRing`.
`ol.geom.Geometry` now inherits from `ol.Object`.