### PR TITLE
Make package.json compatible for npm frontend use

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,7 @@
   "bugs": {
     "url": "https://github.com/openlayers/ol3/issues"
   },
-  "browser": {
-    "openlayers": "dist/ol.js"
-  },
+  "browser": "dist/ol.js",
   "style": [
     "css/ol.css"
   ],

--- a/package.json
+++ b/package.json
@@ -24,6 +24,12 @@
   "bugs": {
     "url": "https://github.com/openlayers/ol3/issues"
   },
+  "browser": {
+    "ol": "./node_modules/openlayers/dist/ol.js"
+  },
+  "style": [
+    "./node_modules/openlayers/css/ol.css"
+  ],
   "dependencies": {
     "async": "0.9.0",
     "closure-util": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "url": "https://github.com/openlayers/ol3/issues"
   },
   "browser": {
-    "ol": "./node_modules/openlayers/dist/ol.js"
+    "openlayers": "dist/ol.js"
   },
   "style": [
-    "./node_modules/openlayers/css/ol.css"
+    "css/ol.css"
   ],
   "dependencies": {
     "async": "0.9.0",


### PR DESCRIPTION
This PR augments package.json to ease OpenLayers 3 frontend development through NPM.
See [this post on NPM blog](http://blog.npmjs.org/post/112712169830/making-your-jquery-plugin-work-better-with-npm) to get more informations and evaluate if it's worth to accept.
If you use Browserify and/or Parcelify, you can use this informations out of the box.
`browser` part is in [this spec](https://gist.github.com/defunctzombie/4339901)

It's up to you to decide if providing paths to js and css is good.
In fact, it's quite similar to Bower but we don't create a new file, we only use existing `package.json`.