### PR TITLE
Add /examples/index.js to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 /build/
+/examples/index.js
 /node_modules/
 /dist/
 /coverage/


### PR DESCRIPTION
The file is created by `tasks/build-examples.js`