### PR TITLE
Add missing goog.provides in drawinteraction.js

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -5,6 +5,7 @@
 #### `ol.interaction.Draw` changes
 
 * The `minPointsPerRing` config option has been renamed to `minPoints`. It is now also available for linestring drawing, not only for polygons.
+* The `ol.DrawEvent` and `ol.DrawEventType` types were renamed to `ol.interaction.DrawEvent` and `ol.interaction.DrawEventType`. This has an impact on your code only if your code is compiled together with ol3.
 
 #### `ol.tilegrid` changes
 

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -2360,7 +2360,7 @@ olx.interaction.DragZoomOptions.prototype.style;
  *     maxPoints: (number|undefined),
  *     minPoints: (number|undefined),
  *     style: (ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined),
- *     geometryFunction: (ol.interaction.Draw.GeometryFunctionType|undefined),
+ *     geometryFunction: (ol.interaction.DrawGeometryFunctionType|undefined),
  *     geometryName: (string|undefined),
  *     condition: (ol.events.ConditionType|undefined),
  *     freehandCondition: (ol.events.ConditionType|undefined)}}
@@ -2430,7 +2430,7 @@ olx.interaction.DrawOptions.prototype.style;
 
 /**
  * Function that is called when a geometry's coordinates are updated.
- * @type {ol.interaction.Draw.GeometryFunctionType|undefined}
+ * @type {ol.interaction.DrawGeometryFunctionType|undefined}
  * @api
  */
 olx.interaction.DrawOptions.prototype.geometryFunction;

--- a/src/ol/interaction/drawinteraction.js
+++ b/src/ol/interaction/drawinteraction.js
@@ -1,6 +1,8 @@
 goog.provide('ol.DrawEvent');
 goog.provide('ol.DrawEventType');
 goog.provide('ol.interaction.Draw');
+goog.provide('ol.interaction.Draw.GeometryFunctionType');
+goog.provide('ol.interaction.DrawMode');
 
 goog.require('goog.asserts');
 goog.require('goog.events');

--- a/src/ol/interaction/drawinteraction.js
+++ b/src/ol/interaction/drawinteraction.js
@@ -1,7 +1,7 @@
-goog.provide('ol.DrawEvent');
-goog.provide('ol.DrawEventType');
 goog.provide('ol.interaction.Draw');
-goog.provide('ol.interaction.Draw.GeometryFunctionType');
+goog.provide('ol.interaction.DrawEvent');
+goog.provide('ol.interaction.DrawEventType');
+goog.provide('ol.interaction.DrawGeometryFunctionType');
 goog.provide('ol.interaction.DrawMode');
 
 goog.require('goog.asserts');
@@ -34,16 +34,16 @@ goog.require('ol.style.Style');
 /**
  * @enum {string}
  */
