### PR TITLE
PointerEventHandler exception with Overlay containing SVG and IE9

### DIFF
--- a/src/ol/pointer/pointereventhandler.js
+++ b/src/ol/pointer/pointereventhandler.js
@@ -31,6 +31,7 @@
 goog.provide('ol.pointer.PointerEventHandler');
 
 goog.require('goog.array');
+goog.require('goog.dom');
 goog.require('goog.events');
 goog.require('goog.events.BrowserEvent');
 goog.require('goog.events.Event');
@@ -367,7 +368,10 @@ ol.pointer.PointerEventHandler.prototype.enterOver =
  */
 ol.pointer.PointerEventHandler.prototype.contains_ =
     function(container, contained) {
-  return container.contains(contained);
+  if (goog.isNull(contained)) {
+    return false;
+  }
+  return goog.dom.contains(container, contained);
 };
 
 


### PR DESCRIPTION
Using an ol.Overlay as marker I put inside an SVG graphic element. As soon I move the mouse over the SVG the error appear.
In IE9 the SVG Element does not have the contains function so it throws the exception, on the contrary using goog.dom.contains it handles the cross-browser issues.

I wrote something also on the list:
https://groups.google.com/forum/#!topic/ol3-dev/DBi2HCTqulU

This is my first pull request.. I hope to do thinks in the right way..