### PR TITLE
vector-esri-edit.html uses non api method

### DIFF
--- a/examples/vector-esri-edit.js
+++ b/examples/vector-esri-edit.js
@@ -90,7 +90,7 @@ selected.on('remove', function(evt) {
   var fid = feature.getId();
   if (dirty[fid] === true) {
     var payload = '[' + esrijsonFormat.writeFeature(feature, {
-      featureProjection: select.getMap().getView().getProjection()
+      featureProjection: map.getView().getProjection()
     }) + ']';
     var url = serviceUrl + layer + '/updateFeatures';
     $.post(url, { f: 'json', features: payload }).done(function(data) {
@@ -110,7 +110,7 @@ selected.on('remove', function(evt) {
 draw.on('drawend', function(evt) {
   var feature = evt.feature;
   var payload = '[' + esrijsonFormat.writeFeature(feature, {
-    featureProjection: evt.target.getMap().getView().getProjection()
+    featureProjection: map.getView().getProjection()
   }) + ']';
   var url = serviceUrl + layer + '/addFeatures';
   $.post(url, { f: 'json', features: payload }).done(function(data) {


### PR DESCRIPTION
It uses getMap on the select and draw interaction but this is not marked as ```@api``` so this will not work in the hosted example.