### PR TITLE
ol3 overwrites WMS format_options instead of extending them.

### DIFF
--- a/src/ol/source/imagewmssource.js
+++ b/src/ol/source/imagewmssource.js
@@ -295,7 +295,11 @@ ol.source.ImageWMS.prototype.getRequestUrl_ =
     switch (this.serverType_) {
       case ol.source.wms.ServerType.GEOSERVER:
         var dpi = (90 * pixelRatio + 0.5) | 0;
-        params['FORMAT_OPTIONS'] = 'dpi:' + dpi;
+        if (goog.isDef(params['FORMAT_OPTIONS'])) {
+          params['FORMAT_OPTIONS'] += ';dpi:' + dpi;
+        } else {
+          params['FORMAT_OPTIONS'] = 'dpi:' + dpi;
+        }
         break;
       case ol.source.wms.ServerType.MAPSERVER:
         params['MAP_RESOLUTION'] = 90 * pixelRatio;

--- a/src/ol/source/tilewmssource.js
+++ b/src/ol/source/tilewmssource.js
@@ -241,7 +241,11 @@ ol.source.TileWMS.prototype.getRequestUrl_ =
     switch (this.serverType_) {
       case ol.source.wms.ServerType.GEOSERVER:
         var dpi = (90 * pixelRatio + 0.5) | 0;
-        params['FORMAT_OPTIONS'] = 'dpi:' + dpi;
+        if (goog.isDef(params['FORMAT_OPTIONS'])) {
+          params['FORMAT_OPTIONS'] += ';dpi:' + dpi;
+        } else {
+          params['FORMAT_OPTIONS'] = 'dpi:' + dpi;
+        }
         break;
       case ol.source.wms.ServerType.MAPSERVER:
         params['MAP_RESOLUTION'] = 90 * pixelRatio;

--- a/test/spec/ol/source/imagewmssource.test.js
+++ b/test/spec/ol/source/imagewmssource.test.js
@@ -112,6 +112,17 @@ describe('ol.source.ImageWMS', function() {
       expect(queryData.get('FORMAT_OPTIONS')).to.be('dpi:180');
     });
 
+    it('extends FORMAT_OPTIONS if it is already present', function() {
+      options.serverType = ol.source.wms.ServerType.GEOSERVER;
+      var source = new ol.source.ImageWMS(options);
+      options.params.FORMAT_OPTIONS = 'param1:value1';
+      pixelRatio = 2;
+      var image = source.getImage(extent, resolution, pixelRatio, projection);
+      var uri = new goog.Uri(image.src_);
+      var queryData = uri.getQueryData();
+      expect(queryData.get('FORMAT_OPTIONS')).to.be('param1:value1;dpi:180');
+    });
+
     it('rounds FORMAT_OPTIONS to an integer when the server is GeoServer',
        function() {
          options.serverType = ol.source.wms.ServerType.GEOSERVER;

--- a/test/spec/ol/source/tilewmssource.test.js
+++ b/test/spec/ol/source/tilewmssource.test.js
@@ -105,6 +105,35 @@ describe('ol.source.TileWMS', function() {
       expect(queryData.get('BBOX')).to.be('-90,-45,-45,0');
     });
 
+    it('sets FORMAT_OPTIONS when the server is GeoServer', function() {
+      options.serverType = ol.source.wms.ServerType.GEOSERVER;
+      var source = new ol.source.TileWMS(options);
+      var tile = source.getTile(3, 2, 1, 2, ol.proj.get('CRS:84'));
+      var uri = new goog.Uri(tile.src_);
+      var queryData = uri.getQueryData();
+      expect(queryData.get('FORMAT_OPTIONS')).to.be('dpi:180');
+    });
+
+    it('extends FORMAT_OPTIONS if it is already present', function() {
+      options.serverType = ol.source.wms.ServerType.GEOSERVER;
+      var source = new ol.source.TileWMS(options);
+      options.params.FORMAT_OPTIONS = 'param1:value1';
+      var tile = source.getTile(3, 2, 1, 2, ol.proj.get('CRS:84'));
+      var uri = new goog.Uri(tile.src_);
+      var queryData = uri.getQueryData();
+      expect(queryData.get('FORMAT_OPTIONS')).to.be('param1:value1;dpi:180');
+    });
+
+    it('rounds FORMAT_OPTIONS to an integer when the server is GeoServer',
+       function() {
+         options.serverType = ol.source.wms.ServerType.GEOSERVER;
+         var source = new ol.source.TileWMS(options);
+         var tile = source.getTile(3, 2, 1, 1.325, ol.proj.get('CRS:84'));
+         var uri = new goog.Uri(tile.src_);
+         var queryData = uri.getQueryData();
+         expect(queryData.get('FORMAT_OPTIONS')).to.be('dpi:119');
+       });
+
   });
 
   describe('#tileUrlFunction', function() {
@@ -219,5 +248,6 @@ describe('ol.source.TileWMS', function() {
 goog.require('goog.Uri');
 goog.require('ol.ImageTile');
 goog.require('ol.source.TileWMS');
+goog.require('ol.source.wms.ServerType');
 goog.require('ol.proj');
 goog.require('ol.tilegrid.TileGrid');


### PR DESCRIPTION
I am working on an ol3 application that sends a WMS getMap request with the `FORMAT_OPTIONS` parameter set. If I run this application on a high-resolution display, the value of `FORMAT_OPTIONS` is overwritten by `FORMAT_OPTIONS=dpi%3A180`.