### PR TITLE
Remove layerGroup.setLayers(null) test

### DIFF
--- a/test/spec/ol/layer/layergroup.test.js
+++ b/test/spec/ol/layer/layergroup.test.js
@@ -341,9 +341,6 @@ describe('ol.layer.Group', function() {
       layerGroup.setLayers(layers);
       expect(layerGroup.getLayers()).to.be(layers);
 
-      layerGroup.setLayers(null);
-      expect(layerGroup.getLayers()).to.be(null);
-
       goog.dispose(layerGroup);
       goog.dispose(layer);
       goog.dispose(layers);


### PR DESCRIPTION
Since 96f7d6323a, the `layers` parameter to `ol.layer.Group#setLayers` can't be `null`.