### PR TITLE
Always show links to related API documentation

### DIFF
--- a/examples/resources/common.js
+++ b/examples/resources/common.js
@@ -10,31 +10,6 @@
     });
   }
 
-  // Check whether links to API-docs of used classes actually point to
-  // existing html-files:
-  $('#api-links a').each(function() {
-    var url = this.href;
-    $.ajax({
-      type: 'HEAD',
-      url: url,
-      context: this,
-      error: function() {
-        // We get into the error if either the resource didn't exist
-        // or if HEAD was not allowed (when serving locally via node)
-        // => remove the <li> and the following comma
-        var li = $(this).parent();
-        var comma = $(li[0].nextSibling);
-        comma.remove();
-        li.remove();
-        // It may be that this was the last <li>, if that's the case,
-        // remove the complete <div>, as we don't have an API-links
-        if ($('#api-links li').length === 0) {
-          $('#api-links').remove();
-        }
-      }
-    });
-  });
-
   if (window.location.host === 'localhost:3000') {
     return;
   }


### PR DESCRIPTION
This is based on the assumptions that

 * our examples always `goog.require` something `ol.*` (otherwise why have the example)
 * our examples only `goog.require` exportable symbols or "namespaces" for exportable symbols (e.g. `ol.control` for the `defaults` function)
 * we have an API doc page for each exportable symbol and each "namespace" that has exportable symbols (e.g. `ol.Map.html` and `ol.control.html`)
 * we never `goog.require` a typedef (e.g. `ol.Coordinate`) in an example (since these don't have dedicated pages)

It may be that this assumption proves to be wrong, but it would be nice to avoid the extra network traffic and layout shifting when examples load.