### PR TITLE
Make geometry.transform api stable again

### DIFF
--- a/src/ol/geom/geometry.js
+++ b/src/ol/geom/geometry.js
@@ -229,6 +229,7 @@ ol.geom.Geometry.prototype.translate = goog.abstractMethod;
  *     string identifier or a {@link ol.proj.Projection} object.
  * @return {ol.geom.Geometry} This geometry.  Note that original geometry is
  *     modified in place.
+ * @api stable
  */
 ol.geom.Geometry.prototype.transform = function(source, destination) {
   this.applyTransform(ol.proj.getTransform(source, destination));


### PR DESCRIPTION
As mentioned in https://github.com/openlayers/ol3/pull/3464#issuecomment-113155115 I'm assuming that the api stable tag on geom.Geometry.transform was removed by mistake. Only Circle implements this function, so if you try and generate an export for this method for other geometries you get an error. Putting this back should fix this, and mean the function appears in the api docs again as well.