### PR TITLE
Fix test-coverage.js script

### DIFF
--- a/tasks/test-coverage.js
+++ b/tasks/test-coverage.js
@@ -139,7 +139,15 @@ var foundAllJavaScriptSourceFiles = function(err, files) {
   files.forEach(function(file) {
     cnt++;
     var content = fs.readFileSync(file, 'utf-8');
-    var outfile = file.replace(/\/src\//, '/src-instrumented/');
+    // derive output file name from input file name, by replacing the *last*
+    // occurence of /src/ by /src-instrumented/
+    var re = new RegExp('/src/', 'g');
+    var m, match;
+    while ((m = re.exec(file)) !== null) {
+      match = m;
+    }
+    var outfile = file.substr(0, match.index) + '/src-instrumented/' +
+        file.substr(match.index + '/src/'.length);
     var instrumented = instrumenter.instrumentSync(content, file);
     fs.writeFileSync(outfile, instrumented);
     if (cnt % 10 === 0) {


### PR DESCRIPTION
Fix test-coverage by only replacing the last occurence of `/src/` when deriving the instrumented file path from the original file path.

Fixes #3643.

There may be a better way to do this, but that's the one I've been able to come up with.