### PR TITLE
Use a valid SPDX license expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "type": "git",
     "url": "git://github.com/openlayers/ol3.git"
   },
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "bugs": {
     "url": "https://github.com/openlayers/ol3/issues"
   },


### PR DESCRIPTION
`npm` warns that `BSD` in the `license` field of our `package.json` is not a valid SPDX license expression, see e.g. [here on travis](https://travis-ci.org/openlayers/ol3/builds/62689647#L430).

Here is the list it understands: http://spdx.org/licenses/

I chose to go with [`BSD-2-Clause`](http://spdx.org/licenses/BSD-2-Clause.html), even though it doesn't have the last paragraph that we have in `LICENSE.md`

```
The views and conclusions contained in the software and documentation are those
of the authors and should not be interpreted as representing official policies,
either expressed or implied, of OpenLayers Contributors.
```

Please review.