### PR TITLE
fix ol.source.Vector#getFeaturesAtCoordinate

### DIFF
--- a/src/ol/source/vectorsource.js
+++ b/src/ol/source/vectorsource.js
@@ -343,35 +343,6 @@ ol.source.Vector.prototype.forEachFeature = function(callback, opt_this) {
 
 
 /**
- * Iterate through all features whose geometries contain the provided
- * coordinate, calling the callback with each feature.  If the callback returns
- * a "truthy" value, iteration will stop and the function will return the same
- * value.
- *
- * @param {ol.Coordinate} coordinate Coordinate.
- * @param {function(this: T, ol.Feature): S} callback Called with each feature
- *     whose goemetry contains the provided coordinate.
- * @param {T=} opt_this The object to use as `this` in the callback.
- * @return {S|undefined} The return value from the last call to the callback.
- * @template T,S
- */
-ol.source.Vector.prototype.forEachFeatureAtCoordinateDirect =
-    function(coordinate, callback, opt_this) {
-  var extent = [coordinate[0], coordinate[1], coordinate[0], coordinate[1]];
-  return this.forEachFeatureInExtent(extent, function(feature) {
-    var geometry = feature.getGeometry();
-    goog.asserts.assert(goog.isDefAndNotNull(geometry),
-        'feature geometry is defined and not null');
-    if (geometry.intersectsExtent(extent)) {
-      return callback.call(opt_this, feature);
-    } else {
-      return undefined;
-    }
-  });
-};
-
-
-/**
  * Iterate through all features whose bounding box intersects the provided
  * extent (note that the feature's geometry may not intersect the extent),
  * calling the callback with each feature.  If the callback returns a "truthy"
@@ -471,7 +442,8 @@ ol.source.Vector.prototype.getFeatures = function() {
  */
 ol.source.Vector.prototype.getFeaturesAtCoordinate = function(coordinate) {
   var features = [];
-  this.forEachFeatureAtCoordinateDirect(coordinate, function(feature) {
+  var extent = [coordinate[0], coordinate[1], coordinate[0], coordinate[1]];
+  this.forEachFeatureIntersectingExtent(extent, function(feature) {
     features.push(feature);
   });
   return features;

--- a/src/ol/source/vectorsource.js
+++ b/src/ol/source/vectorsource.js
@@ -362,7 +362,7 @@ ol.source.Vector.prototype.forEachFeatureAtCoordinateDirect =
     var geometry = feature.getGeometry();
     goog.asserts.assert(goog.isDefAndNotNull(geometry),
         'feature geometry is defined and not null');
-    if (geometry.containsCoordinate(coordinate)) {
+    if (geometry.intersectsExtent(extent)) {
       return callback.call(opt_this, feature);
     } else {
       return undefined;


### PR DESCRIPTION
As noted in https://github.com/openlayers/ol3/issues/3703, ol.source.Vector#getFeaturesAtCoordinate sometimes returns empty when it should return matching features.

Currently, it only returns features containing the coordinate, while the docs state that it should return all intersecting geometries. This PR changes this.

While doing this, I noted that ol.geom.Circle and ol.geom.LinearRing doesn't implements ol.geom.Geometry's abstract intersectsExtent method. This means that using this method will fail on any source containing those geometries. I'll open an issue about implementing intersectsExtent on those geometries. Perhaps that should be fixed, and these tests updated, before merging this PR?