### PR TITLE
ol.View#fit()

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -6,6 +6,10 @@
 
 * The `minPointsPerRing` config option has been renamed to `minPoints`. It is now also available for linestring drawing, not only for polygons.
 
+#### Replace `ol.View.fitExtent()` and `ol.View.fitGeometry()` with `ol.View.fit()`
+* This combines two previously distinct functions into one more flexible call which takes either a geometry or an extent.
+* Rename all calls to `fitExtent` and `fitGeometry` to `fit`
+
 #### `ol.tilegrid` changes
 
 * The `ol.tilegrid.XYZ` constructor has been replaced by a static `ol.tilegrid.createXYZ()` function. The `ol.tilegrid.createXYZ()` function takes the same arguments as the previous `ol.tilegrid.XYZ` constructor, but returns an `ol.tilegrid.TileGrid` instance.

--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -8,7 +8,7 @@
 
 #### Replace `ol.View.fitExtent()` and `ol.View.fitGeometry()` with `ol.View.fit()`
 * This combines two previously distinct functions into one more flexible call which takes either a geometry or an extent.
-* Rename all calls to `fitExtent` and `fitGeometry` to `fit`
+* Rename all calls to `fitExtent` and `fitGeometry` to `fit`.
 
 #### `ol.tilegrid` changes
 

--- a/examples/center.html
+++ b/examples/center.html
@@ -6,7 +6,7 @@ docs: >
   This example demonstrates how a map's view can be
   adjusted so a geometry or coordinate is positioned at a specific
   pixel location. The map above has top, right, bottom, and left
-  padding applied inside the viewport. The view's <code>fitGeometry</code> method
+  padding applied inside the viewport. The view's <code>fit</code> method
   is used to fit a geometry in the view with the same padding. The
   view's <code>centerOn</code> method is used to position a coordinate (Lausanne)
   at a specific pixel location (the center of the black box).

