### PR TITLE
Check for exports before define

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -17,10 +17,10 @@ var log = closure.log;
 var root = path.join(__dirname, '..');
 
 var umdWrapper = '(function (root, factory) {\n' +
-    '  if (typeof define === "function" && define.amd) {\n' +
-    '    define([], factory);\n' +
-    '  } else if (typeof exports === "object") {\n' +
+    '  if (typeof exports === "object") {\n' +
     '    module.exports = factory();\n' +
+    '  } else if (typeof define === "function" && define.amd) {\n' +
+    '    define([], factory);\n' +
     '  } else {\n' +
     '    root.ol = factory();\n' +
     '  }\n' +


### PR DESCRIPTION
OL3 builds do not currently work with Webpack without some [awkward](https://github.com/openlayers/ol3/issues/3162#issuecomment-83955345) [configuration](https://github.com/webgeodatavore/demo_browserify_webpack_ol3/blob/e35b80c5e5e5212d4d55a0fe8f607d7e555fa975/webpack.config.js).  By checking for `exports` before `define`, our "umd" builds work with both Browserify and Webpack.

There may still be a problem with people trying to use OpenLayers builds with require.js.  If there are any of those people, we can address that problem separately.

Fixes #3162.
