### PR TITLE
Clarify docs for renderBuffer option

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -3556,8 +3556,9 @@ olx.layer.VectorOptions.prototype.opacity;
 
 /**
  * The buffer around the viewport extent used by the renderer when getting
- * features from the vector source. Recommended value: the size of the
- * largest symbol or line width. Default is 100 pixels.
+ * features from the vector source for the rendering or hit-detection.
+ * Recommended value: the size of the largest symbol, line width or label.
+ * Default is 100 pixels.
  * @type {number|undefined}
  * @api
  */


### PR DESCRIPTION
An attempt to clarify the description of the `renderBuffer` option on `ol.vector.Layer`.