### PR TITLE
Use graceful-fs in place of fs

### DIFF
--- a/tasks/generate-requires.js
+++ b/tasks/generate-requires.js
@@ -1,4 +1,4 @@
-var fs = require('fs');
+var fs = require('graceful-fs');
 
 // The number of files that we need to generate goog.require's for.
 var numFiles = process.argv.length - 1;


### PR DESCRIPTION
Change generate-requires.js to use the graceful-fs module instead of fs. This is to avoid EMFILE errors on OSX because the maximum number of file descriptors have been reached.

@bartvde, could you please test this change?