### PR TITLE
Add a one sentence summary for ol.geom.* exportable symbols

### DIFF
--- a/src/ol/geom/circle.js
+++ b/src/ol/geom/circle.js
@@ -85,6 +85,7 @@ ol.geom.Circle.prototype.containsXY = function(x, y) {
 
 
 /**
+ * Return the center of the circle as {@link ol.Coordinate coordinate}.
  * @return {ol.Coordinate} Center.
  * @api
  */
@@ -107,6 +108,7 @@ ol.geom.Circle.prototype.computeExtent = function(extent) {
 
 
 /**
+ * Return the radius of the circle.
  * @return {number} Radius.
  * @api
  */
@@ -136,6 +138,7 @@ ol.geom.Circle.prototype.getType = function() {
 
 
 /**
+ * Set the center of the circle as {@link ol.Coordinate coordinate}.
  * @param {ol.Coordinate} center Center.
  * @api
  */
@@ -155,6 +158,8 @@ ol.geom.Circle.prototype.setCenter = function(center) {
 
 
 /**
+ * Set the center (as {@link ol.Coordinate coordinate}) and the radius (as
+ * number) of the circle.
  * @param {ol.Coordinate} center Center.
  * @param {number} radius Radius.
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
@@ -196,7 +201,7 @@ ol.geom.Circle.prototype.setFlatCoordinates =
 
 
 /**
- * The radius is in the units of the projection.
+ * Set the radius of the circle. The radius is in the units of the projection.
  * @param {number} radius Radius.
  * @api
  */

--- a/src/ol/geom/geometry.js
+++ b/src/ol/geom/geometry.js
@@ -112,6 +112,8 @@ ol.geom.Geometry.prototype.closestPointXY = goog.abstractMethod;
 
 
 /**
+ * Return the closest point of the geometry to the passed point as
+ * {@link ol.Coordinate coordinate}.
  * @param {ol.Coordinate} point Point.
  * @param {ol.Coordinate=} opt_closestPoint Closest point.
  * @return {ol.Coordinate} Closest point.

--- a/src/ol/geom/geometrycollection.js
+++ b/src/ol/geom/geometrycollection.js
@@ -141,6 +141,7 @@ ol.geom.GeometryCollection.prototype.computeExtent = function(extent) {
 
 
 /**
+ * Return the geometries that make up this geometry collection.
  * @return {Array.<ol.geom.Geometry>} Geometries.
  * @api stable
  */
@@ -235,6 +236,7 @@ ol.geom.GeometryCollection.prototype.isEmpty = function() {
 
 
 /**
+ * Set the geometries that make up this geometry collection.
  * @param {Array.<ol.geom.Geometry>} geometries Geometries.
  * @api stable
  */

--- a/src/ol/geom/linearring.js
+++ b/src/ol/geom/linearring.js
@@ -79,6 +79,7 @@ ol.geom.LinearRing.prototype.closestPointXY =
 
 
 /**
+ * Return the area of the linear ring on projected plane.
  * @return {number} Area (on projected plane).
  * @api stable
  */
@@ -89,6 +90,7 @@ ol.geom.LinearRing.prototype.getArea = function() {
 
 
 /**
+ * Return the coordinates of the linear ring.
  * @return {Array.<ol.Coordinate>} Coordinates.
  * @api stable
  */
@@ -124,6 +126,7 @@ ol.geom.LinearRing.prototype.getType = function() {
 
 
 /**
+ * Set the coordinates of the linear ring.
  * @param {Array.<ol.Coordinate>} coordinates Coordinates.
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
  * @api stable

--- a/src/ol/geom/linestring.js
+++ b/src/ol/geom/linestring.js
@@ -63,6 +63,7 @@ goog.inherits(ol.geom.LineString, ol.geom.SimpleGeometry);
 
 
 /**
+ * Append the passed coordinate to the coordinates of the linestring.
  * @param {ol.Coordinate} coordinate Coordinate.
  * @api stable
  */
@@ -155,6 +156,7 @@ ol.geom.LineString.prototype.getCoordinateAtM = function(m, opt_extrapolate) {
 
 
 /**
+ * Return the coordinates of the linestring.
  * @return {Array.<ol.Coordinate>} Coordinates.
  * @api stable
  */
@@ -165,6 +167,7 @@ ol.geom.LineString.prototype.getCoordinates = function() {
 
 
 /**
+ * Return the length of the linestring on projected plane.
  * @return {number} Length (on projected plane).
  * @api stable
  */
@@ -225,6 +228,7 @@ ol.geom.LineString.prototype.intersectsExtent = function(extent) {
 
 
 /**
+ * Set the coordinates of the linestring.
  * @param {Array.<ol.Coordinate>} coordinates Coordinates.
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
  * @api stable

--- a/src/ol/geom/multilinestring.js
+++ b/src/ol/geom/multilinestring.js
@@ -56,6 +56,7 @@ goog.inherits(ol.geom.MultiLineString, ol.geom.SimpleGeometry);
 
 
 /**
+ * Append the passed linestring to the multilinestring.
  * @param {ol.geom.LineString} lineString LineString.
  * @api stable
  */
@@ -143,6 +144,7 @@ ol.geom.MultiLineString.prototype.getCoordinateAtM =
 
 
 /**
+ * Return the coordinates of the multilinestring.
  * @return {Array.<Array.<ol.Coordinate>>} Coordinates.
  * @api stable
  */
@@ -161,6 +163,7 @@ ol.geom.MultiLineString.prototype.getEnds = function() {
 
 
 /**
+ * Return the linestring at the specified index.
  * @param {number} index Index.
  * @return {ol.geom.LineString} LineString.
  * @api stable
@@ -179,6 +182,7 @@ ol.geom.MultiLineString.prototype.getLineString = function(index) {
 
 
 /**
+ * Return the linestrings of this multilinestring.
  * @return {Array.<ol.geom.LineString>} LineStrings.
  * @api stable
  */
@@ -259,6 +263,7 @@ ol.geom.MultiLineString.prototype.intersectsExtent = function(extent) {
 
 
 /**
+ * Set the coordinates of the multilinestring.
  * @param {Array.<Array.<ol.Coordinate>>} coordinates Coordinates.
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
  * @api stable

--- a/src/ol/geom/multipoint.js
+++ b/src/ol/geom/multipoint.js
@@ -32,6 +32,7 @@ goog.inherits(ol.geom.MultiPoint, ol.geom.SimpleGeometry);
 
 
 /**
+ * Append the passed point to this multipoint.
  * @param {ol.geom.Point} point Point.
  * @api stable
  */
@@ -87,6 +88,7 @@ ol.geom.MultiPoint.prototype.closestPointXY =
 
 
 /**
+ * Return the coordinates of the multipoint.
  * @return {Array.<ol.Coordinate>} Coordinates.
  * @api stable
  */
@@ -97,6 +99,7 @@ ol.geom.MultiPoint.prototype.getCoordinates = function() {
 
 
 /**
+ * Return the point at the specified index.
  * @param {number} index Index.
  * @return {ol.geom.Point} Point.
  * @api stable
@@ -117,6 +120,7 @@ ol.geom.MultiPoint.prototype.getPoint = function(index) {
 
 
 /**
+ * Return the points of this multipoint.
  * @return {Array.<ol.geom.Point>} Points.
  * @api stable
  */
@@ -165,6 +169,7 @@ ol.geom.MultiPoint.prototype.intersectsExtent = function(extent) {
 
 
 /**
+ * Set the coordinates of the multipoint.
  * @param {Array.<ol.Coordinate>} coordinates Coordinates.
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
  * @api stable

--- a/src/ol/geom/multipolygon.js
+++ b/src/ol/geom/multipolygon.js
@@ -85,6 +85,7 @@ goog.inherits(ol.geom.MultiPolygon, ol.geom.SimpleGeometry);
 
 
 /**
+ * Append the passed polygon to this multipolygon.
  * @param {ol.geom.Polygon} polygon Polygon.
  * @api stable
  */
@@ -154,6 +155,7 @@ ol.geom.MultiPolygon.prototype.containsXY = function(x, y) {
 
 
 /**
+ * Return the area of the multipolygon on projected plane.
  * @return {number} Area (on projected plane).
  * @api stable
  */
@@ -216,6 +218,7 @@ ol.geom.MultiPolygon.prototype.getFlatInteriorPoints = function() {
 
 
 /**
+ * Return the interior points as {@link ol.geom.MultiPoint multipoint}.
  * @return {ol.geom.MultiPoint} Interior points.
  * @api stable
  */
@@ -267,6 +270,7 @@ ol.geom.MultiPolygon.prototype.getSimplifiedGeometryInternal =
 
 
 /**
+ * Return the polygon at the specified index.
  * @param {number} index Index.
  * @return {ol.geom.Polygon} Polygon.
  * @api stable
@@ -300,6 +304,7 @@ ol.geom.MultiPolygon.prototype.getPolygon = function(index) {
 
 
 /**
+ * Return the polygons of this multipolygon.
  * @return {Array.<ol.geom.Polygon>} Polygons.
  * @api stable
  */
@@ -348,6 +353,7 @@ ol.geom.MultiPolygon.prototype.intersectsExtent = function(extent) {
 
 
 /**
+ * Set the coordinates of the multipolygon.
  * @param {Array.<Array.<Array.<ol.Coordinate>>>} coordinates Coordinates.
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
  * @api stable

--- a/src/ol/geom/point.js
+++ b/src/ol/geom/point.js
@@ -62,6 +62,7 @@ ol.geom.Point.prototype.closestPointXY =
 
 
 /**
+ * Return the coordinate of the point.
  * @return {ol.Coordinate} Coordinates.
  * @api stable
  */
@@ -98,6 +99,7 @@ ol.geom.Point.prototype.intersectsExtent = function(extent) {
 
 
 /**
+ * Set the coordinate of the point.
  * @param {ol.Coordinate} coordinates Coordinates.
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
  * @api stable

--- a/src/ol/geom/polygon.js
+++ b/src/ol/geom/polygon.js
@@ -84,6 +84,7 @@ goog.inherits(ol.geom.Polygon, ol.geom.SimpleGeometry);
 
 
 /**
+ * Append the passed linear ring to this polygon.
  * @param {ol.geom.LinearRing} linearRing Linear ring.
  * @api stable
  */
@@ -143,6 +144,7 @@ ol.geom.Polygon.prototype.containsXY = function(x, y) {
 
 
 /**
+ * Return the area of the polygon on projected plane.
  * @return {number} Area (on projected plane).
  * @api stable
  */
@@ -204,6 +206,7 @@ ol.geom.Polygon.prototype.getFlatInteriorPoint = function() {
 
 
 /**
+ * Return an interior point of the polygon.
  * @return {ol.geom.Point} Interior point.
  * @api stable
  */
@@ -248,6 +251,7 @@ ol.geom.Polygon.prototype.getLinearRing = function(index) {
 
 
 /**
+ * Return the linear rings of the polygon.
  * @return {Array.<ol.geom.LinearRing>} Linear rings.
  * @api stable
  */
@@ -328,6 +332,7 @@ ol.geom.Polygon.prototype.intersectsExtent = function(extent) {
 
 
 /**
+ * Set the coordinates of the polygon.
  * @param {Array.<Array.<ol.Coordinate>>} coordinates Coordinates.
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
  * @api stable

--- a/src/ol/geom/simplegeometry.js
+++ b/src/ol/geom/simplegeometry.js
@@ -99,6 +99,7 @@ ol.geom.SimpleGeometry.prototype.computeExtent = function(extent) {
 
 
 /**
+ * Return the first coordinate of the geometry.
  * @return {ol.Coordinate} First coordinate.
  * @api stable
  */
@@ -116,6 +117,7 @@ ol.geom.SimpleGeometry.prototype.getFlatCoordinates = function() {
 
 
 /**
+ * Return the last coordinate of the geometry.
  * @return {ol.Coordinate} Last point.
  * @api stable
  */
@@ -125,6 +127,7 @@ ol.geom.SimpleGeometry.prototype.getLastCoordinate = function() {
 
 
 /**
+ * Return the {@link ol.geom.GeometryLayout layout} of the geometry.
  * @return {ol.geom.GeometryLayout} Layout.
  * @api stable
  */


### PR DESCRIPTION
This PR adds basic documentation to `@api` symbols of `ol.geom*`. This never ends...

Please review.

See also

* #3488: first batch of docs by @tschaub
* #3497: overview issue of missing docs
* #3583: docs for `ol.proj.*`, ol.layer.*`
* #3580: docs for `ol.source.*`
* #3613: docs for `ol.interaction*`