### PR TITLE
Add mapBrowserEvent as a member of ol.SelectEvent

### DIFF
--- a/externs/oli.js
+++ b/externs/oli.js
@@ -120,19 +120,25 @@ oli.MapEvent.prototype.frameState;
 /**
  * @interface
  */
- oli.SelectEvent = function() {};
+oli.SelectEvent = function() {};
 
 
- /**
-  * @type {Array.<ol.Feature>}
-  */
+/**
+ * @type {Array.<ol.Feature>}
+ */
 oli.SelectEvent.prototype.deselected;
 
 
- /**
-  * @type {Array.<ol.Feature>}
-  */
+/**
+ * @type {Array.<ol.Feature>}
+ */
 oli.SelectEvent.prototype.selected;
+
+
+/**
+ * @type {ol.MapBrowserEvent}
+ */
+oli.SelectEvent.prototype.mapBrowserEvent;
 
 
 

--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -46,11 +46,13 @@ ol.interaction.SelectFilterFunction;
  * @param {string} type The event type.
  * @param {Array.<ol.Feature>} selected Selected features.
  * @param {Array.<ol.Feature>} deselected Deselected features.
+ * @param {ol.MapBrowserEvent} mapBrowserEvent Associated
+ *     {@link ol.MapBrowserEvent}.
  * @implements {oli.SelectEvent}
  * @extends {goog.events.Event}
  * @constructor
  */
-ol.SelectEvent = function(type, selected, deselected) {
+ol.SelectEvent = function(type, selected, deselected, mapBrowserEvent) {
   goog.base(this, type);
 
   /**
@@ -66,6 +68,13 @@ ol.SelectEvent = function(type, selected, deselected) {
    * @api
    */
   this.deselected = deselected;
+
+  /**
+   * Associated {@link ol.MapBrowserEvent}.
+   * @type {ol.MapBrowserEvent}
+   * @api
+   */
+  this.mapBrowserEvent = mapBrowserEvent;
 };
 goog.inherits(ol.SelectEvent, goog.events.Event);
 
@@ -266,7 +275,8 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
   }
   if (change) {
     this.dispatchEvent(
-        new ol.SelectEvent(ol.SelectEventType.SELECT, selected, deselected));
+        new ol.SelectEvent(ol.SelectEventType.SELECT, selected, deselected,
+            mapBrowserEvent));
   }
   return ol.events.condition.pointerMove(mapBrowserEvent);
 };


### PR DESCRIPTION
As discussed in #3737 the goog.event.Event is not enough sometimes, for instance you might want to know the shiftKey status or the pixel clicked.