### PR TITLE
Simplify dragAndDropInteraction in examples

### DIFF
--- a/examples/drag-and-drop-image-vector.js
+++ b/examples/drag-and-drop-image-vector.js
@@ -114,17 +114,15 @@ var map = new ol.Map({
 
 dragAndDropInteraction.on('addfeatures', function(event) {
   var vectorSource = new ol.source.Vector({
-    features: event.features,
-    projection: event.projection
+    features: event.features
   });
-  map.getLayers().push(new ol.layer.Image({
+  map.addLayer(new ol.layer.Image({
     source: new ol.source.ImageVector({
       source: vectorSource,
       style: styleFunction
     })
   }));
-  var view = map.getView();
-  view.fitExtent(
+  map.getView().fitExtent(
       vectorSource.getExtent(), /** @type {ol.Size} */ (map.getSize()));
 });
 

--- a/examples/drag-and-drop.js
+++ b/examples/drag-and-drop.js
@@ -112,15 +112,13 @@ var map = new ol.Map({
 
 dragAndDropInteraction.on('addfeatures', function(event) {
   var vectorSource = new ol.source.Vector({
-    features: event.features,
-    projection: event.projection
+    features: event.features
   });
-  map.getLayers().push(new ol.layer.Vector({
+  map.addLayer(new ol.layer.Vector({
     source: vectorSource,
     style: styleFunction
   }));
-  var view = map.getView();
-  view.fitExtent(
+  map.getView().fitExtent(
       vectorSource.getExtent(), /** @type {ol.Size} */ (map.getSize()));
 });
 


### PR DESCRIPTION
I started off removing source.projection (overlooked in #3481), but thought I might as well change `getLayers().push` (huh?) as well, and remove an unnecessary var.