### PR TITLE
Modify draw interaction dispatch order

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -118,7 +118,11 @@ size of a sub-rectangle in an image sprite.
 
 ### Support for non-square tiles
 
-The return value of ´ol.tilegrid.TileGrid#getTileSize()` will now be an `ol.Size` array instead of a number if non-square tiles (i.e. an `ol.Size` array instead of a number as `tilsSize`) are used. To always get an `ol.Size`, the new `ol.size.toSize()` was added.
+The return value of `ol.tilegrid.TileGrid#getTileSize()` will now be an `ol.Size` array instead of a number if non-square tiles (i.e. an `ol.Size` array instead of a number as `tilsSize`) are used. To always get an `ol.Size`, the new `ol.size.toSize()` was added.
+
+### Change to `ol.interaction.Draw`
+
+When finishing a draw, the `drawend` event is now dispatched before the feature is inserted to either the source or the collection. This change allows application code to finish setting up the feature.
 
 ### v3.4.0
 

--- a/src/ol/interaction/drawinteraction.js
+++ b/src/ol/interaction/drawinteraction.js
@@ -517,6 +517,8 @@ ol.interaction.Draw.prototype.addToDrawing_ = function(event) {
 
 /**
  * Stop drawing and add the sketch feature to the target layer.
+ * The {@link ol.DrawEventType.DRAWEND} event is dispatched before inserting
+ * the feature.
  * @api
  */
 ol.interaction.Draw.prototype.finishDrawing = function() {
@@ -557,13 +559,16 @@ ol.interaction.Draw.prototype.finishDrawing = function() {
     sketchFeature.setGeometry(new ol.geom.MultiPolygon([coordinates]));
   }
 
+  // First dispatch event to allow full set up of feature
+  this.dispatchEvent(new ol.DrawEvent(ol.DrawEventType.DRAWEND, sketchFeature));
+
+  // Then insert feature
   if (!goog.isNull(this.features_)) {
     this.features_.push(sketchFeature);
   }
   if (!goog.isNull(this.source_)) {
     this.source_.addFeature(sketchFeature);
   }
-  this.dispatchEvent(new ol.DrawEvent(ol.DrawEventType.DRAWEND, sketchFeature));
 };
 
 

--- a/test/spec/ol/interaction/drawinteraction.test.js
+++ b/test/spec/ol/interaction/drawinteraction.test.js
@@ -145,6 +145,29 @@ describe('ol.interaction.Draw', function() {
       expect(ds).to.be.called(2);
       expect(de).to.be.called(1);
     });
+
+    it('triggers drawend event before inserting the feature', function() {
+      var receivedEvents = {
+        end: 0,
+        addfeature: 0
+      };
+      goog.events.listen(draw, ol.DrawEventType.DRAWEND, function() {
+        expect(receivedEvents.end).to.be(0);
+        expect(receivedEvents.addfeature).to.be(0);
+        ++receivedEvents.end;
+      });
+      source.on(ol.source.VectorEventType.ADDFEATURE, function() {
+        expect(receivedEvents.end).to.be(1);
+        expect(receivedEvents.addfeature).to.be(0);
+        receivedEvents.addfeature++;
+      });
+      simulateEvent('pointermove', 10, 20);
+      simulateEvent('pointerdown', 10, 20);
+      simulateEvent('pointerup', 10, 20);
+      simulateEvent('pointermove', 20, 20);
+      expect(receivedEvents.end).to.be(1);
+      expect(receivedEvents.addfeature).to.be(1);
+    });
   });
 
   describe('drawing multipoints', function() {
@@ -661,3 +684,4 @@ goog.require('ol.interaction.Interaction');
 goog.require('ol.layer.Vector');
 goog.require('ol.pointer.PointerEvent');
 goog.require('ol.source.Vector');
+goog.require('ol.source.VectorEventType');


### PR DESCRIPTION
When finishing drawing, this PR dispatches the `drawend` event before adding
the feature to the source or collection.

This change allows user code to finish configuring the feature (setting style,
properties, ...).

It is useful since inserting a feature, or later on modifying it, may trigger
processing which only makes sense if the feature is ready. For example,
ol3-cesium will recreate a 3D counterpart.