### PR TITLE
Smooth rendering of parameter changes

### DIFF
--- a/examples/smooth-params.html
+++ b/examples/smooth-params.html
@@ -1,0 +1,23 @@
+---
+template: example.html
+title: Smooth parameters example 
+shortdesc: Example of smooth tile transitions when working with a WMTS server that takes extra parameters
+docs: >
+  <p> Demonstrates smooth reloading of layers when changing a dimension continously. The demonstration layer is a global sea-level computation (flooding computation from <a href="http://scalgo.com">SCALGO</a>, underlying data from <a href="http://www.cgiar-csi.org/data/srtm-90m-digital-elevation-database-v4-1">CGIAR-CSI SRTM</a>) where cells that are flooded if the sea-level rises to more than <em>x</em> m are colored blue. The user selects the sea-level dimension using a slider.</p>
+tags: "wmts, parameter"
+---
+<div class="row-fluid">
+	<div class="span6">
+		<h4>Regular</h4>
+		<div id="map" class="map"></div>
+	</div>
+	<div class="span6">
+		<h4>Smooth</h4>
+		<div id="map_smooth" class="map"></div>
+	</div><br />
+	<div class="span6 offset3">
+		Sea-level:	
+		<input id="slider" type="range" value="10" step="0.25" max="100" min="-1" />
+		<span id="theinfo"></span>
+	</div>
+</div>

--- a/examples/smooth-params.js
+++ b/examples/smooth-params.js
@@ -1,0 +1,133 @@
+goog.require('ol.Attribution');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.control');
+goog.require('ol.control.Attribution');
+goog.require('ol.control.Zoom');
+goog.require('ol.extent');
+goog.require('ol.layer.Tile');
+goog.require('ol.proj');
+goog.require('ol.source.OSM');
+goog.require('ol.source.WMTS');
+goog.require('ol.tilegrid.WMTS');
+
+
+// create the WMTS tile grid in the google projection
+var projection = ol.proj.get('EPSG:3857');
+var tileSizePixels = 256;
+var tileSizeMtrs = ol.extent.getWidth(projection.getExtent()) / tileSizePixels;
+var matrixIds = [];
+var resolutions = [];
+var attributions = [
+  new ol.Attribution({
+    html: '<a href="http://scalgo.com">SCALGO</a>'
+  }),
+  new ol.Attribution({
+    html: '<a href="http://www.cgiar-csi.org/data/' +
+        'srtm-90m-digital-elevation-database-v4-1">CGIAR-CSI SRTM</a>'
+  })
+];
+
+for (var i = 0; i <= 14; i++) {
+  matrixIds[i] = i;
+  resolutions[i] = tileSizeMtrs / Math.pow(2, i);
+}
+var tileGrid = new ol.tilegrid.WMTS({
+  origin: ol.extent.getTopLeft(projection.getExtent()),
+  resolutions: resolutions,
+  matrixIds: matrixIds
+});
+
+var scalgo_token = 'CC5BF28A7D96B320C7DFBFD1236B5BEB';
+
+// make the special WMTS layer
+var layerSmooth = new ol.layer.Tile({
+  opacity: 0.5,
+  source: new ol.source.WMTS({
+    url: 'http://ts2.scalgo.com/global/wmts?token=' + scalgo_token,
+    layer: 'hydrosheds:sea-levels',
+    format: 'image/png',
+    matrixSet: 'EPSG:3857',
+    attributions: attributions,
+    tileGrid: tileGrid,
+    style: 'default',
+    dimensions: {
+      threshold: 100
+    },
+    keyPrefixIgnoredDimensions: ['threshold']
+  })
+});
+
+var layer = new ol.layer.Tile({
+  opacity: 0.5,
+  source: new ol.source.WMTS({
+    url: 'http://ts2.scalgo.com/global/wmts?token=' + scalgo_token,
+    layer: 'hydrosheds:sea-levels',
+    format: 'image/png',
+    matrixSet: 'EPSG:3857',
+    attributions: attributions,
+    tileGrid: tileGrid,
+    style: 'default',
+    dimensions: {
+      threshold: 100
+    }
+  })
+});
+
+var mapSmooth = new ol.Map({
+  target: 'map_smooth',
+  view: new ol.View({
+    projection: projection,
+    center: [-3052589, 3541786],
+    zoom: 3
+  }),
+  controls: [
+    new ol.control.Zoom(),
+    new ol.control.Attribution()
+  ],
+  layers: [
+    new ol.layer.Tile({
+      source: new ol.source.OSM()
+    }),
+    layerSmooth
+  ]
+});
+
+var map = new ol.Map({
+  target: 'map',
+  view: mapSmooth.getView(),
+  controls: [
+    new ol.control.Zoom(),
+    new ol.control.Attribution()
+  ],
+  layers: [
+    new ol.layer.Tile({
+      source: new ol.source.OSM()
+    }),
+    layer
+  ]
+});
+
+var setLayerParam = function(map, layer, sliderVal, isSmooth) {
+  // update the layer dimensions
+  // normally this would result in e tile reload,
+  // but we're ignoring the 'threshold' dimension in this example
+  layer.getSource().updateDimensions({
+    threshold: sliderVal
+  });
+
+
+  if (isSmooth) {
+    // explicitly load the tiles for the new threshold
+    layer.getSource().reloadVisibleTilesOutOfBand(map);
+  }
+  document.getElementById('theinfo').innerHTML = sliderVal + ' meters.';
+};
+
+setLayerParam(map, layer, 10, false);
+setLayerParam(mapSmooth, layerSmooth, 10, true);
+
+document.getElementById('slider').addEventListener('input', function() {
+  setLayerParam(map, layer, this.value, false);
+  setLayerParam(mapSmooth, layerSmooth, this.value, true);
+});

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -5193,7 +5193,8 @@ olx.source.VectorOptions.prototype.wrapX;
  *     tileClass: (function(new: ol.ImageTile, ol.TileCoord,
  *                          ol.TileState, string, ?string,
  *                          ol.TileLoadFunctionType)|undefined),
