### PR TITLE
More specific regex in serve.js

### DIFF
--- a/tasks/serve.js
+++ b/tasks/serve.js
@@ -44,7 +44,7 @@ var createServer = exports.createServer = function(callback) {
   manager.on('ready', function() {
     server = new closure.Server({
       manager: manager,
-      loader: /^.*\/loader\.js/,
+      loader: /^\/(?:(?:build\/examples)|(?:test(?:_rendering)?))\/loader\.js/,
       getMain: function(req) {
         var main;
         var query = url.parse(req.url, true).query;


### PR DESCRIPTION
This is to be able to use the dev server (`npm start`) to serve the hosted examples (located in the `build/hosted/<branch>` dir after `make host-examples`).

Addresses https://github.com/openlayers/ol3/pull/3150#issuecomment-97648392 from @sarametz.