--- a/examples/center.js
+++ b/examples/center.js
@@ -65,7 +65,7 @@ zoomtoswitzerlandbest.addEventListener('click', function() {
   var feature = source.getFeatures()[0];
   var polygon = /** @type {ol.geom.SimpleGeometry} */ (feature.getGeometry());
   var size = /** @type {ol.Size} */ (map.getSize());
-  view.fitGeometry(
+  view.fit(
       polygon,
       size,
       {
@@ -81,7 +81,7 @@ zoomtoswitzerlandconstrained.addEventListener('click', function() {
   var feature = source.getFeatures()[0];
   var polygon = /** @type {ol.geom.SimpleGeometry} */ (feature.getGeometry());
   var size = /** @type {ol.Size} */ (map.getSize());
-  view.fitGeometry(
+  view.fit(
       polygon,
       size,
       {
@@ -96,7 +96,7 @@ zoomtoswitzerlandnearest.addEventListener('click', function() {
   var feature = source.getFeatures()[0];
   var polygon = /** @type {ol.geom.SimpleGeometry} */ (feature.getGeometry());
   var size = /** @type {ol.Size} */ (map.getSize());
-  view.fitGeometry(
+  view.fit(
       polygon,
       size,
       {
@@ -111,7 +111,7 @@ zoomtolausanne.addEventListener('click', function() {
   var feature = source.getFeatures()[1];
   var point = /** @type {ol.geom.SimpleGeometry} */ (feature.getGeometry());
   var size = /** @type {ol.Size} */ (map.getSize());
-  view.fitGeometry(
+  view.fit(
       point,
       size,
       {

--- a/examples/drag-and-drop-image-vector.js
+++ b/examples/drag-and-drop-image-vector.js
@@ -122,7 +122,7 @@ dragAndDropInteraction.on('addfeatures', function(event) {
       style: styleFunction
     })
   }));
-  map.getView().fitExtent(
+  map.getView().fit(
       vectorSource.getExtent(), /** @type {ol.Size} */ (map.getSize()));
 });
 

--- a/examples/drag-and-drop.js
+++ b/examples/drag-and-drop.js
@@ -118,7 +118,7 @@ dragAndDropInteraction.on('addfeatures', function(event) {
     source: vectorSource,
     style: styleFunction
   }));
-  map.getView().fitExtent(
+  map.getView().fit(
       vectorSource.getExtent(), /** @type {ol.Size} */ (map.getSize()));
 });
 

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -1,3 +1,4 @@
+
 /**
  * @type {Object}
  */
@@ -6301,7 +6302,7 @@ olx.view;
  *     minResolution: (number|undefined)}}
  * @api
  */
-olx.view.FitGeometryOptions;
+olx.view.FitOptions;
 
 
 /**
@@ -6310,7 +6311,7 @@ olx.view.FitGeometryOptions;
  * @type {!Array.<number>}
  * @api
  */
-olx.view.FitGeometryOptions.prototype.padding;
+olx.view.FitOptions.prototype.padding;
 
 
 /**
@@ -6318,7 +6319,7 @@ olx.view.FitGeometryOptions.prototype.padding;
  * @type {boolean|undefined}
  * @api
  */
-olx.view.FitGeometryOptions.prototype.constrainResolution;
+olx.view.FitOptions.prototype.constrainResolution;
 
 
 /**
@@ -6326,7 +6327,7 @@ olx.view.FitGeometryOptions.prototype.constrainResolution;
  * @type {boolean|undefined}
  * @api
  */
-olx.view.FitGeometryOptions.prototype.nearest;
+olx.view.FitOptions.prototype.nearest;
 
 
 /**
@@ -6334,7 +6335,7 @@ olx.view.FitGeometryOptions.prototype.nearest;
  * @type {number|undefined}
  * @api
  */
-olx.view.FitGeometryOptions.prototype.minResolution;
+olx.view.FitOptions.prototype.minResolution;
 
 
 /**
@@ -6343,7 +6344,7 @@ olx.view.FitGeometryOptions.prototype.minResolution;
  * @type {number|undefined}
  * @api
  */
-olx.view.FitGeometryOptions.prototype.maxZoom;
+olx.view.FitOptions.prototype.maxZoom;
 
 
 /* typedefs for object literals exposed by the library */

--- a/src/ol/control/overviewmapcontrol.js
+++ b/src/ol/control/overviewmapcontrol.js
@@ -343,7 +343,7 @@ ol.control.OverviewMap.prototype.resetExtent_ = function() {
       ol.OVERVIEWMAP_MAX_RATIO / ol.OVERVIEWMAP_MIN_RATIO) / Math.LN2;
   var ratio = 1 / (Math.pow(2, steps / 2) * ol.OVERVIEWMAP_MIN_RATIO);
   ol.extent.scaleFromCenter(extent, ratio);
-  ovview.fitExtent(extent, ovmapSize);
+  ovview.fit(extent, ovmapSize);
 };
 
 

--- a/src/ol/control/zoomtoextentcontrol.js
+++ b/src/ol/control/zoomtoextentcontrol.js
@@ -82,5 +82,5 @@ ol.control.ZoomToExtent.prototype.handleZoomToExtent_ = function() {
       view.getProjection().getExtent() : this.extent_;
   var size = map.getSize();
   goog.asserts.assert(goog.isDef(size), 'size should be defined');
-  view.fitExtent(extent, size);
+  view.fit(extent, size);
 };

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -14,6 +14,8 @@ goog.require('ol.RotationConstraintType');
 goog.require('ol.Size');
 goog.require('ol.coordinate');
 goog.require('ol.extent');
+goog.require('ol.geom.Polygon');
+goog.require('ol.geom.SimpleGeometry');
 goog.require('ol.proj');
 goog.require('ol.proj.METERS_PER_UNIT');
 goog.require('ol.proj.Projection');
@@ -431,35 +433,19 @@ ol.View.prototype.getZoom = function() {
 
 
 /**
- * Fit the map view to the passed extent and size. The size is pixel dimensions
- * of the box to fit the extent into. In most cases you will want to use the map
- * size, that is `map.getSize()`.
- * @param {ol.Extent} extent Extent.
+ * Fit the given geometry or extent based on the given map size and border.
+ * Take care on the map angle.
+ * @param {ol.geom.SimpleGeometry|ol.Extent} geometry Geometry.
  * @param {ol.Size} size Box pixel size.
+ * @param {olx.view.FitOptions=} opt_options Options.
  * @api
  */
-ol.View.prototype.fitExtent = function(extent, size) {
-  if (!ol.extent.isEmpty(extent)) {
-    this.setCenter(ol.extent.getCenter(extent));
-    var resolution = this.getResolutionForExtent(extent, size);
-    var constrainedResolution = this.constrainResolution(resolution, 0, 0);
-    if (constrainedResolution < resolution) {
-      constrainedResolution =
-          this.constrainResolution(constrainedResolution, -1, 0);
-    }
-    this.setResolution(constrainedResolution);
+ol.View.prototype.fit = function(geometry, size, opt_options) {
+
+  if (!(geometry instanceof ol.geom.SimpleGeometry)) {
+    geometry = ol.geom.Polygon.fromExtent(geometry);
   }
-};
 
-
-/**
- * Fit the given geometry into the view based on the given map size and border.
- * @param {ol.geom.SimpleGeometry} geometry Geometry.
- * @param {ol.Size} size Box pixel size.
- * @param {olx.view.FitGeometryOptions=} opt_options Options.
- * @api
- */
-ol.View.prototype.fitGeometry = function(geometry, size, opt_options) {
   var options = goog.isDef(opt_options) ? opt_options : {};
 
   var padding = goog.isDef(options.padding) ? options.padding : [0, 0, 0, 0];

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -436,6 +436,8 @@ ol.View.prototype.getZoom = function() {
 
 /**
  * Fit the given geometry or extent based on the given map size and border.
+ * The size is pixel deminsions of the box to fit the extent into.
+ * In most cases you will want to use the map size, that is `map.getSize()`.
  * Take care on the map angle.
  * @param {ol.geom.SimpleGeometry|ol.Extent} geometry Geometry.
  * @param {ol.Size} size Box pixel size.
@@ -443,8 +445,11 @@ ol.View.prototype.getZoom = function() {
  * @api
  */
 ol.View.prototype.fit = function(geometry, size, opt_options) {
-
   if (!(geometry instanceof ol.geom.SimpleGeometry)) {
+    goog.asserts.assert(goog.isArray(geometry),
+        'invalid extent or geometry');
+    goog.asserts.assert(!ol.extent.isEmpty(geometry),
+        'cannot fit empty extent');
     geometry = ol.geom.Polygon.fromExtent(geometry);
   }
 

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -275,15 +275,17 @@ ol.View.prototype.getHints = function() {
  * @api stable
  */
 ol.View.prototype.calculateExtent = function(size) {
-  goog.asserts.assert(this.isDef(),
-      'the view was not defined (had no center and/or resolution)');
   var center = this.getCenter();
+  goog.asserts.assert(goog.isDefAndNotNull(center),
+      'The view center is not defined');
   var resolution = this.getResolution();
-  var minX = center[0] - resolution * size[0] / 2;
-  var maxX = center[0] + resolution * size[0] / 2;
-  var minY = center[1] - resolution * size[1] / 2;
-  var maxY = center[1] + resolution * size[1] / 2;
-  return [minX, minY, maxX, maxY];
+  goog.asserts.assert(goog.isDef(resolution),
+      'The view resolution is not defined');
+  var rotation = this.getRotation();
+  goog.asserts.assert(goog.isDef(rotation),
+      'The view rotation is not defined');
+
+  return ol.extent.getForViewAndSize(center, resolution, rotation, size);
 };
 
 

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -364,7 +364,7 @@ describe('ol.View', function() {
     });
   });
 
-  describe('fitGeometry', function() {
+  describe('fit', function() {
     var view;
     beforeEach(function() {
       view = new ol.View({
@@ -372,7 +372,7 @@ describe('ol.View', function() {
       });
     });
     it('fit correctly to the geometry', function() {
-      view.fitGeometry(
+      view.fit(
           new ol.geom.LineString([[6000, 46000], [6000, 47100], [7000, 46000]]),
           [200, 200],
           {
@@ -384,7 +384,7 @@ describe('ol.View', function() {
       expect(view.getCenter()[0]).to.be(5950);
       expect(view.getCenter()[1]).to.be(47100);
 
-      view.fitGeometry(
+      view.fit(
           new ol.geom.LineString([[6000, 46000], [6000, 47100], [7000, 46000]]),
           [200, 200],
           {
@@ -395,7 +395,7 @@ describe('ol.View', function() {
       expect(view.getCenter()[0]).to.be(5500);
       expect(view.getCenter()[1]).to.be(47550);
 
-      view.fitGeometry(
+      view.fit(
           new ol.geom.LineString([[6000, 46000], [6000, 47100], [7000, 46000]]),
           [200, 200],
           {
@@ -407,7 +407,7 @@ describe('ol.View', function() {
       expect(view.getCenter()[0]).to.be(6000);
       expect(view.getCenter()[1]).to.be(47050);
 
-      view.fitGeometry(
+      view.fit(
           new ol.geom.Point([6000, 46000]),
           [200, 200],
           {
@@ -419,7 +419,7 @@ describe('ol.View', function() {
       expect(view.getCenter()[0]).to.be(5900);
       expect(view.getCenter()[1]).to.be(46100);
 
-      view.fitGeometry(
+      view.fit(
           new ol.geom.Point([6000, 46000]),
           [200, 200],
           {
@@ -433,7 +433,7 @@ describe('ol.View', function() {
       expect(view.getCenter()[1]).to.be(46100);
 
       view.setRotation(Math.PI / 4);
-      view.fitGeometry(
+      view.fit(
           new ol.geom.LineString([[6000, 46000], [6000, 47100], [7000, 46000]]),
           [200, 200],
           {
@@ -444,6 +444,12 @@ describe('ol.View', function() {
       expect(view.getResolution()).to.roughlyEqual(14.849242404917458, 1e-9);
       expect(view.getCenter()[0]).to.roughlyEqual(5200, 1e-9);
       expect(view.getCenter()[1]).to.roughlyEqual(46300, 1e-9);
+    });
+    it('fit correctly to the extent', function() {
+      view.fit([1000, 1000, 2000, 2000], [200, 200]);
+      expect(view.getResolution()).to.be(5);
+      expect(view.getCenter()[0]).to.be(1500);
+      expect(view.getCenter()[1]).to.be(1500);
     });
   });
 

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -480,6 +480,16 @@ describe('ol.View', function() {
       expect(view.getCenter()[0]).to.be(1500);
       expect(view.getCenter()[1]).to.be(1500);
     });
+    it('throws on invalid geometry/extent value', function() {
+      expect(function() {
+        view.fit(true, [200, 200]);
+      }).to.throwException();
+    });
+    it('throws on empty extent', function() {
+      expect(function() {
+        view.fit(ol.extent.createEmpty(), [200, 200]);
+      }).to.throwException();
+    });
   });
 
   describe('centerOn', function() {
@@ -512,5 +522,6 @@ describe('ol.View', function() {
 });
 
 goog.require('ol.View');
+goog.require('ol.extent');
 goog.require('ol.geom.LineString');
 goog.require('ol.geom.Point');

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -364,6 +364,35 @@ describe('ol.View', function() {
     });
   });
 
+  describe('#calculateExtent', function() {
+    it('returns the expect extent', function() {
+      var view = new ol.View({
+        resolutions: [512],
+        zoom: 0,
+        center: [0, 0]
+      });
+
+      var extent = view.calculateExtent([100, 200]);
+      expect(extent[0]).to.be(-25600);
+      expect(extent[1]).to.be(-51200);
+      expect(extent[2]).to.be(25600);
+      expect(extent[3]).to.be(51200);
+    });
+    it('returns the expected extent with rotation', function() {
+      var view = new ol.View({
+        resolutions: [512],
+        zoom: 0,
+        center: [0, 0],
+        rotation: Math.PI / 2
+      });
+      var extent = view.calculateExtent([100, 200]);
+      expect(extent[0]).to.roughlyEqual(-51200, 1e-9);
+      expect(extent[1]).to.roughlyEqual(-25600, 1e-9);
+      expect(extent[2]).to.roughlyEqual(51200, 1e-9);
+      expect(extent[3]).to.roughlyEqual(25600, 1e-9);
+    });
+  });
+
   describe('fit', function() {
     var view;
     beforeEach(function() {


### PR DESCRIPTION
This adds an ol.View#fit() that accepts either a geometry or an extent.

This combines two previously distinct functions -- ol.View#fitGeometry and ol.View#fitExtent
into a single more flexible call. Rotation support and options previously only available to fitGeometry can now be used when fitting extents.

Also ol.View#calculateExtent() now takes into account rotation state.