- *     wrapX: (boolean|undefined)}}
+ *     wrapX: (boolean|undefined),
+ *     keyPrefixIgnoredDimensions: (Array.<string>|undefined)}}
  * @api
  */
 olx.source.WMTSOptions;
@@ -5360,6 +5361,14 @@ olx.source.WMTSOptions.prototype.urls;
  * @api
  */
 olx.source.WMTSOptions.prototype.wrapX;
+
+
+/**
+ * Ignored dimensions for prefix keys
+ * @type {Array.<string>|undefined}
+ * @api
+ */
+olx.source.WMTSOptions.prototype.keyPrefixIgnoredDimensions;
 
 
 /**

--- a/src/ol/imagetile.js
+++ b/src/ol/imagetile.js
@@ -60,8 +60,108 @@ ol.ImageTile = function(tileCoord, state, src, crossOrigin, tileLoadFunction) {
    */
   this.tileLoadFunction_ = tileLoadFunction;
 
+  /**
+   * @private
+   * @type {number}
+   */
+  this.sequenceNumber_ = 0;
+
+
+  /**
+   * @private
+   * @type {ol.ImageTile}
+   */
+  this.outOfBandTile_ = null;
+
 };
 goog.inherits(ol.ImageTile, ol.Tile);
+
+
+/**
+ * set the url for the out-of-band tile
+ *
+ * @param {string} url The url to load out-of-band.
+ * @return {ol.ImageTile}
+ */
+ol.ImageTile.prototype.setOutOfBandUrl = function(url) {
+  if (this.outOfBandTile_ === null) {
+
+    // create a new tile
+    this.outOfBandTile_ = this.createOutOfBandTile_(url);
+    this.assertSequence_();
+    return this.outOfBandTile_;
+
+  } else if (this.outOfBandTile_.state == ol.TileState.IDLE) {
+    goog.asserts.assert(this.outOfBandTile_.outOfBandTile_ === null);
+
+    // replace the old tile, and cause it to be dropped from the tile queue
+    var newTile = this.createOutOfBandTile_(url);
+    // this sets the tile load priority to DROP
+    this.outOfBandTile_.tileCoord = [-1, 0, 0];
+    this.outOfBandTile_ = newTile;
+    this.assertSequence_();
+    return this.outOfBandTile_;
+
+  } else if (this.outOfBandTile_.state == ol.TileState.LOADING ||
+      this.outOfBandTile_.state == ol.TileState.LOADED ||
+      this.outOfBandTile_.state == ol.TileState.ERROR) {
+    return this.outOfBandTile_.setOutOfBandUrl(url);
+  } else {
+    throw "don't know what to do when outOfBandTile is in state" +
+        this.outOfBandTile_.state;
+  }
+};
+
+
+/**
+ * create the out-of-band tile
+ *
+ * @param {string} url The url to load out of band
+ * @return {ol.ImageTile}
+ * @private
+ */
+ol.ImageTile.prototype.createOutOfBandTile_ = function(url) {
+  var tile = new ol.ImageTile(
+      this.tileCoord,
+      ol.TileState.IDLE,
+      url,
+      this.image_.crossOrigin === '' ? null : this.image_.crossOrigin,
+      this.tileLoadFunction_);
+  tile.sequenceNumber_ = this.getHighestSequenceNumber() + 1;
+  return tile;
+};
+
+
+/**
+ * get the out of band tile
+ *
+ * @return {ol.ImageTile}
+ */
+ol.ImageTile.prototype.getOutOfBandTile = function() {
+  this.assertSequence_();
+  return this.outOfBandTile_;
+};
+
+
+/**
+ * update the out of band tile with a new tile
+ *
+ * @param {ol.ImageTile} tile The new tile
+ */
+ol.ImageTile.prototype.updateOutOfBandTile = function(tile) {
+  if (tile.outOfBandTile_ !== null) {
+    if (this.outOfBandTile_ === null) {
+      if (this.sequenceNumber_ < tile.outOfBandTile_.sequenceNumber_) {
+        this.outOfBandTile_ = tile.outOfBandTile_;
+        this.assertSequence_();
+      }
+    } else if (this.outOfBandTile_.sequenceNumber_ <
+        tile.outOfBandTile_.sequenceNumber_) {
+      this.outOfBandTile_ = tile.outOfBandTile_;
+      this.assertSequence_();
+    }
+  }
+};
 
 
 /**
@@ -171,4 +271,45 @@ ol.ImageTile.prototype.unlistenImage_ = function() {
       'this.imageListenerKeys_ should not be null');
   goog.array.forEach(this.imageListenerKeys_, goog.events.unlistenByKey);
   this.imageListenerKeys_ = null;
+};
+
+
+/**
+ * Gets the sequence number.
+ *
+ * @return {number} sequence number
+ * @api
+ */
+ol.ImageTile.prototype.getSequenceNumber = function() {
+  this.assertSequence_();
+  return this.sequenceNumber_;
+};
+
+
+/**
+ * Gets the highest sequence number of the tile, or its OOB tile, recursively
+ *
+ * @return {number}
+ */
+ol.ImageTile.prototype.getHighestSequenceNumber = function() {
+  this.assertSequence_();
+  if (this.outOfBandTile_ !== null) {
+    return this.outOfBandTile_.getHighestSequenceNumber();
+  } else {
+    return this.sequenceNumber_;
+  }
+};
+
+
+/**
+ * Asserts that the sequence of tiles is correct
+ *
+ * @private
+ */
+ol.ImageTile.prototype.assertSequence_ = function() {
+  if (this.outOfBandTile_ !== null) {
+    goog.asserts.assert(this.outOfBandTile_.sequenceNumber_ >
+        this.sequenceNumber_);
+    this.outOfBandTile_.assertSequence_();
+  }
 };

