### PR TITLE
Add a one sentence summary for ol.interaction* exportable symbols

### DIFF
--- a/src/ol/interaction/doubleclickzoominteraction.js
+++ b/src/ol/interaction/doubleclickzoominteraction.js
@@ -41,6 +41,8 @@ goog.inherits(ol.interaction.DoubleClickZoom, ol.interaction.Interaction);
 
 
 /**
+ * Handles the {@link ol.MapBrowserEvent map browser event} (if it was a
+ * doubleclick) and eventually zooms the map.
  * @param {ol.MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} `false` to stop event propagation.
  * @this {ol.interaction.DoubleClickZoom}

--- a/src/ol/interaction/draganddropinteraction.js
+++ b/src/ol/interaction/draganddropinteraction.js
@@ -136,6 +136,8 @@ ol.interaction.DragAndDrop.prototype.handleResult_ = function(file, result) {
 
 
 /**
+ * Handles the {@link ol.MapBrowserEvent map browser event} unconditionally and
+ * neither prevents the browser default nor stops event propagation.
  * @param {ol.MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} `false` to stop event propagation.
  * @this {ol.interaction.DragAndDrop}

--- a/src/ol/interaction/drawinteraction.js
+++ b/src/ol/interaction/drawinteraction.js
@@ -241,6 +241,8 @@ ol.interaction.Draw.prototype.setMap = function(map) {
 
 
 /**
+ * Handles the {@link ol.MapBrowserEvent map browser event} and may actually
+ * draw or finish the drawing.
  * @param {ol.MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} `false` to stop event propagation.
  * @this {ol.interaction.Draw}

--- a/src/ol/interaction/interaction.js
+++ b/src/ol/interaction/interaction.js
@@ -57,6 +57,7 @@ goog.inherits(ol.interaction.Interaction, ol.Object);
 
 
 /**
+ * Return whether the interaction is currently active.
  * @return {boolean} `true` if the interaction is active, `false` otherwise.
  * @observable
  * @api

--- a/src/ol/interaction/keyboardpaninteraction.js
+++ b/src/ol/interaction/keyboardpaninteraction.js
@@ -61,6 +61,9 @@ goog.inherits(ol.interaction.KeyboardPan, ol.interaction.Interaction);
 
 
 /**
+ * Handles the {@link ol.MapBrowserEvent map browser event} if it was a
+ * `KeyEvent`, and decides the direction to pan to (if an arrow key was
+ * pressed).
  * @param {ol.MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} `false` to stop event propagation.
  * @this {ol.interaction.KeyboardPan}

--- a/src/ol/interaction/keyboardzoominteraction.js
+++ b/src/ol/interaction/keyboardzoominteraction.js
@@ -57,6 +57,9 @@ goog.inherits(ol.interaction.KeyboardZoom, ol.interaction.Interaction);
 
 
 /**
+ * Handles the {@link ol.MapBrowserEvent map browser event} if it was a
+ * `KeyEvent`, and decides whether to zoom in or out (depending on whether the
+ * key pressed was '+' or '-').
  * @param {ol.MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} `false` to stop event propagation.
  * @this {ol.interaction.KeyboardZoom}

--- a/src/ol/interaction/modifyinteraction.js
+++ b/src/ol/interaction/modifyinteraction.js
@@ -535,6 +535,8 @@ ol.interaction.Modify.handleUpEvent_ = function(evt) {
 
 
 /**
+ * Handles the {@link ol.MapBrowserEvent map browser event} and may modify the
+ * geometry.
  * @param {ol.MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} `false` to stop event propagation.
  * @this {ol.interaction.Modify}

--- a/src/ol/interaction/mousewheelzoominteraction.js
+++ b/src/ol/interaction/mousewheelzoominteraction.js
@@ -62,6 +62,8 @@ goog.inherits(ol.interaction.MouseWheelZoom, ol.interaction.Interaction);
 
 
 /**
+ * Handles the {@link ol.MapBrowserEvent map browser event} (if it was a
+ * mousewheel-event) and eventually zooms the map.
  * @param {ol.MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} `false` to stop event propagation.
  * @this {ol.interaction.MouseWheelZoom}

--- a/src/ol/interaction/pointerinteraction.js
+++ b/src/ol/interaction/pointerinteraction.js
@@ -171,6 +171,9 @@ ol.interaction.Pointer.handleMoveEvent = goog.nullFunction;
 
 
 /**
+ * Handles the {@link ol.MapBrowserEvent map browser event} and may call into
+ * other functions, if event sequences like e.g. 'drag' or 'down-up' etc. are
+ * detected.
  * @param {ol.MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} `false` to stop event propagation.
  * @this {ol.interaction.Pointer}

--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -187,6 +187,8 @@ ol.interaction.Select.prototype.getFeatures = function() {
 
 
 /**
+ * Handles the {@link ol.MapBrowserEvent map browser event} and may change the
+ * selected state of features.
  * @param {ol.MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} `false` to stop event propagation.
  * @this {ol.interaction.Select}

--- a/src/ol/interaction/snapinteraction.js
+++ b/src/ol/interaction/snapinteraction.js
@@ -152,6 +152,7 @@ goog.inherits(ol.interaction.Snap, ol.interaction.Pointer);
 
 
 /**
+ * Add a feature to the collection of features that we may snap to.
  * @param {ol.Feature} feature Feature.
  * @param {boolean=} opt_listen Whether to listen to the geometry change or not
  *     Defaults to `true`.
@@ -278,6 +279,7 @@ ol.interaction.Snap.prototype.handleGeometryModify_ = function(feature, evt) {
 
 
 /**
+ * Remove a feature from the collection of features that we may snap to.
  * @param {ol.Feature} feature Feature
  * @param {boolean=} opt_unlisten Whether to unlisten to the geometry change
  *     or not. Defaults to `true`.


### PR DESCRIPTION
This PR adds basic documentation to `@api` symbols of `ol.interaction`.

Please review.

See also

* #3488: first batch of docs by @tschaub)
* #3497: overview issue of missing docs
* #3583: docs for `ol.proj.*`, `ol.layer.*`
* #3580: docs for `ol.source.*`