### PR TITLE
Rework build-examples.js task

### DIFF
--- a/config/examples/example.html
+++ b/config/examples/example.html
@@ -29,16 +29,12 @@
       {{{ contents }}}
 
       <div class="row-fluid">
-
         <div class="span12">
           <h4 id="title">{{ title }}</h4>
           <p id="shortdesc">{{ shortdesc }}</p>
-          <div id="docs">
-            {{ md docs }}
-          </div>
+          <div id="docs">{{ md docs }}</div>
           <div id="tags">{{ tags }}</div>
         </div>
-
       </div>
 
       <div class="row-fluid">

--- a/config/examples/example.html
+++ b/config/examples/example.html
@@ -34,7 +34,7 @@
           <h4 id="title">{{ title }}</h4>
           <p id="shortdesc">{{ shortdesc }}</p>
           <div id="docs">
-            {{{ docs }}}
+            {{ md docs }}
           </div>
           <div id="tags">{{ tags }}</div>
         </div>

--- a/config/examples/example.html
+++ b/config/examples/example.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap.min.css" type="text/css">
     <link rel="stylesheet" href="../resources/layout.css" type="text/css">
     <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap-responsive.min.css" type="text/css">
-    {{{ extra_head }}}
+    {{{ extraHead }}}
     {{{ css.tag }}}
     <link rel="stylesheet" href="../resources/prism/prism.css" type="text/css">
     <script src="../resources/zeroclipboard/ZeroClipboard.min.js"></script>
@@ -50,7 +50,7 @@
           <textarea class="hidden" name="css">{{ css.source }}</textarea>
           <textarea class="hidden" name="html">{{ contents }}</textarea>
           <input type="hidden" name="wrap" value="l">
-          <input type="hidden" name="resources" value="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css,https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js,https://cdnjs.cloudflare.com/ajax/libs/ol3/{{ ol_version }}/ol.css,https://cdnjs.cloudflare.com/ajax/libs/ol3/{{ ol_version }}/ol.js">
+          <input type="hidden" name="resources" value="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css,https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js,https://cdnjs.cloudflare.com/ajax/libs/ol3/{{ olVersion }}/ol.css,https://cdnjs.cloudflare.com/ajax/libs/ol3/{{ olVersion }}/ol.js">
           <pre><code id="example-source" class="language-markup">&lt;!DOCTYPE html&gt;
 &lt;html&gt;
 &lt;head&gt;
@@ -58,8 +58,8 @@
 &lt;script src="https://code.jquery.com/jquery-1.11.2.min.js"&gt;&lt;/script&gt;
 &lt;link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css"&gt;
 &lt;script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"&gt;&lt;/script&gt;
