### PR TITLE
Add wrapX support for vector layers (canvas renderer only)

### DIFF
--- a/examples/draw-features.js
+++ b/examples/draw-features.js
@@ -14,7 +14,7 @@ var raster = new ol.layer.Tile({
   source: new ol.source.MapQuest({layer: 'sat'})
 });
 
-var source = new ol.source.Vector();
+var source = new ol.source.Vector({wrapX: false});
 
 var vector = new ol.layer.Vector({
   source: source,

--- a/examples/modify-features.js
+++ b/examples/modify-features.js
@@ -19,7 +19,8 @@ var raster = new ol.layer.Tile({
 var vector = new ol.layer.Vector({
   source: new ol.source.Vector({
     url: 'data/geojson/countries.geojson',
-    format: new ol.format.GeoJSON()
+    format: new ol.format.GeoJSON(),
+    wrapX: false
   })
 });
 

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -4949,7 +4949,7 @@ olx.source.VectorOptions.prototype.url;
 
 /**
  * Wrap the world horizontally. Default is `true`. For vector editing across the
- * 0° and 180° meridians to work properly, this should be set to `false`. The
+ * -180° and 180° meridians to work properly, this should be set to `false`. The
  * resulting geometry coordinates will then exceed the world bounds.
  * @type {boolean|undefined}
  * @api

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -4877,7 +4877,8 @@ olx.source.TileWMSOptions.prototype.wrapX;
  *     loader: (ol.FeatureLoader|undefined),
  *     logo: (string|olx.LogoOptions|undefined),
  *     strategy: (ol.LoadingStrategy|undefined),
- *     url: (string|undefined)}}
+ *     url: (string|undefined),
+ *     wrapX: (boolean|undefined)}}
  * @api
  */
 olx.source.VectorOptions;
@@ -4944,6 +4945,16 @@ olx.source.VectorOptions.prototype.strategy;
  * @api
  */
 olx.source.VectorOptions.prototype.url;
+
+
+/**
+ * Wrap the world horizontally. Default is `true`. For vector editing across the
+ * 0° and 180° meridians to work properly, this should be set to `false`. The
+ * resulting geometry coordinates will then exceed the world bounds.
+ * @type {boolean|undefined}
+ * @api
+ */
+olx.source.VectorOptions.prototype.wrapX;
 
 
 /**

--- a/src/ol/proj/proj.js
+++ b/src/ol/proj/proj.js
@@ -120,6 +120,9 @@ ol.proj.Projection = function(options) {
    * @type {boolean}
    */
   this.global_ = goog.isDef(options.global) ? options.global : false;
+  if (this.global_) {
+    goog.asserts.assert(!goog.isNull(this.extent_));
+  }
 
   /**
   * @private

--- a/src/ol/proj/proj.js
+++ b/src/ol/proj/proj.js
@@ -120,9 +120,13 @@ ol.proj.Projection = function(options) {
    * @type {boolean}
    */
   this.global_ = goog.isDef(options.global) ? options.global : false;
-  if (this.global_) {
-    goog.asserts.assert(!goog.isNull(this.extent_));
-  }
+
+
+  /**
+   * @private
+   * @type {boolean}
+   */
+  this.canWrapX_ = this.global_ && !goog.isNull(this.extent_);
 
   /**
   * @private
@@ -172,6 +176,14 @@ ol.proj.Projection = function(options) {
     }
   }
 
+};
+
+
+/**
+ * @return {boolean} The projection is suitable for wrapping the x-axis
+ */
+ol.proj.Projection.prototype.canWrapX = function() {
+  return this.canWrapX_;
 };
 
 
@@ -258,6 +270,7 @@ ol.proj.Projection.prototype.isGlobal = function() {
 */
 ol.proj.Projection.prototype.setGlobal = function(global) {
   this.global_ = global;
+  this.canWrapX_ = global && !goog.isNull(this.extent_);
 };
 
 
@@ -284,6 +297,7 @@ ol.proj.Projection.prototype.setDefaultTileGrid = function(tileGrid) {
  */
 ol.proj.Projection.prototype.setExtent = function(extent) {
   this.extent_ = extent;
+  this.canWrapX_ = this.global_ && !goog.isNull(extent);
 };
 
 

--- a/src/ol/renderer/canvas/canvaslayerrenderer.js
+++ b/src/ol/renderer/canvas/canvaslayerrenderer.js
@@ -127,7 +127,7 @@ ol.renderer.canvas.Layer.prototype.dispatchComposeEvent_ =
   var layer = this.getLayer();
   if (layer.hasListener(type)) {
     var transform = goog.isDef(opt_transform) ?
-        opt_transform : this.getTransform(frameState);
+        opt_transform : this.getTransform(frameState, 0);
     var render = new ol.render.canvas.Immediate(
         context, frameState.pixelRatio, frameState.extent, transform,
         frameState.viewState.rotation);
@@ -192,15 +192,14 @@ ol.renderer.canvas.Layer.prototype.getImageTransform = goog.abstractMethod;
 
 /**
  * @param {olx.FrameState} frameState Frame state.
- * @param {number=} opt_offsetX Offset on the x-axis in view coordinates.
+ * @param {number} offsetX Offset on the x-axis in view coordinates.
  * @protected
  * @return {!goog.vec.Mat4.Number} Transform.
  */
 ol.renderer.canvas.Layer.prototype.getTransform =
-    function(frameState, opt_offsetX) {
+    function(frameState, offsetX) {
   var viewState = frameState.viewState;
   var pixelRatio = frameState.pixelRatio;
-  var offsetX = goog.isDef(opt_offsetX) ? opt_offsetX : 0;
   return ol.vec.Mat4.makeTransform2D(this.transform_,
       pixelRatio * frameState.size[0] / 2,
       pixelRatio * frameState.size[1] / 2,

--- a/src/ol/renderer/canvas/canvaslayerrenderer.js
+++ b/src/ol/renderer/canvas/canvaslayerrenderer.js
@@ -192,19 +192,23 @@ ol.renderer.canvas.Layer.prototype.getImageTransform = goog.abstractMethod;
 
 /**
  * @param {olx.FrameState} frameState Frame state.
+ * @param {number=} opt_offsetX Offset on the x-axis in view coordinates.
  * @protected
  * @return {!goog.vec.Mat4.Number} Transform.
  */
-ol.renderer.canvas.Layer.prototype.getTransform = function(frameState) {
+ol.renderer.canvas.Layer.prototype.getTransform =
+    function(frameState, opt_offsetX) {
   var viewState = frameState.viewState;
   var pixelRatio = frameState.pixelRatio;
+  var offsetX = goog.isDef(opt_offsetX) ? opt_offsetX : 0;
   return ol.vec.Mat4.makeTransform2D(this.transform_,
       pixelRatio * frameState.size[0] / 2,
       pixelRatio * frameState.size[1] / 2,
       pixelRatio / viewState.resolution,
       -pixelRatio / viewState.resolution,
       -viewState.rotation,
-      -viewState.center[0], -viewState.center[1]);
+      -viewState.center[0] + offsetX,
+      -viewState.center[1]);
 };
 
 

--- a/src/ol/renderer/canvas/canvasmaprenderer.js
+++ b/src/ol/renderer/canvas/canvasmaprenderer.js
@@ -229,6 +229,8 @@ ol.renderer.canvas.Map.prototype.renderFrame = function(frameState) {
       continue;
     }
     if (layerRenderer.prepareFrame(frameState, layerState)) {
+      // As soon as a vector layer on the map has wrapX set to true, we make
+      // feature overlays wrap the x-axis too.
       if (layer instanceof ol.layer.Vector && layer.getSource().getWrapX()) {
         wrapX = true;
       }

--- a/src/ol/renderer/canvas/canvasmaprenderer.js
+++ b/src/ol/renderer/canvas/canvasmaprenderer.js
@@ -108,7 +108,7 @@ ol.renderer.canvas.Map.prototype.dispatchComposeEvent_ =
     var projectionExtent = projection.getExtent();
     var resolution = viewState.resolution;
     var rotation = viewState.rotation;
-    var repeatReplay = (wrapX && projection.isGlobal() &&
+    var repeatReplay = (wrapX && projection.canWrapX() &&
         !ol.extent.containsExtent(projectionExtent, extent));
     var skippedFeaturesHash = {};
 

--- a/src/ol/renderer/canvas/canvasmaprenderer.js
+++ b/src/ol/renderer/canvas/canvasmaprenderer.js
@@ -135,14 +135,16 @@ ol.renderer.canvas.Map.prototype.dispatchComposeEvent_ =
         var worldWidth = ol.extent.getWidth(projectionExtent);
         var world = 0;
         while (startX < projectionExtent[0]) {
-          transform = this.getTransform(frameState, worldWidth * (--world));
+          --world;
+          transform = this.getTransform(frameState, worldWidth * world);
           replayGroup.replay(context, pixelRatio, transform, rotation, {});
           startX += worldWidth;
         }
         world = 0;
         startX = extent[2];
         while (startX > projectionExtent[2]) {
-          transform = this.getTransform(frameState, worldWidth * (++world));
+          ++world;
+          transform = this.getTransform(frameState, worldWidth * ++world);
           replayGroup.replay(context, pixelRatio, transform, rotation, {});
           startX -= worldWidth;
         }

--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -110,7 +110,7 @@ ol.renderer.canvas.VectorLayer.prototype.composeFrame =
     replayGroup.replay(
         replayContext, pixelRatio, transform, rotation, skippedFeatureUids);
 
-    if (vectorSource.getWrapX() && projection.isGlobal() &&
+    if (vectorSource.getWrapX() && projection.canWrapX() &&
         !ol.extent.containsExtent(projectionExtent, frameState.extent)) {
       var startX = extent[0];
       var worldWidth = ol.extent.getWidth(projectionExtent);
@@ -229,7 +229,7 @@ ol.renderer.canvas.VectorLayer.prototype.prepareFrame =
       vectorLayerRenderBuffer * resolution);
   var projectionExtent = viewState.projection.getExtent();
 
-  if (vectorSource.getWrapX() && viewState.projection.isGlobal() &&
+  if (vectorSource.getWrapX() && viewState.projection.canWrapX() &&
       !ol.extent.containsExtent(projectionExtent, frameState.extent)) {
     // do not clip when the view crosses the -180° or 180° meridians
     extent[0] = projectionExtent[0];

--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -116,7 +116,8 @@ ol.renderer.canvas.VectorLayer.prototype.composeFrame =
       var worldWidth = ol.extent.getWidth(projectionExtent);
       var world = 0;
       while (startX < projectionExtent[0]) {
-        transform = this.getTransform(frameState, worldWidth * (--world));
+        --world;
+        transform = this.getTransform(frameState, worldWidth * world);
         replayGroup.replay(
             replayContext, pixelRatio, transform, rotation, skippedFeatureUids);
         startX += worldWidth;
@@ -124,7 +125,8 @@ ol.renderer.canvas.VectorLayer.prototype.composeFrame =
       world = 0;
       startX = extent[2];
       while (startX > projectionExtent[2]) {
-        transform = this.getTransform(frameState, worldWidth * (++world));
+        ++world;
+        transform = this.getTransform(frameState, worldWidth * world);
         replayGroup.replay(
             replayContext, pixelRatio, transform, rotation, skippedFeatureUids);
         startX -= worldWidth;
@@ -229,7 +231,7 @@ ol.renderer.canvas.VectorLayer.prototype.prepareFrame =
 
   if (vectorSource.getWrapX() && viewState.projection.isGlobal() &&
       !ol.extent.containsExtent(projectionExtent, frameState.extent)) {
-    // do not clip when the view crosses the 0 or 180 meridians
+    // do not clip when the view crosses the -180° or 180° meridians
     extent[0] = projectionExtent[0];
     extent[2] = projectionExtent[2];
   }

--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -86,7 +86,7 @@ ol.renderer.canvas.VectorLayer.prototype.composeFrame =
   var vectorSource = this.getLayer().getSource();
   goog.asserts.assertInstanceof(vectorSource, ol.source.Vector);
 
-  var transform = this.getTransform(frameState);
+  var transform = this.getTransform(frameState, 0);
 
   this.dispatchPreComposeEvent(context, frameState, transform);
 

--- a/src/ol/renderer/maprenderer.js
+++ b/src/ol/renderer/maprenderer.js
@@ -41,6 +41,7 @@ ol.renderer.Map = function(container, map) {
 
   goog.base(this);
 
+
   /**
    * @private
    * @type {ol.Map}
@@ -156,25 +157,20 @@ ol.renderer.Map.prototype.forEachFeatureAtCoordinate =
 
   var projection = viewState.projection;
 
-  var translatedX;
+  var translatedCoordinate = coordinate;
   if (projection.canWrapX()) {
     var projectionExtent = projection.getExtent();
     var worldWidth = ol.extent.getWidth(projectionExtent);
     var x = coordinate[0];
     if (x < projectionExtent[0] || x > projectionExtent[2]) {
       var worldsAway = Math.ceil((projectionExtent[0] - x) / worldWidth);
-      translatedX = x + worldWidth * worldsAway;
+      translatedCoordinate = [x + worldWidth * worldsAway, coordinate[1]];
     }
   }
 
   if (!goog.isNull(this.replayGroup)) {
-    result = this.replayGroup.forEachFeatureAtCoordinate(coordinate,
+    result = this.replayGroup.forEachFeatureAtCoordinate(translatedCoordinate,
         viewResolution, viewRotation, {}, forEachFeatureAtCoordinate);
-    if (!result && goog.isDef(translatedX)) {
-      result = this.replayGroup.forEachFeatureAtCoordinate(
-          [translatedX, coordinate[1]],
-          viewResolution, viewRotation, {}, forEachFeatureAtCoordinate);
-    }
     if (result) {
       return result;
     }
@@ -189,11 +185,8 @@ ol.renderer.Map.prototype.forEachFeatureAtCoordinate =
         layerFilter.call(thisArg2, layer)) {
       var layerRenderer = this.getLayerRenderer(layer);
       result = layerRenderer.forEachFeatureAtCoordinate(
-          coordinate, frameState, callback, thisArg);
-      if (!result && goog.isDef(translatedX)) {
-        result = layerRenderer.forEachFeatureAtCoordinate(
-            [translatedX, coordinate[1]], frameState, callback, thisArg);
-      }
+          layer.getSource().getWrapX() ? translatedCoordinate : coordinate,
+          frameState, callback, thisArg);
       if (result) {
         return result;
       }

--- a/src/ol/renderer/maprenderer.js
+++ b/src/ol/renderer/maprenderer.js
@@ -157,7 +157,7 @@ ol.renderer.Map.prototype.forEachFeatureAtCoordinate =
   var projection = viewState.projection;
 
   var translatedX;
-  if (projection.isGlobal()) {
+  if (projection.canWrapX()) {
     var projectionExtent = projection.getExtent();
     var worldWidth = ol.extent.getWidth(projectionExtent);
     var x = coordinate[0];

--- a/src/ol/source/source.js
+++ b/src/ol/source/source.js
@@ -24,7 +24,8 @@ ol.source.State = {
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
  *            logo: (string|olx.LogoOptions|undefined),
  *            projection: ol.proj.ProjectionLike,
- *            state: (ol.source.State|undefined)}}
+ *            state: (ol.source.State|undefined),
+ *            wrapX: (boolean|undefined)}}
  */
 ol.source.SourceOptions;
 
@@ -71,6 +72,12 @@ ol.source.Source = function(options) {
    */
   this.state_ = goog.isDef(options.state) ?
       options.state : ol.source.State.READY;
+
+  /**
+   * @private
+   * @type {boolean|undefined}
+   */
+  this.wrapX_ = options.wrapX;
 
 };
 goog.inherits(ol.source.Source, ol.Object);
@@ -132,6 +139,14 @@ ol.source.Source.prototype.getResolutions = goog.abstractMethod;
  */
 ol.source.Source.prototype.getState = function() {
   return this.state_;
+};
+
+
+/**
+ * @return {boolean|undefined} Wrap X.
+ */
+ol.source.Source.prototype.getWrapX = function() {
+  return this.wrapX_;
 };
 
 

--- a/src/ol/source/tilesource.js
+++ b/src/ol/source/tilesource.js
@@ -47,7 +47,8 @@ ol.source.Tile = function(options) {
     extent: options.extent,
     logo: options.logo,
     projection: options.projection,
-    state: options.state
+    state: options.state,
+    wrapX: options.wrapX
   });
 
   /**
@@ -80,12 +81,6 @@ ol.source.Tile = function(options) {
    * @type {ol.Size}
    */
   this.tmpSize = [0, 0];
-
-  /**
-   * @private
-   * @type {boolean|undefined}
-   */
-  this.wrapX_ = options.wrapX;
 
 };
 goog.inherits(ol.source.Tile, ol.source.Source);
@@ -221,10 +216,10 @@ ol.source.Tile.prototype.getTilePixelSize =
 
 
 /**
- * Handles x-axis wrapping. When `this.wrapX_` is undefined or the projection
- * is not a global projection, `tileCoord` will be returned unaltered. When
- * `this.wrapX_` is true, the tile coordinate will be wrapped horizontally.
- * When `this.wrapX_` is `false`, `null` will be returned for tiles that are
+ * Handles x-axis wrapping. When `wrapX` is `undefined` or the projection is not
+ * a global projection, `tileCoord` will be returned unaltered. When `wrapX` is
+ * `true`, the tile coordinate will be wrapped horizontally.
+ * When `wrapX` is `false`, `null` will be returned for tiles that are
  * outside the projection extent.
  * @param {ol.TileCoord} tileCoord Tile coordinate.
  * @param {ol.proj.Projection=} opt_projection Projection.
@@ -235,8 +230,9 @@ ol.source.Tile.prototype.getWrapXTileCoord =
   var projection = goog.isDef(opt_projection) ?
       opt_projection : this.getProjection();
   var tileGrid = this.getTileGridForProjection(projection);
-  if (goog.isDef(this.wrapX_) && tileGrid.isGlobal(tileCoord[0], projection)) {
-    return this.wrapX_ ?
+  var wrapX = this.getWrapX();
+  if (goog.isDef(wrapX) && tileGrid.isGlobal(tileCoord[0], projection)) {
+    return wrapX ?
         ol.tilecoord.wrapX(tileCoord, tileGrid, projection) :
         ol.tilecoord.clipX(tileCoord, tileGrid, projection);
   } else {

--- a/src/ol/source/vectorsource.js
+++ b/src/ol/source/vectorsource.js
@@ -146,6 +146,12 @@ ol.source.Vector = function(opt_options) {
     this.addFeaturesInternal(options.features);
   }
 
+  /**
+   * @type {boolean}
+   * @private
+   */
+  this.wrapX_ = goog.isDef(options.wrapX) ? options.wrapX : true;
+
 };
 goog.inherits(ol.source.Vector, ol.source.Source);
 
@@ -561,6 +567,14 @@ ol.source.Vector.prototype.getExtent = function() {
 ol.source.Vector.prototype.getFeatureById = function(id) {
   var feature = this.idIndex_[id.toString()];
   return goog.isDef(feature) ? feature : null;
+};
+
+
+/**
+ * @return {boolean}
+ */
+ol.source.Vector.prototype.getWrapX = function() {
+  return this.wrapX_;
 };
 
 

--- a/src/ol/source/vectorsource.js
+++ b/src/ol/source/vectorsource.js
@@ -79,7 +79,8 @@ ol.source.Vector = function(opt_options) {
     attributions: options.attributions,
     logo: options.logo,
     projection: undefined,
-    state: ol.source.State.READY
+    state: ol.source.State.READY,
+    wrapX: goog.isDef(options.wrapX) ? options.wrapX : true
   });
 
   /**
@@ -145,12 +146,6 @@ ol.source.Vector = function(opt_options) {
   if (goog.isDef(options.features)) {
     this.addFeaturesInternal(options.features);
   }
-
-  /**
-   * @type {boolean}
-   * @private
-   */
-  this.wrapX_ = goog.isDef(options.wrapX) ? options.wrapX : true;
 
 };
 goog.inherits(ol.source.Vector, ol.source.Source);
@@ -567,14 +562,6 @@ ol.source.Vector.prototype.getExtent = function() {
 ol.source.Vector.prototype.getFeatureById = function(id) {
   var feature = this.idIndex_[id.toString()];
   return goog.isDef(feature) ? feature : null;
-};
-
-
-/**
- * @return {boolean}
- */
-ol.source.Vector.prototype.getWrapX = function() {
-  return this.wrapX_;
 };
 
 

--- a/test/spec/ol/proj/proj.test.js
+++ b/test/spec/ol/proj/proj.test.js
@@ -138,6 +138,46 @@ describe('ol.proj', function() {
     });
   });
 
+  describe('canWrapX()', function() {
+
+    it('requires an extent for allowing wrapX', function() {
+      var proj = new ol.proj.Projection({
+        code: 'foo',
+        global: true
+      });
+      expect(proj.canWrapX()).to.be(false);
+      proj.setExtent([1, 2, 3, 4]);
+      expect(proj.canWrapX()).to.be(true);
+      proj = new ol.proj.Projection({
+        code: 'foo',
+        global: true,
+        extent: [1, 2, 3, 4]
+      });
+      expect(proj.canWrapX()).to.be(true);
+      proj.setExtent(null);
+      expect(proj.canWrapX()).to.be(false);
+    });
+
+    it('requires global to be true for allowing wrapX', function() {
+      var proj = new ol.proj.Projection({
+        code: 'foo',
+        extent: [1, 2, 3, 4]
+      });
+      expect(proj.canWrapX()).to.be(false);
+      proj.setGlobal(true);
+      expect(proj.canWrapX()).to.be(true);
+      proj = new ol.proj.Projection({
+        code: 'foo',
+        global: true,
+        extent: [1, 2, 3, 4]
+      });
+      expect(proj.canWrapX()).to.be(true);
+      proj.setGlobal(false);
+      expect(proj.canWrapX()).to.be(false);
+    });
+
+  });
+
   describe('transformExtent()', function() {
 
     it('transforms an extent given projection identifiers', function() {

--- a/test/spec/ol/renderer/canvas/canvasmaprenderer.test.js
+++ b/test/spec/ol/renderer/canvas/canvasmaprenderer.test.js
@@ -55,7 +55,7 @@ describe('ol.renderer.canvas.Map', function() {
       };
       renderer.renderFrame(frameState);
       // precompose without wrapX
-      expect(spy.getCall(0).args[2]).to.be(undefined);
+      expect(spy.getCall(0).args[2]).to.be(false);
       // postcompose with wrapX
       expect(spy.getCall(1).args[2]).to.be(true);
     });

--- a/test/spec/ol/renderer/canvas/canvasmaprenderer.test.js
+++ b/test/spec/ol/renderer/canvas/canvasmaprenderer.test.js
@@ -1,0 +1,71 @@
+goog.provide('ol.test.renderer.canvas.Map');
+
+describe('ol.renderer.canvas.Map', function() {
+
+  describe('constructor', function() {
+
+    it('creates a new instance', function() {
+      var map = new ol.Map({
+        target: document.createElement('div')
+      });
+      var renderer = new ol.renderer.canvas.Map(map.viewport_, map);
+      expect(renderer).to.be.a(ol.renderer.canvas.Map);
+    });
+
+  });
+
+  describe('#renderFrame()', function() {
+    var layer, map, renderer;
+
+    beforeEach(function() {
+      map = new ol.Map({});
+      layer = new ol.layer.Vector({
+        source: new ol.source.Vector({wrapX: true})
+      });
+      renderer = map.getRenderer();
+      renderer.layerRenderers_ = {};
+      var layerRenderer = new ol.renderer.canvas.Layer(layer);
+      layerRenderer.prepareFrame = function() { return true; };
+      layerRenderer.getImage = function() { return null; };
+      renderer.layerRenderers_[goog.getUid(layer)] = layerRenderer;
+    });
+
+    it('calls #dispatchComposeEvent_() with a wrapX argument', function() {
+      var spy = sinon.spy(renderer, 'dispatchComposeEvent_');
+      var frameState = {
+        coordinateToPixelMatrix: map.coordinateToPixelMatrix_,
+        pixelToCoordinateMatrix: map.pixelToCoordinateMatrix_,
+        pixelRatio: 1,
+        size: [100, 100],
+        skippedFeatureUids: {},
+        viewState: {
+          center: [0, 0],
+          resolution: 1,
+          rotation: 0
+        },
+        layerStates: {},
+        layerStatesArray: [{
+          layer: layer,
+          sourceState: 'ready',
+          visible: true,
+          minResolution: 1,
+          maxResolution: 2
+        }],
+        postRenderFunctions: []
+      };
+      renderer.renderFrame(frameState);
+      // precompose without wrapX
+      expect(spy.getCall(0).args[2]).to.be(undefined);
+      // postcompose with wrapX
+      expect(spy.getCall(1).args[2]).to.be(true);
+    });
+  });
+
+});
+
+
+goog.require('ol.layer.Vector');
+goog.require('ol.Map');
+goog.require('ol.renderer.canvas.Layer');
+goog.require('ol.renderer.canvas.Map');
+goog.require('ol.source.Vector');

--- a/test/spec/ol/renderer/canvas/canvasmaprenderer.test.js
+++ b/test/spec/ol/renderer/canvas/canvasmaprenderer.test.js
@@ -19,6 +19,7 @@ describe('ol.renderer.canvas.Map', function() {
 
     beforeEach(function() {
       map = new ol.Map({});
+      map.on('postcompose', function() {});
       layer = new ol.layer.Vector({
         source: new ol.source.Vector({wrapX: true})
       });
@@ -30,16 +31,23 @@ describe('ol.renderer.canvas.Map', function() {
       renderer.layerRenderers_[goog.getUid(layer)] = layerRenderer;
     });
 
-    it('calls #dispatchComposeEvent_() with a wrapX argument', function() {
-      var spy = sinon.spy(renderer, 'dispatchComposeEvent_');
+    it('uses correct extent and offset on wrapped worlds', function() {
+      var spy = sinon.spy(renderer, 'getTransform');
+      var proj = new ol.proj.Projection({
+        code: 'foo',
+        extent: [-180, -90, 180, 90],
+        global: true
+      });
       var frameState = {
         coordinateToPixelMatrix: map.coordinateToPixelMatrix_,
         pixelToCoordinateMatrix: map.pixelToCoordinateMatrix_,
         pixelRatio: 1,
         size: [100, 100],
         skippedFeatureUids: {},
+        extent: proj.getExtent(),
         viewState: {
           center: [0, 0],
+          projection: proj,
           resolution: 1,
           rotation: 0
         },
@@ -53,11 +61,21 @@ describe('ol.renderer.canvas.Map', function() {
         }],
         postRenderFunctions: []
       };
+      frameState.focus = [0, 0];
+      // focus is on real world
       renderer.renderFrame(frameState);
-      // precompose without wrapX
-      expect(spy.getCall(0).args[2]).to.be(false);
-      // postcompose with wrapX
-      expect(spy.getCall(1).args[2]).to.be(true);
+      expect(spy.getCall(0).args[1]).to.be(0);
+      expect(renderer.replayGroup.maxExtent_).to.eql([-180, -90, 180, 90]);
+      frameState.focus = [-200, 0];
+      // focus is one world left of the real world
+      renderer.renderFrame(frameState);
+      expect(spy.getCall(1).args[1]).to.be(360);
+      expect(renderer.replayGroup.maxExtent_).to.eql([180, -90, 540, 90]);
+      frameState.focus = [200, 0];
+      // focus is one world right of the real world
+      renderer.renderFrame(frameState);
+      expect(spy.getCall(2).args[1]).to.be(-360);
+      expect(renderer.replayGroup.maxExtent_).to.eql([-540, -90, -180, 90]);
     });
   });
 
@@ -66,6 +84,7 @@ describe('ol.renderer.canvas.Map', function() {
 
 goog.require('ol.layer.Vector');
 goog.require('ol.Map');
+goog.require('ol.proj.Projection');
 goog.require('ol.renderer.canvas.Layer');
 goog.require('ol.renderer.canvas.Map');
 goog.require('ol.source.Vector');

--- a/test/spec/ol/renderer/canvas/canvasvectorlayerrenderer.test.js
+++ b/test/spec/ol/renderer/canvas/canvasvectorlayerrenderer.test.js
@@ -55,10 +55,10 @@ describe('ol.renderer.canvas.VectorLayer', function() {
   });
 
   describe('#forEachFeatureAtCoordinate', function() {
-    var renderer;
+    var layer, renderer;
 
     beforeEach(function() {
-      var layer = new ol.layer.Vector({
+      layer = new ol.layer.Vector({
         source: new ol.source.Vector()
       });
       renderer = new ol.renderer.canvas.VectorLayer(layer);
@@ -66,14 +66,13 @@ describe('ol.renderer.canvas.VectorLayer', function() {
       renderer.replayGroup_ = replayGroup;
       replayGroup.forEachFeatureAtCoordinate = function(coordinate,
           resolution, rotation, skippedFeaturesUids, callback) {
-        var geometry = new ol.geom.Point([0, 0]);
         var feature = new ol.Feature();
-        callback(geometry, feature);
-        callback(geometry, feature);
+        callback(feature);
+        callback(feature);
       };
     });
 
-    it('calls callback once per feature', function() {
+    it('calls callback once per feature with a layer as 2nd arg', function() {
       var spy = sinon.spy();
       var coordinate = [0, 0];
       var frameState = {
@@ -86,6 +85,7 @@ describe('ol.renderer.canvas.VectorLayer', function() {
       renderer.forEachFeatureAtCoordinate(
           coordinate, frameState, spy, undefined);
       expect(spy.callCount).to.be(1);
+      expect(spy.getCall(0).args[1]).to.equal(layer);
     });
   });
 

--- a/test/spec/ol/renderer/canvas/canvasvectorlayerrenderer.test.js
+++ b/test/spec/ol/renderer/canvas/canvasvectorlayerrenderer.test.js
@@ -5,14 +5,10 @@ describe('ol.renderer.canvas.VectorLayer', function() {
   describe('constructor', function() {
 
     it('creates a new instance', function() {
-      var map = new ol.Map({
-        target: document.createElement('div')
-      });
       var layer = new ol.layer.Vector({
         source: new ol.source.Vector()
       });
-      var renderer = new ol.renderer.canvas.VectorLayer(map.getRenderer(),
-          layer);
+      var renderer = new ol.renderer.canvas.VectorLayer(layer);
       expect(renderer).to.be.a(ol.renderer.canvas.VectorLayer);
     });
 
@@ -62,12 +58,10 @@ describe('ol.renderer.canvas.VectorLayer', function() {
     var renderer;
 
     beforeEach(function() {
-      var map = new ol.Map({});
       var layer = new ol.layer.Vector({
         source: new ol.source.Vector()
       });
-      renderer = new ol.renderer.canvas.VectorLayer(
-          map.getRenderer(), layer);
+      renderer = new ol.renderer.canvas.VectorLayer(layer);
       var replayGroup = {};
       renderer.replayGroup_ = replayGroup;
       replayGroup.forEachFeatureAtCoordinate = function(coordinate,


### PR DESCRIPTION
This pull request adds wrapX support for vector layers, vector overlays, and the map's replay group. It also ensures that `ol.Map#forEachFeatureAtPixel()` works when viewing a wrapped world.