### PR TITLE
Minor TileUTFGrid error fix

### DIFF
--- a/src/ol/source/tileutfgridsource.js
+++ b/src/ol/source/tileutfgridsource.js
@@ -271,7 +271,7 @@ ol.source.TileUTFGridTile_.prototype.getImage = function(opt_context) {
  */
 ol.source.TileUTFGridTile_.prototype.getData = function(coordinate) {
   if (goog.isNull(this.grid_) || goog.isNull(this.keys_) ||
-      goog.isNull(this.data_)) {
+      !goog.isDefAndNotNull(this.data_)) {
     return null;
   }
   var xRelative = (coordinate[0] - this.extent_[0]) /


### PR DESCRIPTION
According to the UTFGrid spec, the `data` field is optional.

The types at https://github.com/openlayers/ol3/blob/master/src/ol/source/tileutfgridsource.js#L252 are correct, but the subsequent type check fails to check for the undefined value (see the diff).
As a result, an exception (`Uncaught TypeError: Cannot read property '' of undefined`) is thrown when accessing UTFGrid tile without the `data` key.

This PR fixes this error.