### PR TITLE
Restore Modify interaction constructor test

### DIFF
--- a/test/spec/ol/interaction/modifyinteraction.test.js
+++ b/test/spec/ol/interaction/modifyinteraction.test.js
@@ -78,6 +78,20 @@ describe('ol.interaction.Modify', function() {
     map.handleMapBrowserEvent(event);
   }
 
+  describe('constructor', function() {
+    it('adds features to the RTree', function() {
+      var feature = new ol.Feature(
+          new ol.geom.Point([0, 0]));
+      var features = new ol.Collection([feature]);
+      var modify = new ol.interaction.Modify({
+        features: features
+      });
+      var rbushEntries = modify.rBush_.getAll();
+      expect(rbushEntries.length).to.be(1);
+      expect(rbushEntries[0].feature === feature).to.be.ok();
+    });
+  });
+
   describe('boundary modification', function() {
 
     it('clicking without drag should not add vertex but +r2', function() {


### PR DESCRIPTION
I accidentally removed the existing constructor test that also tested some rbush internals when making additional tests in #3630, sorry. This PR should restore what I removed.