### PR TITLE
Reorder assertions and variable declarations.

### DIFF
--- a/src/ol/render/webgl/webglreplay.js
+++ b/src/ol/render/webgl/webglreplay.js
@@ -935,30 +935,30 @@ ol.render.webgl.ImageReplay.prototype.setFillStrokeStyle = goog.abstractMethod;
  */
 ol.render.webgl.ImageReplay.prototype.setImageStyle = function(imageStyle) {
   var anchor = imageStyle.getAnchor();
-  goog.asserts.assert(!goog.isNull(anchor), 'imageStyle anchor is not null');
   var image = imageStyle.getImage(1);
-  goog.asserts.assert(!goog.isNull(image), 'imageStyle image is not null');
   var imageSize = imageStyle.getImageSize();
+  var hitDetectionImage = imageStyle.getHitDetectionImage(1);
+  var hitDetectionImageSize = imageStyle.getHitDetectionImageSize();
+  var opacity = imageStyle.getOpacity();
+  var origin = imageStyle.getOrigin();
+  var rotateWithView = imageStyle.getRotateWithView();
+  var rotation = imageStyle.getRotation();
+  var size = imageStyle.getSize();
+  var scale = imageStyle.getScale();
+  goog.asserts.assert(!goog.isNull(anchor), 'imageStyle anchor is not null');
+  goog.asserts.assert(!goog.isNull(image), 'imageStyle image is not null');
   goog.asserts.assert(!goog.isNull(imageSize),
       'imageStyle imageSize is not null');
-  var hitDetectionImage = imageStyle.getHitDetectionImage(1);
   goog.asserts.assert(!goog.isNull(hitDetectionImage),
       'imageStyle hitDetectionImage is not null');
-  var hitDetectionImageSize = imageStyle.getHitDetectionImageSize();
   goog.asserts.assert(!goog.isNull(hitDetectionImageSize),
       'imageStyle hitDetectionImageSize is not null');
-  var opacity = imageStyle.getOpacity();
   goog.asserts.assert(goog.isDef(opacity), 'imageStyle opacity is defined');
-  var origin = imageStyle.getOrigin();
   goog.asserts.assert(!goog.isNull(origin), 'imageStyle origin is not null');
-  var rotateWithView = imageStyle.getRotateWithView();
   goog.asserts.assert(goog.isDef(rotateWithView),
       'imageStyle rotateWithView is defined');
-  var rotation = imageStyle.getRotation();
   goog.asserts.assert(goog.isDef(rotation), 'imageStyle rotation is defined');
-  var size = imageStyle.getSize();
   goog.asserts.assert(!goog.isNull(size), 'imageStyle size is not null');
-  var scale = imageStyle.getScale();
   goog.asserts.assert(goog.isDef(scale), 'imageStyle scale is defined');
 
   var currentImage;


### PR DESCRIPTION
This PR suggests to reorder variable declarations and assertions so that reading the particular code gets easier.

Before: 

![before](https://cloud.githubusercontent.com/assets/227934/6914279/24252bee-d789-11e4-870a-675b7b170791.png)

https://github.com/openlayers/ol3/blob/master/src/ol/render/webgl/webglreplay.js#L937-L962

After:

![after](https://cloud.githubusercontent.com/assets/227934/6914285/2fd86762-d789-11e4-8a84-e707fc0ab363.png)

https://github.com/openlayers/ol3/blob/3ab13b86a45135d48697104db5718a41f9983d3a/src/ol/render/webgl/webglreplay.js#L937-L962