### PR TITLE
Check proj equivalence by code

### DIFF
--- a/src/ol/proj/proj.js
+++ b/src/ol/proj/proj.js
@@ -656,6 +656,8 @@ ol.proj.get = function(projectionLike) {
 ol.proj.equivalent = function(projection1, projection2) {
   if (projection1 === projection2) {
     return true;
+  } else if (projection1.getCode() === projection2.getCode()) {
+    return true;
   } else if (projection1.getUnits() != projection2.getUnits()) {
     return false;
   } else {

--- a/test/spec/ol/proj/proj.test.js
+++ b/test/spec/ol/proj/proj.test.js
@@ -30,6 +30,27 @@ describe('ol.proj', function() {
       ]);
     });
 
+    it('gives that custom 3413 is equivalent to self', function() {
+      var code = 'EPSG:3413';
+
+      var source = new ol.proj.Projection({
+        code: code
+      });
+
+      var destination = new ol.proj.Projection({
+        code: code
+      });
+
+      expect(ol.proj.equivalent(source, destination)).to.be.ok();
+    });
+
+    it('gives that default 3857 is equivalent to self', function() {
+      _testAllEquivalent([
+        'EPSG:3857',
+        'EPSG:3857'
+      ]);
+    });
+
     it('gives that CRS:84, urn:ogc:def:crs:EPSG:6.6:4326, EPSG:4326 are ' +
        'equivalent', function() {
           _testAllEquivalent([


### PR DESCRIPTION
Maybe I don't understand something, but this method doesn't work properly if the projections has the same code, but are not the same objects by reference.

![](http://i.imgur.com/xmCMUb3.png)
![](http://i.imgur.com/pSEXQOo.png)
Am I right?