-ol.DrawEventType = {
+ol.interaction.DrawEventType = {
   /**
    * Triggered upon feature draw start
-   * @event ol.DrawEvent#drawstart
+   * @event ol.interaction.DrawEvent#drawstart
    * @api stable
    */
   DRAWSTART: 'drawstart',
   /**
    * Triggered upon feature draw end
-   * @event ol.DrawEvent#drawend
+   * @event ol.interaction.DrawEvent#drawend
    * @api stable
    */
   DRAWEND: 'drawend'
@@ -59,10 +59,10 @@ ol.DrawEventType = {
  * @constructor
  * @extends {goog.events.Event}
  * @implements {oli.DrawEvent}
- * @param {ol.DrawEventType} type Type.
+ * @param {ol.interaction.DrawEventType} type Type.
  * @param {ol.Feature} feature The feature drawn.
  */
-ol.DrawEvent = function(type, feature) {
+ol.interaction.DrawEvent = function(type, feature) {
 
   goog.base(this, type);
 
@@ -74,7 +74,7 @@ ol.DrawEvent = function(type, feature) {
   this.feature = feature;
 
 };
-goog.inherits(ol.DrawEvent, goog.events.Event);
+goog.inherits(ol.interaction.DrawEvent, goog.events.Event);
 
 
 
@@ -84,7 +84,7 @@ goog.inherits(ol.DrawEvent, goog.events.Event);
  *
  * @constructor
  * @extends {ol.interaction.Pointer}
- * @fires ol.DrawEvent
+ * @fires ol.interaction.DrawEvent
  * @param {olx.interaction.DrawOptions} options Options.
  * @api stable
  */
@@ -210,7 +210,7 @@ ol.interaction.Draw = function(options) {
   }
 
   /**
-   * @type {ol.interaction.Draw.GeometryFunctionType}
+   * @type {ol.interaction.DrawGeometryFunctionType}
    * @private
    */
   this.geometryFunction_ = geometryFunction;
@@ -516,8 +516,8 @@ ol.interaction.Draw.prototype.startDrawing_ = function(event) {
   }
   this.sketchFeature_.setGeometry(geometry);
   this.updateSketchFeatures_();
-  this.dispatchEvent(new ol.DrawEvent(ol.DrawEventType.DRAWSTART,
-      this.sketchFeature_));
+  this.dispatchEvent(new ol.interaction.DrawEvent(
+      ol.interaction.DrawEventType.DRAWSTART, this.sketchFeature_));
 };
 
 
@@ -614,8 +614,8 @@ ol.interaction.Draw.prototype.addToDrawing_ = function(event) {
 
 /**
  * Stop drawing and add the sketch feature to the target layer.
- * The {@link ol.DrawEventType.DRAWEND} event is dispatched before inserting
- * the feature.
+ * The {@link ol.interaction.DrawEventType.DRAWEND} event is dispatched before
+ * inserting the feature.
  * @api
  */
 ol.interaction.Draw.prototype.finishDrawing = function() {
@@ -649,7 +649,8 @@ ol.interaction.Draw.prototype.finishDrawing = function() {
   }
 
   // First dispatch event to allow full set up of feature
-  this.dispatchEvent(new ol.DrawEvent(ol.DrawEventType.DRAWEND, sketchFeature));
+  this.dispatchEvent(new ol.interaction.DrawEvent(
+      ol.interaction.DrawEventType.DRAWEND, sketchFeature));
 
   // Then insert feature
   if (!goog.isNull(this.features_)) {
@@ -726,7 +727,7 @@ ol.interaction.Draw.prototype.updateState_ = function() {
  * @param {number=} opt_angle Angle of the first point in radians. 0 means East.
  *     Default is the angle defined by the heading from the center of the
  *     regular polygon to the current pointer position.
- * @return {ol.interaction.Draw.GeometryFunctionType} Function that draws a
+ * @return {ol.interaction.DrawGeometryFunctionType} Function that draws a
  *     polygon.
  * @api
  */
@@ -791,7 +792,7 @@ ol.interaction.Draw.getMode_ = function(type) {
  *     ol.geom.SimpleGeometry}
  * @api
  */
-ol.interaction.Draw.GeometryFunctionType;
+ol.interaction.DrawGeometryFunctionType;
 
 
 /**

--- a/test/spec/ol/interaction/drawinteraction.test.js
+++ b/test/spec/ol/interaction/drawinteraction.test.js
@@ -136,8 +136,8 @@ describe('ol.interaction.Draw', function() {
     it('triggers draw events', function() {
       var ds = sinon.spy();
       var de = sinon.spy();
-      goog.events.listen(draw, ol.DrawEventType.DRAWSTART, ds);
-      goog.events.listen(draw, ol.DrawEventType.DRAWEND, de);
+      goog.events.listen(draw, ol.interaction.DrawEventType.DRAWSTART, ds);
+      goog.events.listen(draw, ol.interaction.DrawEventType.DRAWEND, de);
       simulateEvent('pointermove', 10, 20);
       simulateEvent('pointerdown', 10, 20);
       simulateEvent('pointerup', 10, 20);
@@ -151,11 +151,12 @@ describe('ol.interaction.Draw', function() {
         end: 0,
         addfeature: 0
       };
-      goog.events.listen(draw, ol.DrawEventType.DRAWEND, function() {
-        expect(receivedEvents.end).to.be(0);
-        expect(receivedEvents.addfeature).to.be(0);
-        ++receivedEvents.end;
-      });
+      goog.events.listen(draw, ol.interaction.DrawEventType.DRAWEND,
+          function() {
+            expect(receivedEvents.end).to.be(0);
+            expect(receivedEvents.addfeature).to.be(0);
+            ++receivedEvents.end;
+          });
       source.on(ol.source.VectorEventType.ADDFEATURE, function() {
         expect(receivedEvents.end).to.be(1);
         expect(receivedEvents.addfeature).to.be(0);
@@ -279,8 +280,8 @@ describe('ol.interaction.Draw', function() {
     it('triggers draw events', function() {
       var ds = sinon.spy();
       var de = sinon.spy();
-      goog.events.listen(draw, ol.DrawEventType.DRAWSTART, ds);
-      goog.events.listen(draw, ol.DrawEventType.DRAWEND, de);
+      goog.events.listen(draw, ol.interaction.DrawEventType.DRAWSTART, ds);
+      goog.events.listen(draw, ol.interaction.DrawEventType.DRAWEND, de);
 
       // first point
       simulateEvent('pointermove', 10, 20);
@@ -435,8 +436,8 @@ describe('ol.interaction.Draw', function() {
     it('triggers draw events', function() {
       var ds = sinon.spy();
       var de = sinon.spy();
-      goog.events.listen(draw, ol.DrawEventType.DRAWSTART, ds);
-      goog.events.listen(draw, ol.DrawEventType.DRAWEND, de);
+      goog.events.listen(draw, ol.interaction.DrawEventType.DRAWSTART, ds);
+      goog.events.listen(draw, ol.interaction.DrawEventType.DRAWEND, de);
 
       // first point
       simulateEvent('pointermove', 10, 20);
@@ -573,8 +574,8 @@ describe('ol.interaction.Draw', function() {
     it('triggers draw events', function() {
       var ds = sinon.spy();
       var de = sinon.spy();
-      goog.events.listen(draw, ol.DrawEventType.DRAWSTART, ds);
-      goog.events.listen(draw, ol.DrawEventType.DRAWEND, de);
+      goog.events.listen(draw, ol.interaction.DrawEventType.DRAWSTART, ds);
+      goog.events.listen(draw, ol.interaction.DrawEventType.DRAWEND, de);
 
       // first point
       simulateEvent('pointermove', 10, 20);
@@ -744,7 +745,6 @@ goog.require('goog.dispose');
 goog.require('goog.events');
 goog.require('goog.events.BrowserEvent');
 goog.require('goog.style');
-goog.require('ol.DrawEventType');
 goog.require('ol.Map');
 goog.require('ol.MapBrowserPointerEvent');
 goog.require('ol.View');
@@ -757,6 +757,7 @@ goog.require('ol.geom.MultiPolygon');
 goog.require('ol.geom.Point');
 goog.require('ol.geom.Polygon');
 goog.require('ol.interaction.Draw');
+goog.require('ol.interaction.DrawEventType');
 goog.require('ol.interaction.Interaction');
 goog.require('ol.layer.Vector');
 goog.require('ol.pointer.PointerEvent');


### PR DESCRIPTION
This PR adds missing `goog.provides` to the `drawinteraction.js` file. The compilation of applications fails without these `goog.provides` if the draw interaction is not used.