### PR TITLE
Replace non-breaking space (U+00A0) with regular space (U+0020)

### DIFF
--- a/changelog/v3.1.0.md
+++ b/changelog/v3.1.0.md
@@ -112,7 +112,7 @@ The 3.1.0 release maintains a backwards-compatible API with the 3.0.0 release, s
  * [#2781](https://github.com/openlayers/ol3/pull/2781) - Use a standard title attribute for the control buttons ([@fredj](https://github.com/fredj))
  * [#2852](https://github.com/openlayers/ol3/pull/2852) - Add missing space between class names ([@fredj](https://github.com/fredj))
  * [#2891](https://github.com/openlayers/ol3/pull/2891) - Introduce a load function for image sources ([@ahocevar](https://github.com/ahocevar))
- * [#2885](https://github.com/openlayers/ol3/pull/2885) - Add wrapX option to TileJSON source ([@elemoine](https://github.com/elemoine))
+ * [#2885](https://github.com/openlayers/ol3/pull/2885) - Add wrapX option to TileJSON source ([@elemoine](https://github.com/elemoine))
  * [#2890](https://github.com/openlayers/ol3/pull/2890) - Use correct layer property names ([@elemoine](https://github.com/elemoine))
  * [#2887](https://github.com/openlayers/ol3/pull/2887) - Explicitly pass coordinate dimension before transforming. ([@tschaub](https://github.com/tschaub))
  * [#2886](https://github.com/openlayers/ol3/pull/2886) - Use ternary notation ([@elemoine](https://github.com/elemoine))

--- a/changelog/v3.2.0.md
+++ b/changelog/v3.2.0.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-The 3.1.0 release includes 70 merged pull requests since 3.1.0.  Of note, the KML format [now parses `NetworkingLink` tags](https://github.com/openlayers/ol3/pull/3171).  The [measure example](http://openlayers.org/en/v3.2.0/examples/measure.html) was [reworked](https://github.com/openlayers/ol3/pull/3206) to display measurements and help messages while drawing.  A WMTS GetCapabilities format was [added](https://github.com/openlayers/ol3/pull/3026).  The WebGL renderer [now supports feature hit detection](https://github.com/openlayers/ol3/pull/3065) (on point features).  And you can now [detect](https://github.com/openlayers/ol3/pull/3172) features/colored pixels on image and tile layers!  See the full list of [changes](#changes) below.
+The 3.1.0 release includes 70 merged pull requests since 3.1.0.  Of note, the KML format [now parses `NetworkingLink` tags](https://github.com/openlayers/ol3/pull/3171).  The [measure example](http://openlayers.org/en/v3.2.0/examples/measure.html) was [reworked](https://github.com/openlayers/ol3/pull/3206) to display measurements and help messages while drawing.  A WMTS GetCapabilities format was [added](https://github.com/openlayers/ol3/pull/3026).  The WebGL renderer [now supports feature hit detection](https://github.com/openlayers/ol3/pull/3065) (on point features).  And you can now [detect](https://github.com/openlayers/ol3/pull/3172) features/colored pixels on image and tile layers!  See the full list of [changes](#changes) below.
 
 ## Upgrade notes
 

--- a/doc/tutorials/closure.md
+++ b/doc/tutorials/closure.md
@@ -283,9 +283,9 @@ Here is a version of `config.json` with more compilation checks enabled:
 }
 ```
 
-## Create an HTML file for the Application
+## Create an HTML file for the Application
 
-You can now go ahead and create a simple HTML for the application. Create
+You can now go ahead and create a simple HTML for the application. Create
 a `index.html` file with the following content at the root the application
 directory:
 

--- a/doc/tutorials/custom-builds.md
+++ b/doc/tutorials/custom-builds.md
@@ -159,7 +159,7 @@ As a test, you can use the following HTML file to verify that your custom build 
 
 Closure allows you to define constants that can be set at compile time. The `define` config property above sets four `goog` properties for the Closure library. The OpenLayers 3 code also has defined values you can set.
 
-Setting some of these to `false` means that the portions of the code relating to this setting become "dead", i.e. are never executed. As Closure Compiler's `ADVANCED` mode removes dead code, this makes the size of the advanced compiled file smaller.
+Setting some of these to `false` means that the portions of the code relating to this setting become "dead", i.e. are never executed. As Closure Compiler's `ADVANCED` mode removes dead code, this makes the size of the advanced compiled file smaller.
 
 You might have noticed that the build file you've just created is considerably smaller than the full build, but it can be reduced further. This is because all three renderers and all layer types are included by default. We only need one renderer, and only need the tile layer, so can exclude the others by setting these properties with `define`s. So add the following to the define section of the config above:
 ```

--- a/examples/icon-sprite-webgl.html
+++ b/examples/icon-sprite-webgl.html
@@ -1,6 +1,6 @@
 ---
 template: example.html
-title: Icon sprites with WebGL example
+title: Icon sprites with WebGL example
 shortdesc: Icon sprite with WebGL
 docs: >
   <p>In this example a sprite image is used for the icon styles. Using a sprite is required to get good performance with WebGL.</p>

--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -19,7 +19,7 @@ ol.FeatureLoader;
 
 
 /**
- * @param {string} url Feature URL service.
+ * @param {string} url Feature URL service.
  * @param {ol.format.Feature} format Feature format.
  * @param {function(this:ol.source.Vector, Array.<ol.Feature>)} success
  *     Function called with the loaded features. Called with the vector
@@ -87,7 +87,7 @@ ol.featureloader.loadFeaturesXhr = function(url, format, success) {
  * Create an XHR feature loader for a `url` and `format`. The feature loader
  * loads features (with XHR), parses the features, and adds them to the
  * vector source.
- * @param {string} url Feature URL service.
+ * @param {string} url Feature URL service.
  * @param {ol.format.Feature} format Feature format.
  * @return {ol.FeatureLoader} The feature loader.
  * @api

--- a/src/ol/source/imagewmssource.js
+++ b/src/ol/source/imagewmssource.js
@@ -327,7 +327,7 @@ ol.source.ImageWMS.prototype.getRequestUrl_ =
 
 
 /**
- * Return the URL used for this WMS source.
+ * Return the URL used for this WMS source.
  * @return {string|undefined} URL.
  * @api stable
  */

--- a/src/ol/source/tilearcgisrestsource.js
+++ b/src/ol/source/tilearcgisrestsource.js
@@ -158,7 +158,7 @@ ol.source.TileArcGISRest.prototype.getTilePixelSize =
 
 
 /**
- * Return the URLs used for this ArcGIS source.
+ * Return the URLs used for this ArcGIS source.
  * @return {!Array.<string>} URLs.
  * @api stable
  */

--- a/src/ol/source/tilewmssource.js
+++ b/src/ol/source/tilewmssource.js
@@ -298,7 +298,7 @@ ol.source.TileWMS.prototype.getTilePixelSize =
 
 
 /**
- * Return the URLs used for this WMS source.
+ * Return the URLs used for this WMS source.
  * @return {!Array.<string>} URLs.
  * @api stable
  */

--- a/src/ol/webgl/context.js
+++ b/src/ol/webgl/context.js
@@ -215,7 +215,7 @@ ol.webgl.Context.prototype.getHitDetectionFramebuffer = function() {
 
 /**
  * Get shader from the cache if it's in the cache. Otherwise, create
- * the WebGL shader, compile it, and add entry to cache.
+ * the WebGL shader, compile it, and add entry to cache.
  * @param {ol.webgl.Shader} shaderObject Shader object.
  * @return {WebGLShader} Shader.
  */
@@ -246,7 +246,7 @@ ol.webgl.Context.prototype.getShader = function(shaderObject) {
 
 /**
  * Get the program from the cache if it's in the cache. Otherwise create
- * the WebGL program, attach the shaders to it, and add an entry to the
+ * the WebGL program, attach the shaders to it, and add an entry to the
  * cache.
  * @param {ol.webgl.shader.Fragment} fragmentShaderObject Fragment shader.
  * @param {ol.webgl.shader.Vertex} vertexShaderObject Vertex shader.

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -338,7 +338,7 @@ ol.xml.setAttributeNS =
 
 
 /**
- * Parse an XML string to an XML Document.
+ * Parse an XML string to an XML Document.
  * @param {string} xml XML.
  * @return {Document} Document.
  * @api

--- a/tasks/generate-externs.js
+++ b/tasks/generate-externs.js
@@ -161,7 +161,7 @@ function generateExterns(typedefs, symbols, externs, base) {
   // defined as types in the ol externs file. But the corresponding @typedef's
   // are not marked with an @api annotation because abstract base classes are
   // not instantiated by applications. Yet, we need to have a type defined
-  // in the ol externs file for these options types. So we just use
+  // in the ol externs file for these options types. So we just use
   // @typedef {Object}.
   Object.keys(constructorOptionsTypes).forEach(function(key) {
     lines.push('/**');


### PR DESCRIPTION
We have a number of unintentional `NO-BREAK-SPACE` (U+00A0) characters scattered around.  These mess with text flow in documentation.  These creep in when people copy/paste or inadvertently type Alt + Space (on OSX).  In the future, we can have [a linter](http://eslint.org/docs/rules/no-irregular-whitespace) that warns about this.