### PR TITLE
Add a one sentence summary for ol.source.* exportable symbols

### DIFF
--- a/src/ol/source/bingmapssource.js
+++ b/src/ol/source/bingmapssource.js
@@ -64,6 +64,8 @@ goog.inherits(ol.source.BingMaps, ol.source.TileImage);
 
 
 /**
+ * The attribution containing a link to the Microsoft® Bing™ Maps Platform APIs’
+ * Terms Of Use.
  * @const
  * @type {ol.Attribution}
  * @api

--- a/src/ol/source/clustersource.js
+++ b/src/ol/source/clustersource.js
@@ -16,6 +16,9 @@ goog.require('ol.source.Vector');
 
 
 /**
+ * @classdesc
+ * Layer source to cluster vector data.
+ *
  * @constructor
  * @param {olx.source.ClusterOptions} options
  * @extends {ol.source.Vector}

--- a/src/ol/source/imagemapguidesource.js
+++ b/src/ol/source/imagemapguidesource.js
@@ -166,6 +166,7 @@ ol.source.ImageMapGuide.prototype.getImage =
 
 
 /**
+ * Return the image load function of the source.
  * @return {ol.ImageLoadFunctionType} The image load function.
  * @api
  */
@@ -176,7 +177,7 @@ ol.source.ImageMapGuide.prototype.getImageLoadFunction = function() {
 
 /**
  * @param {ol.Extent} extent The map extents.
- * @param {ol.Size} size the viewport size.
+ * @param {ol.Size} size The viewport size.
  * @param {number} metersPerUnit The meters-per-unit value.
  * @param {number} dpi The display resolution.
  * @return {number} The computed map scale.
@@ -238,6 +239,7 @@ ol.source.ImageMapGuide.prototype.getUrl =
 
 
 /**
+ * Set the image load function of the MapGuide source.
  * @param {ol.ImageLoadFunctionType} imageLoadFunction Image load function.
  * @api
  */

--- a/src/ol/source/imagewmssource.js
+++ b/src/ol/source/imagewmssource.js
@@ -260,6 +260,7 @@ ol.source.ImageWMS.prototype.getImage =
 
 
 /**
+ * Return the image load function of the source.
  * @return {ol.ImageLoadFunctionType} The image load function.
  * @api
  */
@@ -336,6 +337,7 @@ ol.source.ImageWMS.prototype.getUrl = function() {
 
 
 /**
+ * Set the image load function of the source.
  * @param {ol.ImageLoadFunctionType} imageLoadFunction Image load function.
  * @api
  */
@@ -348,6 +350,7 @@ ol.source.ImageWMS.prototype.setImageLoadFunction = function(
 
 
 /**
+ * Set the URL to use for requests.
  * @param {string|undefined} url URL.
  * @api stable
  */

--- a/src/ol/source/mapquestsource.js
+++ b/src/ol/source/mapquestsource.js
@@ -90,6 +90,7 @@ ol.source.MapQuestConfig = {
 
 
 /**
+ * Get the layer of the source, either `osm`, `sat`, or `hyb`.
  * @return {string} Layer.
  * @api
  */

--- a/src/ol/source/osmsource.js
+++ b/src/ol/source/osmsource.js
@@ -46,6 +46,8 @@ goog.inherits(ol.source.OSM, ol.source.XYZ);
 
 
 /**
+ * The attribution containing a link to the OpenStreetMap Copyright and License
+ * page.
  * @const
  * @type {ol.Attribution}
  * @api

--- a/src/ol/source/source.js
+++ b/src/ol/source/source.js
@@ -90,6 +90,7 @@ ol.source.Source.prototype.forEachFeatureAtCoordinate =
 
 
 /**
+ * Get the attributions of the source.
  * @return {Array.<ol.Attribution>} Attributions.
  * @api stable
  */
@@ -99,6 +100,7 @@ ol.source.Source.prototype.getAttributions = function() {
 
 
 /**
+ * Get the logo of the source.
  * @return {string|olx.LogoOptions|undefined} Logo.
  * @api stable
  */
@@ -108,6 +110,7 @@ ol.source.Source.prototype.getLogo = function() {
 
 
 /**
+ * Get the projection of the source.
  * @return {ol.proj.Projection} Projection.
  * @api
  */
@@ -123,6 +126,7 @@ ol.source.Source.prototype.getResolutions = goog.abstractMethod;
 
 
 /**
+ * Get the state of the source, see {@link ol.source.State} for possible states.
  * @return {ol.source.State} State.
  * @api
  */
@@ -132,6 +136,7 @@ ol.source.Source.prototype.getState = function() {
 
 
 /**
+ * Set the attributions of the source.
  * @param {Array.<ol.Attribution>} attributions Attributions.
  */
 ol.source.Source.prototype.setAttributions = function(attributions) {
@@ -140,6 +145,7 @@ ol.source.Source.prototype.setAttributions = function(attributions) {
 
 
 /**
+ * Set the logo of the source.
  * @param {string|olx.LogoOptions|undefined} logo Logo.
  */
 ol.source.Source.prototype.setLogo = function(logo) {
@@ -148,6 +154,7 @@ ol.source.Source.prototype.setLogo = function(logo) {
 
 
 /**
+ * Set the state of the source.
  * @param {ol.source.State} state State.
  * @protected
  */
@@ -158,7 +165,8 @@ ol.source.Source.prototype.setState = function(state) {
 
 
 /**
- * @param {ol.proj.Projection} projection Projetion.
+ * Set the projection of the source.
+ * @param {ol.proj.Projection} projection Projection.
  */
 ol.source.Source.prototype.setProjection = function(projection) {
   this.projection_ = projection;

--- a/src/ol/source/tilearcgisrestsource.js
+++ b/src/ol/source/tilearcgisrestsource.js
@@ -168,6 +168,7 @@ ol.source.TileArcGISRest.prototype.getUrls = function() {
 
 
 /**
+ * Set the URL to use for requests.
  * @param {string|undefined} url URL.
  * @api stable
  */
@@ -178,6 +179,7 @@ ol.source.TileArcGISRest.prototype.setUrl = function(url) {
 
 
 /**
+ * Set the URLs to use for requests.
  * @param {Array.<string>|undefined} urls URLs.
  * @api stable
  */

--- a/src/ol/source/tileimagesource.js
+++ b/src/ol/source/tileimagesource.js
@@ -112,6 +112,7 @@ ol.source.TileImage.prototype.getTile =
 
 
 /**
+ * Return the tile load function of the source.
  * @return {ol.TileLoadFunctionType} TileLoadFunction
  * @api
  */
@@ -121,6 +122,7 @@ ol.source.TileImage.prototype.getTileLoadFunction = function() {
 
 
 /**
+ * Return the tile URL function of the source.
  * @return {ol.TileUrlFunctionType} TileUrlFunction
  * @api
  */
@@ -154,6 +156,7 @@ ol.source.TileImage.prototype.handleTileChange_ = function(event) {
 
 
 /**
+ * Set the tile load function of the source.
  * @param {ol.TileLoadFunctionType} tileLoadFunction Tile load function.
  * @api
  */
@@ -165,6 +168,7 @@ ol.source.TileImage.prototype.setTileLoadFunction = function(tileLoadFunction) {
 
 
 /**
+ * Set the tile URL function of the source.
  * @param {ol.TileUrlFunctionType} tileUrlFunction Tile URL function.
  * @api
  */

--- a/src/ol/source/tilesource.js
+++ b/src/ol/source/tilesource.js
@@ -184,6 +184,7 @@ ol.source.Tile.prototype.getTile = goog.abstractMethod;
 
 
 /**
+ * Return the tile grid of the tile source.
  * @return {ol.tilegrid.TileGrid} Tile grid.
  * @api stable
  */

--- a/src/ol/source/tileutfgridsource.js
+++ b/src/ol/source/tileutfgridsource.js
@@ -58,6 +58,7 @@ goog.inherits(ol.source.TileUTFGrid, ol.source.Tile);
 
 
 /**
+ * Return the template from TileJSON.
  * @return {string|undefined} The template from TileJSON.
  * @api
  */

--- a/src/ol/source/tilevectorsource.js
+++ b/src/ol/source/tilevectorsource.js
@@ -194,6 +194,7 @@ ol.source.TileVector.prototype.getExtent = goog.abstractMethod;
 
 
 /**
+ * Return the features of the TileVector source.
  * @inheritDoc
  * @api
  */

--- a/src/ol/source/tilewmssource.js
+++ b/src/ol/source/tilewmssource.js
@@ -329,6 +329,7 @@ ol.source.TileWMS.prototype.resetCoordKeyPrefix_ = function() {
 
 
 /**
+ * Set the URL to use for requests.
  * @param {string|undefined} url URL.
  * @api stable
  */
@@ -339,6 +340,7 @@ ol.source.TileWMS.prototype.setUrl = function(url) {
 
 
 /**
+ * Set the URLs to use for requests.
  * @param {Array.<string>|undefined} urls URLs.
  * @api stable
  */

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -225,6 +225,7 @@ ol.source.WMTS.prototype.getDimensions = function() {
 
 
 /**
+ * Return the image format of the WMTS source.
  * @return {string} Format.
  * @api
  */
@@ -242,6 +243,7 @@ ol.source.WMTS.prototype.getKeyZXY = function(z, x, y) {
 
 
 /**
+ * Return the layer of the WMTS source.
  * @return {string} Layer.
  * @api
  */
@@ -251,6 +253,7 @@ ol.source.WMTS.prototype.getLayer = function() {
 
 
 /**
+ * Return the matrix set of the WMTS source.
  * @return {string} MatrixSet.
  * @api
  */
@@ -260,6 +263,7 @@ ol.source.WMTS.prototype.getMatrixSet = function() {
 
 
 /**
+ * Return the style of the WMTS source.
  * @return {string} Style.
  * @api
  */
@@ -269,6 +273,7 @@ ol.source.WMTS.prototype.getStyle = function() {
 
 
 /**
+ * Return the version of the WMTS source.
  * @return {string} Version.
  * @api
  */

--- a/src/ol/source/xyzsource.js
+++ b/src/ol/source/xyzsource.js
@@ -68,6 +68,7 @@ ol.source.XYZ.prototype.setTileUrlFunction = function(tileUrlFunction) {
 
 
 /**
+ * Set the URL to use for requests.
  * @param {string} url URL.
  * @api stable
  */
@@ -78,6 +79,7 @@ ol.source.XYZ.prototype.setUrl = function(url) {
 
 
 /**
+ * Set the URLs to use for requests.
  * @param {Array.<string>} urls URLs.
  */
 ol.source.XYZ.prototype.setUrls = function(urls) {


### PR DESCRIPTION
This PR adds basic documentation to `@api` symbols, and is a follow-up of #3497 (which itself is a follow-up of #3488).

Please review.