### PR TITLE
ArcGIS tiled example broken in Chrome

### DIFF
--- a/src/ol/source/tilearcgisrestsource.js
+++ b/src/ol/source/tilearcgisrestsource.js
@@ -111,7 +111,7 @@ ol.source.TileArcGISRest.prototype.getRequestUrl_ =
   params['BBOX'] = tileExtent.join(',');
   params['BBOXSR'] = srid;
   params['IMAGESR'] = srid;
-  params['DPI'] = 90 * pixelRatio;
+  params['DPI'] = Math.round(90 * pixelRatio);
 
   var url;
   if (urls.length == 1) {

--- a/test/spec/ol/source/tilearcgisrestsource.test.js
+++ b/test/spec/ol/source/tilearcgisrestsource.test.js
@@ -33,6 +33,14 @@ describe('ol.source.TileArcGISRest', function() {
 
     });
 
+    it('returns a non floating point DPI value', function() {
+      var source = new ol.source.TileArcGISRest(options);
+      var tile = source.getTile(3, 2, -7, 1.12, ol.proj.get('EPSG:3857'));
+      var uri = new goog.Uri(tile.src_);
+      var queryData = uri.getQueryData();
+      expect(queryData.get('DPI')).to.be('101');
+    });
+
     it('returns a tile with the expected URL with url list', function() {
 
       options.urls = ['http://test1.com/MapServer',


### PR DESCRIPTION
http://openlayers.org/en/v3.6.0/examples/arcgis-tiled.html?q=arcgisrest

Works fine in Safari though.

Issue is the non-integer dpi value.

http://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Specialty/ESRI_StateCityHighway_USA/MapServer/export?F=image&FORMAT=PNG32&TRANSPARENT=true&SIZE=230%2C230&BBOX=-7514065.628545966%2C2504688.542848654%2C-5009377.08569731%2C5009377.08569731&BBOXSR=3857&IMAGESR=3857&DPI=80.99999785423279

Status Code:404 'dpi' parameter is invalid