### PR TITLE
Update comments about remaining GeoJSON work

### DIFF
--- a/src/ol/format/geojsonformat.js
+++ b/src/ol/format/geojsonformat.js
@@ -1,4 +1,5 @@
-// FIXME reprojection
+// TODO: serialize dataProjection as crs member when writing
+// see https://github.com/openlayers/ol3/issues/2078
 
 goog.provide('ol.format.GeoJSON');
 

--- a/src/ol/format/geojsonformat.js
+++ b/src/ol/format/geojsonformat.js
@@ -1,4 +1,3 @@
-// FIXME coordinate order
 // FIXME reprojection
 
 goog.provide('ol.format.GeoJSON');


### PR DESCRIPTION
We now allow control over coordinate order when serializing GeoJSON but still don't correctly serialize the `crs` member.