### PR TITLE
Snap example: remove featureoverlay from tags

### DIFF
--- a/examples/snap.html
+++ b/examples/snap.html
@@ -29,7 +29,7 @@ docs: >
       </select>
     </div>
   </form>
-tags: "draw, edit, modify, vector, featureoverlay, snap"
+tags: "draw, edit, modify, vector, snap"
 ---
 <div class="row-fluid">
   <div class="span12">


### PR DESCRIPTION
Minor point, but the snap example doesn't use a FeatureOverlay