### PR TITLE
Write the error stack instead of the error itself

### DIFF
--- a/tasks/test-rendering.js
+++ b/tasks/test-rendering.js
@@ -53,7 +53,7 @@ serve.createServer(function(err, server) {
         if (err) {
           process.stderr.write(
               'Error getting the exit status of SlimerJS' + '\n');
-          process.stderr.write(err);
+          process.stderr.write(err.stack + '\n');
           process.exit(1);
         } else {
           process.exit(data);


### PR DESCRIPTION
`process.stderr.write` takes a `string` instead of an `Error`.

Compare the output on master:
```
ol3 (master)$ node tasks/test-rendering.js 
Error getting the exit status of SlimerJS

net.js:615
    throw new TypeError('invalid data');
          ^
TypeError: invalid data
    at WriteStream.Socket.write (net.js:615:11)
    at WriteStream.stream.write (/Users/tschaub/projects/ol3/node_modules/closure-util/node_modules/npmlog/node_modules/ansi/lib/newlines.js:36:21)
    at /Users/tschaub/projects/ol3/tasks/test-rendering.js:56:26
    at fs.js:208:20
    at Object.oncomplete (fs.js:108:15)
```

And the output on this branch:
```
ol3 (slimer-error)$ node tasks/test-rendering.js 
Error getting the exit status of SlimerJS
Error: ENOENT, open '/Users/tschaub/projects/ol3/build/slimerjs-profile/exitstatus'
```
