### PR TITLE
Add metadata to examples

### DIFF
--- a/examples/geolocation-orientation.html
+++ b/examples/geolocation-orientation.html
@@ -1,5 +1,8 @@
 ---
-template: "example-verbatim.html"
+template: example-verbatim.html
+title: Geolocation Tracking with Orientation
+shortdesc: Example of a geolocated and oriented map.
+tags: "fullscreen, geolocation, orientation, mobile"
 ---
 <!doctype html>
 <html lang="en">
@@ -41,15 +44,8 @@ template: "example-verbatim.html"
         <button id="geolocate">Geolocate Me!</button>
         <button id="simulate">Simulate</button>
     </div>
-
     <script src="http://code.jquery.com/jquery-1.9.1.min.js" type="text/javascript"></script>
     <script src="./resources/common.js" type="text/javascript"></script>
     <script src="loader.js?id=geolocation-orientation" type="text/javascript"></script>
-
-    <div style="display: none;">
-      <div id="title">Geolocation tracking with orientation example</div>
-      <div id="shortdesc">Example of a geolocated and oriented map.</div>
-      <div id="tags">fullscreen, geolocation, orientation, mobile</div>
-    </div>
   </body>
 </html>

--- a/examples/mobile-full-screen.html
+++ b/examples/mobile-full-screen.html
@@ -1,5 +1,8 @@
 ---
-template: "example-verbatim.html"
+template: example-verbatim.html
+title: Full-Screen Mobile
+shortdesc: Example of a full screen map.
+tags: "fullscreen, geolocation, mobile"
 ---
 <!doctype html>
 <html lang="en">
@@ -23,11 +26,5 @@ template: "example-verbatim.html"
     <script src="./resources/common.js" type="text/javascript"></script>
     <script src="http://cdnjs.cloudflare.com/ajax/libs/fastclick/1.0.6/fastclick.min.js" type="text/javascript"></script>
     <script src="loader.js?id=mobile-full-screen" type="text/javascript"></script>
-
-    <div style="display: none;">
-      <div id="title">Mobile full screen example</div>
-      <div id="shortdesc">Example of a full screen map.</div>
-      <div id="tags">fullscreen, bing, geolocation, mobile</div>
-    </div>
   </body>
 </html>


### PR DESCRIPTION
This adds missing metadata to the examples.

![image](https://cloud.githubusercontent.com/assets/41094/7536344/46e3dffa-f54c-11e4-9d3c-d9e851682653.png)

Fixes #3674.