### PR TITLE
Rename ol.feature.FeatureStyleFunction to ol.FeatureStyleFunction

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -139,13 +139,17 @@
 with the `imgSize` option and not with `size`. `size` is supposed to be used for the
 size of a sub-rectangle in an image sprite.
 
-### Support for non-square tiles
+#### Support for non-square tiles
 
 The return value of `ol.tilegrid.TileGrid#getTileSize()` will now be an `ol.Size` array instead of a number if non-square tiles (i.e. an `ol.Size` array instead of a number as `tilsSize`) are used. To always get an `ol.Size`, the new `ol.size.toSize()` was added.
 
-### Change to `ol.interaction.Draw`
+#### Change to `ol.interaction.Draw`
 
 When finishing a draw, the `drawend` event is now dispatched before the feature is inserted to either the source or the collection. This change allows application code to finish setting up the feature.
+
+#### Misc.
+
+If you compile your application together with the library and use the `ol.feature.FeatureStyleFunction` type annotation (this should be extremely rare), the type is now named `ol.FeatureStyleFunction`.
 
 ### v3.4.0
 

--- a/doc/tutorials/introduction.md
+++ b/doc/tutorials/introduction.md
@@ -39,6 +39,4 @@ Class namespaces, such as `ol.layer` have a base class type with the same name, 
 
 Source files are similarly organised, with a directory for each class namespace. Names are however all lower-case, and the subclasses repeat the superclass type in their name, for example, `ol/layer/vectorlayer.js`.
 
-The naming structure means that there are sometimes 2 objects with the same name but different initial, such as `ol.feature`, a simple object with static functions to be used with features, and `ol.Feature`, a class used to instantiate new features. These two objects are however stored in the same file, in this case, `ol/feature.js`
-
 OL3 follows the convention that the names of private properties and methods, that is, those that are not part of the API, end in an underscore. In general, instance properties are private and accessed using accessors.

--- a/src/ol/feature.js
+++ b/src/ol/feature.js
@@ -1,5 +1,5 @@
 goog.provide('ol.Feature');
-goog.provide('ol.feature');
+goog.provide('ol.FeatureStyleFunction');
 
 goog.require('goog.asserts');
 goog.require('goog.events');
@@ -78,13 +78,13 @@ ol.Feature = function(opt_geometryOrProperties) {
    * User provided style.
    * @private
    * @type {ol.style.Style|Array.<ol.style.Style>|
-   *     ol.feature.FeatureStyleFunction}
+   *     ol.FeatureStyleFunction}
    */
   this.style_ = null;
 
   /**
    * @private
-   * @type {ol.feature.FeatureStyleFunction|undefined}
+   * @type {ol.FeatureStyleFunction|undefined}
    */
   this.styleFunction_ = undefined;
 
