### PR TITLE
external resources not correctly in inline source of example

### DIFF
--- a/config/examples/example.html
+++ b/config/examples/example.html
@@ -56,7 +56,7 @@
 &lt;script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"&gt;&lt;/script&gt;
 &lt;link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ol3/{{ olVersion }}/ol.css" type="text/css"&gt;
 &lt;script src="https://cdnjs.cloudflare.com/ajax/libs/ol3/{{ olVersion }}/ol.js"&gt;&lt;/script&gt;
-{{ resources }}
+{{ extraHead }}
 {{#if css.source}}
 &lt;style&gt;
 {{ css.source }}


### PR DESCRIPTION
For example:

```
<script src="https://cdnjs.cloudflare.com/ajax/libs/ol3/3.4.0/ol.js"></script>
../resources/terraformer.min.js,../resources/terraformer-arcgis-parser.min.js
</head>
<body>
```

So the script tags are not generated

@tschaub is this related to your recent change by any chance?

I'll investigate later.