--- a/src/ol/source/tileimagesource.js
+++ b/src/ol/source/tileimagesource.js
@@ -9,6 +9,7 @@ goog.require('ol.TileLoadFunctionType');
 goog.require('ol.TileState');
 goog.require('ol.TileUrlFunction');
 goog.require('ol.TileUrlFunctionType');
+goog.require('ol.extent');
 goog.require('ol.source.Tile');
 goog.require('ol.source.TileEvent');
 
@@ -68,6 +69,12 @@ ol.source.TileImage = function(options) {
    */
   this.tileClass = goog.isDef(options.tileClass) ?
       options.tileClass : ol.ImageTile;
+
+  /**
+   * @private
+   * @type {Object.<string, *>}
+   */
+  this.loadRequests_ = {};
 
 };
 goog.inherits(ol.source.TileImage, ol.source.Tile);
@@ -191,4 +198,142 @@ ol.source.TileImage.prototype.useTile = function(z, x, y) {
   if (this.tileCache.containsKey(tileCoordKey)) {
     this.tileCache.get(tileCoordKey);
   }
+};
+
+
+/**
+ * start reloading the visible tiles, using the out-of-band mechanism
+ *
+ * @param {ol.Map} map A map instance.
+ * @api
+ */
+ol.source.TileImage.prototype.reloadVisibleTilesOutOfBand = function(map) {
+
+  // find all the visible tiles
+  var size = map.getSize() || null;
+  var viewState = map.getView().getState();
+  var extent = ol.extent.getForViewAndSize(
+      viewState.center,
+      viewState.resolution,
+      viewState.rotation,
+      size);
+  var z = this.tileGrid.getZForResolution(viewState.resolution);
+  var tileResolution = this.tileGrid.getResolution(z);
+  var tileRange = this.tileGrid.getTileRangeForExtentAndResolution(extent,
+      tileResolution);
+
+  // request reloads for all the visible tiles
+  for (var x = tileRange.minX; x <= tileRange.maxX; ++x) {
+    for (var y = tileRange.minY; y <= tileRange.maxY; ++y) {
+      var tileCoordKey = this.getKeyZXY(z, x, y);
+      this.loadRequests_[tileCoordKey] = { z: z, x: x, y: y };
+    }
+  }
+
+  // execute the load requests after a little bit
+  // this lets multiple load requests in rapid succession overwrite each other
+  // it means we end up skipping some load requests entirely if they were
+  // immediately succeeded by another request for the same tile
+  // if this function is called by a UI slider (which can generate a huge
+  // number of requests in a short time), this delay can offer a significant
+  // speedup
+  var afterDelay = function() {
+    this.executeLoadRequests(map, z, tileRange, viewState.projection);
+  };
+  window.setTimeout(goog.bind(afterDelay, this), 100);
+};
+
+
+/**
+ * run the queued out-of-band load requests
+ *
+ * @param {ol.Map} map A map instance.
+ * @param {number} z The zoom.
+ * @param {ol.TileRange} tileRange A range of tiles.
+ * @param {ol.proj.Projection} projection The map view projection.
+ */
+ol.source.TileImage.prototype.executeLoadRequests =
+    function(map, z, tileRange, projection) {
+
+  var x, y, tileCoordKey;
+
+  if (this.tileCache.getCount() > 0) {
+    // clear any tiles that are not visible out of the cache
+    // it looks like we can only remove old things from the cache
+    // so collect our visible tiles
+    var cachedTiles = {};
+    for (x = tileRange.minX; x <= tileRange.maxX; ++x) {
+      for (y = tileRange.minY; y <= tileRange.maxY; ++y) {
+        tileCoordKey = this.getKeyZXY(z, x, y);
+        if (this.tileCache.containsKey(tileCoordKey)) {
+          cachedTiles[tileCoordKey] = this.tileCache.get(tileCoordKey);
+        }
+      }
+    }
+
+    // clear the cache, then put our tiles back
+    this.tileCache.clear();
+    for (tileCoordKey in cachedTiles) {
+      this.tileCache.set(tileCoordKey, cachedTiles[tileCoordKey]);
+    }
+  }
+
+  // set up the tile load handler
+  var setLoadHandler = function(tileCoordKey, outOfBandTile) {
+    var onTileLoad = function() {
+      if (outOfBandTile.getState() == ol.TileState.LOADING) {
+        // listen again to get the next event
+        goog.events.listenOnce(outOfBandTile, goog.events.EventType.CHANGE,
+            onTileLoad, false, this);
+      } else if (outOfBandTile.getState() == ol.TileState.LOADED ||
+          outOfBandTile.getState() == ol.TileState.ERROR) {
+        if (this.tileCache.containsKey(tileCoordKey)) {
+          // tile loads can come in out of order. make sure we only
+          // use the most recent tile
+          var cachedTile = this.tileCache.get(tileCoordKey);
+          if (outOfBandTile.getSequenceNumber() >
+              cachedTile.getSequenceNumber()) {
+            // make sure we don't overwrite a newer out-of-band-tile
+            outOfBandTile.updateOutOfBandTile(cachedTile);
+            // replace the old tile
+            this.tileCache.replace(tileCoordKey, outOfBandTile);
+          }
+        } else {
+          // we've never seen this tile before, just add it to the cache
+          this.tileCache.set(tileCoordKey, outOfBandTile);
+        }
+        // make sure the map draws a frame after the tile is loaded
+        map.render();
+      }
+    };
+    goog.events.listenOnce(outOfBandTile, goog.events.EventType.CHANGE,
+        onTileLoad, false, this);
+  };
+
+  // actually execute the tile load requests that are still in the current view
+  for (x = tileRange.minX; x <= tileRange.maxX; ++x) {
+    for (y = tileRange.minY; y <= tileRange.maxY; ++y) {
+      tileCoordKey = this.getKeyZXY(z, x, y);
+      var request = this.loadRequests_[tileCoordKey];
+      if (request !== null) {
+        var urlTileCoord = this.getTileCoordForTileUrlFunction([z, x, y],
+            projection);
+        var url = this.tileUrlFunction(urlTileCoord, this.getTilePixelRatio(),
+            projection);
+        if (this.tileCache.containsKey(tileCoordKey)) {
+          // add an out-of-band tile to the tile at this position
+          // it will get picked up by the tile queue and loaded some time later
+          var cachedTile = this.tileCache.get(tileCoordKey);
+          var outOfBandTile = cachedTile.setOutOfBandUrl(url, map);
+          setLoadHandler.call(this, tileCoordKey, outOfBandTile);
+        } else {
+          // there's no tile at this position yet, just ignore this request
+        }
+      }
+    }
+  }
+  this.loadRequests_ = {};
+
+  // tell the map to render to start processing the tile queue
+  map.render();
 };

