### PR TITLE
Allow ol.View.fitExtent to accept options for resolution constraining

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -6389,6 +6389,30 @@ olx.tilegrid.ZoomifyOptions.prototype.resolutions;
  */
 olx.view;
 
+/**
+ * @typedef {{padding: !Array.<number>,
+ *     constrainResolution: (boolean|undefined),
+ *     nearest: (boolean|undefined)}}
+ * @api
+ */
+olx.view.FitExtentOptions;
+
+
+/**
+ * Constrain the resolution. Default is `true`.
+ * @type {boolean|undefined}
+ * @api
+ */
+olx.view.FitExtentOptions.prototype.constrainResolution;
+
+
+/**
+ * Get the nearest extent. Default is `false`.
+ * @type {boolean|undefined}
+ * @api
+ */
+olx.view.FitExtentOptions.prototype.nearest;
+
 
 /**
  * @typedef {{padding: !Array.<number>,

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -436,18 +436,28 @@ ol.View.prototype.getZoom = function() {
  * size, that is `map.getSize()`.
  * @param {ol.Extent} extent Extent.
  * @param {ol.Size} size Box pixel size.
+ * @param {olx.view.FitExtentOptions=} opt_options Options.
  * @api
  */
-ol.View.prototype.fitExtent = function(extent, size) {
+ol.View.prototype.fitExtent = function(extent, size, opt_options) {
+  var options = goog.isDef(opt_options) ? opt_options : {};
+
+  var constrainResolution = goog.isDef(options.constrainResolution) ?
+      options.constrainResolution : true;
+  var nearest = goog.isDef(options.nearest) ? options.nearest : false;
+
   if (!ol.extent.isEmpty(extent)) {
     this.setCenter(ol.extent.getCenter(extent));
     var resolution = this.getResolutionForExtent(extent, size);
-    var constrainedResolution = this.constrainResolution(resolution, 0, 0);
-    if (constrainedResolution < resolution) {
-      constrainedResolution =
-          this.constrainResolution(constrainedResolution, -1, 0);
+    if (constrainResolution) {
+      var constrainedResolution = this.constrainResolution(resolution, 0, 0);
+      if (!nearest && constrainedResolution < resolution) {
+        constrainedResolution = this.constrainResolution(
+            constrainedResolution, -1, 0);
+      }
+      resolution = constrainedResolution;
     }
-    this.setResolution(constrainedResolution);
+    this.setResolution(resolution);
   }
 };
 


### PR DESCRIPTION
For the user, fitExtent and fitGeometry are very similar. At the moment,
fitExtent does not accept any options while fitGeometry() accepts
parameters like padding, minResolution or constrainResolution.
Argueably, a padding option is not really of any value here because
ol.Extent can be padded easily before calling fitExtent(). Also, a
minResolution/maxZoom option doesn't seem relevant for a function that
is specifically called to fit the map into the specified extent.

This commit however introduces 'constrainResolution' and 'nearest'
options for fitExtent. The resolution constraint is actually preventing
fitExtent() from fitting the map exactly into the provided extent. It
should be possible to turn this behavior off, because otherwise
ol.View.fitExtent  is unable to do what its name suggests.