### PR TITLE
Add ol.source.ImageArcGISRest

### DIFF
--- a/examples/feature-animation.html
+++ b/examples/feature-animation.html
@@ -1,0 +1,15 @@
+---
+template: example.html
+title: Feature animation example
+shortdesc: Demonstrates how to animate features.
+docs: >
+  This example shows how to use <b>postcompose</b> and <b>vectorContext</b> to
+  animate features. Here we choose to do a flash animation each time a feature
+  is added to the layer.
+tags: "animation, vector, feature, flash"
+---
+<div class="row">
+  <div class="span8">
+    <div id="map" class="map"></div>
+  </div>
+</div>

--- a/examples/feature-animation.js
+++ b/examples/feature-animation.js
@@ -1,0 +1,96 @@
+goog.require('ol.Feature');
+goog.require('ol.Map');
+goog.require('ol.Observable');
+goog.require('ol.View');
+goog.require('ol.control');
+goog.require('ol.easing');
+goog.require('ol.geom.Point');
+goog.require('ol.layer.Tile');
+goog.require('ol.layer.Vector');
+goog.require('ol.proj');
+goog.require('ol.source.OSM');
+goog.require('ol.source.Vector');
+goog.require('ol.style.Circle');
+goog.require('ol.style.Stroke');
+
+
+var map = new ol.Map({
+  layers: [
+    new ol.layer.Tile({
+      source: new ol.source.OSM({
+        wrapX: false
+      })
+    })
+  ],
+  controls: ol.control.defaults({
+    attributionOptions: /** @type {olx.control.AttributionOptions} */ ({
+      collapsible: false
+    })
+  }),
+  renderer: common.getRendererFromQueryString(),
+  target: 'map',
+  view: new ol.View({
+    center: [0, 0],
+    zoom: 1
+  })
+});
+
+var source = new ol.source.Vector({
+  wrapX: false
+});
+var vector = new ol.layer.Vector({
+  source: source
+});
+map.addLayer(vector);
+
+function addRandomFeature() {
+  var x = Math.random() * 360 - 180;
+  var y = Math.random() * 180 - 90;
+  var geom = new ol.geom.Point(ol.proj.transform([x, y],
+      'EPSG:4326', 'EPSG:3857'));
+  var feature = new ol.Feature(geom);
+  source.addFeature(feature);
+}
+
+var duration = 3000;
+function flash(feature) {
+  var start = new Date().getTime();
+  var listenerKey;
+
+  function animate(event) {
+    var vectorContext = event.vectorContext;
+    var frameState = event.frameState;
+    var flashGeom = feature.getGeometry().clone();
+    var elapsed = frameState.time - start;
+    var elapsedRatio = elapsed / duration;
+    // radius will be 5 at start and 30 at end.
+    var radius = ol.easing.easeOut(elapsedRatio) * 25 + 5;
+    var opacity = ol.easing.easeOut(1 - elapsedRatio);
+
+    var flashStyle = new ol.style.Circle({
+      radius: radius,
+      snapToPixel: false,
+      stroke: new ol.style.Stroke({
+        color: 'rgba(255, 0, 0, ' + opacity + ')',
+        width: 1,
+        opacity: opacity
+      })
+    });
+
+    vectorContext.setImageStyle(flashStyle);
+    vectorContext.drawPointGeometry(flashGeom, null);
+    if (elapsed > duration) {
+      ol.Observable.unByKey(listenerKey);
+      return;
+    }
+    // tell OL3 to continue postcompose animation
+    frameState.animate = true;
+  }
+  listenerKey = map.on('postcompose', animate);
+}
+
+source.on('addfeature', function(e) {
+  flash(e.feature);
+});
+
+window.setInterval(addRandomFeature, 1000);

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -472,6 +472,7 @@ olx.ProjectionOptions.prototype.global;
  */
 olx.ProjectionOptions.prototype.worldExtent;
 
+
 /**
  * Function to determine resolution at a point. The function is called with a
  * `{number}` view resolution and an `{ol.Coordinate}` as arguments, and returns
@@ -910,6 +911,7 @@ olx.control.AttributionOptions.prototype.tipLabel;
  * @api
  */
 olx.control.AttributionOptions.prototype.label;
