### PR TITLE
Add tests for previously untested classes

### DIFF
--- a/test/spec/ol/binary.test.js
+++ b/test/spec/ol/binary.test.js
@@ -1,0 +1,16 @@
+goog.provide('ol.test.buffer');
+
+describe('ol.binary.Buffer', function() {
+
+  describe('constructor', function() {
+
+    it('can be constructed without arguments', function() {
+      var instance = new ol.binary.Buffer();
+      expect(instance).to.be.an(ol.binary.Buffer);
+    });
+
+  });
+
+});
+
+goog.require('ol.binary.Buffer');

--- a/test/spec/ol/control/fullscreencontrol.test.js
+++ b/test/spec/ol/control/fullscreencontrol.test.js
@@ -1,0 +1,16 @@
+goog.provide('ol.test.control.FullScreen');
+
+describe('ol.control.FullScreen', function() {
+
+  describe('constructor', function() {
+
+    it('can be constructed without arguments', function() {
+      var instance = new ol.control.FullScreen();
+      expect(instance).to.be.an(ol.control.FullScreen);
+    });
+
+  });
+
+});
+
+goog.require('ol.control.FullScreen');

--- a/test/spec/ol/control/mousepositioncontrol.test.js
+++ b/test/spec/ol/control/mousepositioncontrol.test.js
@@ -1,0 +1,16 @@
+goog.provide('ol.test.control.MousePosition');
+
+describe('ol.control.MousePosition', function() {
+
+  describe('constructor', function() {
+
+    it('can be constructed without arguments', function() {
+      var instance = new ol.control.MousePosition();
+      expect(instance).to.be.an(ol.control.MousePosition);
+    });
+
+  });
+
+});
+
+goog.require('ol.control.MousePosition');

--- a/test/spec/ol/control/scalelinecontrol.test.js
+++ b/test/spec/ol/control/scalelinecontrol.test.js
@@ -1,0 +1,16 @@
+goog.provide('ol.test.control.ScaleLine');
+
+describe('ol.control.ScaleLine', function() {
+
+  describe('constructor', function() {
+
+    it('can be constructed without arguments', function() {
+      var instance = new ol.control.ScaleLine();
+      expect(instance).to.be.an(ol.control.ScaleLine);
+    });
+
+  });
+
+});
+
+goog.require('ol.control.ScaleLine');

--- a/test/spec/ol/control/zoomtoextentcontrol.test.js
+++ b/test/spec/ol/control/zoomtoextentcontrol.test.js
@@ -1,0 +1,16 @@
+goog.provide('ol.test.control.ZoomToExtent');
+
+describe('ol.control.ZoomToExtent', function() {
+
+  describe('constructor', function() {
+
+    it('can be constructed without arguments', function() {
+      var instance = new ol.control.ZoomToExtent();
+      expect(instance).to.be.an(ol.control.ZoomToExtent);
+    });
+
+  });
+
+});
+
+goog.require('ol.control.ZoomToExtent');

--- a/test/spec/ol/deviceorientation.test.js
+++ b/test/spec/ol/deviceorientation.test.js
@@ -1,0 +1,16 @@
+goog.provide('ol.test.DeviceOrientation');
+
+describe('ol.DeviceOrientation', function() {
+
+  describe('constructor', function() {
+
+    it('can be constructed without arguments', function() {
+      var instance = new ol.DeviceOrientation();
+      expect(instance).to.be.an(ol.DeviceOrientation);
+    });
+
+  });
+
+});
+
+goog.require('ol.DeviceOrientation');

--- a/test/spec/ol/format/binaryfeatureformat.test.js
+++ b/test/spec/ol/format/binaryfeatureformat.test.js
@@ -1,0 +1,16 @@
+goog.provide('ol.test.format.BinaryFeature');
+
+describe('ol.format.BinaryFeature', function() {
+
+  describe('constructor', function() {
+
+    it('can be constructed without arguments', function() {
+      var instance = new ol.format.BinaryFeature();
+      expect(instance).to.be.an(ol.format.BinaryFeature);
+    });
+
+  });
+
+});
+
+goog.require('ol.format.BinaryFeature');

