### PR TITLE
Add proj4js and projection definition files to example resources

### DIFF
--- a/examples/wms-image-custom-proj.html
+++ b/examples/wms-image-custom-proj.html
@@ -5,6 +5,9 @@ shortdesc: Example of integrating Proj4js for coordinate transforms.
 docs: >
   With transparent [Proj4js](http://proj4js.org/) integration, OpenLayers can transform coordinates between arbitrary projections.
 tags: "wms, single image, proj4js, projection"
+resources:
+  - http://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.6/proj4.js
+  - http://epsg.io/21781-1753.js
 ---
 <div class="row-fluid">
   <div class="span12">


### PR DESCRIPTION
The example `examples/wms-image-custom-proj.html` needs both proj4js and the `EPSG:21781` definition file from epsg.io.

Please review.