### PR TITLE
Fix ol.extent.containsExtent documentation

### DIFF
--- a/src/ol/extent.js
+++ b/src/ol/extent.js
@@ -164,12 +164,15 @@ ol.extent.containsCoordinate = function(extent, coordinate) {
 
 
 /**
- * Check if one extent is contained by or on the edge of another.
+ * Check if one extent contains another.
+ *
+ * An extent is deemed contained if it lies completely within the other extent,
+ * including if they share one or more edges.
  *
  * @param {ol.Extent} extent1 Extent 1.
  * @param {ol.Extent} extent2 Extent 2.
- * @return {boolean} The first extent is contained by or on the edge of the
- *     second.
+ * @return {boolean} The second extent is contained by or on the edge of the
+ *     first.
  * @api stable
  */
 ol.extent.containsExtent = function(extent1, extent2) {


### PR DESCRIPTION
The `ol.extent.containsExtent` documentation had its arguments backwards (or the implementation did).

The documentation said "the first extent is contained by or on the edge of the second", but the function checked the opposite.

The wording was also a little strange, since from the name of the function alone `containsExtent` I'd guess that the first argument would be the (potential) container, and the second would be the (potentially) contained. But the documentation has the wording "check if one extent is *contained by* or on the edge of another", suggesting the first argument is the contained and the second the container.

This patch keeps the current functionality but clarifies the documentation.