### PR TITLE
Handle left/right segment intersections for top/bottom spans

### DIFF
--- a/src/ol/extent.js
+++ b/src/ol/extent.js
@@ -814,17 +814,20 @@ ol.extent.intersectsSegment = function(extent, start, end) {
       // potentially intersects top
       x = endX - ((endY - maxY) / slope);
       intersects = x >= minX && x <= maxX;
-    } else if (!!(endRel & ol.extent.Relationship.RIGHT) &&
+    }
+    if (!intersects && !!(endRel & ol.extent.Relationship.RIGHT) &&
         !(startRel & ol.extent.Relationship.RIGHT)) {
       // potentially intersects right
       y = endY - ((endX - maxX) * slope);
       intersects = y >= minY && y <= maxY;
-    } else if (!!(endRel & ol.extent.Relationship.BELOW) &&
+    }
+    if (!intersects && !!(endRel & ol.extent.Relationship.BELOW) &&
         !(startRel & ol.extent.Relationship.BELOW)) {
       // potentially intersects bottom
       x = endX - ((endY - minY) / slope);
       intersects = x >= minX && x <= maxX;
-    } else if (!!(endRel & ol.extent.Relationship.LEFT) &&
+    }
+    if (!intersects && !!(endRel & ol.extent.Relationship.LEFT) &&
         !(startRel & ol.extent.Relationship.LEFT)) {
       // potentially intersects left
       y = endY - ((endX - minX) * slope);

--- a/test/spec/ol/extent.test.js
+++ b/test/spec/ol/extent.test.js
@@ -472,6 +472,22 @@ describe('ol.extent', function() {
       expect(intersects).to.be(false);
     });
 
+    it('works for left/right intersection spanning top to bottom', function() {
+      var extent = [2, 1, 3, 4];
+      var start = [0, 0];
+      var end = [5, 5];
+      expect(ol.extent.intersectsSegment(extent, start, end)).to.be(true);
+      expect(ol.extent.intersectsSegment(extent, end, start)).to.be(true);
+    });
+
+    it('works for top/bottom intersection spanning left to right', function() {
+      var extent = [1, 2, 4, 3];
+      var start = [0, 0];
+      var end = [5, 5];
+      expect(ol.extent.intersectsSegment(extent, start, end)).to.be(true);
+      expect(ol.extent.intersectsSegment(extent, end, start)).to.be(true);
+    });
+
   });
 
   describe('#applyTransform()', function() {


### PR DESCRIPTION
The `ol.extent.intersectsSegment` function was not correctly handling segments that span from above to below an extent while intersecting the sides.

Fixes #3585.