### PR TITLE
Add ol.source.WMTS#getUrls and getRequestEncoding

### DIFF
--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -96,9 +96,16 @@ ol.source.WMTS = function(options) {
 
   // FIXME: should we guess this requestEncoding from options.url(s)
   //        structure? that would mean KVP only if a template is not provided.
-  var requestEncoding = goog.isDef(options.requestEncoding) ?
+
+  /**
+   * @private
+   * @type {ol.source.WMTSRequestEncoding}
+   */
+  this.requestEncoding_ = goog.isDef(options.requestEncoding) ?
       /** @type {ol.source.WMTSRequestEncoding} */ (options.requestEncoding) :
       ol.source.WMTSRequestEncoding.KVP;
+
+  var requestEncoding = this.requestEncoding_;
 
   // FIXME: should we create a default tileGrid?
   // we could issue a getCapabilities xhr to retrieve missing configuration
@@ -265,6 +272,16 @@ ol.source.WMTS.prototype.getLayer = function() {
  */
 ol.source.WMTS.prototype.getMatrixSet = function() {
   return this.matrixSet_;
+};
+
+
+/**
+ * Return the request encoding, either "KVP" or "REST".
+ * @return {ol.source.WMTSRequestEncoding} Request encoding.
+ * @api
+ */
+ol.source.WMTS.prototype.getRequestEncoding = function() {
+  return this.requestEncoding_;
 };
 
 

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -83,6 +83,17 @@ ol.source.WMTS = function(options) {
    */
   this.style_ = options.style;
 
+  var urls = options.urls;
+  if (!goog.isDef(urls) && goog.isDef(options.url)) {
+    urls = ol.TileUrlFunction.expandUrl(options.url);
+  }
+
+  /**
+   * @private
+   * @type {!Array.<string>}
+   */
+  this.urls_ = goog.isDefAndNotNull(urls) ? urls : [];
+
   // FIXME: should we guess this requestEncoding from options.url(s)
   //        structure? that would mean KVP only if a template is not provided.
   var requestEncoding = goog.isDef(options.requestEncoding) ?
@@ -158,15 +169,10 @@ ol.source.WMTS = function(options) {
         });
   }
 
-  var tileUrlFunction = ol.TileUrlFunction.nullTileUrlFunction;
-  var urls = options.urls;
-  if (!goog.isDef(urls) && goog.isDef(options.url)) {
-    urls = ol.TileUrlFunction.expandUrl(options.url);
-  }
-  if (goog.isDef(urls)) {
-    tileUrlFunction = ol.TileUrlFunction.createFromTileUrlFunctions(
-        goog.array.map(urls, createFromWMTSTemplate));
-  }
+  var tileUrlFunction = this.urls_.length > 0 ?
+      ol.TileUrlFunction.createFromTileUrlFunctions(
+          goog.array.map(this.urls_, createFromWMTSTemplate)) :
+      ol.TileUrlFunction.nullTileUrlFunction;
 
   var tmpExtent = ol.extent.createEmpty();
   tileUrlFunction = ol.TileUrlFunction.withTileCoordTransform(
@@ -269,6 +275,16 @@ ol.source.WMTS.prototype.getMatrixSet = function() {
  */
 ol.source.WMTS.prototype.getStyle = function() {
   return this.style_;
+};
+
+
+/**
+ * Return the URLs used for this WMTS source.
+ * @return {!Array.<string>} URLs.
+ * @api
+ */
+ol.source.WMTS.prototype.getUrls = function() {
+  return this.urls_;
 };
 
 

--- a/src/ol/tileurlfunction.js
+++ b/src/ol/tileurlfunction.js
@@ -2,6 +2,7 @@ goog.provide('ol.TileUrlFunction');
 goog.provide('ol.TileUrlFunctionType');
 
 goog.require('goog.array');
+goog.require('goog.asserts');
 goog.require('goog.math');
 goog.require('ol.TileCoord');
 goog.require('ol.tilecoord');
@@ -74,6 +75,8 @@ ol.TileUrlFunction.createFromTemplates = function(templates) {
  * @return {ol.TileUrlFunctionType} Tile URL function.
  */
 ol.TileUrlFunction.createFromTileUrlFunctions = function(tileUrlFunctions) {
+  goog.asserts.assert(tileUrlFunctions.length > 0,
+      'Length of tile url functions should be greater than 0');
   if (tileUrlFunctions.length === 1) {
     return tileUrlFunctions[0];
   }

--- a/test/spec/ol/source/wmtssource.test.js
+++ b/test/spec/ol/source/wmtssource.test.js
@@ -162,6 +162,53 @@ describe('ol.source.WMTS', function() {
              'Demographics/USA_Population_Density/MapServer/WMTS?');
         });
   });
+
+  describe('#getUrls', function() {
+
+    var sourceOptions;
+    var source;
+
+    beforeEach(function() {
+      sourceOptions = {
+        layer: 'layer',
+        style: 'default',
+        matrixSet: 'foo',
+        requestEncoding: 'REST',
+        tileGrid: new ol.tilegrid.WMTS({
+          origin: [0, 0],
+          resolutions: [],
+          matrixIds: []
+        })
+      };
+    });
+
+    describe('using a "url" option', function() {
+      beforeEach(function() {
+        sourceOptions.url = 'some_wmts_url';
+        source = new ol.source.WMTS(sourceOptions);
+      });
+
+      it('returns the WMTS URLs', function() {
+        var urls = source.getUrls();
+        expect(urls).to.be.eql(['some_wmts_url']);
+      });
+
+    });
+
+    describe('using a "urls" option', function() {
+      beforeEach(function() {
+        sourceOptions.urls = ['some_wmts_url1', 'some_wmts_url2'];
+        source = new ol.source.WMTS(sourceOptions);
+      });
+
+      it('returns the WMTS URLs', function() {
+        var urls = source.getUrls();
+        expect(urls).to.be.eql(['some_wmts_url1', 'some_wmts_url2']);
+      });
+
+    });
+
+  });
 });
 
 goog.require('ol.format.WMTSCapabilities');

--- a/test/spec/ol/source/wmtssource.test.js
+++ b/test/spec/ol/source/wmtssource.test.js
@@ -209,6 +209,32 @@ describe('ol.source.WMTS', function() {
     });
 
   });
+
+  describe('#getRequestEncoding', function() {
+
+    var source;
+
+    beforeEach(function() {
+      source = new ol.source.WMTS({
+        layer: 'layer',
+        style: 'default',
+        matrixSet: 'foo',
+        requestEncoding: 'REST',
+        tileGrid: new ol.tilegrid.WMTS({
+          origin: [0, 0],
+          resolutions: [],
+          matrixIds: []
+        })
+      });
+    });
+
+    it('returns the request encoding', function() {
+      var requestEncoding = source.getRequestEncoding();
+      expect(requestEncoding).to.be.eql('REST');
+    });
+
+  });
+
 });
 
 goog.require('ol.format.WMTSCapabilities');


### PR DESCRIPTION
This PR adds a `getUrls` method to `ol.source.WMTS`. This is on par with the `getUrls` method on `ol.source.TileArcGISRest` and `ol.source.TileWMS`.

Please review.