### PR TITLE
Call custom image load functions with an image element

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -1,5 +1,9 @@
 ## Upgrade notes
 
+### v3.5.0
+
+* If your application is using an `ol.source.ImageMapGuide`, `ol.source.ImageWMS`, or `ol.source.ImageStatic` with a custom `imageLoadFunction`, this function will now be called with an HTML image element instead of an `ol.Image` element as the first argument (see [#3427](https://github.com/openlayers/ol3/pull/3427)).
+
 ### v3.4.0
 
 ### v3.3.0

--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -1,10 +1,14 @@
 ## Upgrade notes
 
+This file includes upgrade notes for applications that are using experimental features (parts of the API that are not yet marked as stable).
+
 ### v3.5.0
 
 * If your application is using an `ol.source.ImageMapGuide`, `ol.source.ImageWMS`, or `ol.source.ImageStatic` with a custom `imageLoadFunction`, this function will now be called with an HTML image element instead of an `ol.Image` element as the first argument (see [#3427](https://github.com/openlayers/ol3/pull/3427)).
 
 ### v3.4.0
+
+There are no special considerations for applications upgrading from `v3.3.0` to `v3.4.0`.
 
 ### v3.3.0
 

--- a/src/ol/image.js
+++ b/src/ol/image.js
@@ -74,7 +74,6 @@ goog.inherits(ol.Image, ol.ImageBase);
 /**
  * @param {Object=} opt_context Object.
  * @return {HTMLCanvasElement|Image|HTMLVideoElement} Image.
- * @api
  */
 ol.Image.prototype.getImage = function(opt_context) {
   if (goog.isDef(opt_context)) {
@@ -136,7 +135,7 @@ ol.Image.prototype.load = function() {
       goog.events.listenOnce(this.image_, goog.events.EventType.LOAD,
           this.handleImageLoad_, false, this)
     ];
-    this.imageLoadFunction_(this, this.src_);
+    this.imageLoadFunction_(this.getImage(), this.src_);
   }
 };
 

--- a/src/ol/imageloadfunction.js
+++ b/src/ol/imageloadfunction.js
@@ -2,20 +2,20 @@ goog.provide('ol.ImageLoadFunctionType');
 
 
 /**
- * A function that takes an {@link ol.Image} for the image and a `{string}` for
- * the src as arguments. It is supposed to make it so the underlying image
- * {@link ol.Image#getImage} is assigned the content specified by the src. If
- * not specified, the default is
+ * A function used to load an image.  The function is called with the image
+ * element and the URL for the image.  The simplest image load function (which
+ * is provided for you by default) would set the `image.src` attribute to the
+ * provided URL.  E.g.
  *
  *     function(image, src) {
- *       image.getImage().src = src;
+ *       image.src = src;
  *     }
  *
  * Providing a custom `imageLoadFunction` can be useful to load images with
  * post requests or - in general - through XHR requests, where the src of the
  * image element would be set to a data URI when the content is loaded.
  *
- * @typedef {function(ol.Image, string)}
+ * @typedef {function((HTMLCanvasElement|Image|HTMLVideoElement), string)}
  * @api
  */
 ol.ImageLoadFunctionType;


### PR DESCRIPTION
This changes the signature of the custom image load function from
```
function(ol.Image, string)
```
to
```
function((HTMLCanvasElement|Image|HTMLVideoElement), string)
```

This means instead of a function that looks like this
```
function(image, src) {
  image.getImage().src = src;
}
```
applications should do something like this
```
function(image, src) {
  image.src = src;
}
```

This affects applications that are using an `ol.source.ImageMapGuide`, `ol.source.ImageWMS`, or `ol.source.ImageStatic` with the (experimental) `imageLoadFunction` option.
