### PR TITLE
Enable use of custom XHR loader for TileVector sources

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -4022,10 +4022,11 @@ olx.source.TileImageOptions.prototype.wrapX;
 
 /**
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
- *     format: ol.format.Feature,
+ *     format: (ol.format.Feature|undefined),
  *     logo: (string|olx.LogoOptions|undefined),
  *     tileGrid: ol.tilegrid.TileGrid,
  *     tileUrlFunction: (ol.TileUrlFunctionType|undefined),
+ *     tileLoadFunction: (ol.TileVectorLoadFunctionType|undefined),
  *     url: (string|undefined),
  *     urls: (Array.<string>|undefined),
  *     wrapX: (boolean|undefined)}}
@@ -4043,8 +4044,8 @@ olx.source.TileVectorOptions.prototype.attributions;
 
 
 /**
- * Format.
- * @type {ol.format.Feature}
+ * Format. Required unless tileLoadFunction is used.
+ * @type {ol.format.Feature|undefined}
  * @api
  */
 olx.source.TileVectorOptions.prototype.format;
@@ -4073,6 +4074,16 @@ olx.source.TileVectorOptions.prototype.tileGrid;
  * @api
  */
 olx.source.TileVectorOptions.prototype.tileUrlFunction;
+
+
+/**
+ * Optional function to override the default loading and format parsing behaviour.
+ * If this option is used format is ignored and the provided function will be
+ * responsible for data retrieval and transformation into features.
+ * @type {ol.TileVectorLoadFunctionType|undefined}
+ * @api
+ */
+olx.source.TileVectorOptions.prototype.tileLoadFunction;
 
 
 /**

--- a/src/ol/tileloadfunction.js
+++ b/src/ol/tileloadfunction.js
@@ -1,4 +1,5 @@
 goog.provide('ol.TileLoadFunctionType');
+goog.provide('ol.TileVectorLoadFunctionType');
 
 
 /**
@@ -9,3 +10,13 @@ goog.provide('ol.TileLoadFunctionType');
  * @api
  */
 ol.TileLoadFunctionType;
+
+
+/**
+ * A function that is called with a tile url for the features to load and
+ * a callback that takes the loaded features as argument.
+ *
+ * @typedef {function(string, function(Array.<ol.Feature>))}
+ * @api
+ */
+ol.TileVectorLoadFunctionType;


### PR DESCRIPTION
Currently it's possible to fully customize only the plain Vector source. The TileVector source forces the use of the built in XHR implementation which in turn is coupled to the Format API which is not extensible outside OpenLayers.

The use case is when one wants to use external custom data sources with custom format (see #3754 and #3756) without modifying and custom building OpenLayers.