### PR TITLE
Improve TileGrid documentation and examples

### DIFF
--- a/examples/xyz-esri-4326-512.js
+++ b/examples/xyz-esri-4326-512.js
@@ -25,7 +25,7 @@ var map = new ol.Map({
         attributions: [attribution],
         maxZoom: 16,
         projection: projection,
-        tileSize: 512,
+        tileSize: tileSize,
         tileUrlFunction: function(tileCoord) {
           return urlTemplate.replace('{z}', (tileCoord[0] - 1).toString())
                             .replace('{x}', tileCoord[1].toString())

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -6149,8 +6149,8 @@ olx.tilegrid.TileGridOptions.prototype.minZoom;
 
 /**
  * The tile grid origin, i.e. where the `x` and `y` axes meet (`[z, 0, 0]`).
- * Tile coordinates increase from left to right and from bottom to top. Default
- * is null.
+ * Tile coordinates increase from left to right and from bottom to top. If not
+ * specified, `extent` or `origins` must be provided.
  * @type {ol.Coordinate|undefined}
  * @api stable
  */
@@ -6161,7 +6161,8 @@ olx.tilegrid.TileGridOptions.prototype.origin;
  * Tile grid origins, i.e. where the `x` and `y` axes meet (`[z, 0, 0]`), for
  * each zoom level. If given, the array length should match the length of the
  * `resolutions` array, i.e. each resolution can have a different origin. Tile
- * coordinates increase from left to right and from bottom to top.
+ * coordinates increase from left to right and from bottom to top. If not
+ * specified, `extent` or `origin` must be provided.
  * @type {Array.<ol.Coordinate>|undefined}
  * @api stable
  */

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -6148,7 +6148,9 @@ olx.tilegrid.TileGridOptions.prototype.minZoom;
 
 
 /**
- * Origin, i.e. the bottom-left corner of the grid. Default is null.
+ * The tile grid origin, i.e. where the `x` and `y` axes meet (`[z, 0, 0]`).
+ * Tile coordinates increase from left to right and from bottom to top. Default
+ * is null.
  * @type {ol.Coordinate|undefined}
  * @api stable
  */
@@ -6156,9 +6158,10 @@ olx.tilegrid.TileGridOptions.prototype.origin;
 
 
 /**
- * Origins, i.e. the bottom-left corners of the grid for each zoom level. If
- * given, the array length should match the length of the `resolutions` array,
- * i.e. each resolution can have a different origin.
+ * Tile grid origins, i.e. where the `x` and `y` axes meet (`[z, 0, 0]`), for
+ * each zoom level. If given, the array length should match the length of the
+ * `resolutions` array, i.e. each resolution can have a different origin. Tile
+ * coordinates increase from left to right and from bottom to top.
  * @type {Array.<ol.Coordinate>|undefined}
  * @api stable
  */


### PR DESCRIPTION
The term 'bottom-left corner' in the docs is misleading. This pull request aims to improve the documentation. It also simplifies the `xyz-esri-4326-512` example by actually using the `tileSize` variable.