+
 
 /**
  * Text label to use for the expanded attributions button. Default is `»`.
@@ -2828,6 +2830,7 @@ olx.interaction.SelectOptions.prototype.removeCondition;
  */
 olx.interaction.SelectOptions.prototype.toggleCondition;
 
+
 /**
  * A boolean that determines if the default behaviour should select only
  * single features or all (overlapping) features at the clicked map
@@ -2836,6 +2839,7 @@ olx.interaction.SelectOptions.prototype.toggleCondition;
  * @api
  */
 olx.interaction.SelectOptions.prototype.multi;
+
 
 /**
  * A function that takes an {@link ol.Feature} and an {@link ol.layer.Layer} and
@@ -4194,7 +4198,6 @@ olx.source.ImageMapGuideOptions.prototype.ratio;
 olx.source.ImageMapGuideOptions.prototype.resolutions;
 
 
-
 /**
  * Optional function to load an image given a URL.
  * @type {ol.TileLoadFunctionType|undefined}
@@ -4342,6 +4345,104 @@ olx.source.OSMOptions.prototype.url;
  * @api
  */
 olx.source.OSMOptions.prototype.wrapX;
+
+
+/**
+ * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ *     crossOrigin: (null|string|undefined),
+ *     logo: (string|olx.LogoOptions|undefined),
+ *     imageLoadFunction: (ol.ImageLoadFunctionType|undefined),
+ *     params: Object.<string,*>,
+ *     projection: ol.proj.ProjectionLike,
+ *     ratio: (number|undefined),
+ *     resolutions: (Array.<number>|undefined),
+ *     url: (string|undefined)}}
+ * @api
+ */
+olx.source.ImageArcGISRestOptions;
+
+
+/**
+ * Attributions.
+ * @type {Array.<ol.Attribution>|undefined}
+ * @api stable
+ */
+olx.source.ImageArcGISRestOptions.prototype.attributions;
+
+
+/**
+ * The `crossOrigin` attribute for loaded images.  Note that you must provide a
+ * `crossOrigin` value if you are using the WebGL renderer or if you want to
+ * access pixel data with the Canvas renderer.  See
+ * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
+ * for more detail.
+ * @type {null|string|undefined}
+ * @api stable
+ */
+olx.source.ImageArcGISRestOptions.prototype.crossOrigin;
+
+
+/**
+ * Logo.
+ * @type {string|olx.LogoOptions|undefined}
+ * @api stable
+ */
+olx.source.ImageArcGISRestOptions.prototype.logo;
+
+
+/**
+ * Optional function to load an image given a URL.
+ * @type {ol.TileLoadFunctionType|undefined}
+ * @api
+ */
+olx.source.ImageArcGISRestOptions.prototype.imageLoadFunction;
+
+
+/**
+ * ArcGIS Rest parameters. This field is optional. Service defaults will be
+ * used for any fields not specified. `FORMAT` is `PNG32` by default. `F` is `IMAGE` by
+ * default. `TRANSPARENT` is `true` by default.  `BBOX, `SIZE`, `BBOXSR`,
+ * and `IMAGESR` will be set dynamically. Set `LAYERS` to
+ * override the default service layer visibility. See
+ * {@link http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Export_Map/02r3000000v7000000/}
+ * for further reference.
+ * @type {Object.<string,*>|undefined}
+ * @api
+ */
+olx.source.ImageArcGISRestOptions.prototype.params;
+
+
+/**
+ * Projection.
+ * @type {ol.proj.ProjectionLike}
+ * @api
+ */
+olx.source.ImageArcGISRestOptions.prototype.projection;
+
+
+/**
+ * Ratio. `1` means image requests are the size of the map viewport, `2` means
+ * twice the size of the map viewport, and so on. Default is `1.5`.
+ * @type {number|undefined}
+ * @api stable
+ */
+olx.source.ImageArcGISRestOptions.prototype.ratio;
+
+
+/**
+ * Resolutions. If specified, requests will be made for these resolutions only.
+ * @type {Array.<number>|undefined}
+ * @api stable
+ */
+olx.source.ImageArcGISRestOptions.prototype.resolutions;
+
+
+/**
+ * ArcGIS Rest service URL.
+ * @type {string|undefined}
+ * @api stable
+ */
+olx.source.ImageArcGISRestOptions.prototype.url;
 
 
 /**
@@ -4765,6 +4866,7 @@ olx.source.ImageStaticOptions.prototype.url;
  */
 olx.source.TileArcGISRestOptions;
 
