### PR TITLE
Fix WMTS.optionsFromCapabilities if no OperationsMetadata section

### DIFF
--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -458,7 +458,8 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
       'requestEncoding (%s) is one of "REST", "RESTful", "KVP" or ""',
       requestEncoding);
 
-  if (!wmtsCap['OperationsMetadata'].hasOwnProperty('GetTile') ||
+  if (!wmtsCap.hasOwnProperty('OperationsMetadata') ||
+      !wmtsCap['OperationsMetadata'].hasOwnProperty('GetTile') ||
       goog.string.startsWith(requestEncoding, 'REST')) {
     // Add REST tile resource url
     requestEncoding = ol.source.WMTSRequestEncoding.REST;


### PR DESCRIPTION
This function is currently failing if there is no OperationsMetadata section in the document, but this is not required. I think this is the correct fix.