### PR TITLE
Add tests and implementation for intersectsExtent (ol.geom.Geometry)

### DIFF
--- a/src/ol/geom/circle.js
+++ b/src/ol/geom/circle.js
@@ -138,6 +138,29 @@ ol.geom.Circle.prototype.getType = function() {
 
 
 /**
+ * @inheritDoc
+ * @api stable
+ */
+ol.geom.Circle.prototype.intersectsExtent = function(extent) {
+  var circleExtent = this.getExtent();
+  if (ol.extent.intersects(extent, circleExtent)) {
+    var center = this.getCenter();
+
+    if (extent[0] <= center[0] && extent[2] >= center[0]) {
+      return true;
+    }
+    if (extent[1] <= center[1] && extent[3] >= center[1]) {
+      return true;
+    }
+
+    return ol.extent.forEachCorner(extent, this.containsCoordinate, this);
+  }
+  return false;
+
+};
+
+
+/**
  * Set the center of the circle as {@link ol.Coordinate coordinate}.
  * @param {ol.Coordinate} center Center.
  * @api

--- a/test/spec/ol/geom/circle.test.js
+++ b/test/spec/ol/geom/circle.test.js
@@ -205,24 +205,67 @@ describe('ol.geom.Circle', function() {
 
     describe('#intersectsExtent', function() {
 
-      it('return false for non matching extent', function() {
-        expect(circle.intersectsExtent([0.9, 0.9, 10, 10])).to.be(false);
+      it('returns false for non-intersecting extents (wide outside own bbox)',
+         function() {
+           var wideOutsideLeftTop = [-3, 2, -2, 3];
+           var wideOutsideRightTop = [2, 2, 3, 3];
+           var wideOutsideRightBottom = [2, -3, 3, -2];
+           var wideOutsideLeftBottom = [-3, -3, -2, -2];
+           expect(circle.intersectsExtent(wideOutsideLeftTop)).to.be(false);
+           expect(circle.intersectsExtent(wideOutsideRightTop)).to.be(false);
+           expect(circle.intersectsExtent(wideOutsideRightBottom)).to.be(false);
+           expect(circle.intersectsExtent(wideOutsideLeftBottom)).to.be(false);
+         }
+      );
+
+      it('returns false for non-intersecting extents (inside own bbox)',
+         function() {
+           var nearOutsideLeftTop = [-1, 0.9, -0.9, 1];
+           var nearOutsideRightTop = [0.9, 0.9, 1, 1];
+           var nearOutsideRightBottom = [0.9, -1, 1, -0.9];
+           var nearOutsideLeftBottom = [-1, -1, -0.9, -0.9];
+           expect(circle.intersectsExtent(nearOutsideLeftTop)).to.be(false);
+           expect(circle.intersectsExtent(nearOutsideRightTop)).to.be(false);
+           expect(circle.intersectsExtent(nearOutsideRightBottom)).to.be(false);
+           expect(circle.intersectsExtent(nearOutsideLeftBottom)).to.be(false);
+         }
+      );
+
+      it('returns true for extents that intersect clearly', function() {
+        var intersectingLeftTop = [-1.5, 0.5, -0.5, 1.5];
+        var intersectingRightTop = [0.5, 0.5, 1.5, 1.5];
+        var intersectingRightBottom = [0.5, -1.5, 1.5, -0.5];
+        var intersectingLeftBottom = [-1.5, -1.5, -0.5, -0.5];
+        expect(circle.intersectsExtent(intersectingLeftTop)).to.be(true);
+        expect(circle.intersectsExtent(intersectingRightTop)).to.be(true);
+        expect(circle.intersectsExtent(intersectingRightBottom)).to.be(true);
+        expect(circle.intersectsExtent(intersectingLeftBottom)).to.be(true);
       });
 
-      it('return true for extent within circle', function() {
-        expect(circle.intersectsExtent([0.5, 0.5, 0.5, 0.5])).to.be(true);
+      it('returns true for extents that touch the circumference', function() {
+        var touchCircumferenceLeft = [-2, 0, -1, 1];
+        var touchCircumferenceTop = [0, 1, 1, 2];
+        var touchCircumferenceRight = [1, -1, 2, 0];
+        var touchCircumferenceBottom = [-1, -2, 0, -1];
+        expect(circle.intersectsExtent(touchCircumferenceLeft)).to.be(true);
+        expect(circle.intersectsExtent(touchCircumferenceTop)).to.be(true);
+        expect(circle.intersectsExtent(touchCircumferenceRight)).to.be(true);
+        expect(circle.intersectsExtent(touchCircumferenceBottom)).to.be(true);
       });
 
-      it('return true for extent overlapping circle', function() {
-        expect(circle.intersectsExtent([0.5, 0.5, 10, 10])).to.be(true);
+      it('returns true for a contained extent', function() {
+        var containedExtent = [-0.5, -0.5, 0.5, 0.5];
+        expect(circle.intersectsExtent(containedExtent)).to.be(true);
       });
 
-      it('return true for non-overlapping but intersecting extent', function() {
-        expect(circle.intersectsExtent([0, 1, 1, 2])).to.be(true);
+      it('returns true for a covering extent', function() {
+        var bigCoveringExtent = [-5, -5, 5, 5];
+        expect(circle.intersectsExtent(bigCoveringExtent)).to.be(true);
       });
 
       it('returns true for the geom\'s own extent', function() {
-        expect(circle.intersectsExtent(circle.getExtent())).to.be(true);
+        var circleExtent = circle.getExtent();
+        expect(circle.intersectsExtent(circleExtent)).to.be(true);
       });
 
     });

--- a/test/spec/ol/geom/circle.test.js
+++ b/test/spec/ol/geom/circle.test.js
@@ -203,6 +203,30 @@ describe('ol.geom.Circle', function() {
 
     });
 
+    describe('#intersectsExtent', function() {
+
+      it('return false for non matching extent', function() {
+        expect(circle.intersectsExtent([0.9, 0.9, 10, 10])).to.be(false);
+      });
+
+      it('return true for extent within circle', function() {
+        expect(circle.intersectsExtent([0.5, 0.5, 0.5, 0.5])).to.be(true);
+      });
+
+      it('return true for extent overlapping circle', function() {
+        expect(circle.intersectsExtent([0.5, 0.5, 10, 10])).to.be(true);
+      });
+
+      it('return true for non-overlapping but intersecting extent', function() {
+        expect(circle.intersectsExtent([0, 1, 1, 2])).to.be(true);
+      });
+
+      it('returns true for the geom\'s own extent', function() {
+        expect(circle.intersectsExtent(circle.getExtent())).to.be(true);
+      });
+
+    });
+
   });
 
 });

--- a/test/spec/ol/geom/geometrycollection.test.js
+++ b/test/spec/ol/geom/geometrycollection.test.js
@@ -1,5 +1,6 @@
 goog.provide('ol.test.geom.GeometryCollection');
 
+goog.require('ol.extent');
 
 describe('ol.geom.GeometryCollection', function() {
 
@@ -110,6 +111,35 @@ describe('ol.geom.GeometryCollection', function() {
       expect(extent[2]).to.be(30);
       expect(extent[1]).to.be(2);
       expect(extent[3]).to.be(40);
+    });
+
+  });
+
+  describe('#intersectsExtent()', function() {
+
+    beforeEach(function() {
+      point = new ol.geom.Point([5, 20]);
+      line = new ol.geom.LineString([[10, 20], [30, 40]]);
+      poly = new ol.geom.Polygon([outer, inner1, inner2]);
+      multi = new ol.geom.GeometryCollection([point, line, poly]);
+    });
+
+    it('returns true for intersecting point', function() {
+      expect(multi.intersectsExtent([5, 20, 5, 20])).to.be(true);
+    });
+
+    it('returns true for intersecting part of lineString', function() {
+      expect(multi.intersectsExtent([25, 35, 30, 40])).to.be(true);
+    });
+
+    it('returns true for intersecting part of polygon', function() {
+      expect(multi.intersectsExtent([0, 0, 5, 5])).to.be(true);
+    });
+
+
+    it('returns false for non-matching extent within own extent', function() {
+      var extent = [0, 35, 5, 40];
+      expect(poly.intersectsExtent(extent)).to.be(false);
     });
 
   });

--- a/test/spec/ol/geom/linestring.test.js
+++ b/test/spec/ol/geom/linestring.test.js
@@ -73,6 +73,22 @@ describe('ol.geom.LineString', function() {
       expect(lineString.getStride()).to.be(2);
     });
 
+    describe('#intersectsExtent', function() {
+
+      it('return false for non matching extent', function() {
+        expect(lineString.intersectsExtent([1, 3, 1.9, 4])).to.be(false);
+      });
+
+      it('return true for extent on midpoint', function() {
+        expect(lineString.intersectsExtent([2, 3, 4, 3])).to.be(true);
+      });
+
+      it('returns true for the geom\'s own extent', function() {
+        expect(lineString.intersectsExtent(lineString.getExtent())).to.be(true);
+      });
+
+    });
+
   });
 
   describe('construct with 3D coordinates', function() {
@@ -100,6 +116,22 @@ describe('ol.geom.LineString', function() {
 
     it('has the expected stride', function() {
       expect(lineString.getStride()).to.be(3);
+    });
+
+    describe('#intersectsExtent', function() {
+
+      it('return false for non matching extent', function() {
+        expect(lineString.intersectsExtent([1, 3, 1.9, 4])).to.be(false);
+      });
+
+      it('return true for extent on midpoint', function() {
+        expect(lineString.intersectsExtent([2, 3, 4, 3])).to.be(true);
+      });
+
+      it('returns true for the geom\'s own extent', function() {
+        expect(lineString.intersectsExtent(lineString.getExtent())).to.be(true);
+      });
+
     });
 
   });
@@ -132,6 +164,22 @@ describe('ol.geom.LineString', function() {
       expect(lineString.getStride()).to.be(3);
     });
 
+    describe('#intersectsExtent', function() {
+
+      it('return false for non matching extent', function() {
+        expect(lineString.intersectsExtent([1, 3, 1.9, 4])).to.be(false);
+      });
+
+      it('return true for extent on midpoint', function() {
+        expect(lineString.intersectsExtent([2, 3, 4, 3])).to.be(true);
+      });
+
+      it('returns true for the geom\'s own extent', function() {
+        expect(lineString.intersectsExtent(lineString.getExtent())).to.be(true);
+      });
+
+    });
+
   });
 
   describe('construct with 4D coordinates', function() {
@@ -159,6 +207,22 @@ describe('ol.geom.LineString', function() {
 
     it('has the expected stride', function() {
       expect(lineString.getStride()).to.be(4);
+    });
+
+    describe('#intersectsExtent', function() {
+
+      it('return false for non matching extent', function() {
+        expect(lineString.intersectsExtent([1, 3, 1.9, 4])).to.be(false);
+      });
+
+      it('return true for extent on midpoint', function() {
+        expect(lineString.intersectsExtent([2, 3, 4, 3])).to.be(true);
+      });
+
+      it('returns true for the geom\'s own extent', function() {
+        expect(lineString.intersectsExtent(lineString.getExtent())).to.be(true);
+      });
+
     });
 
   });

--- a/test/spec/ol/geom/multilinestring.test.js
+++ b/test/spec/ol/geom/multilinestring.test.js
@@ -88,6 +88,18 @@ describe('ol.geom.MultiLineString', function() {
 
     });
 
+    describe('#intersectsExtent()', function() {
+
+      it('returns true for intersecting part of lineString', function() {
+        expect(multiLineString.intersectsExtent([1, 2, 2, 3])).to.be(true);
+      });
+
+      it('returns false for non-matching extent within own extent', function() {
+        expect(multiLineString.intersectsExtent([1, 7, 2, 8])).to.be(false);
+      });
+
+    });
+
   });
 
   describe('construct with 3D coordinates', function() {

--- a/test/spec/ol/geom/multipoint.test.js
+++ b/test/spec/ol/geom/multipoint.test.js
@@ -73,6 +73,18 @@ describe('ol.geom.MultiPoint', function() {
       expect(multiPoint.getStride()).to.be(2);
     });
 
+    describe('#intersectsExtent()', function() {
+
+      it('returns true for extent covering a point', function() {
+        expect(multiPoint.intersectsExtent([1, 2, 2, 2])).to.be(true);
+      });
+
+      it('returns false for non-matching extent within own extent', function() {
+        expect(multiPoint.intersectsExtent([2, 3, 2, 4])).to.be(false);
+      });
+
+    });
+
   });
 
   describe('construct with 3D coordinates', function() {

--- a/test/spec/ol/geom/multipolygon.test.js
+++ b/test/spec/ol/geom/multipolygon.test.js
@@ -115,6 +115,14 @@ describe('ol.geom.MultiPolygon', function() {
 
     });
 
+    describe('#getExtent()', function() {
+
+      it('returns expected result', function() {
+        expect(multiPolygon.getExtent()).to.eql([0, 0, 5, 2]);
+      });
+
+    });
+
     describe('#getSimplifiedGeometry', function() {
 
       it('returns the expected result', function() {
@@ -125,6 +133,22 @@ describe('ol.geom.MultiPolygon', function() {
           [[[3, 0], [5, 2], [5, 0]]]
         ]);
       });
+    });
+
+    describe('#intersectsExtent()', function() {
+
+      it('returns true for extent of of each polygon', function() {
+        var polygons = multiPolygon.getPolygons();
+        for (var i = 0; i < polygons.length; i++) {
+          expect(multiPolygon.intersectsExtent(
+              polygons[i].getExtent())).to.be(true);
+        }
+      });
+
+      it('returns false for non-matching extent within own extent', function() {
+        expect(multiPolygon.intersectsExtent([2.1, 0, 2.9, 2])).to.be(false);
+      });
+
     });
 
   });

--- a/test/spec/ol/geom/point.test.js
+++ b/test/spec/ol/geom/point.test.js
@@ -37,6 +37,14 @@ describe('ol.geom.Point', function() {
       expect(point.getStride()).to.be(2);
     });
 
+    it('does not intersect non matching extent', function() {
+      expect(point.intersectsExtent([0, 0, 10, 0.5])).to.be(false);
+    });
+
+    it('does intersect it\'s extent', function() {
+      expect(point.intersectsExtent(point.getExtent())).to.be(true);
+    });
+
   });
 
   describe('construct with 3D coordinates and layout XYM', function() {
@@ -66,6 +74,14 @@ describe('ol.geom.Point', function() {
       expect(point.getStride()).to.be(3);
     });
 
+    it('does not intersect non matching extent', function() {
+      expect(point.intersectsExtent([0, 0, 10, 0.5])).to.be(false);
+    });
+
+    it('does intersect it\'s extent', function() {
+      expect(point.intersectsExtent(point.getExtent())).to.be(true);
+    });
+
   });
 
   describe('construct with 4D coordinates', function() {
@@ -93,6 +109,14 @@ describe('ol.geom.Point', function() {
 
     it('has the expected stride', function() {
       expect(point.getStride()).to.be(4);
+    });
+
+    it('does not intersect non matching extent', function() {
+      expect(point.intersectsExtent([0, 0, 10, 0.5])).to.be(false);
+    });
+
+    it('does intersect it\'s extent', function() {
+      expect(point.intersectsExtent(point.getExtent())).to.be(true);
     });
 
     describe('#getClosestPoint', function() {

--- a/test/spec/ol/geom/polygon.test.js
+++ b/test/spec/ol/geom/polygon.test.js
@@ -215,6 +215,33 @@ describe('ol.geom.Polygon', function() {
       expect(polygon.containsCoordinate(insideInner)).to.be(false);
     });
 
+    describe('#intersectsExtent', function() {
+
+      it('does not intersect outside extent', function() {
+        expect(polygon.intersectsExtent(
+            ol.extent.boundingExtent([outsideOuter]))).to.be(false);
+      });
+
+      it('does intersect inside extent', function() {
+        expect(polygon.intersectsExtent(
+            ol.extent.boundingExtent([inside]))).to.be(true);
+      });
+
+      it('does intersect boundary extent', function() {
+        var firstMidX = (outerRing[0][0] + outerRing[1][0]) / 2;
+        var firstMidY = (outerRing[0][1] + outerRing[1][1]) / 2;
+
+        expect(polygon.intersectsExtent(ol.extent.boundingExtent([[firstMidX,
+          firstMidY]]))).to.be(true);
+      });
+
+      it('does not intersect extent fully contained by inner ring', function() {
+        expect(polygon.intersectsExtent(
+            ol.extent.boundingExtent([insideInner]))).to.be(false);
+      });
+
+    });
+
     describe('#getOrientedFlatCoordinates', function() {
 
       it('reverses the outer ring if necessary', function() {
@@ -285,6 +312,33 @@ describe('ol.geom.Polygon', function() {
 
     it('does not contain inside inner coordinates', function() {
       expect(polygon.containsCoordinate(insideInner)).to.be(false);
+    });
+
+    describe('#intersectsExtent', function() {
+
+      it('does not intersect outside extent', function() {
+        expect(polygon.intersectsExtent(
+            ol.extent.boundingExtent([outsideOuter]))).to.be(false);
+      });
+
+      it('does intersect inside extent', function() {
+        expect(polygon.intersectsExtent(
+            ol.extent.boundingExtent([inside]))).to.be(true);
+      });
+
+      it('does intersect boundary extent', function() {
+        var firstMidX = (outerRing[0][0] + outerRing[1][0]) / 2;
+        var firstMidY = (outerRing[0][1] + outerRing[1][1]) / 2;
+
+        expect(polygon.intersectsExtent(ol.extent.boundingExtent([[firstMidX,
+          firstMidY]]))).to.be(true);
+      });
+
+      it('does not intersect extent fully contained by inner ring', function() {
+        expect(polygon.intersectsExtent(
+            ol.extent.boundingExtent([insideInner]))).to.be(false);
+      });
+
     });
 
     describe('#getOrientedFlatCoordinates', function() {
@@ -365,6 +419,35 @@ describe('ol.geom.Polygon', function() {
     it('does not contain inside inner coordinates', function() {
       expect(polygon.containsCoordinate(insideInner1)).to.be(false);
       expect(polygon.containsCoordinate(insideInner2)).to.be(false);
+    });
+
+    describe('#intersectsExtent', function() {
+
+      it('does not intersect outside extent', function() {
+        expect(polygon.intersectsExtent(
+            ol.extent.boundingExtent([outsideOuter]))).to.be(false);
+      });
+
+      it('does intersect inside extent', function() {
+        expect(polygon.intersectsExtent(
+            ol.extent.boundingExtent([inside]))).to.be(true);
+      });
+
+      it('does intersect boundary extent', function() {
+        var firstMidX = (outerRing[0][0] + outerRing[1][0]) / 2;
+        var firstMidY = (outerRing[0][1] + outerRing[1][1]) / 2;
+
+        expect(polygon.intersectsExtent(ol.extent.boundingExtent([[firstMidX,
+          firstMidY]]))).to.be(true);
+      });
+
+      it('does not intersect extent fully contained by inner ring', function() {
+        expect(polygon.intersectsExtent(
+            ol.extent.boundingExtent([insideInner1]))).to.be(false);
+        expect(polygon.intersectsExtent(
+            ol.extent.boundingExtent([insideInner2]))).to.be(false);
+      });
+
     });
 
     describe('#getOrientedFlatCoordinates', function() {


### PR DESCRIPTION
This PR implements ol.geom.Circle.prototype.intersectsExtent, and adds tests for that method on all geometry types that support it.

I noticed the missing tests and support on ol.geom.Circle while doing PR https://github.com/openlayers/ol3/pull/3761.

I didn't implement intersectsExtent on ol.geom.LinearRing since I noticed it's not supposed to be used as anything else than polygon components. After this PR, allt renderable geometry types support intersectsExtent, which would make it useable for ol.source.Vector#getFeaturesAtCoordinate in PR https://github.com/openlayers/ol3/pull/3761

The implementation for Circle#intersectsExtent treats it as a surface, so any extent intersecting it's contents or boundary will return true.

Feel free to comment, I'll fix and rebase if I've missed any important conventions.