### PR TITLE
Dispatch change event even when geometry is set to null

### DIFF
--- a/src/ol/feature.js
+++ b/src/ol/feature.js
@@ -218,8 +218,8 @@ ol.Feature.prototype.handleGeometryChanged_ = function() {
   if (goog.isDefAndNotNull(geometry)) {
     this.geometryChangeKey_ = goog.events.listen(geometry,
         goog.events.EventType.CHANGE, this.handleGeometryChange_, false, this);
-    this.changed();
   }
+  this.changed();
 };
 
 

--- a/test/spec/ol/feature.test.js
+++ b/test/spec/ol/feature.test.js
@@ -416,6 +416,19 @@ describe('ol.Feature', function() {
     });
   });
 
+  describe('#setGeometry()', function() {
+
+    it('dispatches a change event when geometry is set to null',
+        function() {
+          var feature = new ol.Feature({
+            geometry: new ol.geom.Point([0, 0])
+          });
+          var spy = sinon.spy();
+          feature.on('change', spy);
+          feature.setGeometry(null);
+          expect(spy.callCount).to.be(1);
+        });
+  });
 
 });
 


### PR DESCRIPTION
This pull request aims to fix an issue where I was setting geometry to null for a feature and that feature still being displayed on map.

Please review.