@@ -175,7 +175,7 @@ ol.Feature.prototype.getGeometryName = function() {
  * Get the feature's style.  This return for this method depends on what was
  * provided to the {@link ol.Feature#setStyle} method.
  * @return {ol.style.Style|Array.<ol.style.Style>|
- *     ol.feature.FeatureStyleFunction} The feature style.
+ *     ol.FeatureStyleFunction} The feature style.
  * @api stable
  */
 ol.Feature.prototype.getStyle = function() {
@@ -185,7 +185,7 @@ ol.Feature.prototype.getStyle = function() {
 
 /**
  * Get the feature's style function.
- * @return {ol.feature.FeatureStyleFunction|undefined} Return a function
+ * @return {ol.FeatureStyleFunction|undefined} Return a function
  * representing the current style of this feature.
  * @api stable
  */
@@ -236,13 +236,13 @@ ol.Feature.prototype.setGeometry = function(geometry) {
  * of styles, or a function that takes a resolution and returns an array of
  * styles. If it is `null` the feature has no style (a `null` style).
  * @param {ol.style.Style|Array.<ol.style.Style>|
- *     ol.feature.FeatureStyleFunction} style Style for this feature.
+ *     ol.FeatureStyleFunction} style Style for this feature.
  * @api stable
  */
 ol.Feature.prototype.setStyle = function(style) {
   this.style_ = style;
   this.styleFunction_ = goog.isNull(style) ?
-      undefined : ol.feature.createFeatureStyleFunction(style);
+      undefined : ol.Feature.createStyleFunction(style);
   this.changed();
 };
 
@@ -287,26 +287,25 @@ ol.Feature.prototype.setGeometryName = function(name) {
  * @typedef {function(this: ol.Feature, number): Array.<ol.style.Style>}
  * @api stable
  */
-ol.feature.FeatureStyleFunction;
+ol.FeatureStyleFunction;
 
 
 /**
  * Convert the provided object into a feature style function.  Functions passed
  * through unchanged.  Arrays of ol.style.Style or single style objects wrapped
  * in a new feature style function.
- * @param {ol.feature.FeatureStyleFunction|!Array.<ol.style.Style>|
- *     !ol.style.Style} obj A feature style function, a single style, or an
- *     array of styles.
- * @return {ol.feature.FeatureStyleFunction} A style function.
+ * @param {ol.FeatureStyleFunction|!Array.<ol.style.Style>|!ol.style.Style} obj
+ *     A feature style function, a single style, or an array of styles.
+ * @return {ol.FeatureStyleFunction} A style function.
  */
-ol.feature.createFeatureStyleFunction = function(obj) {
+ol.Feature.createStyleFunction = function(obj) {
   /**
-   * @type {ol.feature.FeatureStyleFunction}
+   * @type {ol.FeatureStyleFunction}
    */
   var styleFunction;
 
   if (goog.isFunction(obj)) {
-    styleFunction = /** @type {ol.feature.FeatureStyleFunction} */ (obj);
+    styleFunction = /** @type {ol.FeatureStyleFunction} */ (obj);
   } else {
     /**
      * @type {Array.<ol.style.Style>}

--- a/src/ol/feature.jsdoc
+++ b/src/ol/feature.jsdoc
@@ -1,3 +1,0 @@
-/**
- * @namespace ol.feature
- */

--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -14,8 +14,8 @@ goog.require('goog.math');
 goog.require('goog.object');
 goog.require('goog.string');
 goog.require('ol.Feature');
+goog.require('ol.FeatureStyleFunction');
 goog.require('ol.color');
-goog.require('ol.feature');
 goog.require('ol.format.Feature');
 goog.require('ol.format.XMLFeature');
 goog.require('ol.format.XSD');
@@ -120,7 +120,7 @@ ol.format.KML = function(opt_options) {
 
   /**
    * @private
-   * @type {ol.feature.FeatureStyleFunction}
+   * @type {ol.FeatureStyleFunction}
    */
   this.featureStyleFunction_ =
       /**

--- a/test/spec/ol/feature.test.js
+++ b/test/spec/ol/feature.test.js
@@ -432,16 +432,16 @@ describe('ol.Feature', function() {
 
 });
 
-describe('ol.feature.createFeatureStyleFunction()', function() {
+describe('ol.Feature.createStyleFunction()', function() {
   var style = new ol.style.Style();
 
   it('creates a feature style function from a single style', function() {
-    var styleFunction = ol.feature.createFeatureStyleFunction(style);
+    var styleFunction = ol.Feature.createStyleFunction(style);
     expect(styleFunction()).to.eql([style]);
   });
 
   it('creates a feature style function from an array of styles', function() {
-    var styleFunction = ol.feature.createFeatureStyleFunction([style]);
+    var styleFunction = ol.Feature.createStyleFunction([style]);
     expect(styleFunction()).to.eql([style]);
   });
 
@@ -449,13 +449,13 @@ describe('ol.feature.createFeatureStyleFunction()', function() {
     var original = function() {
       return [style];
     };
-    var styleFunction = ol.feature.createFeatureStyleFunction(original);
+    var styleFunction = ol.Feature.createStyleFunction(original);
     expect(styleFunction).to.be(original);
   });
 
   it('throws on (some) unexpected input', function() {
     expect(function() {
-      ol.feature.createFeatureStyleFunction({bogus: 'input'});
+      ol.Feature.createStyleFunction({bogus: 'input'});
     }).to.throwException();
   });
 
@@ -465,6 +465,5 @@ describe('ol.feature.createFeatureStyleFunction()', function() {
 goog.require('goog.events');
 goog.require('goog.object');
 goog.require('ol.Feature');
-goog.require('ol.feature');
 goog.require('ol.geom.Point');
 goog.require('ol.style.Style');

--- a/test/spec/ol/layer/vectorlayer.test.js
+++ b/test/spec/ol/layer/vectorlayer.test.js
@@ -1,7 +1,5 @@
 goog.provide('ol.test.layer.Vector');
 
-goog.require('ol.feature');
-
 describe('ol.layer.Vector', function() {
 
   describe('constructor', function() {


### PR DESCRIPTION
This puts `ol.FeatureStyleFunction` in the heap of `ol` function typedefs (along with `ol.CanvasFunctionType`, `ol.CoordinateFormatType`, `ol.ImageLoadFunctionType`, `ol.PreRenderFunction`, `ol.TileLoadFunctionType`, `ol.TileUrlFunctionType`, `ol.TransformFunction`).

This is really about avoiding problems with the API docs where a namespace matches a symbol in a case insensitive way (see #2149).  But it also seems somewhat justified given the other `*Function` types.

Fixes #2149.