--- a/test/spec/ol/geolocation.test.js
+++ b/test/spec/ol/geolocation.test.js
@@ -1,0 +1,16 @@
+goog.provide('ol.test.Geolocation');
+
+describe('ol.Geolocation', function() {
+
+  describe('constructor', function() {
+
+    it('can be constructed without arguments', function() {
+      var instance = new ol.Geolocation();
+      expect(instance).to.be.an(ol.Geolocation);
+    });
+
+  });
+
+});
+
+goog.require('ol.Geolocation');

--- a/test/spec/ol/imageurlfunction.test.js
+++ b/test/spec/ol/imageurlfunction.test.js
@@ -1,0 +1,101 @@
+goog.provide('ol.test.ImageUrlFunction');
+
+describe('ol.ImageUrlFunction', function() {
+
+  describe('#createFromParamsFunction', function() {
+
+    it('is a defined function', function() {
+      expect(ol.ImageUrlFunction.createFromParamsFunction).to.not.be(undefined);
+      expect(ol.ImageUrlFunction.createFromParamsFunction).to.be.a(Function);
+    });
+
+    it('returns a function that throws when called (no arguments)', function() {
+      var got = ol.ImageUrlFunction.createFromParamsFunction();
+      expect(function() {
+        got();
+      }).to.throwException();
+    });
+
+    it('returns a function that doesn\'t throw when called (valid arguments)',
+        function() {
+          var baseUrl = 'foo',
+              params = {foo: 'bar'},
+              paramsFunction = sinon.spy(),
+              got = ol.ImageUrlFunction.createFromParamsFunction(baseUrl,
+                  params, paramsFunction);
+
+          expect(function() {
+            got();
+          }).to.not.throwException();
+        }
+    );
+
+    it('passes given baseUrl to given paramsFunction', function() {
+      var baseUrl = 'foo',
+          params = {foo: 'bar'},
+          spy = sinon.spy(),
+          got = ol.ImageUrlFunction.createFromParamsFunction(baseUrl, params,
+              spy);
+
+      got();
+
+      expect(spy.called).to.be(true);
+      expect(spy.calledOnce).to.be(true);
+      expect(spy.calledWith(baseUrl)).to.be(true);
+    });
+
+    it('passes given params to given paramsFunction', function() {
+      var baseUrl = 'foo',
+          params = {foo: 'bar'},
+          spy = sinon.spy(),
+          got = ol.ImageUrlFunction.createFromParamsFunction(baseUrl, params,
+              spy);
+
+      got();
+
+      expect(spy.called).to.be(true);
+      expect(spy.calledOnce).to.be(true);
+      expect(spy.calledWith(baseUrl, params)).to.be(true);
+    });
+
+    it('passes five params to given paramsFunction', function() {
+      var baseUrl = 'foo',
+          params = {foo: 'bar'},
+          extent = [1, 2, 3, 4],
+          size = [47, 11],
+          projection = ol.proj.get('CRS:84'),
+          spy = sinon.spy(),
+          firstArgs,
+          got = ol.ImageUrlFunction.createFromParamsFunction(baseUrl, params,
+              spy);
+
+      got(extent, size, projection);
+      firstArgs = spy.args[0];
+
+      expect(spy.called).to.be(true);
+      expect(spy.calledOnce).to.be(true);
+
+      expect(firstArgs.length).to.be(5);
+      expect(firstArgs).to.eql([baseUrl, params, extent, size, projection]);
+    });
+
+  });
+
+  describe('#nullImageUrlFunction', function() {
+
+    it('is a defined function', function() {
+      expect(ol.ImageUrlFunction.nullImageUrlFunction).to.not.be(undefined);
+      expect(ol.ImageUrlFunction.nullImageUrlFunction).to.be.a(Function);
+    });
+
+    it('always returns undefined', function() {
+      var got = ol.ImageUrlFunction.nullImageUrlFunction();
+      expect(got).to.be(undefined);
+    });
+
+  });
+
+});
+
+goog.require('ol.proj');
+goog.require('ol.ImageUrlFunction');

--- a/test/spec/ol/interaction/draganddropinteraction.test.js
+++ b/test/spec/ol/interaction/draganddropinteraction.test.js
@@ -1,0 +1,16 @@
+goog.provide('ol.test.interaction.DragAndDrop');
+
+describe('ol.interaction.DragAndDrop', function() {
+
+  describe('constructor', function() {
+
+    it('can be constructed without arguments', function() {
+      var instance = new ol.interaction.DragAndDrop();
+      expect(instance).to.be.an(ol.interaction.DragAndDrop);
+    });
+
+  });
+
+});
+
+goog.require('ol.interaction.DragAndDrop');

