### PR TITLE
Use HTTPS were available

### DIFF
--- a/examples/overviewmap-custom.js
+++ b/examples/overviewmap-custom.js
@@ -14,7 +14,7 @@ var overviewMapControl = new ol.control.OverviewMap({
   layers: [
     new ol.layer.Tile({
       source: new ol.source.OSM({
-        'url': '//{a-c}.tile.opencyclemap.org/cycle/{z}/{x}/{y}.png'
+        'url': 'https://{a-c}.tile.opencyclemap.org/cycle/{z}/{x}/{y}.png'
       })
     })
   ],

--- a/examples/overviewmap-custom.js
+++ b/examples/overviewmap-custom.js
@@ -14,7 +14,7 @@ var overviewMapControl = new ol.control.OverviewMap({
   layers: [
     new ol.layer.Tile({
       source: new ol.source.OSM({
-        'url': 'https://{a-c}.tile.opencyclemap.org/cycle/{z}/{x}/{y}.png'
+        'url': 'http://{a-c}.tile.opencyclemap.org/cycle/{z}/{x}/{y}.png'
       })
     })
   ],

--- a/src/ol/ol.js
+++ b/src/ol/ol.js
@@ -154,14 +154,6 @@ ol.INITIAL_ATLAS_SIZE = 256;
 
 
 /**
- * The page is loaded using HTTPS.
- * @const
- * @type {boolean}
- */
-ol.IS_HTTPS = goog.global.location.protocol === 'https:';
-
-
-/**
  * Whether the current browser is legacy IE
  * @const
  * @type {boolean}

--- a/src/ol/source/bingmapssource.js
+++ b/src/ol/source/bingmapssource.js
@@ -4,7 +4,6 @@ goog.require('goog.Uri');
 goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.net.Jsonp');
-goog.require('ol');
 goog.require('ol.Attribution');
 goog.require('ol.TileRange');
 goog.require('ol.TileUrlFunction');
@@ -49,15 +48,14 @@ ol.source.BingMaps = function(options) {
    */
   this.maxZoom_ = goog.isDef(options.maxZoom) ? options.maxZoom : -1;
 
-  var protocol = ol.IS_HTTPS ? 'https:' : 'http:';
   var uri = new goog.Uri(
-      protocol + '//dev.virtualearth.net/REST/v1/Imagery/Metadata/' +
+      'https://dev.virtualearth.net/REST/v1/Imagery/Metadata/' +
       options.imagerySet);
 
   var jsonp = new goog.net.Jsonp(uri, 'jsonp');
   jsonp.send({
     'include': 'ImageryProviders',
-    'uriScheme': ol.IS_HTTPS ? 'https' : 'http',
+    'uriScheme': 'https',
     'key': options.key
   }, goog.bind(this.handleImageryMetadataResponse, this));
 
@@ -93,7 +91,7 @@ ol.source.BingMaps.prototype.handleImageryMetadataResponse =
   }
 
   var brandLogoUri = response.brandLogoUri;
-  if (ol.IS_HTTPS && brandLogoUri.indexOf('https') == -1) {
+  if (brandLogoUri.indexOf('https') == -1) {
     brandLogoUri = brandLogoUri.replace('http', 'https');
   }
   //var copyright = response.copyright;  // FIXME do we need to display this?

--- a/src/ol/source/mapquestsource.js
+++ b/src/ol/source/mapquestsource.js
@@ -40,7 +40,7 @@ ol.source.MapQuest = function(opt_options) {
   goog.base(this, {
     attributions: layerConfig.attributions,
     crossOrigin: 'anonymous',
-    logo: '//developer.mapquest.com/content/osm/mq_logo.png',
+    logo: 'https://developer.mapquest.com/content/osm/mq_logo.png',
     maxZoom: layerConfig.maxZoom,
     opaque: true,
     tileLoadFunction: options.tileLoadFunction,

--- a/src/ol/source/mapquestsource.js
+++ b/src/ol/source/mapquestsource.js
@@ -1,7 +1,6 @@
 goog.provide('ol.source.MapQuest');
 
 goog.require('goog.asserts');
-goog.require('ol');
 goog.require('ol.Attribution');
 goog.require('ol.source.OSM');
 goog.require('ol.source.XYZ');
@@ -32,9 +31,8 @@ ol.source.MapQuest = function(opt_options) {
    */
   this.layer_ = options.layer;
 
-  var protocol = ol.IS_HTTPS ? 'https:' : 'http:';
   var url = goog.isDef(options.url) ? options.url :
-      protocol + '//otile{1-4}-s.mqcdn.com/tiles/1.0.0/' +
+      'https://otile{1-4}-s.mqcdn.com/tiles/1.0.0/' +
       this.layer_ + '/{z}/{x}/{y}.jpg';
 
   goog.base(this, {

--- a/src/ol/source/osmsource.js
+++ b/src/ol/source/osmsource.js
@@ -1,6 +1,5 @@
 goog.provide('ol.source.OSM');
 
-goog.require('ol');
 goog.require('ol.Attribution');
 goog.require('ol.source.XYZ');
 
@@ -29,9 +28,8 @@ ol.source.OSM = function(opt_options) {
   var crossOrigin = goog.isDef(options.crossOrigin) ?
       options.crossOrigin : 'anonymous';
 
-  var protocol = ol.IS_HTTPS ? 'https:' : 'http:';
   var url = goog.isDef(options.url) ?
-      options.url : protocol + '//{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+      options.url : 'https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png';
 
   goog.base(this, {
     attributions: attributions,

--- a/src/ol/source/stamensource.js
+++ b/src/ol/source/stamensource.js
@@ -1,7 +1,6 @@
 goog.provide('ol.source.Stamen');
 
 goog.require('goog.asserts');
-goog.require('ol');
 goog.require('ol.Attribution');
 goog.require('ol.source.OSM');
 goog.require('ol.source.XYZ');
@@ -99,11 +98,9 @@ ol.source.Stamen = function(options) {
       'known layer configured');
   var layerConfig = ol.source.StamenLayerConfig[options.layer];
 
-  var root = ol.IS_HTTPS ? 'https://stamen-tiles-{a-d}.a.ssl.fastly.net/' :
-      'http://{a-d}.tile.stamen.com/';
   var url = goog.isDef(options.url) ? options.url :
-      root + options.layer + '/{z}/{x}/{y}.' +
-      layerConfig.extension;
+      'https://stamen-tiles-{a-d}.a.ssl.fastly.net/' + options.layer +
+      '/{z}/{x}/{y}.' + layerConfig.extension;
 
   goog.base(this, {
     attributions: ol.source.Stamen.ATTRIBUTIONS,


### PR DESCRIPTION
This removes our use of protocol relative URLs (these were generating errors in PhantomJS and would break for anyone else running in a context that uses the "file" protocol).

In addition, this changes the Stamen, MapQuest, OSM, and Bing sources to always use HTTPS.

Because it is no longer used, and to discourage its future use, `ol.IS_HTTPS` is removed.

Fixes #3574.

