### PR TITLE
Remove @api annotation from ol.WEBGL_MAX_TEXTURE_SIZE

### DIFF
--- a/src/ol/ol.js
+++ b/src/ol/ol.js
@@ -233,7 +233,6 @@ ol.WEBGL_TEXTURE_CACHE_HIGH_WATER_MARK = 1024;
  * supported, the value is set to `undefined`.
  * @const
  * @type {number|undefined}
- * @api
  */
 ol.WEBGL_MAX_TEXTURE_SIZE; // value is set in `ol.has`
 


### PR DESCRIPTION
We already have 2,690 exportable symbols in the library.  The GUI build client would be way more usable if we only had 2,689 checkboxes.
