### PR TITLE
Always write the GeoJSONFeature geometry property

### DIFF
--- a/externs/geojson.js
+++ b/externs/geojson.js
@@ -123,7 +123,7 @@ var GeoJSONFeature = function() {};
 
 
 /**
- * @type {GeoJSONGeometry}
+ * @type {GeoJSONGeometry|GeoJSONGeometryCollection}
  */
 GeoJSONFeature.prototype.geometry;
 

--- a/src/ol/format/geojsonformat.js
+++ b/src/ol/format/geojsonformat.js
@@ -541,6 +541,8 @@ ol.format.GeoJSON.prototype.writeFeatureObject = function(
   if (goog.isDefAndNotNull(geometry)) {
     object['geometry'] =
         ol.format.GeoJSON.writeGeometry_(geometry, opt_options);
+  } else {
+    object['geometry'] = null;
   }
   var properties = feature.getProperties();
   goog.object.remove(properties, feature.getGeometryName());

--- a/test/spec/ol/format/geojsonformat.test.js
+++ b/test/spec/ol/format/geojsonformat.test.js
@@ -530,6 +530,12 @@ describe('ol.format.GeoJSON', function() {
       expect(geojson.properties).to.eql(null);
     });
 
+    it('writes out a feature without geometry correctly', function() {
+      var feature = new ol.Feature();
+      var geojson = format.writeFeatureObject(feature);
+      expect(geojson.geometry).to.eql(null);
+    });
+
   });
 
   describe('#writeGeometry', function() {


### PR DESCRIPTION
From http://geojson.org/geojson-spec.html#feature-objects:

*A feature object must have a member with the name "geometry". The value of the geometry member is a geometry object as defined above or a JSON null value.*