### PR TITLE
Add ol.size.hasArea

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -57,6 +57,7 @@ goog.require('ol.renderer.Map');
 goog.require('ol.renderer.canvas.Map');
 goog.require('ol.renderer.dom.Map');
 goog.require('ol.renderer.webgl.Map');
+goog.require('ol.size');
 goog.require('ol.structs.PriorityQueue');
 goog.require('ol.tilecoord');
 goog.require('ol.vec.Mat4');
@@ -1263,25 +1264,11 @@ ol.Map.prototype.renderFrame_ = function(time) {
 
   var i, ii, viewState;
 
-  /**
-   * Check whether a size has non-zero width and height.  Note that this
-   * function is here because the compiler doesn't recognize that size is
-   * defined in the frameState assignment below when the same code is inline in
-   * the condition below.  The compiler inlines this function itself, so the
-   * resulting code is the same.
-   *
-   * @param {ol.Size} size The size to test.
-   * @return {boolean} Has non-zero width and height.
-   */
-  function hasArea(size) {
-    return size[0] > 0 && size[1] > 0;
-  }
-
   var size = this.getSize();
   var view = this.getView();
   /** @type {?olx.FrameState} */
   var frameState = null;
-  if (goog.isDef(size) && hasArea(size) &&
+  if (goog.isDef(size) && ol.size.hasArea(size) &&
       !goog.isNull(view) && view.isDef()) {
     var viewHints = view.getHints();
     var layerStatesArray = this.getLayerGroup().getLayerStatesArray();

--- a/src/ol/size.js
+++ b/src/ol/size.js
@@ -42,6 +42,16 @@ ol.size.equals = function(a, b) {
 
 
 /**
+ * Determines if a size has a positive area.
+ * @param {ol.Size} size The size to test.
+ * @return {boolean} The size has a positive area.
+ */
+ol.size.hasArea = function(size) {
+  return size[0] > 0 && size[1] > 0;
+};
+
+
+/**
  * Returns a size scaled by a ratio. The result will be an array of integers.
  * @param {ol.Size} size Size.
  * @param {number} ratio Ratio.

--- a/test/spec/ol/size.test.js
+++ b/test/spec/ol/size.test.js
@@ -3,7 +3,7 @@ goog.provide('ol.test.size');
 
 describe('ol.size', function() {
 
-  describe('#buffer()', function() {
+  describe('buffer()', function() {
 
     it('buffers a size', function() {
       var size = [50, 75];
@@ -20,7 +20,21 @@ describe('ol.size', function() {
 
   });
 
-  describe('#scale()', function() {
+  describe('hasArea()', function() {
+
+    it('determines if a size has a positive area', function() {
+      expect(ol.size.hasArea([50, 75])).to.equal(true);
+      expect(ol.size.hasArea([0, 75])).to.equal(false);
+      expect(ol.size.hasArea([50, 0])).to.equal(false);
+      expect(ol.size.hasArea([0, 0])).to.equal(false);
+      expect(ol.size.hasArea([-1, 75])).to.equal(false);
+      expect(ol.size.hasArea([50, -1])).to.equal(false);
+      expect(ol.size.hasArea([-1, -1])).to.equal(false);
+    });
+
+  });
+
+  describe('scale()', function() {
 
     it('scales a size and rounds the result', function() {
       var size = [50, 75];
@@ -37,7 +51,7 @@ describe('ol.size', function() {
 
   });
 
-  describe('#toSize()', function() {
+  describe('toSize()', function() {
 
     it('creates a size array from a number', function() {
       var size = ol.size.toSize(512);


### PR DESCRIPTION
This pulls the `hasArea` function from `map.js` and puts it in `size.js`.  The compiled output is the same with and without this, so it is mainly a stylistic change.  I'm working on removing cases where we shadow variables.  An alternative would be to rename the argument for `hasArea`, but it seems more appropriate to have `ol.size.hasArea`.