### PR TITLE
Add a one sentence summary for ol.proj.* and ol.layer.* exportable symbols

### DIFF
--- a/src/ol/layer/heatmaplayer.js
+++ b/src/ol/layer/heatmaplayer.js
@@ -191,6 +191,7 @@ ol.layer.Heatmap.prototype.createCircle_ = function() {
 
 
 /**
+ * Return the blur size in pixels.
  * @return {number} Blur size in pixels.
  * @api
  * @observable
@@ -201,6 +202,7 @@ ol.layer.Heatmap.prototype.getBlur = function() {
 
 
 /**
+ * Return the gradient colors as array of strings.
  * @return {Array.<string>} Colors.
  * @api
  * @observable
@@ -212,6 +214,7 @@ ol.layer.Heatmap.prototype.getGradient = function() {
 
 
 /**
+ * Return the size of the radius in pixels.
  * @return {number} Radius size in pixel.
  * @api
  * @observable
@@ -266,6 +269,7 @@ ol.layer.Heatmap.prototype.handleRender_ = function(event) {
 
 
 /**
+ * Set the blur size in pixels.
  * @param {number} blur Blur size in pixels.
  * @api
  * @observable
@@ -276,6 +280,7 @@ ol.layer.Heatmap.prototype.setBlur = function(blur) {
 
 
 /**
+ * Set the gradient colors as array of strings.
  * @param {Array.<string>} colors Gradient.
  * @api
  * @observable
@@ -286,6 +291,7 @@ ol.layer.Heatmap.prototype.setGradient = function(colors) {
 
 
 /**
+ * Set the size of the radius in pixels.
  * @param {number} radius Radius size in pixel.
  * @api
  * @observable

--- a/src/ol/layer/imagelayer.js
+++ b/src/ol/layer/imagelayer.js
@@ -26,6 +26,7 @@ goog.inherits(ol.layer.Image, ol.layer.Layer);
 
 
 /**
+ * Return the associated {@link ol.source.Image source} of the image layer.
  * @function
  * @return {ol.source.Image} Source.
  * @api stable

--- a/src/ol/layer/layerbase.js
+++ b/src/ol/layer/layerbase.js
@@ -87,6 +87,7 @@ goog.inherits(ol.layer.Base, ol.Object);
 
 
 /**
+ * Return the brightness of the layer.
  * @return {number} The brightness of the layer.
  * @observable
  * @api
@@ -97,6 +98,7 @@ ol.layer.Base.prototype.getBrightness = function() {
 
 
 /**
+ * Return the contrast of the layer.
  * @return {number} The contrast of the layer.
  * @observable
  * @api
@@ -107,6 +109,7 @@ ol.layer.Base.prototype.getContrast = function() {
 
 
 /**
+ * Return the hue of the layer.
  * @return {number} The hue of the layer.
  * @observable
  * @api
@@ -163,6 +166,8 @@ ol.layer.Base.prototype.getLayerStatesArray = goog.abstractMethod;
 
 
 /**
+ * Return the {@link ol.Extent extent} of the layer or `undefined` if it
+ * will be visible regardless of extent.
  * @return {ol.Extent|undefined} The layer extent.
  * @observable
  * @api stable
@@ -174,6 +179,7 @@ ol.layer.Base.prototype.getExtent = function() {
 
 
 /**
+ * Return the maximum resolution of the layer.
  * @return {number} The maximum resolution of the layer.
  * @observable
  * @api stable
@@ -185,6 +191,7 @@ ol.layer.Base.prototype.getMaxResolution = function() {
 
 
 /**
+ * Return the minimum resolution of the layer.
  * @return {number} The minimum resolution of the layer.
  * @observable
  * @api stable
@@ -196,6 +203,7 @@ ol.layer.Base.prototype.getMinResolution = function() {
 
 
 /**
+ * Return the opacity of the layer (between 0 and 1).
  * @return {number} The opacity of the layer.
  * @observable
  * @api stable
@@ -206,6 +214,7 @@ ol.layer.Base.prototype.getOpacity = function() {
 
 
 /**
+ * Return the saturation of the layer.
  * @return {number} The saturation of the layer.
  * @observable
  * @api
@@ -222,6 +231,7 @@ ol.layer.Base.prototype.getSourceState = goog.abstractMethod;
 
 
 /**
+ * Return the visibility of the layer (`true` or `false`).
  * @return {boolean} The visibility of the layer.
  * @observable
  * @api stable
@@ -297,6 +307,7 @@ ol.layer.Base.prototype.setExtent = function(extent) {
 
 
 /**
+ * Set the maximum resolution at which the layer is visible.
  * @param {number} maxResolution The maximum resolution of the layer.
  * @observable
  * @api stable
@@ -307,6 +318,7 @@ ol.layer.Base.prototype.setMaxResolution = function(maxResolution) {
 
 
 /**
+ * Set the minimum resolution at which the layer is visible.
  * @param {number} minResolution The minimum resolution of the layer.
  * @observable
  * @api stable
@@ -317,6 +329,7 @@ ol.layer.Base.prototype.setMinResolution = function(minResolution) {
 
 
 /**
+ * Set the opacity of the layer, allowed values range from 0 to 1.
  * @param {number} opacity The opacity of the layer.
  * @observable
  * @api stable
@@ -342,6 +355,7 @@ ol.layer.Base.prototype.setSaturation = function(saturation) {
 
 
 /**
+ * Set the visibility of the layer (`true` or `false`).
  * @param {boolean} visible The visibility of the layer.
  * @observable
  * @api stable

--- a/src/ol/layer/layergroup.js
+++ b/src/ol/layer/layergroup.js
@@ -144,8 +144,10 @@ ol.layer.Group.prototype.handleLayersRemove_ = function(collectionEvent) {
 
 
 /**
+ * Returns the {@link ol.Collection collection} of {@link ol.layer.Layer layers}
+ * in this group.
  * @return {!ol.Collection.<ol.layer.Base>} Collection of
- * {@link ol.layer.Layer layers} that are part of this group.
+ *   {@link ol.layer.Layer layers} that are part of this group.
  * @observable
  * @api stable
  */
@@ -156,8 +158,10 @@ ol.layer.Group.prototype.getLayers = function() {
 
 
 /**
+ * Set the {@link ol.Collection collection} of {@link ol.layer.Layer layers}
+ * in this group.
  * @param {!ol.Collection.<ol.layer.Base>} layers Collection of
- * {@link ol.layer.Layer layers} that are part of this group.
+ *   {@link ol.layer.Layer layers} that are part of this group.
  * @observable
  * @api stable
  */

--- a/src/ol/layer/tilelayer.js
+++ b/src/ol/layer/tilelayer.js
@@ -45,6 +45,7 @@ goog.inherits(ol.layer.Tile, ol.layer.Layer);
 
 
 /**
+ * Return the level as number to which we will preload tiles up to.
  * @return {number} The level to preload tiles up to.
  * @observable
  * @api
@@ -55,6 +56,7 @@ ol.layer.Tile.prototype.getPreload = function() {
 
 
 /**
+ * Return the associated {@link ol.source.Tile tilesource} of the layer.
  * @function
  * @return {ol.source.Tile} Source.
  * @api stable
@@ -63,6 +65,7 @@ ol.layer.Tile.prototype.getSource;
 
 
 /**
+ * Set the level as number to which we will preload tiles up to.
  * @param {number} preload The level to preload tiles up to.
  * @observable
  * @api
@@ -73,6 +76,7 @@ ol.layer.Tile.prototype.setPreload = function(preload) {
 
 
 /**
+ * Whether we use interim tiles on error.
  * @return {boolean} Use interim tiles on error.
  * @observable
  * @api
@@ -84,6 +88,7 @@ ol.layer.Tile.prototype.getUseInterimTilesOnError = function() {
 
 
 /**
+ * Set whether we use interim tiles on error.
  * @param {boolean} useInterimTilesOnError Use interim tiles on error.
  * @observable
  * @api

--- a/src/ol/layer/vectorlayer.js
+++ b/src/ol/layer/vectorlayer.js
@@ -100,6 +100,7 @@ ol.layer.Vector.prototype.getRenderOrder = function() {
 
 
 /**
+ * Return the associated {@link ol.source.Vector vectorsource} of the layer.
  * @function
  * @return {ol.source.Vector} Source.
  * @api stable

--- a/src/ol/proj/proj.js
+++ b/src/ol/proj/proj.js
@@ -24,7 +24,7 @@ ol.proj.ProjectionLike;
 
 
 /**
- * Projection units: `'degrees'`, `'ft'`, `'m'` or `'pixels'`.
+ * Projection units: `'degrees'`, `'ft'`, `'m'`, `'pixels'`, or `'us-ft'`.
  * @enum {string}
  * @api stable
  */


### PR DESCRIPTION
This PR adds basic documentation to `@api` symbols of `ol.proj.*` and `ol.layer.*`.

Please review.

See also #3497, #3488 and #3580.