### PR TITLE
Allow custom tileGrid in ol.source.XYZ

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -5358,6 +5358,7 @@ olx.source.WMTSOptions.prototype.wrapX;
  *     projection: ol.proj.ProjectionLike,
  *     maxZoom: (number|undefined),
  *     minZoom: (number|undefined),
+ *     tileGrid: (ol.tilegrid.TileGrid|undefined),
  *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
  *     tilePixelRatio: (number|undefined),
  *     tileSize: (number|ol.Size|undefined),
@@ -5420,6 +5421,14 @@ olx.source.XYZOptions.prototype.maxZoom;
  * @api
  */
 olx.source.XYZOptions.prototype.minZoom;
+
+
+/**
+ * Tile grid.
+ * @type {ol.tilegrid.TileGrid}
+ * @api
+ */
+olx.source.XYZOptions.prototype.tileGrid;
 
 
 /**

--- a/src/ol/source/xyzsource.js
+++ b/src/ol/source/xyzsource.js
@@ -19,11 +19,12 @@ ol.source.XYZ = function(options) {
   var projection = goog.isDef(options.projection) ?
       options.projection : 'EPSG:3857';
 
-  var tileGrid = ol.tilegrid.createXYZ({
-    extent: ol.tilegrid.extentFromProjection(projection),
-    maxZoom: options.maxZoom,
-    tileSize: options.tileSize
-  });
+  var tileGrid = goog.isDef(options.tileGrid) ? options.tileGrid :
+      ol.tilegrid.createXYZ({
+        extent: ol.tilegrid.extentFromProjection(projection),
+        maxZoom: options.maxZoom,
+        tileSize: options.tileSize
+      });
 
   goog.base(this, {
     attributions: options.attributions,

--- a/test/spec/ol/source/xyzsource.test.js
+++ b/test/spec/ol/source/xyzsource.test.js
@@ -5,6 +5,14 @@ describe('ol.source.XYZ', function() {
 
   describe('constructor', function() {
 
+    it('can be constructed with a custom tile grid', function() {
+      var tileGrid = ol.tilegrid.createXYZ();
+      var tileSource = new ol.source.XYZ({
+        tileGrid: tileGrid
+      });
+      expect(tileSource.getTileGrid()).to.be(tileGrid);
+    });
+
     it('can be constructed with a custom tile size', function() {
       var tileSource = new ol.source.XYZ({
         tileSize: 512


### PR DESCRIPTION
It is required for certain dataset to be able to pass custom tileGrid to `ol.source.XYZ` constructor.
Mainly because the extent of the dataset is only a subset of the projection extent.

Creating viewer for such XYZ tiles was possible in OL2: https://7a21d5a95f2b008cad7a4e1c15217921ef62368c.googledrive.com/host/0BwUe1kqIRJWSfllBSnJTT3pZM1RHdHBzaVBnQ29wQUNZWFg2Uy1mWVRjd3NvWlU1TG9MUEE/openlayers.html, but it is very hard in OL3 now.

This PR adds `tileGrid` constructor option to `ol.source.XYZ` (the default behavior is unchanged).