### PR TITLE
Remove unnecessary entry in `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.pyc
 /build/
-/examples/index.js
 /node_modules/
 /dist/
 /coverage/


### PR DESCRIPTION
The `examples/index.js` file is a pre #3558 relic.  You can delete it (or `git clean`), and it shouldn't be generated again.  If it is, that is a bug.