+
 /**
  * Attributions.
  * @type {Array.<ol.Attribution>|undefined}
@@ -4805,6 +4907,7 @@ olx.source.TileArcGISRestOptions.prototype.logo;
  * @api
  */
 olx.source.TileArcGISRestOptions.prototype.tileGrid;
+
 
 /**
  * Projection.

--- a/src/ol/source/imagearcgisrestsource.js
+++ b/src/ol/source/imagearcgisrestsource.js
@@ -1,0 +1,283 @@
+goog.provide('ol.source.ImageArcGISRest');
+
+goog.require('goog.asserts');
+goog.require('goog.events');
+goog.require('goog.events.EventType');
+goog.require('goog.object');
+goog.require('goog.string');
+goog.require('goog.uri.utils');
+goog.require('ol');
+goog.require('ol.Image');
+goog.require('ol.ImageLoadFunctionType');
+goog.require('ol.extent');
+goog.require('ol.proj');
+goog.require('ol.source.Image');
+
+
+
+/**
+ * @classdesc
+ * Source for data from ArcGIS Rest services providing single, untiled images.
+ * Useful when underlying map service has labels.
+ *
+ * If underlying map service is not using labels,
+ * take advantage of ol image caching and use
+ * {@link ol.source.TileArcGISRest} data source.
+ *
+ * @constructor
+ * @fires ol.source.ImageEvent
+ * @extends {ol.source.Image}
+ * @param {olx.source.ImageArcGISRestOptions=} opt_options Options.
+ * @api
+ */
+ol.source.ImageArcGISRest = function(opt_options) {
+
+  var options = goog.isDef(opt_options) ? opt_options : {};
+
+  var params = goog.isDef(options.params) ? options.params : {};
+
+  goog.base(this, {
+    attributions: options.attributions,
+    logo: options.logo,
+    projection: options.projection,
+    resolutions: options.resolutions
+  });
+
+  /**
+         * @private
+         * @type {?string}
+         */
+  this.crossOrigin_ =
+      goog.isDef(options.crossOrigin) ? options.crossOrigin : null;
+
+  /**
+         * @private
+         * @type {string|undefined}
+         */
+  this.url_ = options.url;
+
+  /**
+         * @private
+         * @type {ol.ImageLoadFunctionType}
+         */
+  this.imageLoadFunction_ = goog.isDef(options.imageLoadFunction) ?
+      options.imageLoadFunction : ol.source.Image.defaultImageLoadFunction;
+
+  /**
+         * @private
+         * @type {Object}
+         */
+  this.params_ = params;
+
+  /**
+         * @private
+         * @type {ol.Image}
+         */
+  this.image_ = null;
+
+  /**
+         * @private
+         * @type {ol.Size}
+         */
+  this.imageSize_ = [0, 0];
+
+
+  /**
+     * @private
+     * @type {number}
+     */
+  this.renderedRevision_ = 0;
+
+  /**
+         * @private
+         * @type {number}
+         */
+  this.ratio_ = goog.isDef(options.ratio) ? options.ratio : 1.5;
+
+};
+goog.inherits(ol.source.ImageArcGISRest, ol.source.Image);
+
+
+/**
+ * Get the user-provided params, i.e. those passed to the constructor through
+ * the "params" option, and possibly updated using the updateParams method.
+ * @return {Object} Params.
+ * @api stable
+ */
+ol.source.ImageArcGISRest.prototype.getParams = function() {
+  return this.params_;
+};
+
+
+/**
+ * @inheritDoc
+ */
+ol.source.ImageArcGISRest.prototype.getImage =
+    function(extent, resolution, pixelRatio, projection) {
+
+  if (!goog.isDef(this.url_)) {
+    return null;
+  }
+
+  resolution = this.findNearestResolution(resolution);
+
+  var image = this.image_;
+  if (!goog.isNull(image) &&
+      this.renderedRevision_ == this.getRevision() &&
+      image.getResolution() == resolution &&
+      image.getPixelRatio() == pixelRatio &&
+      ol.extent.containsExtent(image.getExtent(), extent)) {
+    return image;
+  }
+
+  var params = {
+    'F': 'image',
+    'FORMAT': 'PNG32',
+    'TRANSPARENT': true
+  };
+  goog.object.extend(params, this.params_);
+
+  extent = extent.slice();
+  var centerX = (extent[0] + extent[2]) / 2;
+  var centerY = (extent[1] + extent[3]) / 2;
+  if (this.ratio_ != 1) {
+    var halfWidth = this.ratio_ * ol.extent.getWidth(extent) / 2;
+    var halfHeight = this.ratio_ * ol.extent.getHeight(extent) / 2;
+    extent[0] = centerX - halfWidth;
+    extent[1] = centerY - halfHeight;
+    extent[2] = centerX + halfWidth;
+    extent[3] = centerY + halfHeight;
+  }
+
+  var imageResolution = resolution / pixelRatio;
+
+  // Compute an integer width and height.
+  var width = Math.ceil(ol.extent.getWidth(extent) / imageResolution);
+  var height = Math.ceil(ol.extent.getHeight(extent) / imageResolution);
+
+  // Modify the extent to match the integer width and height.
+  extent[0] = centerX - imageResolution * width / 2;
+  extent[2] = centerX + imageResolution * width / 2;
+  extent[1] = centerY - imageResolution * height / 2;
+  extent[3] = centerY + imageResolution * height / 2;
+
+  this.imageSize_[0] = width;
+  this.imageSize_[1] = height;
+
+  var url = this.getRequestUrl_(extent, this.imageSize_, pixelRatio,
+      projection, params);
+
+  this.image_ = new ol.Image(extent, resolution, pixelRatio,
+      this.getAttributions(), url, this.crossOrigin_, this.imageLoadFunction_);
+
+  this.renderedRevision_ = this.getRevision();
+
+  goog.events.listen(this.image_, goog.events.EventType.CHANGE,
+      this.handleImageChange, false, this);
+
+  return this.image_;
+
+};
+
+
+/**
+ * Return the image load function of the source.
+ * @return {ol.ImageLoadFunctionType} The image load function.
+ * @api
+ */
+ol.source.ImageArcGISRest.prototype.getImageLoadFunction = function() {
+  return this.imageLoadFunction_;
+};
+
+
+/**
+ * @param {ol.Extent} extent Extent.
+ * @param {ol.Size} size Size.
+ * @param {number} pixelRatio Pixel ratio.
+ * @param {ol.proj.Projection} projection Projection.
+ * @param {Object} params Params.
+ * @return {string} Request URL.
+ * @private
+ */
+ol.source.ImageArcGISRest.prototype.getRequestUrl_ =
+    function(extent, size, pixelRatio, projection, params) {
+
+  goog.asserts.assert(goog.isDef(this.url_), 'url is defined');
+
+  // ArcGIS Server only wants the numeric portion of the projection ID.
+  var srid = projection.getCode().split(':').pop();
+
+  params['SIZE'] = size[0] + ',' + size[1];
+  params['BBOX'] = extent.join(',');
+  params['BBOXSR'] = srid;
+  params['IMAGESR'] = srid;
+  params['DPI'] = 90 * pixelRatio;
+
+  var url = this.url_;
+
+  if (!goog.string.endsWith(url, '/')) {
+    url = url + '/';
+  }
+
+  // If a MapServer, use export. If an ImageServer, use exportImage.
+  if (goog.string.endsWith(url, 'MapServer/')) {
+    url = url + 'export';
+  }
+  else if (goog.string.endsWith(url, 'ImageServer/')) {
+    url = url + 'exportImage';
+  }
+  else {
+    goog.asserts.fail('Unknown Rest Service', url);
+  }
+
+  return goog.uri.utils.appendParamsFromMap(url, params);
+};
+
+
+/**
+ * Return the URL used for this ArcGIS source.
+ * @return {string|undefined} URL.
+ * @api stable
+ */
+ol.source.ImageArcGISRest.prototype.getUrl = function() {
+  return this.url_;
+};
+
+
+/**
+ * Set the image load function of the source.
+ * @param {ol.ImageLoadFunctionType} imageLoadFunction Image load function.
+ * @api
+ */
+ol.source.ImageArcGISRest.prototype.setImageLoadFunction = function(
+    imageLoadFunction) {
+  this.image_ = null;
+  this.imageLoadFunction_ = imageLoadFunction;
+  this.changed();
+};
+
+
+/**
+ * Set the URL to use for requests.
+ * @param {string|undefined} url URL.
+ * @api stable
+ */
+ol.source.ImageArcGISRest.prototype.setUrl = function(url) {
+  if (url != this.url_) {
+    this.url_ = url;
+    this.image_ = null;
+    this.changed();
+  }
+};
+
+
+/**
+ * Update the user-provided params.
+ * @param {Object} params Params.
+ * @api stable
+ */
+ol.source.ImageArcGISRest.prototype.updateParams = function(params) {
+  goog.object.extend(this.params_, params);
+  this.image_ = null;
+  this.changed();
+};