--- a/test/spec/ol/interaction/dragrotateandzoominteraction.test.js
+++ b/test/spec/ol/interaction/dragrotateandzoominteraction.test.js
@@ -1,0 +1,16 @@
+goog.provide('ol.test.interaction.DragRotateAndZoom');
+
+describe('ol.interaction.DragRotateAndZoom', function() {
+
+  describe('constructor', function() {
+
+    it('can be constructed without arguments', function() {
+      var instance = new ol.interaction.DragRotateAndZoom();
+      expect(instance).to.be.an(ol.interaction.DragRotateAndZoom);
+    });
+
+  });
+
+});
+
+goog.require('ol.interaction.DragRotateAndZoom');

--- a/test/spec/ol/interaction/snapinteraction.test.js
+++ b/test/spec/ol/interaction/snapinteraction.test.js
@@ -1,0 +1,16 @@
+goog.provide('ol.test.interaction.Snap');
+
+describe('ol.interaction.Snap', function() {
+
+  describe('constructor', function() {
+
+    it('can be constructed without arguments', function() {
+      var instance = new ol.interaction.Snap();
+      expect(instance).to.be.an(ol.interaction.Snap);
+    });
+
+  });
+
+});
+
+goog.require('ol.interaction.Snap');

--- a/test/spec/ol/layer/heatmaplayer.test.js
+++ b/test/spec/ol/layer/heatmaplayer.test.js
@@ -1,0 +1,16 @@
+goog.provide('ol.test.layer.Heatmap');
+
+describe('ol.layer.Heatmap', function() {
+
+  describe('constructor', function() {
+
+    it('can be constructed without arguments', function() {
+      var instance = new ol.layer.Heatmap();
+      expect(instance).to.be.an(ol.layer.Heatmap);
+    });
+
+  });
+
+});
+
+goog.require('ol.layer.Heatmap');

--- a/test/spec/ol/overlay.test.js
+++ b/test/spec/ol/overlay.test.js
@@ -1,0 +1,16 @@
+goog.provide('ol.test.Overlay');
+
+describe('ol.Overlay', function() {
+
+  describe('constructor', function() {
+
+    it('can be constructed with minimal arguments', function() {
+      var instance = new ol.Overlay({});
+      expect(instance).to.be.an(ol.Overlay);
+    });
+
+  });
+
+});
+
+goog.require('ol.Overlay');

--- a/test/spec/ol/tilegrid/zoomifytilegrid.test.js
+++ b/test/spec/ol/tilegrid/zoomifytilegrid.test.js
@@ -1,0 +1,21 @@
+goog.provide('ol.test.tilegrid.Zoomify');
+
+describe('ol.tilegrid.Zoomify', function() {
+
+  describe('constructor', function() {
+
+    it('can be constructed with minimal arguments', function() {
+      var instance = new ol.tilegrid.Zoomify({
+        resolutions: [],
+        extent: [],
+        origin: [],
+        tileSize: []
+      });
+      expect(instance).to.be.an(ol.tilegrid.Zoomify);
+    });
+
+  });
+
+});
+
+goog.require('ol.tilegrid.Zoomify');


### PR DESCRIPTION
Since #3470 we know that certain files do not have any tests at all, and are not all tested as side-effect of other tests (#3514 lists them all).

This pull request contains basic tests for all files not previously covered by tests; most of the time we simply test whether an instance can be constructed with minimal arguments. Commit fbc940c is an exception, it basically tests everything that `ol.ImageUrlFunction` has to offer.

#3514 lists more files than are included here, I left out all `ol.source.*` as they were refactored in #3481.

Included is a commit testing the basics of `ol.format.BinaryFeature`, for which there is an open PR (#3516) that will remove that particular class. I can easily remove the commit for that class as it may seem useless.

I think it makes sense to have these tests in `master`, even though #3518 suggests a different approach to have a more reliable coverage info.

It is very likely that test coverage goes down, as now more sources are included in the report, while mostly basic tests have been added.

Please review.

Closes #3514