-&lt;link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ol3/{{ ol_version }}/ol.css" type="text/css"&gt;
-&lt;script src="https://cdnjs.cloudflare.com/ajax/libs/ol3/{{ ol_version }}/ol.js"&gt;&lt;/script&gt;
+&lt;link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ol3/{{ olVersion }}/ol.css" type="text/css"&gt;
+&lt;script src="https://cdnjs.cloudflare.com/ajax/libs/ol3/{{ olVersion }}/ol.js"&gt;&lt;/script&gt;
 {{ resources }}
 {{#if css.source}}
 &lt;style&gt;

--- a/config/examples/example.html
+++ b/config/examples/example.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="../resources/layout.css" type="text/css">
     <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap-responsive.min.css" type="text/css">
     {{{ resources }}}
-    {{{ css_resource }}}
+    {{{ css.tag }}}
     <link rel="stylesheet" href="../resources/prism/prism.css" type="text/css">
     <script src="../resources/zeroclipboard/ZeroClipboard.min.js"></script>
     <title>{{ title }}</title>
@@ -46,8 +46,8 @@
         <form method="POST" target="_blank" action="http://jsfiddle.net/api/post/jquery/1.11.0/">
           <input type="button" class="btn btn-info" id="copy-button" value="Copy example code">
           <input type="submit" class="btn btn-primary" id="jsfiddle-button" value="Create JSFiddle">
-          <textarea class="hidden" name="js">{{ js_inline }}</textarea>
-          <textarea class="hidden" name="css">{{ css_inline }}</textarea>
+          <textarea class="hidden" name="js">{{ js.source }}</textarea>
+          <textarea class="hidden" name="css">{{ css.source }}</textarea>
           <textarea class="hidden" name="html">{{ contents }}</textarea>
           <input type="hidden" name="wrap" value="l">
           <input type="hidden" name="resources" value="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css,https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js,https://cdnjs.cloudflare.com/ajax/libs/ol3/{{ ol_version }}/ol.css,https://cdnjs.cloudflare.com/ajax/libs/ol3/{{ ol_version }}/ol.js">
@@ -61,9 +61,9 @@
 &lt;link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ol3/{{ ol_version }}/ol.css" type="text/css"&gt;
 &lt;script src="https://cdnjs.cloudflare.com/ajax/libs/ol3/{{ ol_version }}/ol.js"&gt;&lt;/script&gt;
 {{ resources }}
-{{#if css_inline}}
+{{#if css.source}}
 &lt;style&gt;
-{{ css_inline }}
+{{ css.source }}
 &lt;/style&gt;
 {{/if}}
 &lt;/head&gt;
@@ -73,7 +73,7 @@
 {{ contents }}
 &lt;/div&gt;
 &lt;script&gt;
-{{ js_inline }}
+{{ js.source }}
 &lt;/script&gt;
 &lt;/body&gt;
 &lt;/html&gt;</code></pre>
@@ -85,7 +85,7 @@
     <script src="../resources/bootstrap/js/bootstrap.min.js"></script>
     <script src="../resources/example-behaviour.js"></script>
     <script src="../resources/prism/prism.min.js"></script>
-    {{{ js_resource }}}
+    {{{ js.tag }}}
 
   </body>
 </html>

--- a/config/examples/example.html
+++ b/config/examples/example.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap.min.css" type="text/css">
     <link rel="stylesheet" href="../resources/layout.css" type="text/css">
     <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap-responsive.min.css" type="text/css">
-    {{{ resources }}}
+    {{{ extra_head }}}
     {{{ css.tag }}}
     <link rel="stylesheet" href="../resources/prism/prism.css" type="text/css">
     <script src="../resources/zeroclipboard/ZeroClipboard.min.js"></script>

--- a/examples_src/accessible.html
+++ b/examples_src/accessible.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Accessibility example"
-shortdesc: "Example of an accessible map."
+template: example.html
+title: Accessibility example
+shortdesc: Example of an accessible map.
 docs: >
   <p>This page's <code>map</code> element has its <code>tabindex</code> attribute set to <code>"0"</code>, that makes it focusable. To focus the map element you can either navigate to it using the "tab" key or use the skip link. When the <code>map</code> element is focused the + and - keys can be used to zoom in and out and the arrow keys can be used to pan.</p>
   <p>When clicked the "Zoom in" and "Zoom out" buttons below the map zoom the map in and out, respectively. You can navigate to the buttons using the "tab" key, and press the "enter" key to trigger the zooming action.</p>

--- a/examples_src/accessible.html
+++ b/examples_src/accessible.html
@@ -3,8 +3,11 @@ template: example.html
 title: Accessibility example
 shortdesc: Example of an accessible map.
 docs: >
-  <p>This page's <code>map</code> element has its <code>tabindex</code> attribute set to <code>"0"</code>, that makes it focusable. To focus the map element you can either navigate to it using the "tab" key or use the skip link. When the <code>map</code> element is focused the + and - keys can be used to zoom in and out and the arrow keys can be used to pan.</p>
-  <p>When clicked the "Zoom in" and "Zoom out" buttons below the map zoom the map in and out, respectively. You can navigate to the buttons using the "tab" key, and press the "enter" key to trigger the zooming action.</p>
+  This page's `map` element has its `tabindex` attribute set to `"0"`, that makes it focusable. To focus the map element you can either navigate to it using the "tab" key or use the skip link. When the `map` element is focused the + and - keys can be used to zoom in and out and the arrow keys can be used to pan.
+
+
+  Clicking on the "Zoom in" and "Zoom out" buttons below the map zooms the map in and out. You can navigate to the buttons using the "tab" key, and press the "enter" key to trigger the zooming action.
+
 tags: "accessibility, tabindex"
 ---
 <div class="row-fluid">

--- a/examples_src/animation.html
+++ b/examples_src/animation.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Animation example"
-shortdesc: "Demonstrates animated pan, zoom, and rotation."
+template: example.html
+title: Animation example
+shortdesc: Demonstrates animated pan, zoom, and rotation.
 docs: >
   This example shows how to use the beforeRender function on the Map to run one
   or more animations.

--- a/examples_src/arcgis-tiled.html
+++ b/examples_src/arcgis-tiled.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Tiled ArcGIS MapServer example"
-shortdesc: "Example of a tiled ArcGIS layer."
+template: example.html
+title: Tiled ArcGIS MapServer example
+shortdesc: Example of a tiled ArcGIS layer.
 docs: >
   This example shows how to use an ArcGIS REST MapService as tiles.
   This source type supports Map and Image Services. For cached ArcGIS

--- a/examples_src/attributions.html
+++ b/examples_src/attributions.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Attributions example"
-shortdesc: "Example of a attributions visibily change on map resize, to collapse them on small maps."
+template: example.html
+title: Attributions example
+shortdesc: Example of a attributions visibily change on map resize, to collapse them on small maps.
 docs: >
   When the map gets too small because of a resize, the attribution will be collapsed.
   This is because the <code>collapsible</code> option is set to true if the width

--- a/examples_src/bind-input.html
+++ b/examples_src/bind-input.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Bind HTML input example"
-shortdesc: "Demonstrates two-way binding of HTML input elements to OpenLayers objects."
+template: example.html
+title: Bind HTML input example
+shortdesc: Demonstrates two-way binding of HTML input elements to OpenLayers objects.
 docs: >
   <p id="has-webgl" style="display: none">With the <a href="?renderer=webgl">WebGL renderer</a>, <strong>hue</strong>, <strong>saturation</strong>, <strong>contrast</strong> and <strong>brightness</strong> can also be controlled.</p>
   <div id="no-webgl" class="alert alert-warning" style="display: none">

--- a/examples_src/bing-maps.html
+++ b/examples_src/bing-maps.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Bing Maps example"
-shortdesc: "Example of a Bing Maps layer."
+template: example.html
+title: Bing Maps example
+shortdesc: Example of a Bing Maps layer.
 docs: >
   <p>When the Bing Maps tile service doesn't have tiles for a given resolution and region it returns "placeholder" tiles indicating that. Zoom the map beyond level 19 to see the "placeholder" tiles. If you want OpenLayers to display stretched tiles in place of "placeholder" tiles beyond zoom level 19 then set <code>maxZoom</code> to <code>19</code> in the options passed to <code>ol.source.BingMaps</code>.</p>
 tags: "bing, bing-maps"

--- a/examples_src/box-selection.html
+++ b/examples_src/box-selection.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Box selection example"
-shortdesc: "Using a DragBox interaction to select features."
+template: example.html
+title: Box selection example
+shortdesc: Using a DragBox interaction to select features.
 docs: >
   <p>This example shows how to use a <code>DragBox</code> interaction to select features. Selected features are added
   to the feature overlay of a select interaction (<code>ol.interaction.Select</code>) for highlighting.</p>

--- a/examples_src/brightness-contrast.html
+++ b/examples_src/brightness-contrast.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Brightness/contrast example"
-shortdesc: "Example of brightness/contrast control on the client (WebGL only)."
+template: example.html
+title: Brightness/contrast example
+shortdesc: Example of brightness/contrast control on the client (WebGL only).
 docs: >
   This example shows how to control brightness/contrast on the client,
   the example is limited to WebGL.

--- a/examples_src/button-title.html
+++ b/examples_src/button-title.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Custom tooltips example"
-shortdesc: "This example shows how to customize the buttons tooltips with Bootstrap."
+template: example.html
+title: Custom tooltips example
+shortdesc: This example shows how to customize the buttons tooltips with Bootstrap.
 docs: >
   This example shows how to customize the buttons tooltips with <a href="http://getbootstrap.com/javascript/#tooltips">Bootstrap</a>.
 tags: "custom, tooltip"

--- a/examples_src/canvas-tiles.html
+++ b/examples_src/canvas-tiles.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Canvas tiles example"
-shortdesc: "Renders tiles with coordinates for debugging."
+template: example.html
+title: Canvas tiles example
+shortdesc: Renders tiles with coordinates for debugging.
 docs: >
   <p>The black grid tiles are generated on the client with an HTML5 canvas. Note that the tile coordinates are ol3 normalized tile coordinates (origin bottom left), not
   OSM tile coordinates (origin top left).</p>

--- a/examples_src/center.html
+++ b/examples_src/center.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Advanced View Positioning example"
-shortdesc: "This example demonstrates how a map's view can be adjusted so a geometry or coordinate is positioned at a specific pixel location."
+template: example.html
+title: Advanced View Positioning example
+shortdesc: This example demonstrates how a map's view can be adjusted so a geometry or coordinate is positioned at a specific pixel location.
 docs: >
   This example demonstrates how a map's view can be
   adjusted so a geometry or coordinate is positioned at a specific

--- a/examples_src/cluster.html
+++ b/examples_src/cluster.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Clustering example"
-shortdesc: "Example of using <code>ol.source.Cluster</code>."
+template: example.html
+title: Clustering example
+shortdesc: Example of using <code>ol.source.Cluster</code>.
 docs: >
   This example shows how to do clustering on point features.
 tags: "cluster, vector"

--- a/examples_src/custom-controls.html
+++ b/examples_src/custom-controls.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Custom control example"
-shortdesc: "Shows how to create custom controls."
+template: example.html
+title: Custom control example
+shortdesc: Shows how to create custom controls.
 docs: >
   This example creates a "rotate to north" button.
 tags: "custom, control"

--- a/examples_src/d3.html
+++ b/examples_src/d3.html
@@ -5,7 +5,9 @@ shortdesc: "Example of using ol3 and d3 together."
 docs: >
   <p>The example loads TopoJSON geometries and uses d3 (<code>d3.geo.path</code>) to render these geometries to a canvas element that is then used as the image of an ol3 image layer.</p>
 tags: "d3"
-resources: "http://d3js.org/d3.v3.min.js,http://d3js.org/topojson.v1.min.js"
+resources:
+  - http://d3js.org/d3.v3.min.js
+  - http://d3js.org/topojson.v1.min.js
 ---
 <div class="row-fluid">
   <div class="span12">

--- a/examples_src/d3.html
+++ b/examples_src/d3.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "d3 integration example"
-shortdesc: "Example of using ol3 and d3 together."
+template: example.html
+title: d3 integration example
+shortdesc: Example of using ol3 and d3 together.
 docs: >
   <p>The example loads TopoJSON geometries and uses d3 (<code>d3.geo.path</code>) to render these geometries to a canvas element that is then used as the image of an ol3 image layer.</p>
 tags: "d3"

--- a/examples_src/device-orientation.html
+++ b/examples_src/device-orientation.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Device-Orientation example"
-shortdesc: "Listen to DeviceOrientation events."
+template: example.html
+title: Device-Orientation example
+shortdesc: Listen to DeviceOrientation events.
 docs: >
   This example shows how to track changes in device orientation.
 tags: "orientation, openstreetmap"

--- a/examples_src/drag-and-drop-image-vector.html
+++ b/examples_src/drag-and-drop-image-vector.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Drag-and-Drop image vector example"
-shortdesc: "Example of using the drag-and-drop interaction with a ol.source.ImageVector. Drag and drop GPX, GeoJSON, IGC, KML, or TopoJSON files on to the map. Each file is rendered to an image on the client."
+template: example.html
+title: Drag-and-Drop image vector example
+shortdesc: Example of using the drag-and-drop interaction with a ol.source.ImageVector. Drag and drop GPX, GeoJSON, IGC, KML, or TopoJSON files on to the map. Each file is rendered to an image on the client.
 docs: >
   Example of using the drag-and-drop interaction with a ol.source.ImageVector. Drag and drop GPX, GeoJSON, IGC, KML, or TopoJSON files on to the map. Each file is rendered to
   an image on the client.

--- a/examples_src/drag-and-drop.html
+++ b/examples_src/drag-and-drop.html
@@ -1,9 +1,9 @@
 ---
-template: "example.html"
-title: "Drag-and-Drop example"
-shortdesc: "Example of using the drag-and-drop interaction. Drag and drop GPX, GeoJSON, IGC, KML, or TopoJSON files on to the map. There is no projection transform support, so this will only work with data in EPSG:4326 and EPSG:3857."
+template: example.html
+title: Drag-and-Drop example
+shortdesc: Example of using the drag-and-drop interaction. Drag and drop GPX, GeoJSON, IGC, KML, or TopoJSON files on to the map. There is no projection transform support, so this will only work with data in EPSG:4326 and EPSG:3857.
 docs: >
-  Example of using the drag-and-drop interaction. Drag and drop GPX, GeoJSON, IGC, KML, or TopoJSON files on to the map. There is no projection transform support, so this will 
+  Example of using the drag-and-drop interaction. Drag and drop GPX, GeoJSON, IGC, KML, or TopoJSON files on to the map. There is no projection transform support, so this will
   only work with data in EPSG:4326 and EPSG:3857.
 tags: "drag-and-drop, gpx, geojson, igc, kml, topojson"
 ---

--- a/examples_src/drag-features.html
+++ b/examples_src/drag-features.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Drag features example"
-shortdesc: "Example of a drag features interaction."
+template: example.html
+title: Drag features example
+shortdesc: Example of a drag features interaction.
 docs: >
   The drag features interaction can be used to drag features to a new position.
 tags: "drag, feature, vector, editing"

--- a/examples_src/drag-rotate-and-zoom.html
+++ b/examples_src/drag-rotate-and-zoom.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Drag rotate and zoom example"
-shortdesc: "A single interaction to drag, rotate, and zoom."
+template: example.html
+title: Drag rotate and zoom example
+shortdesc: A single interaction to drag, rotate, and zoom.
 docs: >
   <p><code>Shift</code> + Drag to rotate and zoom the map around its center.</p>
 tags: "drag, rotate, zoom, interaction"

--- a/examples_src/draw-and-modify-features.html
+++ b/examples_src/draw-and-modify-features.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Draw and modify features example"
-shortdesc: "Example of using the ol.interaction.Draw interaction together with the ol.interaction.Modify interaction."
+template: example.html
+title: Draw and modify features example
+shortdesc: Example of using the ol.interaction.Draw interaction together with the ol.interaction.Modify interaction.
 docs: >
   Example of using the ol.interaction.Draw interaction together with the ol.interaction.Modify interaction.
 tags: "draw, edit, modify, vector, featureoverlay"

--- a/examples_src/draw-features.html
+++ b/examples_src/draw-features.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Draw features example"
-shortdesc: "Example of using the ol.interaction.Draw interaction."
+template: example.html
+title: Draw features example
+shortdesc: Example of using the ol.interaction.Draw interaction.
 docs: >
   Example of using the ol.interaction.Draw interaction.
 tags: "draw, edit, vector"

--- a/examples_src/dynamic-data.html
+++ b/examples_src/dynamic-data.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Dynamic data example"
-shortdesc: "Example of dynamic data."
+template: example.html
+title: Dynamic data example
+shortdesc: Example of dynamic data.
 docs: >
   Example of dynamic data.
 tags: "dynamic-data"

--- a/examples_src/earthquake-clusters.html
+++ b/examples_src/earthquake-clusters.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Earthquake Clusters"
-shortdesc: "Demonstrates the use of style geometries to render source features of a cluster."
+template: example.html
+title: Earthquake Clusters
+shortdesc: Demonstrates the use of style geometries to render source features of a cluster.
 docs: >
   <p>This example parses a KML file and renders the features as clusters on a vector layer.  The styling in this example is quite involved. Single earthquake locations
   (rendered as stars) have a size relative to their magnitude. Clusters have an opacity relative to the number of features in the cluster, and a size that represents

--- a/examples_src/epsg-4326.html
+++ b/examples_src/epsg-4326.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "EPSG:4326 example"
-shortdesc: "Example of a map in EPSG:4326."
+template: example.html
+title: EPSG:4326 example
+shortdesc: Example of a map in EPSG:4326.
 docs: >
   This example shows how to create a map in EPSG:4326.
 tags: "epsg4326"

--- a/examples_src/export-map.html
+++ b/examples_src/export-map.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Export map example"
-shortdesc: "Example of exporting a map as a PNG image."
+template: example.html
+title: Export map example
+shortdesc: Example of exporting a map as a PNG image.
 docs: >
   Example of exporting a map as a PNG image.
 tags: "export, png, openstreetmap"

--- a/examples_src/fractal.html
+++ b/examples_src/fractal.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Fractal Example"
-shortdesc: "Example of a fractal."
+template: example.html
+title: Fractal Example
+shortdesc: Example of a fractal.
 docs: >
   Example of a fractal.
 tags: "fractal, vector"

--- a/examples_src/full-screen-drag-rotate-and-zoom.html
+++ b/examples_src/full-screen-drag-rotate-and-zoom.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Full screen drag rotate and zoom example"
-shortdesc: "Example of drag rotate and zoom control with full screen effect."
+template: example.html
+title: Full screen drag rotate and zoom example
+shortdesc: Example of drag rotate and zoom control with full screen effect.
 docs: >
   <p>Hold down <code>Shift</code> + drag to rotate and zoom.  Click the button in the top right corner to go full screen.  Then do the <code>Shift</code> + drag thing again.</p>
   <p>If there is no button on the map, your browser does not support the <a href="http://caniuse.com/#feat=fullscreen">Full Screen API</a>.</p>

--- a/examples_src/full-screen.html
+++ b/examples_src/full-screen.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Full screen control example"
-shortdesc: "Example of a full screen control."
+template: example.html
+title: Full screen control example
+shortdesc: Example of a full screen control.
 docs: >
   <p>Click the control in the top right corner to go full screen.  Click it again to exit full screen.</p>
   <p>If there is no button on the map, your browser does not support the <a href="http://caniuse.com/#feat=fullscreen">Full Screen API</a>.</p>

--- a/examples_src/geojson.html
+++ b/examples_src/geojson.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "GeoJSON example"
-shortdesc: "Example of GeoJSON features."
+template: example.html
+title: GeoJSON example
+shortdesc: Example of GeoJSON features.
 docs: >
   Example of GeoJSON features.
 tags: "geojson, vector, openstreetmap"

--- a/examples_src/geolocation.html
+++ b/examples_src/geolocation.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Geolocation example"
-shortdesc: "Example of a geolocation map."
+template: example.html
+title: Geolocation example
+shortdesc: Example of a geolocation map.
 docs: >
   Example of a geolocation map.
 tags: "geolocation, openstreetmap"

--- a/examples_src/getfeatureinfo-image.html
+++ b/examples_src/getfeatureinfo-image.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "GetFeatureInfo example (image layer)"
-shortdesc: "This example shows how to trigger WMS GetFeatureInfo requests on click for a WMS image layer."
+template: example.html
+title: GetFeatureInfo example (image layer)
+shortdesc: This example shows how to trigger WMS GetFeatureInfo requests on click for a WMS image layer.
 docs: >
   <p>Additionally <code>map.forEachLayerAtPixel</code> is used to change the mouse pointer when hovering a non-transparent pixel on the map.</p>
 tags: "getfeatureinfo, forEachLayerAtPixel"

--- a/examples_src/getfeatureinfo-tile.html
+++ b/examples_src/getfeatureinfo-tile.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "WMS GetFeatureInfo example (tile layer)"
-shortdesc: "This example shows how to trigger WMS GetFeatureInfo requests on click for a WMS tile layer."
+template: example.html
+title: WMS GetFeatureInfo example (tile layer)
+shortdesc: This example shows how to trigger WMS GetFeatureInfo requests on click for a WMS tile layer.
 docs: >
   <p>Additionally <code>map.forEachLayerAtPixel</code> is used to change the mouse pointer when hovering a non-transparent pixel on the map.</p>
 tags: "getfeatureinfo, forEachLayerAtPixel"

--- a/examples_src/gpx.html
+++ b/examples_src/gpx.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "GPX example"
-shortdesc: "Example of using the GPX source."
+template: example.html
+title: GPX example
+shortdesc: Example of using the GPX source.
 docs: >
   Example of using the GPX source.
 tags: "GPX"
@@ -22,4 +22,4 @@ tags: "GPX"
    </div>
    </div>
  </div>
- 
+

--- a/examples_src/graticule.html
+++ b/examples_src/graticule.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Graticule example"
-shortdesc: "This example shows how to add a graticule overlay to a map."
+template: example.html
+title: Graticule example
+shortdesc: This example shows how to add a graticule overlay to a map.
 docs: >
   This example shows how to add a graticule overlay to a map.
 tags: "graticule"

--- a/examples_src/heatmap-earthquakes.html
+++ b/examples_src/heatmap-earthquakes.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Earthquakes heatmap"
-shortdesc: "Demonstrates the use of a heatmap layer."
+template: example.html
+title: Earthquakes heatmap
+shortdesc: Demonstrates the use of a heatmap layer.
 docs: >
   This example parses a KML file and renders the features as a <code>ol.layer.Heatmap</code> layer.
 tags: "heatmap, kml, vector, style"

--- a/examples_src/hue-saturation.html
+++ b/examples_src/hue-saturation.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Hue/saturation example"
-shortdesc: "Example of hue/saturation control on the client (WebGL only)."
+template: example.html
+title: Hue/saturation example
+shortdesc: Example of hue/saturation control on the client (WebGL only).
 docs: >
   Example of hue/saturation control on the client (WebGL only).
 tags: "custom, control"

--- a/examples_src/icon-sprite-webgl.html
+++ b/examples_src/icon-sprite-webgl.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Icon sprites with WebGL example"
-shortdesc: "Icon sprite with WebGL"
+template: example.html
+title: Icon sprites with WebGL example
+shortdesc: Icon sprite with WebGL
 docs: >
   <p>In this example a sprite image is used for the icon styles. Using a sprite is required to get good performance with WebGL.</p>
 tags: "webgl, icon, sprite, vector, point"

--- a/examples_src/icon.html
+++ b/examples_src/icon.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Vector Icon Example"
-shortdesc: "Example using an icon to symbolize a point."
+template: example.html
+title: Vector Icon Example
+shortdesc: Example using an icon to symbolize a point.
 docs: >
   Example using an icon to symbolize a point.
 tags: "vector, style, icon, marker, popup"

--- a/examples_src/igc.html
+++ b/examples_src/igc.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "IGC example"
-shortdesc: "Example of tracks recorded from multiple paraglider flights on the same day, read from an IGC file."
+template: example.html
+title: IGC example
+shortdesc: Example of tracks recorded from multiple paraglider flights on the same day, read from an IGC file.
 docs: >
   <p>The five tracks contain a total of 49,707 unique coordinates. Zoom in to see more detail. The background layer is from <a href="http://www.opencyclemap.org/">OpenCycleMap</a>.</p>
 tags: "complex-geometry, closest-feature, igc, opencyclemap"

--- a/examples_src/image-filter.html
+++ b/examples_src/image-filter.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Image Filter Example"
-shortdesc: "Apply a filter to imagery"
+template: example.html
+title: Image Filter Example
+shortdesc: Apply a filter to imagery
 docs: >
   <p>Layer rendering can be manipulated in <code>precompose</code> and <code>postcompose</code> event listeners.
   These listeners get an event with a reference to the Canvas rendering context.

--- a/examples_src/image-load-events.html
+++ b/examples_src/image-load-events.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Image load events example"
-shortdesc: "Example using image load events."
+template: example.html
+title: Image load events example
+shortdesc: Example using image load events.
 docs: >
   <p>Image sources fire events related to image loading.  You can
   listen for <code>imageloadstart</code>, <code>imageloadend</code>,

--- a/examples_src/image-vector-layer.html
+++ b/examples_src/image-vector-layer.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Image vector layer example"
-shortdesc: "Example of an image vector layer."
+template: example.html
+title: Image vector layer example
+shortdesc: Example of an image vector layer.
 docs: >
   <p>This example uses a <code>ol.source.ImageVector</code> source. That source gets vector features from the
   <code>ol.source.Vector</code> it's configured with, and draw these features to an HTML5 canvas element that

--- a/examples_src/kml-earthquakes.html
+++ b/examples_src/kml-earthquakes.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Earthquakes in KML"
-shortdesc: "Demonstrates the use of a Shape symbolizer to render earthquake locations."
+template: example.html
+title: Earthquakes in KML
+shortdesc: Demonstrates the use of a Shape symbolizer to render earthquake locations.
 docs: >
   This example parses a KML file and renders the features as a vector layer.  The layer is given a <code>style</code> that renders earthquake locations with a size relative to their magnitude.
 tags: "KML, vector, style, tooltip"

--- a/examples_src/kml-timezones.html
+++ b/examples_src/kml-timezones.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Timezones in KML"
-shortdesc: "Demonstrates rendering timezones from KML."
+template: example.html
+title: Timezones in KML
+shortdesc: Demonstrates rendering timezones from KML.
 docs: >
   This example parses a KML file and renders the features as a vector layer.  The layer is given a <code>ol.style.Style</code> that fills timezones
   yellow with an opacity calculated based on the current offset to local noon.

--- a/examples_src/kml.html
+++ b/examples_src/kml.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "KML example"
-shortdesc: "Example of using the KML source."
+template: example.html
+title: KML example
+shortdesc: Example of using the KML source.
 docs: >
   Example of using the KML source.
 tags: "KML"

--- a/examples_src/layer-clipping-webgl.html
+++ b/examples_src/layer-clipping-webgl.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Layer WebGL clipping example"
-shortdesc: "Layer WebGL clipping example."
+template: example.html
+title: Layer WebGL clipping example
+shortdesc: Layer WebGL clipping example.
 docs: >
   This example shows how to use the <code>precompose</code> and <code>postcompose</code> rendering hooks to clip layers using WebGL.
 tags: "clipping, webgl, openstreetmap"

--- a/examples_src/layer-clipping.html
+++ b/examples_src/layer-clipping.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Layer clipping example"
-shortdesc: "Layer clipping example"
+template: example.html
+title: Layer clipping example
+shortdesc: Layer clipping example
 docs: >
   Layer clipping example
 tags: "clipping, openstreetmap"

--- a/examples_src/layer-extent.html
+++ b/examples_src/layer-extent.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Limited Layer Extent"
-shortdesc: "Restricting layer rendering to a limited extent."
+template: example.html
+title: Limited Layer Extent
+shortdesc: Restricting layer rendering to a limited extent.
 docs: >
   This example uses the <code>layer.setExtent()</code> method to
   modify the extent of the overlay layer.  Use the controls below

--- a/examples_src/layer-group.html
+++ b/examples_src/layer-group.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Layer group example"
-shortdesc: "Example of a map with layer group."
+template: example.html
+title: Layer group example
+shortdesc: Example of a map with layer group.
 docs: >
   Example of a map with layer group.
 tags: "tilejson, input, bind, group, layergroup"

--- a/examples_src/layer-spy.html
+++ b/examples_src/layer-spy.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Layer Spy Example"
-shortdesc: "View a portion of one layer over another"
+template: example.html
+title: Layer Spy Example
+shortdesc: View a portion of one layer over another
 docs: >
   <p>Layer rendering can be manipulated in <code>precompose</code> and <code>postcompose</code> event listeners.
   These listeners get an event with a reference to the Canvas rendering context.

--- a/examples_src/layer-swipe.html
+++ b/examples_src/layer-swipe.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Layer Swipe example"
-shortdesc: "Example of a Layer swipe map."
+template: example.html
+title: Layer Swipe example
+shortdesc: Example of a Layer swipe map.
 docs: >
   Example of a Layer swipe map.
 tags: "swipe, openstreetmap"

--- a/examples_src/lazy-source.html
+++ b/examples_src/lazy-source.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Lazy Source"
-shortdesc: "Example of setting a layer source after construction."
+template: example.html
+title: Lazy Source
+shortdesc: Example of setting a layer source after construction.
 docs: >
   <p>Typically, the source for a layer is provided to the layer constructor.
   If you need to set a layer source after construction, this can be

--- a/examples_src/line-arrows.html
+++ b/examples_src/line-arrows.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "LineString arrows example"
-shortdesc: "Example of drawing arrows for each line string segment."
+template: example.html
+title: LineString arrows example
+shortdesc: Example of drawing arrows for each line string segment.
 docs: >
   Example of drawing arrows for each line string segment.
 tags: "draw, vector, arrow"

--- a/examples_src/localized-openstreetmap.html
+++ b/examples_src/localized-openstreetmap.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Localized OpenStreetMap example"
-shortdesc: "Example of a localized OpenStreetMap map with a custom tile server and a custom attribution."
+template: example.html
+title: Localized OpenStreetMap example
+shortdesc: Example of a localized OpenStreetMap map with a custom tile server and a custom attribution.
 docs: >
   <p>The base layer is <a href="http://www.opencyclemap.org/">OpenCycleMap</a> with an overlay from <a href="http://www.openseamap.org/">OpenSeaMap</a>. The OpenSeaMap tile server
   does not support <a href="http://enable-cors.org/">CORS</a> headers.</p>

--- a/examples_src/mapguide-untiled.html
+++ b/examples_src/mapguide-untiled.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "MapGuide untiled example"
-shortdesc: "Example of a untiled MapGuide map."
+template: example.html
+title: MapGuide untiled example
+shortdesc: Example of a untiled MapGuide map.
 docs: >
   Example of a untiled MapGuide map.
 tags: "mapguide"

--- a/examples_src/mapquest.html
+++ b/examples_src/mapquest.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "MapQuest example"
-shortdesc: "Example of a MapQuest map.Shows how to create custom controls."
+template: example.html
+title: MapQuest example
+shortdesc: Example of a MapQuest map.Shows how to create custom controls.
 docs: >
   Example of a MapQuest map.
 tags: "mapquest"

--- a/examples_src/measure.html
+++ b/examples_src/measure.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Measure example"
-shortdesc: "Example of using the ol.interaction.Draw interaction for creating simple measuring application."
+template: example.html
+title: Measure example
+shortdesc: Example of using the ol.interaction.Draw interaction for creating simple measuring application.
 docs: >
   <p><i>NOTE: If use geodesic measures is not checked, measure is done in simple way on projected plane. Earth curvature is not taken into account</i></p>
 tags: "draw, edit, measure, vector"

--- a/examples_src/min-max-resolution.html
+++ b/examples_src/min-max-resolution.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Min/max resolution example"
-shortdesc: "Show/hide layers depending on current view resolution."
+template: example.html
+title: Min/max resolution example
+shortdesc: Show/hide layers depending on current view resolution.
 docs: >
   <p>Zoom in twice: the MapBox layer should hide whereas the OSM layer should be shown.</p>
   <p>If you continue to zoom in, you'll see the OSM layer also disappear.</p>

--- a/examples_src/modify-features.html
+++ b/examples_src/modify-features.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Modify features example"
-shortdesc: "Editing features with the modify interaction."
+template: example.html
+title: Modify features example
+shortdesc: Editing features with the modify interaction.
 docs: >
   <p>This example demonstrates how the modify and select interactions can be used together.  Zoom in to an area of interest and select a feature for editing.
   Then drag points around to modify the feature.  You can preserve topology by selecting multiple features before editing (<code>Shift</code>+click to select multiple features).</p>

--- a/examples_src/modify-test.html
+++ b/examples_src/modify-test.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Modify features test"
-shortdesc: "Example for testing feature modification."
+template: example.html
+title: Modify features test
+shortdesc: Example for testing feature modification.
 docs: >
   Example for testing feature modification.
 tags: "modify, edit, vector"

--- a/examples_src/mouse-position.html
+++ b/examples_src/mouse-position.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Mouse position example"
-shortdesc: "Example of a mouse position control, outside the map."
+template: example.html
+title: Mouse position example
+shortdesc: Example of a mouse position control, outside the map.
 docs: >
   Example of a mouse position control, outside the map.
 tags: "mouse-position, openstreetmap"

--- a/examples_src/moveend.html
+++ b/examples_src/moveend.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Moveend Example"
-shortdesc: "Use of the moveend event."
+template: example.html
+title: Moveend Example
+shortdesc: Use of the moveend event.
 docs: >
   <p>In this example, a listener is registered for the map's <code>moveend</code> event.  Whenever this listener is called, it updates the inputs below with the map extent in decimal degrees.</p>
 tags: "moveend, map, event"

--- a/examples_src/navigation-controls.html
+++ b/examples_src/navigation-controls.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Navigation controls example"
-shortdesc: "Shows how to add navigation controls."
+template: example.html
+title: Navigation controls example
+shortdesc: Shows how to add navigation controls.
 docs: >
   <p>This example shows how to use the beforeRender function on the Map to run one
   or more animations.</p>

--- a/examples_src/overlay.html
+++ b/examples_src/overlay.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Overlay example"
-shortdesc: "Demonstrates overlays."
+template: example.html
+title: Overlay example
+shortdesc: Demonstrates overlays.
 docs: >
   <p>The popups are created using <a href="http://twitter.github.com/bootstrap/javascript.html#popovers">Popovers</a> from Bootstrap.</p>
 tags: "overlay, popup, bootstrap, popover, mapquest, openaerial"

--- a/examples_src/overlay.html
+++ b/examples_src/overlay.html
@@ -5,7 +5,8 @@ shortdesc: "Demonstrates overlays."
 docs: >
   <p>The popups are created using <a href="http://twitter.github.com/bootstrap/javascript.html#popovers">Popovers</a> from Bootstrap.</p>
 tags: "overlay, popup, bootstrap, popover, mapquest, openaerial"
-resources: overlay.css
+resources:
+  - overlay.css
 ---
 <div class="row-fluid">
   <div class="span12">

--- a/examples_src/overviewmap-custom.html
+++ b/examples_src/overviewmap-custom.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "OverviewMap control example advanced"
-shortdesc: "Example of OverviewMap control with advanced customization."
+template: example.html
+title: OverviewMap control example advanced
+shortdesc: Example of OverviewMap control with advanced customization.
 docs: >
   <p>This example demonstrates how you can customize the overviewmap control using its supported options as well as defining custom CSS.  You can also rotate the map using the shift key to see how the overview map reacts.</p>
 tags: "overview, overviewmap"

--- a/examples_src/overviewmap-custom.html
+++ b/examples_src/overviewmap-custom.html
@@ -5,7 +5,8 @@ shortdesc: "Example of OverviewMap control with advanced customization."
 docs: >
   <p>This example demonstrates how you can customize the overviewmap control using its supported options as well as defining custom CSS.  You can also rotate the map using the shift key to see how the overview map reacts.</p>
 tags: "overview, overviewmap"
-resources: overviewmap-custom.css
+resources:
+  - overviewmap-custom.css
 ---
 <div class="row-fluid">
   <div class="span12">

--- a/examples_src/overviewmap.html
+++ b/examples_src/overviewmap.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "OverviewMap control example"
-shortdesc: "Example of OverviewMap control."
+template: example.html
+title: OverviewMap control example
+shortdesc: Example of OverviewMap control.
 docs: >
   This example demonstrates the use of the OverviewMap control.
 tags: "overview, overviewmap"

--- a/examples_src/polygon-styles.html
+++ b/examples_src/polygon-styles.html
@@ -7,7 +7,8 @@ docs: >
    * The first style is for the polygons themselves.
    * The second style is to draw the vertices of the polygons.
 tags: "polygon, vector, style, GeometryFunction"
-resources: polygon-styles.css
+resources:
+  - polygon-styles.css
 ---
 <div class="row-fluid">
   <div class="span12">

--- a/examples_src/polygon-styles.html
+++ b/examples_src/polygon-styles.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Custom styles for polygons"
-shortdesc: "Showing the vertices of a polygon with a custom style geometry."
+template: example.html
+title: Custom styles for polygons
+shortdesc: Showing the vertices of a polygon with a custom style geometry.
 docs: >
   In this example two different styles are created for the polygons:
    * The first style is for the polygons themselves.

--- a/examples_src/popup.html
+++ b/examples_src/popup.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Popup example"
-shortdesc: "Uses an overlay to create a popup."
+template: example.html
+title: Popup example
+shortdesc: Uses an overlay to create a popup.
 docs: >
   <p>
     Click on the map to get a popup.  The popup is composed of a few basic elements: a container, a close button, and a place for the content.  To anchor the popup to the map, an <code>ol.Overlay</code> is created with the popup container.  A listener is registered for the map's <code>click</code> event to display the popup, and another listener is set as the <code>click</code> handler for the close button to hide the popup.

--- a/examples_src/popup.html
+++ b/examples_src/popup.html
@@ -7,7 +7,8 @@ docs: >
     Click on the map to get a popup.  The popup is composed of a few basic elements: a container, a close button, and a place for the content.  To anchor the popup to the map, an <code>ol.Overlay</code> is created with the popup container.  A listener is registered for the map's <code>click</code> event to display the popup, and another listener is set as the <code>click</code> handler for the close button to hide the popup.
   </p>
 tags: "overlay, popup, mapquest, openaerial"
-resources: popup.css
+resources:
+  - popup.css
 ---
 <div class="row-fluid">
   <div class="span12">

--- a/examples_src/preload.html
+++ b/examples_src/preload.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Preload example"
-shortdesc: "Example of tile preloading."
+template: example.html
+title: Preload example
+shortdesc: Example of tile preloading.
 docs: >
   <p>The map on the left preloads low resolution tiles.  The map on the right does not use any preloading.  Try zooming out and panning to see the difference.</p>
 tags: "preload, bing"

--- a/examples_src/readme.md
+++ b/examples_src/readme.md
@@ -7,4 +7,4 @@ The `.html` files in this folder are built by applying the templates in the `con
 * shortdesc: A short description for the example index
 * docs: Documentation of the example. Can be markdown.
 * tags: Tags for the example index
-* resources: Additional js or css resources required by the example. This is a comma separated list of URLs.
+* resources: Additional js or css resources required by the example. This is a YAML list of URLs.

--- a/examples_src/regularshape.html
+++ b/examples_src/regularshape.html
@@ -1,9 +1,9 @@
 ---
-template: "example.html"
-title: "Regular Shape example"
-shortdesc: "Example of some Regular Shape styles."
+template: example.html
+title: Regular Shape example
+shortdesc: Example of some Regular Shape styles.
 docs: >
-  
+
 tags: "vector, symbol, regularshape, style, square, cross, star, triangle, x"
 ---
 <div class="row-fluid">

--- a/examples_src/rotation.html
+++ b/examples_src/rotation.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Rotation example"
-shortdesc: "Example of a rotated map."
+template: example.html
+title: Rotation example
+shortdesc: Example of a rotated map.
 docs: >
   <p>Use <code>Alt</code>+<code>Shift</code>+drag to rotate the map.</p>
 tags: "rotation, openstreetmap"

--- a/examples_src/scale-line.html
+++ b/examples_src/scale-line.html
@@ -1,9 +1,9 @@
 ---
-template: "example.html"
-title: "Scale line example"
-shortdesc: "Example of a scale line."
+template: example.html
+title: Scale line example
+shortdesc: Example of a scale line.
 docs: >
-  
+
 tags: "scale-line, openstreetmap"
 ---
 <div class="row-fluid">

--- a/examples_src/select-features.html
+++ b/examples_src/select-features.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Select features example"
-shortdesc: "Example of using the Select interaction."
+template: example.html
+title: Select features example
+shortdesc: Example of using the Select interaction.
 docs: >
   Choose between <code>Single-click</code>, <code>Click</code> and <code>Hover</code> as the event type for selection in the combobox below. When using <code>Single-click</code> or <code>Click</code> you can hold do <code>Shift</code> key to toggle the feature in the selection.</p>
           <p>Note: when <code>Single-click</code> is used double-clicks won't select features. This in contrast to <code>Click</code>, where a double-click will both select the feature and zoom the map (because of the <code>DoubleClickZoom</code> interaction). Note that <code>Single-click</code> is less responsive than <code>Click</code> because of the delay it uses to detect double-clicks.</p>

--- a/examples_src/semi-transparent-layer.html
+++ b/examples_src/semi-transparent-layer.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Semi-transparent layer example"
-shortdesc: "Example of a map with a semi-transparent layer."
+template: example.html
+title: Semi-transparent layer example
+shortdesc: Example of a map with a semi-transparent layer.
 docs: >
   This example will display a tiled MaxBox layer semi-transparently over a MapQuest background.
 tags: "transparent, mapquest, tilejson"

--- a/examples_src/side-by-side.html
+++ b/examples_src/side-by-side.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Side-by-side example"
-shortdesc: "The three maps, one WebGL, one Canvas, one DOM, share the same center, resolution, rotation and layers."
+template: example.html
+title: Side-by-side example
+shortdesc: The three maps, one WebGL, one Canvas, one DOM, share the same center, resolution, rotation and layers.
 docs: >
   The three maps, one WebGL, one Canvas, one DOM, share the same center, resolution, rotation and layers.
 tags: "side-by-side, canvas, webgl, dom, canvas, sync, object"

--- a/examples_src/simple.html
+++ b/examples_src/simple.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Simple example"
-shortdesc: "Example of a simple map."
+template: example.html
+title: Simple example
+shortdesc: Example of a simple map.
 docs: >
   A simple map with customized Attribution control.
 tags: "simple, openstreetmap, attribution"

--- a/examples_src/snap.html
+++ b/examples_src/snap.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Snap interaction example"
-shortdesc: "Example of using the snap interaction together with draw and modify interactions."
+template: example.html
+title: Snap interaction example
+shortdesc: Example of using the snap interaction together with draw and modify interactions.
 docs: >
   Example of using the snap interaction together with
   draw and modify interactions. The snap interaction must be added

--- a/examples_src/sphere-mollweide.html
+++ b/examples_src/sphere-mollweide.html
@@ -5,7 +5,8 @@ shortdesc: "Example of a Sphere Mollweide map with a Graticule component."
 docs: >
   Example of a Sphere Mollweide map with a Graticule component.
 tags: "graticule, Mollweide, projection, proj4js"
-resources: http://cdnjs.cloudflare.com/ajax/libs/proj4js/2.2.1/proj4.js
+resources:
+  - http://cdnjs.cloudflare.com/ajax/libs/proj4js/2.2.1/proj4.js
 ---
 <div class="row-fluid">
   <div class="span12">

--- a/examples_src/sphere-mollweide.html
+++ b/examples_src/sphere-mollweide.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Sphere Mollweide example"
-shortdesc: "Example of a Sphere Mollweide map with a Graticule component."
+template: example.html
+title: Sphere Mollweide example
+shortdesc: Example of a Sphere Mollweide map with a Graticule component.
 docs: >
   Example of a Sphere Mollweide map with a Graticule component.
 tags: "graticule, Mollweide, projection, proj4js"

--- a/examples_src/stamen.html
+++ b/examples_src/stamen.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Stamen example"
-shortdesc: "Example of a Stamen tile source."
+template: example.html
+title: Stamen example
+shortdesc: Example of a Stamen tile source.
 docs: >
   Two layers are composed: the watercolor base layer with the terrain labels.
 tags: "stamen, watercolor, terrain-labels, two-layers"

--- a/examples_src/static-image.html
+++ b/examples_src/static-image.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Static image example"
-shortdesc: "Example of a static image layer."
+template: example.html
+title: Static image example
+shortdesc: Example of a static image layer.
 docs: >
   <p>
     This example uses a <a href="http://xkcd.com/256/">static image</a>

--- a/examples_src/symbol-atlas-webgl.html
+++ b/examples_src/symbol-atlas-webgl.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Symbols with WebGL example"
-shortdesc: "Using symbols in an atlas with WebGL."
+template: example.html
+title: Symbols with WebGL example
+shortdesc: Using symbols in an atlas with WebGL.
 docs: >
   <p>When using symbol styles with WebGL, OpenLayers would render the symbol
   on a temporary image and would create a WebGL texture for each image. For a

--- a/examples_src/synthetic-lines.html
+++ b/examples_src/synthetic-lines.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Synthetic lines example"
-shortdesc: "Synthetic lines example."
+template: example.html
+title: Synthetic lines example
+shortdesc: Synthetic lines example.
 docs: >
   <p>Performance results:</p>
   <table border="1">

--- a/examples_src/synthetic-points.html
+++ b/examples_src/synthetic-points.html
@@ -1,9 +1,9 @@
 ---
-template: "example.html"
-title: "Synthetic points example"
-shortdesc: "Synthetic points example."
+template: example.html
+title: Synthetic points example
+shortdesc: Synthetic points example.
 docs: >
-  
+
 tags: "vector"
 ---
 <div class="row-fluid">

--- a/examples_src/teleport.html
+++ b/examples_src/teleport.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Teleport example"
-shortdesc: "Example of moving a map from one target to another."
+template: example.html
+title: Teleport example
+shortdesc: Example of moving a map from one target to another.
 docs: >
   <p>Click on the Teleport button below the map to move the map from one target to another.</p>
 tags: "teleport, openstreetmap"

--- a/examples_src/tile-load-events.html
+++ b/examples_src/tile-load-events.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Tile load events example"
-shortdesc: "Example using tile load events."
+template: example.html
+title: Tile load events example
+shortdesc: Example using tile load events.
 docs: >
   Image tile sources fire events related to tile loading.  You can
   listen for <code>tileloadstart</code>, <code>tileloadend</code>,

--- a/examples_src/tile-vector.html
+++ b/examples_src/tile-vector.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Tile vector example"
-shortdesc: "Example of vector tiles from openstreetmap.us."
+template: example.html
+title: Tile vector example
+shortdesc: Example of vector tiles from openstreetmap.us.
 docs: >
   Example of vector tiles from openstreetmap.us.
 tags: "custom, control"

--- a/examples_src/tilejson.html
+++ b/examples_src/tilejson.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "TileJSON example"
-shortdesc: "Example of a TileJSON layer."
+template: example.html
+title: TileJSON example
+shortdesc: Example of a TileJSON layer.
 docs: >
   Example of a TileJSON layer.
 tags: "tilejson"

--- a/examples_src/tileutfgrid.html
+++ b/examples_src/tileutfgrid.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "TileUTFGrid example"
-shortdesc: "This example shows how to read data from a TileUTFGrid layer."
+template: example.html
+title: TileUTFGrid example
+shortdesc: This example shows how to read data from a TileUTFGrid layer.
 docs: >
   <p>Point to a country to see its name and flag.</p>
   Tiles made with [TileMill](http://tilemill.com). Hosting on MapBox.com or with open-source [TileServer](https://github.com/klokantech/tileserver-php/).

--- a/examples_src/tissot.html
+++ b/examples_src/tissot.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Tissot indicatrix example"
-shortdesc: "Draw Tissot's indicatrices on maps."
+template: example.html
+title: Tissot indicatrix example
+shortdesc: Draw Tissot's indicatrices on maps.
 docs: >
   Example of [Tissot indicatrix](http://en.wikipedia.org/wiki/Tissot's_indicatrix)</a> maps. The map on the left is an EPSG:4326 map. The one on the right is EPSG:3857.
 tags: "tissot, circle"

--- a/examples_src/topojson.html
+++ b/examples_src/topojson.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "TopoJSON example"
-shortdesc: "Demonstrates rendering of features from a TopoJSON topology."
+template: example.html
+title: TopoJSON example
+shortdesc: Demonstrates rendering of features from a TopoJSON topology.
 docs: >
   This example uses a vector layer with a `ol.source.TopoJSON` for rendering features from [TopoJSON](https://github.com/mbostock/topojson/wiki).
 tags: "topojson, vector, style"

--- a/examples_src/vector-labels.html
+++ b/examples_src/vector-labels.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Vector labels example"
-shortdesc: "Example of GeoJSON features with labels."
+template: example.html
+title: Vector labels example
+shortdesc: Example of GeoJSON features with labels.
 docs: >
   **Note:** The 'Text/Wrap' option is currently not working properly. This is because ol3 uses Canvas's strokeText and fillText functions that do not support text wrapping.
 tags: "geojson, vector, openstreetmap, label"

--- a/examples_src/vector-layer.html
+++ b/examples_src/vector-layer.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Vector layer example"
-shortdesc: "Example of a countries vector layer with country information."
+template: example.html
+title: Vector layer example
+shortdesc: Example of a countries vector layer with country information.
 docs: >
   The countries are loaded from a GeoJSON file. Information about countries is shown on hover and click. Zoom in a few times to see country name labels.
 tags: "vector, osm, xml, loading, server"

--- a/examples_src/vector-osm.html
+++ b/examples_src/vector-osm.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "OSM XML example"
-shortdesc: "Example of using the OSM XML source."
+template: example.html
+title: OSM XML example
+shortdesc: Example of using the OSM XML source.
 docs: >
  OSM XML vector data is loaded dynamically from a server using a tiling strategy.
 tags: "vector, osm, xml, loading, server"

--- a/examples_src/vector-wfs.html
+++ b/examples_src/vector-wfs.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "WFS example"
-shortdesc: "Example of using WFS with a BBOX strategy."
+template: example.html
+title: WFS example
+shortdesc: Example of using WFS with a BBOX strategy.
 docs: >
   This example loads new features from GeoServer WFS when the view extent changes.
 tags: "vector, WFS, bbox, loading, server"

--- a/examples_src/wkt.html
+++ b/examples_src/wkt.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "WKT example"
-shortdesc: "Example of using the WKT parser."
+template: example.html
+title: WKT example
+shortdesc: Example of using the WKT parser.
 docs: >
   Create features from geometries in WKT (Well Known Text) format.
 tags: "wkt, well known text"

--- a/examples_src/wms-capabilities.html
+++ b/examples_src/wms-capabilities.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "WMS GetCapabilities parsing example"
-shortdesc: "Example of parsing a WMS GetCapabilities response."
+template: example.html
+title: WMS GetCapabilities parsing example
+shortdesc: Example of parsing a WMS GetCapabilities response.
 docs: >
   This example shows the contents of the result object from parsing a WMS capabilities response.
 tags: "wms, capabilities, getcapabilities"

--- a/examples_src/wms-custom-proj.html
+++ b/examples_src/wms-custom-proj.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Tiled WMS with custom projection example"
-shortdesc: "Example of using custom coordinate transform functions."
+template: example.html
+title: Tiled WMS with custom projection example
+shortdesc: Example of using custom coordinate transform functions.
 docs: >
   With `ol.proj.addCoordinateTransforms()`, custom coordinate transform functions can be added to configured projections.
 tags: "wms, tile, tilelayer, projection"

--- a/examples_src/wms-image-custom-proj.html
+++ b/examples_src/wms-image-custom-proj.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Single image WMS with Proj4js projection example"
-shortdesc: "Example of integrating Proj4js for coordinate transforms."
+template: example.html
+title: Single image WMS with Proj4js projection example
+shortdesc: Example of integrating Proj4js for coordinate transforms.
 docs: >
   With transparent [Proj4js](http://proj4js.org/) integration, OpenLayers can transform coordinates between arbitrary projections.
 tags: "wms, single image, proj4js, projection"

--- a/examples_src/wms-image.html
+++ b/examples_src/wms-image.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Single image WMS example"
-shortdesc: "Example of a single image WMS layer."
+template: example.html
+title: Single image WMS example
+shortdesc: Example of a single image WMS layer.
 docs: >
   WMS can be used as an Image layer, as shown here, or as a Tile layer, as shown in the [Tiled WMS example](wms-tiled.html) example. Tiles can be cached, so the browser will not re-fetch data for areas that were viewed already. But there may be problems with repeated labels for WMS servers that are not aware of tiles, in which case single image WMS will produce better cartography.
 tags: "wms, image"

--- a/examples_src/wms-no-proj.html
+++ b/examples_src/wms-no-proj.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "WMS without client projection example"
-shortdesc: "Example of two WMS layers using the projection EPSG:21781, which is unknown to the client."
+template: example.html
+title: WMS without client projection example
+shortdesc: Example of two WMS layers using the projection EPSG:21781, which is unknown to the client.
 docs: >
   As long as no coordinate transformations are required, OpenLayers 3 works fine with projections that are only configured with a `code` and `units`.
 tags: "wms, projection"

--- a/examples_src/wms-tiled-wrap-180.html
+++ b/examples_src/wms-tiled-wrap-180.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Tiled WMS wrap 180° meridian example"
-shortdesc: "Example of a tiled WMS layer that wraps across the 180° meridian."
+template: example.html
+title: Tiled WMS wrap 180° meridian example
+shortdesc: Example of a tiled WMS layer that wraps across the 180° meridian.
 docs: >
   The `wrapX` option is set to `true` here so tiles will be wrapped around the x-axis.
 tags: "wms, tile, dateline, wrap, 180"

--- a/examples_src/wms-tiled.html
+++ b/examples_src/wms-tiled.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Tiled WMS example"
-shortdesc: "Example of a tiled WMS layer."
+template: example.html
+title: Tiled WMS example
+shortdesc: Example of a tiled WMS layer.
 docs: >
   WMS can be used as a Tile layer, as shown here, or as an Image layer, as shown in the [Single Image WMS example](wms-image.html) example. Tiles can be cached, so the browser will not re-fetch data for areas that were viewed already. But there may be problems with repeated labels for WMS servers that are not aware of tiles, in which case single image WMS will produce better cartography.
 tags: "wms, tile, tilelayer"

--- a/examples_src/wmts-capabilities.html
+++ b/examples_src/wmts-capabilities.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "WMTS GetCapabilities parsing example"
-shortdesc: "Example of parsing a WMTS GetCapabilities response."
+template: example.html
+title: WMTS GetCapabilities parsing example
+shortdesc: Example of parsing a WMTS GetCapabilities response.
 docs: >
   This example shows the contents of the result object from parsing a WMTS capabilities response.
 tags: "wmts, capabilities, getcapabilities"

--- a/examples_src/wmts-hidpi.html
+++ b/examples_src/wmts-hidpi.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "WMTS HiDPI example"
-shortdesc: "Example of a WMTS based HiDPI layer."
+template: example.html
+title: WMTS HiDPI example
+shortdesc: Example of a WMTS based HiDPI layer.
 docs: >
   The WMTS source has a `tilePixelRatio` option. A HiDPI capable WMTS could provide tiles with 512x512 pixel tiles, but use them in a 256x256 pixel tile grid. In this case `tilePixelRatio` needs to be set to `2`.
 tags: "hidpi, retina, wmts"

--- a/examples_src/wmts-layer-from-capabilities.html
+++ b/examples_src/wmts-layer-from-capabilities.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "WMTS Layer from capabilities example"
-shortdesc: "Example of a WMTS source created from a WMTS capabilities document."
+template: example.html
+title: WMTS Layer from capabilities example
+shortdesc: Example of a WMTS source created from a WMTS capabilities document.
 docs: >
   This example shows how to create the configuration for accessing a WMTS from a GetCapabilities response.. The [WMTS example](wmts.html) shows how to create the configuration manually.
 tags: "wmts, capabilities, getcapabilities"

--- a/examples_src/wmts.html
+++ b/examples_src/wmts.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "WMTS example"
-shortdesc: "Example of a WMTS source."
+template: example.html
+title: WMTS example
+shortdesc: Example of a WMTS source.
 docs: >
   This example shows how to manually create the configuration for accessing a WMTS. The [WMTS Layer from capabilities example](wmts-layer-from-capabilities.html) shows how to create the configuration from a GetCapabilities response.
 tags: "wmts"

--- a/examples_src/xyz-esri-4326-512.html
+++ b/examples_src/xyz-esri-4326-512.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "XYZ Esri EPSG:4326 tileSize 512 example"
-shortdesc: "Example of a XYZ source in EPSG:4326 using Esri 512x512 tiles."
+template: example.html
+title: XYZ Esri EPSG:4326 tileSize 512 example
+shortdesc: Example of a XYZ source in EPSG:4326 using Esri 512x512 tiles.
 docs: >
   ArcGIS REST tile services with custom tile sizes (here: 512x512 pixels) and projection (here: EPSG:4326) are supported by `ol.source.XYZ`. A custom tile grid and tile url function are required.
 tags: "xyz, esri, tilesize, custom projection"

--- a/examples_src/xyz-esri.html
+++ b/examples_src/xyz-esri.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "XYZ Esri example"
-shortdesc: "Example of a XYZ source using Esri tiles."
+template: example.html
+title: XYZ Esri example
+shortdesc: Example of a XYZ source using Esri tiles.
 docs: >
   ArcGIS REST tile services are supported by `ol.source.XYZ`.
 tags: "xyz, esri, arcgis rest"

--- a/examples_src/xyz-retina.html
+++ b/examples_src/xyz-retina.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "XYZ Retina tiles example"
-shortdesc: "Example of Retina / HiDPI mercator tiles (512x512px) available as XYZ."
+template: example.html
+title: XYZ Retina tiles example
+shortdesc: Example of Retina / HiDPI mercator tiles (512x512px) available as XYZ.
 docs: >
   The ol.source.XYZ must contain `tilePixelRatio` parameter. The tiles were prepared from a GeoTIFF file with [MapTiler](http://www.maptiler.com/).
 tags: "retina, hidpi, xyz, maptiler, @2x, devicePixelRatio"

--- a/examples_src/xyz.html
+++ b/examples_src/xyz.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "XYZ Example"
-shortdesc: "Example of a XYZ source."
+template: example.html
+title: XYZ Example
+shortdesc: Example of a XYZ source.
 docs: >
   The XYZ source is used for tile data that is accessed through URLs that include a zoom level and tile grid x/y coordinates.
 tags: "xyz"

--- a/examples_src/zoom-constrained.html
+++ b/examples_src/zoom-constrained.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Zoom Constrained Example"
-shortdesc: "Example of a zoom constrained view."
+template: example.html
+title: Zoom Constrained Example
+shortdesc: Example of a zoom constrained view.
 docs: >
   This map has a view that is constrained between zoom levels 9 and 13.  This is done using the `minZoom` and `maxZoom` view options.
 tags: "bing, zoom, minZoom, maxZoom"

--- a/examples_src/zoomify.html
+++ b/examples_src/zoomify.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Zoomify example"
-shortdesc: "Example of a Zoomify source."
+template: example.html
+title: Zoomify example
+shortdesc: Example of a Zoomify source.
 docs: >
   Zoomify is a format for deep-zooming into high resolution images. This example shows how to use the Zoomify source with a pixel projection.
 tags: "zoomify, deep zoom, pixel, projection"

--- a/examples_src/zoomslider.html
+++ b/examples_src/zoomslider.html
@@ -1,7 +1,7 @@
 ---
-template: "example.html"
-title: "Zoom slider example"
-shortdesc: "Example of various ZoomSlider controls."
+template: example.html
+title: Zoom slider example
+shortdesc: Example of various ZoomSlider controls.
 docs: >
   This example shows how to add a zoom slider to a map and how to customize it.
 tags: "zoom, zoomslider, slider, style, styling, css, control"

--- a/tasks/.jshintrc
+++ b/tasks/.jshintrc
@@ -10,10 +10,12 @@
   "trailing": true,
   "maxlen": 80,
   "globals": {
+    "Buffer": false,
     "__dirname": false,
     "exports": true,
     "module": false,
     "process": false,
-    "require": false
+    "require": false,
+    "setImmediate": false
   }
 }

--- a/tasks/build-examples.js
+++ b/tasks/build-examples.js
@@ -77,7 +77,7 @@ function augmentExamples(files, metalsmith, done) {
                 resource + ' is not .js or .css: ' + filename);
           }
         }
-        file.extra_head = resources.join('\n');
+        file.extraHead = resources.join('\n');
       }
     }
   }
@@ -88,7 +88,7 @@ function main(callback) {
       .source(srcDir)
       .destination(destDir)
       .metadata({
-        'ol_version': pkg.version
+        olVersion: pkg.version
       })
       .use(augmentExamples)
       .use(templates({

--- a/tasks/build-examples.js
+++ b/tasks/build-examples.js
@@ -66,7 +66,7 @@ function augmentExamples(files, metalsmith, done) {
       // add additional resources
       if (file.resources) {
         var resources = [];
-        for (var i = file.resources.length - 1; i >= 0; --i) {
+        for (var i = 0, ii = file.resources.length; i < ii; ++i) {
           var resource = file.resources[i];
           if (isJsRegEx.test(resource)) {
             resources[i] = '<script src="' + resource + '"></script>';

--- a/tasks/build-examples.js
+++ b/tasks/build-examples.js
@@ -1,4 +1,5 @@
 /*global Buffer */
+var path = require('path');
 
 var Metalsmith = require('metalsmith');
 var templates = require('metalsmith-templates');
@@ -10,6 +11,10 @@ var fileRegEx = /([^\/^\.]*)\.html$/;
 var cleanupJSRegEx = /.*(goog\.require(.*);|.*renderer: exampleNS\..*,?)[\n]*/g;
 var isCssRegEx = /\.css$/;
 var isJsRegEx = /\.js$/;
+
+var srcDir = path.join(__dirname, '..', 'examples_src');
+var destDir = path.join(__dirname, '..', 'examples');
+var templatesDir = path.join(__dirname, '..', 'config', 'examples');
 
 function main(callback) {
 
@@ -30,10 +35,9 @@ function main(callback) {
           file.ol_version = pjson.version;
           file.js_resource = '<script src="loader.js?id=' + match[1] +
               '"></script>';
-          var js = fs.readFileSync(__dirname + '/../examples_src/' +
-              match[1] + '.js', 'utf8');
+          var js = fs.readFileSync(path.join(srcDir, match[1] + '.js'), 'utf8');
           file.js_inline = js.replace(cleanupJSRegEx, '');
-          var cssFile = __dirname + '/../examples_src/' + match[1] + '.css';
+          var cssFile = path.join(srcDir, match[1] + '.css');
           if (fs.existsSync(cssFile)) {
             file.css_resource = '<link rel="stylesheet" href="' + match[1] +
                 '.css">';
@@ -65,12 +69,12 @@ function main(callback) {
 
 
   new Metalsmith('.')
-      .source('examples_src')
-      .destination('examples')
+      .source(srcDir)
+      .destination(destDir)
       .use(build)
       .use(templates({
         engine: 'handlebars',
-        directory: 'config/examples'
+        directory: templatesDir
       }))
       .build(function(err) {
         callback(err);

--- a/tasks/build-examples.js
+++ b/tasks/build-examples.js
@@ -1,6 +1,7 @@
 var path = require('path');
 
 var Metalsmith = require('metalsmith');
+var handlebars = require('handlebars');
 var templates = require('metalsmith-templates');
 var marked = require('marked');
 var pkg = require('../package.json');
@@ -39,9 +40,6 @@ function augmentExamples(files, metalsmith, done) {
         throw new Error(filename + ': Missing template in YAML front-matter');
       }
       var id = match[1];
-      if (file.docs) {
-        file.docs = marked(file.docs);
-      }
 
       // add js tag and source
       var jsFilename = id + '.js';
@@ -93,7 +91,12 @@ function main(callback) {
       .use(augmentExamples)
       .use(templates({
         engine: 'handlebars',
-        directory: templatesDir
+        directory: templatesDir,
+        helpers: {
+          md: function(str) {
+            return new handlebars.SafeString(marked(str));
+          }
+        }
       }))
       .build(function(err) {
         callback(err);

--- a/tasks/build-examples.js
+++ b/tasks/build-examples.js
@@ -5,7 +5,7 @@ var Metalsmith = require('metalsmith');
 var templates = require('metalsmith-templates');
 var marked = require('marked');
 var fs = require('fs');
-var pjson = require('../package.json');
+var pkg = require('../package.json');
 
 var fileRegEx = /([^\/^\.]*)\.html$/;
 var cleanupJSRegEx = /.*(goog\.require(.*);|.*renderer: exampleNS\..*,?)[\n]*/g;
@@ -32,7 +32,6 @@ function main(callback) {
             str = marked(file.contents.toString());
             file.contents = new Buffer(str);
           }
-          file.ol_version = pjson.version;
           file.js_resource = '<script src="loader.js?id=' + match[1] +
               '"></script>';
           var js = fs.readFileSync(path.join(srcDir, match[1] + '.js'), 'utf8');
@@ -71,6 +70,9 @@ function main(callback) {
   new Metalsmith('.')
       .source(srcDir)
       .destination(destDir)
+      .metadata({
+        'ol_version': pkg.version
+      })
       .use(build)
       .use(templates({
         engine: 'handlebars',

--- a/tasks/build-examples.js
+++ b/tasks/build-examples.js
@@ -4,7 +4,6 @@ var path = require('path');
 var Metalsmith = require('metalsmith');
 var templates = require('metalsmith-templates');
 var marked = require('marked');
-var fs = require('fs');
 var pkg = require('../package.json');
 
 var fileRegEx = /([^\/^\.]*)\.html$/;
@@ -34,13 +33,13 @@ function main(callback) {
           }
           file.js_resource = '<script src="loader.js?id=' + match[1] +
               '"></script>';
-          var js = fs.readFileSync(path.join(srcDir, match[1] + '.js'), 'utf8');
+          var js = files[match[1] + '.js'].contents.toString();
           file.js_inline = js.replace(cleanupJSRegEx, '');
-          var cssFile = path.join(srcDir, match[1] + '.css');
-          if (fs.existsSync(cssFile)) {
-            file.css_resource = '<link rel="stylesheet" href="' + match[1] +
-                '.css">';
-            file.css_inline = fs.readFileSync(cssFile, 'utf-8');
+          var cssFilename = match[1] + '.css';
+          if (cssFilename in files) {
+            file.css_resource = '<link rel="stylesheet" href="' + cssFilename +
+                '">';
+            file.css_inline = files[cssFilename].contents.toString();
           }
           if (file.resources) {
             var resources = file.resources.split(',');
@@ -59,7 +58,7 @@ function main(callback) {
               file.resources = resources.join('\n');
             }
           }
-        } else if (f !== 'index.html'){
+        } else if (f !== 'index.html') {
           callback(new Error(f + ': Invalid YAML front-matter.'));
         }
       }

--- a/tasks/build-examples.js
+++ b/tasks/build-examples.js
@@ -70,22 +70,21 @@ function augmentExamples(files, metalsmith, done) {
 
       // add additional resources
       if (file.resources) {
-        var resources = file.resources.split(',');
-        var resource;
-        for (var i = resources.length - 1; i >= 0; --i) {
-          resource = resources[i];
+        var resources = [];
+        for (var i = file.resources.length - 1; i >= 0; --i) {
+          var resource = file.resources[i];
           if (isJsRegEx.test(resource)) {
             resources[i] = '<script src="' + resource + '"></script>';
           } else if (isCssRegEx.test(resource)) {
             resources[i] = '<link rel="stylesheet" href="' + resource +
                 '">';
           } else {
-            done(new Error('Invalid value for "resource": ' +
-                resource + 'is not .js or .css: ' + filename));
+            done(new Error('Invalid value for resource: ' +
+                resource + ' is not .js or .css: ' + filename));
             return;
           }
-          file.resources = resources.join('\n');
         }
+        file.extra_head = resources.join('\n');
       }
     }
   }


### PR DESCRIPTION
This is a minor reworking of the `build-examples.js` task.  The changes here avoid reading all CSS and JS files twice, refactor the plugin a bit, and change things to use YAML lists for resources instead of comma delimited strings.

I'm in the process of changing the tasks related to building examples, I'd like to merge in this minor change to the task before going further.