--- a/test/spec/ol/source/imagearcgisrestsource.test.js
+++ b/test/spec/ol/source/imagearcgisrestsource.test.js
@@ -1,0 +1,189 @@
+goog.provide('ol.test.source.ImageArcGISRest');
+
+
+describe('ol.source.ImageArcGISRest', function() {
+
+  var options;
+  beforeEach(function() {
+    extent = [10, 20, 30, 40];
+    pixelRatio = 1;
+    projection = ol.proj.get('EPSG:4326');
+    proj3857 = ol.proj.get('EPSG:3857');
+    res = 0.1;
+    options = {
+      params: {},
+      url: 'http://example.com/MapServer'
+    };
+  });
+
+  describe('#getImage', function() {
+
+    it('returns a image with the expected URL', function() {
+      var source = new ol.source.ImageArcGISRest(options);
+      var image = source.getImage([3, 2, -7, 1], res, pixelRatio, proj3857);
+      var uri = new goog.Uri(image.src_);
+      expect(uri.getScheme()).to.be('http');
+      expect(uri.getDomain()).to.be('example.com');
+      expect(uri.getPath()).to.be('/MapServer/export');
+      var queryData = uri.getQueryData();
+      expect(queryData.get('BBOX')).to.be('5.5,2.25,-9.5,0.75');
+      expect(queryData.get('FORMAT')).to.be('PNG32');
+      expect(queryData.get('IMAGESR')).to.be('3857');
+      expect(queryData.get('BBOXSR')).to.be('3857');
+      expect(queryData.get('TRANSPARENT')).to.be('true');
+
+    });
+
+    it('returns a non floating point DPI value', function() {
+      var source = new ol.source.ImageArcGISRest(options);
+      var image = source.getImage([3, 2, -7, 1.12], res, pixelRatio, proj3857);
+      var uri = new goog.Uri(image.src_);
+      var queryData = uri.getQueryData();
+      expect(queryData.get('DPI')).to.be('90');
+    });
+
+    it('returns a image with the expected URL for ImageServer', function() {
+      options.url = 'http://example.com/ImageServer';
+      var source = new ol.source.ImageArcGISRest(options);
+      var image = source.getImage([3, 2, -7, 1], res, pixelRatio, proj3857);
+      var uri = new goog.Uri(image.src_);
+      expect(uri.getScheme()).to.be('http');
+      expect(uri.getDomain()).to.be('example.com');
+      expect(uri.getPath()).to.be('/ImageServer/exportImage');
+      var queryData = uri.getQueryData();
+      expect(queryData.get('BBOX')).to.be('5.5,2.25,-9.5,0.75');
+      expect(queryData.get('FORMAT')).to.be('PNG32');
+      expect(queryData.get('IMAGESR')).to.be('3857');
+      expect(queryData.get('BBOXSR')).to.be('3857');
+      expect(queryData.get('TRANSPARENT')).to.be('true');
+    });
+
+    it('allows various parameters to be overridden', function() {
+      options.params.FORMAT = 'png';
+      options.params.TRANSPARENT = false;
+      var source = new ol.source.ImageArcGISRest(options);
+      var image = source.getImage([3, 2, -3, 1], res, pixelRatio, projection);
+      var uri = new goog.Uri(image.src_);
+      var queryData = uri.getQueryData();
+      expect(queryData.get('FORMAT')).to.be('png');
+      expect(queryData.get('TRANSPARENT')).to.be('false');
+    });
+
+    it('allows adding rest option', function() {
+      options.params.LAYERS = 'show:1,3,4';
+      var source = new ol.source.ImageArcGISRest(options);
+      var image = source.getImage([3, 2, -3, 1], res, pixelRatio, proj3857);
+      var uri = new goog.Uri(image.src_);
+      var queryData = uri.getQueryData();
+      expect(queryData.get('LAYERS')).to.be('show:1,3,4');
+    });
+  });
+
+  describe('#updateParams', function() {
+
+    it('add a new param', function() {
+      var source = new ol.source.ImageArcGISRest(options);
+      source.updateParams({ 'TEST': 'value' });
+
+      var image = source.getImage([3, 2, -7, 1], res, pixelRatio, proj3857);
+      var uri = new goog.Uri(image.src_);
+      var queryData = uri.getQueryData();
+
+      expect(queryData.get('TEST')).to.be('value');
+    });
+
+    it('updates an existing param', function() {
+      options.params.TEST = 'value';
+
+      var source = new ol.source.ImageArcGISRest(options);
+      source.updateParams({ 'TEST': 'newValue' });
+
+      var image = source.getImage([3, 2, -7, 1], res, pixelRatio, proj3857);
+      var uri = new goog.Uri(image.src_);
+      var queryData = uri.getQueryData();
+
+      expect(queryData.get('TEST')).to.be('newValue');
+    });
+
+  });
+
+  describe('#getParams', function() {
+
+    it('verify getting a param', function() {
+      options.params.TEST = 'value';
+      var source = new ol.source.ImageArcGISRest(options);
+
+      var setParams = source.getParams();
+
+      expect(setParams).to.eql({ TEST: 'value' });
+    });
+
+    it('verify on adding a param', function() {
+      options.params.TEST = 'value';
+
+      var source = new ol.source.ImageArcGISRest(options);
+      source.updateParams({ 'TEST2': 'newValue' });
+
+      var setParams = source.getParams();
+
+      expect(setParams).to.eql({ TEST: 'value', TEST2: 'newValue' });
+    });
+
+    it('verify on update a param', function() {
+      options.params.TEST = 'value';
+
+      var source = new ol.source.ImageArcGISRest(options);
+      source.updateParams({ 'TEST': 'newValue' });
+
+      var setParams = source.getParams();
+
+      expect(setParams).to.eql({ TEST: 'newValue' });
+    });
+
+  });
+
+  describe('#getUrl', function() {
+
+    it('verify getting url', function() {
+      options.url = 'http://test.com/MapServer';
+
+      var source = new ol.source.ImageArcGISRest(options);
+
+      var url = source.getUrl();
+
+      expect(url).to.eql('http://test.com/MapServer');
+    });
+
+
+  });
+
+  describe('#setUrl', function() {
+
+    it('verify setting url when not set yet', function() {
+
+      var source = new ol.source.ImageArcGISRest(options);
+      source.setUrl('http://test.com/MapServer');
+
+      var url = source.getUrl();
+
+      expect(url).to.eql('http://test.com/MapServer');
+    });
+
+    it('verify setting url with existing url', function() {
+      options.url = 'http://test.com/MapServer';
+
+      var source = new ol.source.ImageArcGISRest(options);
+      source.setUrl('http://test2.com/MapServer');
+
+      var url = source.getUrl();
+
+      expect(url).to.eql('http://test2.com/MapServer');
+    });
+  });
+
+
+});
+
+goog.require('goog.Uri');
+goog.require('ol.source.ImageArcGISRest');
+goog.require('ol.proj');


### PR DESCRIPTION
ol.source.ImageArcGISRest is added so a single image can be retrieved which is required when labelling is applied to the underlying map service.
it's similar to ol.source.ImageWMS

usage:

```javascript

var layer = new ol.layer.Image({
  source: new ol.source.ImageArcGISRest({
    url: "http://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Specialty/ESRI_StateCityHighway_USA/MapServer",
  })
});


```