### PR TITLE
Problems with XYZ coordinates in snap interaction

### DIFF
--- a/src/ol/interaction/snapinteraction.js
+++ b/src/ol/interaction/snapinteraction.js
@@ -583,7 +583,7 @@ ol.interaction.Snap.SegmentDataType;
 ol.interaction.Snap.handleEvent_ = function(evt) {
   var result = this.snapTo(evt.pixel, evt.coordinate, evt.map);
   if (result.snapped) {
-    evt.coordinate = result.vertex;
+    evt.coordinate = result.vertex.slice(0, 2);
     evt.pixel = result.vertexPixel;
   }
   return ol.interaction.Pointer.handleEvent.call(this, evt);

--- a/test/spec/ol/interaction/snapinteraction.test.js
+++ b/test/spec/ol/interaction/snapinteraction.test.js
@@ -11,6 +11,66 @@ describe('ol.interaction.Snap', function() {
 
   });
 
+  describe('handleEvent_', function() {
+    var target, map;
+
+    var width = 360;
+    var height = 180;
+
+    beforeEach(function(done) {
+      target = document.createElement('div');
+
+      var style = target.style;
+      style.position = 'absolute';
+      style.left = '-1000px';
+      style.top = '-1000px';
+      style.width = width + 'px';
+      style.height = height + 'px';
+      document.body.appendChild(target);
+
+      map = new ol.Map({
+        target: target,
+        view: new ol.View({
+          projection: 'EPSG:4326',
+          center: [0, 0],
+          resolution: 1
+        })
+      });
+
+      map.on('postrender', function() {
+        done();
+      });
+    });
+
+    afterEach(function() {
+      goog.dispose(map);
+      document.body.removeChild(target);
+    });
+
+    it('can handle XYZ coordinates', function() {
+      var point = new ol.Feature(new ol.geom.Point([0, 0, 123]));
+      var snapInteraction = new ol.interaction.Snap({
+        features: new ol.Collection([point])
+      });
+      snapInteraction.setMap(map);
+
+      var event = {
+        pixel: [width / 2, height / 2],
+        coordinate: [0, 0],
+        map: map
+      };
+      ol.interaction.Snap.handleEvent_.call(snapInteraction, event);
+      // check that the coordinate is in XY and not XYZ
+      expect(event.coordinate).to.eql([0, 0]);
+    });
+
+  });
+
 });
 
+goog.require('ol.Collection');
+goog.require('ol.Feature');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.geom.Point');
 goog.require('ol.interaction.Snap');


### PR DESCRIPTION
As reported on the [mailing list](https://groups.google.com/forum/#!topic/ol3-dev/BtIOS4vd4_M), the snap interaction has issues with XYZ coordinates.

When the mouse pointer is snapped to a vertex with XYZ coordinates, the vertex coordinate with three values will be assigned to `event.coordinate` (see https://github.com/openlayers/ol3/blob/master/src/ol/interaction/snapinteraction.js#L586). Because `event.coordinate` is expected to have only two values, this will cause problems elsewhere.

I will work on a fix.