### PR TITLE
Add support for scientific notation to WKT format

### DIFF
--- a/src/ol/format/wktformat.js
+++ b/src/ol/format/wktformat.js
@@ -491,12 +491,23 @@ ol.format.WKT.Lexer.prototype.nextToken = function() {
 ol.format.WKT.Lexer.prototype.readNumber_ = function() {
   var c, index = this.index_;
   var decimal = false;
+  var scientificNotation = false;
   do {
     if (c == '.') {
       decimal = true;
+    } else if (goog.isDef(c) && c.toLowerCase() == 'e') {
+      scientificNotation = true;
     }
     c = this.nextChar_();
-  } while (this.isNumeric_(c, decimal));
+  } while (
+      this.isNumeric_(c, decimal) ||
+      // once c is defined we may have a scientific number indicated by 'e'
+      // but only if we haven't detected a scientific number before
+      !scientificNotation && goog.isDef(c) && c.toLowerCase() == 'e' ||
+      // once we know that we have a scientific number, both '-' and '+'
+      // are allowed
+      scientificNotation && (c == '-' || c == '+')
+  );
   return parseFloat(this.wkt.substring(index, this.index_--));
 };
 

--- a/test/spec/ol/format/wktformat.test.js
+++ b/test/spec/ol/format/wktformat.test.js
@@ -369,6 +369,63 @@ describe('ol.format.WKT', function() {
     expect(format.writeFeatures(features)).to.eql(wkt);
   });
 
+  describe('scientific notation supported', function() {
+
+    it('handles scientific notation correctly', function() {
+      var wkt = 'POINT(3e1 1e1)';
+      var geom = format.readGeometry(wkt);
+      expect(geom.getCoordinates()).to.eql([30, 10]);
+      expect(format.writeGeometry(geom)).to.eql('POINT(30 10)');
+    });
+
+    it('works with with negative exponent', function() {
+      var wkt = 'POINT(3e-1 1e-1)';
+      var geom = format.readGeometry(wkt);
+      expect(geom.getCoordinates()).to.eql([0.3, 0.1]);
+      expect(format.writeGeometry(geom)).to.eql('POINT(0.3 0.1)');
+    });
+
+    it('works with with explicitly positive exponent', function() {
+      var wkt = 'POINT(3e+1 1e+1)';
+      var geom = format.readGeometry(wkt);
+      expect(geom.getCoordinates()).to.eql([30, 10]);
+      expect(format.writeGeometry(geom)).to.eql('POINT(30 10)');
+    });
+
+    it('handles very small numbers in scientific notation', function() {
+      // very small numbers keep the scientific notation, both when reading and
+      // writing
+      var wkt = 'POINT(3e-9 1e-9)';
+      var geom = format.readGeometry(wkt);
+      expect(geom.getCoordinates()).to.eql([3e-9, 1e-9]);
+      expect(format.writeGeometry(geom)).to.eql('POINT(3e-9 1e-9)');
+    });
+
+    it('handles very big numbers in scientific notation', function() {
+      // very big numbers keep the scientific notation, both when reading and
+      // writing
+      var wkt = 'POINT(3e25 1e25)';
+      var geom = format.readGeometry(wkt);
+      expect(geom.getCoordinates()).to.eql([3e25, 1e25]);
+      expect(format.writeGeometry(geom)).to.eql('POINT(3e+25 1e+25)');
+    });
+
+    it('works case insensitively (e / E)', function() {
+      var wkt = 'POINT(3E1 1E1)';
+      var geom = format.readGeometry(wkt);
+      expect(geom.getCoordinates()).to.eql([30, 10]);
+      expect(format.writeGeometry(geom)).to.eql('POINT(30 10)');
+    });
+
+    it('detects invalid scientific notation', function() {
+      expect(function() {
+        // note the double 'e'
+        format.readGeometry('POINT(3ee1 10)');
+      }).to.throwException();
+    });
+
+  });
+
 });
 
 goog.require('ol.Feature');


### PR DESCRIPTION
This PR suggests that we add support for WKTs where the coordinates are in scientific notation.

Please review and share your thoughts.

Fixes #3686