### PR TITLE
Automatically add links to API-docs in examples

### DIFF
--- a/config/examples/example.html
+++ b/config/examples/example.html
@@ -33,6 +33,7 @@
           <p id="shortdesc">{{ shortdesc }}</p>
           <div id="docs">{{ md docs }}</div>
           <div id="tags">{{ tags }}</div>
+          <div id="api-links">Related API documentation: {{{ js.apiHtml }}}</div>
         </div>
       </div>
 

--- a/examples/resources/common.js
+++ b/examples/resources/common.js
@@ -10,6 +10,31 @@
     });
   }
 
+  // Check whether links to API-docs of used classes actually point to
+  // existing html-files:
+  $('#api-links a').each(function() {
+    var url = this.href;
+    $.ajax({
+      type: 'HEAD',
+      url: url,
+      context: this,
+      error: function() {
+        // We get into the error if either the resource didn't exist
+        // or if HEAD was not allowed (when serving locally via node)
+        // => remove the <li> and the following comma
+        var li = $(this).parent();
+        var comma = $(li[0].nextSibling);
+        comma.remove();
+        li.remove();
+        // It may be that this was the last <li>, if that's the case,
+        // remove the complete <div>, as we don't have an API-links
+        if ($('#api-links li').length === 0) {
+          $('#api-links').remove();
+        }
+      }
+    });
+  });
+
   if (window.location.host === 'localhost:3000') {
     return;
   }

--- a/examples/resources/layout.css
+++ b/examples/resources/layout.css
@@ -18,6 +18,9 @@ body {
 #tags, #shortdesc, .hidden {
   display: none;
 }
+#api-links ul {
+  display: inline;
+}
 
 body, h1, h2, h3, h4, p, li, td, th {
   font-family: Quattrocento Sans;


### PR DESCRIPTION
When we create the examples, we know exactly which specific `ol.…` symbols
we `goog.require(…)`. We can create links to the API documentation of these
symbols automatically.

![api-links](https://cloud.githubusercontent.com/assets/227934/7126372/f79c8684-e238-11e4-91be-e1ca6289b70b.png)

Please review.