### PR TITLE
Only do one test run on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ before_install:
 before_script:
   - "rm src/ol/renderer/webgl/*shader.js"
 
-script: "./build.py ci"
-
-after_success:
-  - "npm run test-coverage"
+script:
+  - "./build.py ci"
   - "cat coverage/lcov.info | ./node_modules/.bin/coveralls"

--- a/build.py
+++ b/build.py
@@ -168,7 +168,7 @@ def report_sizes(t):
 virtual('default', 'build')
 
 
-virtual('ci', 'lint', 'build', 'test',
+virtual('ci', 'lint', 'build', 'test-coverage',
     'build/examples/all.combined.js', 'check-examples', 'apidoc')
 
 


### PR DESCRIPTION
Currently we run the istanbul scripts on the post success hook.
It would be easier if we can only do one test run (more immediate feedback, less waiting on PRs). It seems ```npm run test-coverage``` will output the same error when a test fails as does the normal test suite, so we can save us one run.

I'll work on a PR.

cc @marcjansen 