### PR TITLE
Cluster Data Source, Resolves Panning Issue

### DIFF
--- a/build.py
+++ b/build.py
@@ -15,6 +15,7 @@ from pake import Target
 from pake import ifind, main, output, rule, target, variables, virtual, which
 from Queue import Queue
 from threading import Thread
+from distutils import spawn
 
 def sigint_handler(signal, frame):
     print('Exiting')
@@ -102,7 +103,7 @@ else:
     variables.GJSLINT = 'gjslint'
     variables.JSHINT = './node_modules/.bin/jshint'
     variables.JSDOC = './node_modules/.bin/jsdoc'
-    variables.PYTHON = 'python'
+    variables.PYTHON = 'python2' if spawn.find_executable('python2') else 'python'
     variables.PHANTOMJS = './node_modules/.bin/phantomjs'
 
 variables.BRANCH = output(

--- a/examples/cluster-wfs.html
+++ b/examples/cluster-wfs.html
@@ -1,0 +1,13 @@
+---
+template: example.html
+title: Clustering with a WFS data source example
+shortdesc: Example of using <code>ol.source.Cluster</code> with a WFS data source.
+docs: >
+  This example demonstrates clustering with data coming from a WFS source.
+tags: "cluster, vector"
+---
+<div class="row-fluid">
+  <div class="span12">
+    <div id="map" class="map"></div>
+  </div>
+</div>

--- a/examples/cluster-wfs.js
+++ b/examples/cluster-wfs.js
@@ -1,0 +1,95 @@
+goog.require('ol.source.Vector');
+goog.require('ol.source.Cluster');
+goog.require('ol.source.OSM');
+goog.require('ol.format.GeoJSON');
+goog.require('ol.layer.Vector');
+goog.require('ol.layer.Tile');
+goog.require('ol.style.Circle');
+goog.require('ol.style.Fill');
+goog.require('ol.style.Text');
+goog.require('ol.Map');
+goog.require('ol.View');
+
+var vectorSource = new ol.source.Vector({
+    'format': new ol.format.GeoJSON(),
+    'loader': function(extent, resolution, projection) {
+        var url = "http://mhc-macris.net:8080/geoserver/MHC/ows?service=WFS&version=1.0.0"
+                + "&request=GetFeature&typeName=MHC:in_pts&outputFormat=json&outputFormat=text/javascript"
+                + "&format_options=callback:geoJsonLoader"
+                + "&srsname=EPSG:3857&bbox=" + extent.join(",") + ",EPSG:3857";
+        $.ajax({
+            'url': url,
+            'dataType': 'jsonp',
+            'success': function(response) {
+                var format = new ol.format.GeoJSON();
+                var features = format.readFeatures(response, {featureProjection: projection});
+                vectorSource.addFeatures(features);
+            }
+        });
+    },
+    'projection': new ol.proj.Projection({
+        'code': 'EPSG:3857',
+        'units': 'degrees',
+        'axisOrientation': 'nue'}),
+    'strategy': ol.loadingstrategy.bbox
+});
+
+var geoJsonLoader = function(response) {
+    var format = new ol.format.GeoJSON();
+    vectorSource.addFeatures(format.readFeatures(response));
+};
+
+var clusterLayer = new ol.layer.Vector({
+    'source': new ol.source.Cluster({
+        'distance': 40,
+        'source': vectorSource
+    }),
+    'style': function(features, resolution) {
+        var size = features.get('features').length;
+        var sizeOut = size;
+
+        if(sizeOut < 10) {
+            sizeOut = 10;
+        } else if(sizeOut > 50) {
+            sizeOut = 50;
+        }
+
+        var style = [
+            new ol.style.Style({
+                'image': new ol.style.Circle({
+                    'fill': new ol.style.Fill({
+                        'color': [51, 153, 204, 1.0]
+                    }),
+                    'snapToPixel': true,
+                    'radius': sizeOut
+                }),
+                'text': new ol.style.Text({
+                    'offsetX': 0,
+                    'offsetY': 0,
+                    'fill': new ol.style.Fill({
+                        'color': [255, 255, 255, 1.0]
+                    }),
+                    'text': size.toString()
+                })
+            })
+        ];
+
+        return style;
+    }
+});
+
+var tileLayer = new ol.layer.Tile({
+    'title': 'Streets',
+    'source': new ol.source.OSM()
+});
+
+
+var map = new ol.Map({
+    'target': 'map',
+    'layers': [tileLayer, clusterLayer],
+    'view': new ol.View({
+        'center': ol.proj.transform([-72.638429, 42.313229], 'EPSG:4326', 'EPSG:3857'),
+        'zoom': 16,
+        'projection': 'EPSG:3857'
+    })
+});

--- a/examples/cluster-wfs.js
+++ b/examples/cluster-wfs.js
@@ -1,28 +1,30 @@
-goog.require('ol.source.Vector');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.format.GeoJSON');
+goog.require('ol.layer.Tile');
+goog.require('ol.layer.Vector');
 goog.require('ol.source.Cluster');
 goog.require('ol.source.OSM');
-goog.require('ol.format.GeoJSON');
-goog.require('ol.layer.Vector');
-goog.require('ol.layer.Tile');
+goog.require('ol.source.Vector');
 goog.require('ol.style.Circle');
 goog.require('ol.style.Fill');
 goog.require('ol.style.Text');
-goog.require('ol.Map');
-goog.require('ol.View');
 
 var vectorSource = new ol.source.Vector({
   'format': new ol.format.GeoJSON(),
   'loader': function(extent, resolution, projection) {
-    var url = "http://mhc-macris.net:8080/geoserver/MHC/ows?service=WFS&version=1.0.0"
-          + "&request=GetFeature&typeName=MHC:in_pts&outputFormat=json&outputFormat=text/javascript"
-          + "&format_options=callback:geoJsonLoader"
-          + "&srsname=EPSG:3857&bbox=" + extent.join(",") + ",EPSG:3857";
+    var url = 'http://mhc-macris.net:8080/geoserver/MHC/ows?service=WFS&version=1.0.0' +
+          '&request=GetFeature&typeName=MHC:in_pts&outputFormat=json&outputFormat=text/javascript' +
+          '&format_options=callback:geoJsonLoader' +
+          '&srsname=EPSG:3857&bbox=' + extent.join(',') + ',EPSG:3857';
     $.ajax({
       'url': url,
       'dataType': 'jsonp',
       'success': function(response) {
         var format = new ol.format.GeoJSON();
-        var features = format.readFeatures(response, {featureProjection: projection});
+          var features = format.readFeatures(response, {
+              featureProjection: projection
+          });
         vectorSource.addFeatures(features);
       }
     });
@@ -87,9 +89,10 @@ var tileLayer = new ol.layer.Tile({
 var map = new ol.Map({
   'target': 'map',
   'layers': [tileLayer, clusterLayer],
-  'view': new ol.View({
-    'center': ol.proj.transform([-72.638429, 42.313229], 'EPSG:4326', 'EPSG:3857'),
-    'zoom': 16,
+    'view': new ol.View({
+      'center': ol.proj.transform([-72.638429, 42.313229],
+                                  'EPSG:4326', 'EPSG:3857'),
+    'zoom': 16,xs
     'projection': 'EPSG:3857'
   })
 });

--- a/examples/cluster-wfs.js
+++ b/examples/cluster-wfs.js
@@ -11,85 +11,85 @@ goog.require('ol.Map');
 goog.require('ol.View');
 
 var vectorSource = new ol.source.Vector({
-    'format': new ol.format.GeoJSON(),
-    'loader': function(extent, resolution, projection) {
-        var url = "http://mhc-macris.net:8080/geoserver/MHC/ows?service=WFS&version=1.0.0"
-                + "&request=GetFeature&typeName=MHC:in_pts&outputFormat=json&outputFormat=text/javascript"
-                + "&format_options=callback:geoJsonLoader"
-                + "&srsname=EPSG:3857&bbox=" + extent.join(",") + ",EPSG:3857";
-        $.ajax({
-            'url': url,
-            'dataType': 'jsonp',
-            'success': function(response) {
-                var format = new ol.format.GeoJSON();
-                var features = format.readFeatures(response, {featureProjection: projection});
-                vectorSource.addFeatures(features);
-            }
-        });
-    },
-    'projection': new ol.proj.Projection({
-        'code': 'EPSG:3857',
-        'units': 'degrees',
-        'axisOrientation': 'nue'}),
-    'strategy': ol.loadingstrategy.bbox
+  'format': new ol.format.GeoJSON(),
+  'loader': function(extent, resolution, projection) {
+    var url = "http://mhc-macris.net:8080/geoserver/MHC/ows?service=WFS&version=1.0.0"
+          + "&request=GetFeature&typeName=MHC:in_pts&outputFormat=json&outputFormat=text/javascript"
+          + "&format_options=callback:geoJsonLoader"
+          + "&srsname=EPSG:3857&bbox=" + extent.join(",") + ",EPSG:3857";
+    $.ajax({
+      'url': url,
+      'dataType': 'jsonp',
+      'success': function(response) {
+        var format = new ol.format.GeoJSON();
+        var features = format.readFeatures(response, {featureProjection: projection});
+        vectorSource.addFeatures(features);
+      }
+    });
+  },
+  'projection': new ol.proj.Projection({
+    'code': 'EPSG:3857',
+    'units': 'degrees',
+    'axisOrientation': 'nue'}),
+  'strategy': ol.loadingstrategy.bbox
 });
 
 var geoJsonLoader = function(response) {
-    var format = new ol.format.GeoJSON();
-    vectorSource.addFeatures(format.readFeatures(response));
+  var format = new ol.format.GeoJSON();
+  vectorSource.addFeatures(format.readFeatures(response));
 };
 
 var clusterLayer = new ol.layer.Vector({
-    'source': new ol.source.Cluster({
-        'distance': 40,
-        'source': vectorSource
-    }),
-    'style': function(features, resolution) {
-        var size = features.get('features').length;
-        var sizeOut = size;
+  'source': new ol.source.Cluster({
+    'distance': 40,
+    'source': vectorSource
+  }),
+  'style': function(features, resolution) {
+    var size = features.get('features').length;
+    var sizeOut = size;
 
-        if(sizeOut < 10) {
-            sizeOut = 10;
-        } else if(sizeOut > 50) {
-            sizeOut = 50;
-        }
-
-        var style = [
-            new ol.style.Style({
-                'image': new ol.style.Circle({
-                    'fill': new ol.style.Fill({
-                        'color': [51, 153, 204, 1.0]
-                    }),
-                    'snapToPixel': true,
-                    'radius': sizeOut
-                }),
-                'text': new ol.style.Text({
-                    'offsetX': 0,
-                    'offsetY': 0,
-                    'fill': new ol.style.Fill({
-                        'color': [255, 255, 255, 1.0]
-                    }),
-                    'text': size.toString()
-                })
-            })
-        ];
-
-        return style;
+    if(sizeOut < 10) {
+      sizeOut = 10;
+    } else if(sizeOut > 50) {
+      sizeOut = 50;
     }
+
+    var style = [
+      new ol.style.Style({
+        'image': new ol.style.Circle({
+          'fill': new ol.style.Fill({
+            'color': [51, 153, 204, 1.0]
+          }),
+          'snapToPixel': true,
+          'radius': sizeOut
+        }),
+        'text': new ol.style.Text({
+          'offsetX': 0,
+          'offsetY': 0,
+          'fill': new ol.style.Fill({
+            'color': [255, 255, 255, 1.0]
+          }),
+          'text': size.toString()
+        })
+      })
+    ];
+
+    return style;
+  }
 });
 
 var tileLayer = new ol.layer.Tile({
-    'title': 'Streets',
-    'source': new ol.source.OSM()
+  'title': 'Streets',
+  'source': new ol.source.OSM()
 });
 
 
 var map = new ol.Map({
-    'target': 'map',
-    'layers': [tileLayer, clusterLayer],
-    'view': new ol.View({
-        'center': ol.proj.transform([-72.638429, 42.313229], 'EPSG:4326', 'EPSG:3857'),
-        'zoom': 16,
-        'projection': 'EPSG:3857'
-    })
+  'target': 'map',
+  'layers': [tileLayer, clusterLayer],
+  'view': new ol.View({
+    'center': ol.proj.transform([-72.638429, 42.313229], 'EPSG:4326', 'EPSG:3857'),
+    'zoom': 16,
+    'projection': 'EPSG:3857'
+  })
 });

--- a/examples/cluster-wfs.js
+++ b/examples/cluster-wfs.js
@@ -92,7 +92,7 @@ var map = new ol.Map({
     'view': new ol.View({
       'center': ol.proj.transform([-72.638429, 42.313229],
                                   'EPSG:4326', 'EPSG:3857'),
-    'zoom': 16,xs
+    'zoom': 16,
     'projection': 'EPSG:3857'
   })
 });

--- a/src/ol/source/clustersource.js
+++ b/src/ol/source/clustersource.js
@@ -77,13 +77,12 @@ ol.source.Cluster.prototype.getSource = function() {
  */
 ol.source.Cluster.prototype.loadFeatures = function(extent, resolution,
     projection) {
-  if (resolution !== this.resolution_) {
+
     this.clear();
     this.resolution_ = resolution;
     this.source_.loadFeatures(extent, resolution, projection);
     this.cluster_();
     this.addFeatures(this.features_);
-  }
 };
 
 


### PR DESCRIPTION
This patch resolves the issue where the cluster data source wouldn't refresh it's data when the map was panned (only when zoomed). More about this issue can be found [in this discussion thread](https://groups.google.com/forum/#!topic/ol3-dev/N7TGCRax_u0). I have also added a new example that demonstrates this working.

The other change alters the build script to use 'python2' when building if 'python2' is in the environment path. On some systems, like Arch Linux, there will be a 'python' with point to Python 3 and a 'python2' that points to Python 2.

I have submitted a OpenLayers Individual Contributor License Agreement. :-)