### PR TITLE
Respect the tile grid's extent in ol.source.TileVector

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -4045,7 +4045,8 @@ olx.source.TileImageOptions.prototype.wrapX;
  *     tileGrid: ol.tilegrid.TileGrid,
  *     tileUrlFunction: (ol.TileUrlFunctionType|undefined),
  *     url: (string|undefined),
- *     urls: (Array.<string>|undefined)}}
+ *     urls: (Array.<string>|undefined),
+ *     wrapX: (boolean|undefined)}}
  * @api
  */
 olx.source.TileVectorOptions;
@@ -4106,6 +4107,16 @@ olx.source.TileVectorOptions.prototype.url;
  * @api
  */
 olx.source.TileVectorOptions.prototype.urls;
+
+
+/**
+ * Wrap the world horizontally. Default is `true`. For vector editing across the
+ * -180° and 180° meridians to work properly, this should be set to `false`. The
+ * resulting geometry coordinates will then exceed the world bounds.
+ * @type {boolean|undefined}
+ * @api
+ */
+olx.source.TileVectorOptions.prototype.wrapX;
 
 
 /**

--- a/test/spec/ol/source/tilevectorsource.test.js
+++ b/test/spec/ol/source/tilevectorsource.test.js
@@ -9,7 +9,6 @@ describe('ol.source.TileVector', function() {
       var tileCoords = [];
       var source = new ol.source.TileVector({
         format: new ol.format.TopoJSON(),
-        projection: 'EPSG:3857',
         tileGrid: ol.tilegrid.createXYZ({
           maxZoom: 19
         }),
@@ -18,8 +17,9 @@ describe('ol.source.TileVector', function() {
           return null;
         }
       });
+      var projection = ol.proj.get('EPSG:3857');
       source.loadFeatures(
-          [-8238854, 4969777, -8237854, 4970777], 4.8, source.getProjection());
+          [-8238854, 4969777, -8237854, 4970777], 4.8, projection);
       expect(tileCoords[0]).to.eql([15, 9647, 12320]);
       expect(tileCoords[1]).to.eql([15, 9647, 12319]);
       expect(tileCoords[2]).to.eql([15, 9648, 12320]);
@@ -28,8 +28,58 @@ describe('ol.source.TileVector', function() {
 
   });
 
+  describe('#getTileCoordForTileUrlFunction()', function() {
+
+    it('returns the expected tile coordinate - {wrapX: true}', function() {
+      var tileSource = new ol.source.TileVector({
+        format: new ol.format.TopoJSON(),
+        tileGrid: ol.tilegrid.createXYZ({
+          maxZoom: 19
+        }),
+        wrapX: true
+      });
+      var projection = ol.proj.get('EPSG:3857');
+
+      var tileCoord = tileSource.getTileCoordForTileUrlFunction(
+          [6, -31, 41], projection);
+      expect(tileCoord).to.eql([6, 33, 22]);
+
+      tileCoord = tileSource.getTileCoordForTileUrlFunction(
+          [6, 33, 41], projection);
+      expect(tileCoord).to.eql([6, 33, 22]);
+
+      tileCoord = tileSource.getTileCoordForTileUrlFunction(
+          [6, 97, 41], projection);
+      expect(tileCoord).to.eql([6, 33, 22]);
+    });
+
+    it('returns the expected tile coordinate - {wrapX: false}', function() {
+      var tileSource = new ol.source.TileVector({
+        format: new ol.format.TopoJSON(),
+        tileGrid: ol.tilegrid.createXYZ({
+          maxZoom: 19
+        }),
+        wrapX: false
+      });
+      var projection = ol.proj.get('EPSG:3857');
+
+      var tileCoord = tileSource.getTileCoordForTileUrlFunction(
+          [6, -31, 41], projection);
+      expect(tileCoord).to.eql(null);
+
+      tileCoord = tileSource.getTileCoordForTileUrlFunction(
+          [6, 33, 41], projection);
+      expect(tileCoord).to.eql([6, 33, 22]);
+
+      tileCoord = tileSource.getTileCoordForTileUrlFunction(
+          [6, 97, 41], projection);
+      expect(tileCoord).to.eql(null);
+    });
+  });
+
 });
 
 
 goog.require('ol.format.TopoJSON');
+goog.require('ol.proj');
 goog.require('ol.source.TileVector');


### PR DESCRIPTION
By adding a `getTileCoordForTileUrlFuction()` method like for `ol.source.Tile`, we can now properly handle extent and resolution restrictions, and reuse tiles on wrapped worlds. Also adds the missing `wrapX` option to `ol.source.TileVector`.

Fixes #3798.