### PR TITLE
Mark VectorContext @api

### DIFF
--- a/src/ol/render/vectorcontext.js
+++ b/src/ol/render/vectorcontext.js
@@ -5,6 +5,7 @@ goog.provide('ol.render.VectorContext');
 /**
  * @constructor
  * @struct
+ * @api
  */
 ol.render.VectorContext = function() {
 };


### PR DESCRIPTION
VectorContext type must be present in Ol3 externs to compile ol3-cesium.
Previously, the `IVectorContext` interface was exported to the externs.