### PR TITLE
Add ol-touch but keep ol-viewport className.

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -13,6 +13,7 @@ goog.require('goog.debug.Console');
 goog.require('goog.dom');
 goog.require('goog.dom.TagName');
 goog.require('goog.dom.ViewportSizeMonitor');
+goog.require('goog.dom.classlist');
 goog.require('goog.events');
 goog.require('goog.events.BrowserEvent');
 goog.require('goog.events.Event');
@@ -266,7 +267,7 @@ ol.Map = function(options) {
   // prevent page zoom on IE >= 10 browsers
   this.viewport_.style.msTouchAction = 'none';
   if (ol.has.TOUCH) {
-    this.viewport_.className = 'ol-touch';
+    goog.dom.classlist.add(this.viewport_, 'ol-touch');
   }
 
   /**


### PR DESCRIPTION
Currently when displaying a map on a touch device the `ol-touch` className is added to the viewport. Well this className actually replaces `ol-viewport`.

In my application I rely on `ol-viewport` to add styling behavior to element within the viewport and I don't want to add specific css selectors for touch devices.

With this pull request `ol-touch` is effectively added instead of replacing the existing one.

I've tested manually some examples and haven't seen any weird behavior.

Please review.