### PR TITLE
fixed node install failing on closure-util update

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "homepage": "http://openlayers.org/",
   "scripts": {
     "install": "node tasks/install.js",
-    "postinstall": "closure-util update",
+    "postinstall": "node closure-util update",
     "start": "node tasks/serve.js",
     "test": "node tasks/test.js"
   },


### PR DESCRIPTION
npm install

> openlayers@3.5.0 install /home/zvikara/dev/geocell/ol3
> node tasks/install.js


> openlayers@3.5.0 postinstall /home/zvikara/dev/geocell/ol3
> closure-util update

sh: 1: closure-util: not found

npm ERR! Linux 3.13.0-53-generic
npm ERR! argv "/usr/bin/iojs" "/usr/bin/npm" "install"
npm ERR! node v2.0.2
npm ERR! npm  v2.10.1
npm ERR! file sh
npm ERR! code ELIFECYCLE
npm ERR! errno ENOENT
npm ERR! syscall spawn
npm ERR! openlayers@3.5.0 postinstall: `closure-util update`
npm ERR! spawn ENOENT
npm ERR! 
npm ERR! Failed at the openlayers@3.5.0 postinstall script 'closure-util update'.
npm ERR! This is most likely a problem with the openlayers package,
npm ERR! not with npm itself.