### PR TITLE
Add missing goog.provide/goog.require ol.source.TileEvent

### DIFF
--- a/src/ol/source/tileimagesource.js
+++ b/src/ol/source/tileimagesource.js
@@ -10,6 +10,7 @@ goog.require('ol.TileState');
 goog.require('ol.TileUrlFunction');
 goog.require('ol.TileUrlFunctionType');
 goog.require('ol.source.Tile');
+goog.require('ol.source.TileEvent');
 
 
 

--- a/src/ol/source/tilesource.js
+++ b/src/ol/source/tilesource.js
@@ -1,4 +1,5 @@
 goog.provide('ol.source.Tile');
+goog.provide('ol.source.TileEvent');
 goog.provide('ol.source.TileOptions');
 
 goog.require('goog.events.Event');


### PR DESCRIPTION
Issue detected with the latest version of the closure compiler (20150315)