### PR TITLE
Include all source files in coverage

### DIFF
--- a/build.py
+++ b/build.py
@@ -247,7 +247,7 @@ def build_requires(task):
             f.write('goog.require(\'%s\');\n' % (require,))
 
 
-@target('build/test_requires.js', SPEC)
+@target('build/test_requires.js', SPEC, SRC)
 def build_test_requires(t):
   build_requires(t)
 


### PR DESCRIPTION
After merging #3470 our coverage increased by 4%. This wasn't *caused* by the new rendering tests (which are not included in the coverage), but due to the fact that the file loader used in the tests now only included sources that were required by the tests. Because istanbul only considers files that are loaded, all untested files were not included in the coverage.

This PR aims to fix the issue by loading all source files that have a `goog.provide`.

See also #3517 and #3514