### PR TITLE
Add .editorconfig and instructions on its use

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -265,6 +265,14 @@ style of the existing OpenLayers 3 code, which includes:
 
  * Use uppercase for `@const` variables.
 
+### Configure your editor
+
+If possible, configure your editor to follow the coding conventions of the
+library.  A `.editorconfig` file is included at the root of the repository that
+can be used to configure whitespace and charset handling in your editor.  See
+that file for a description of the conventions.  The [EditorConfig](
+http://editorconfig.org/#download) site links to plugins for various editors.
+
 ### Pass the integration tests run automatically by the Travis CI system
 
 The integration tests contain a number of automated checks to ensure that the


### PR DESCRIPTION
This adds a `.editorconfig` file that describes our whitespace and charset use in the library.  People can configure a [variety of editors](http://editorconfig.org/#download) to follow these rules.