--- a/src/ol/source/tilesource.js
+++ b/src/ol/source/tilesource.js
@@ -239,6 +239,14 @@ ol.source.Tile.prototype.getTileCoordForTileUrlFunction =
 
 
 /**
+ * @return {number} Tile pixel ratio.
+ */
+ol.source.Tile.prototype.getTilePixelRatio = function() {
+  return this.tilePixelRatio_;
+};
+
+
+/**
  * Marks a tile coord as being used, without triggering a load.
  * @param {number} z Tile coordinate z.
  * @param {number} x Tile coordinate x.

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -57,6 +57,10 @@ ol.source.WMTS = function(options) {
    */
   this.dimensions_ = goog.isDef(options.dimensions) ? options.dimensions : {};
 
+  this.keyPrefixIgnoredDimensions_ =
+      goog.isDef(options.keyPrefixIgnoredDimensions) ?
+      options.keyPrefixIgnoredDimensions : [];
+
   /**
    * @private
    * @type {string}
@@ -294,7 +298,9 @@ ol.source.WMTS.prototype.resetCoordKeyPrefix_ = function() {
   var i = 0;
   var res = [];
   for (var key in this.dimensions_) {
-    res[i++] = key + '-' + this.dimensions_[key];
+    if (!goog.array.contains(this.keyPrefixIgnoredDimensions_, key)) {
+      res[i++] = key + '-' + this.dimensions_[key];
+    }
   }
   this.coordKeyPrefix_ = res.join('/');
 };

--- a/src/ol/structs/lrucache.js
+++ b/src/ol/structs/lrucache.js
@@ -253,6 +253,18 @@ ol.structs.LRUCache.prototype.set = function(key, value) {
 
 
 /**
+ * @param {string} key Key.
+ * @param {T} value Value.
+ */
+ol.structs.LRUCache.prototype.replace = function(key, value) {
+  var entry = this.entries_[key];
+  goog.asserts.assert(goog.isDef(entry));
+  this.get(key); // make sure this entry gets refreshed
+  entry.value_ = value;
+};
+
+
+/**
  * @typedef {{key_: string,
  *            newer: ol.structs.LRUCacheEntry,
  *            older: ol.structs.LRUCacheEntry,


### PR DESCRIPTION
Rationale:
---------------

There are many use-cases where one or more frequently changing parameter/dimension for a WMTS source are used. One such example is issue #2827 and in our SCALGO Live products we also have several different  types of WMTS layers where a continuous dimension made available in the UI through a slider. An example of this is the [sea-level flooding] (http://scalgo.com/live/global?center=-10546029.2%2C3387094.1&zoom=5&tool=zoom&lrs=basic%2Cglobal%2Fhydrosheds%3Adem%2Cglobal%2Fhydrosheds%3Asea-levels&flooding=10) layer, and there is a similar interaction for [flow accumulation](http://scalgo.com/live/global?center=1717825.6%2C5738245.9&zoom=5&tool=zoom&lrs=basic%2Cglobal%2Fhydrosheds%3Adem%2Cglobal%2Fhydrosheds%3Aedgeflow&edge_flow=3509720000). In the former, the sea-level rise is set via a dimension/parameter to the GetTile request, and when the user drags the slider around, the sea level changes (the WMTS server delivers tiles with the appropriate sea level). In stock openlayers, this is not well supported as no tiles are rendered until the new tiles are ready, resulting in heavy flickering. 

This non-trivial patch changes the image tile renderer to keep rendering old tiles while the new tiles are being loaded, this significantly improves the use cases where such rapid changes in a dimension are being performed. We have created an [example](http://scalgo.com/stuff/ol3/build/examples/smooth-params.html), supplementing the one in issue #2827, that clearly illustrates the use case. You can see the regular WMTS mode on the left, and the new on the right. Use the sea-level slider to change the sea level and notice how the regular WMTS layer flickers significantly, especially when you slowly drag the slider (which is a very common use case). This patch does not change the semantics of existing WMTS layers, the smooth mode has to be explicitly requested by designating which dimensions  should be treated this way.  We have already been running this patch in production for several months (and it's used in the links above) with no issues for both regular WMTS layers and WMTS layers with a smooth dimension.

Details:
---------------
First, the patch tells WTMS sources to ignore certain dimensions when building tile cache keys. That way, when these parameters change, the existing tiles are not immediately discarded (or ignored) from the cache. Instead, the old tiles are still rendered. Without any other changes to the code, just this change would cause the ignored dimensions to have no effect on rendering at all.

When the ignored dimensions do change, we added a new method that, when called, explicitly reloads all the currently-visible tiles, and purges all the not visible tiles.

Tile reloading for this method uses a mechanism we called "out-of-band" in the code. Essentially, we turned each tile in the cache into a linked list of tiles. The head of the list is the current tile, and the second node (if any) is a tile waiting to be loaded. If there's a third node in the linked list (which is less common), that means the second node tile is in a loading state, but yet another tile has been requested. If a linked list gets flooded with load requests (which often happens for e.g. slider inputs), the linked list builder drops tile nodes that it knows will never be rendered. This load shedding generally keeps the length of the linked list to at most three.

This tile loading mechanism uses the ol3 tile load queue, so it still takes advantage of all the nice work scheduling for image loading that the ol3 engine uses.

We also made a small change to the image tile renderer to check the state of the linked list for each tile to decide which one to render for that frame.

The patch passes the Travis CI test and is rebased on top of current ol3 master. We have split the patch into one commit for the base functionality (I am not sure it's necessary to further subdivide that commit) and a separate commit for the example. I have filled out the corporate contributor license agreement and can send that in when it becomes relevant.

We appreciate your comments.
