### PR TITLE
ol.source.TileVector:  at resolution functions

### DIFF
--- a/src/ol/source/tilevectorsource.js
+++ b/src/ol/source/tilevectorsource.js
@@ -313,6 +313,31 @@ ol.source.TileVector.prototype.getFeaturesInExtent = goog.abstractMethod;
 
 
 /**
+ * Get all features in the provided extent at the provided resolution.  Note
+ * that this returns all features whose bounding boxes intersect the given
+ * extent (so it may include features whose geometries do not intersect the
+ * extent).
+ *
+ * @param {ol.Extent} extent Extent.
+ * @param {number} resolution Resolution.
+ * @return {Array.<ol.Feature>} Features.
+ * @api
+ */
+ol.source.TileVector.prototype.getFeaturesInExtentAtResolution =
+    function(extent, resolution) {
+  var features = [];
+  this.forEachFeatureInExtentAtResolution(extent, resolution,
+      /**
+       * @param {ol.Feature} feature Feature.
+       */
+      function(feature) {
+        features.push(feature);
+      });
+  return features;
+};
+
+
+/**
  * Handles x-axis wrapping and returns a tile coordinate transformed from the
  * internal tile scheme to the tile grid's tile scheme. When the tile coordinate
  * is outside the resolution and extent range of the tile grid, `null` will be

--- a/src/ol/source/tilevectorsource.js
+++ b/src/ol/source/tilevectorsource.js
@@ -155,10 +155,23 @@ ol.source.TileVector.prototype.forEachFeatureInExtent = goog.abstractMethod;
 
 
 /**
- * @inheritDoc
+ * Iterate through all features whose bounding box intersects the provided
+ * extent (note that the feature's geometry may not intersect the extent) at
+ * the provided resolution, calling the callback with each feature.  If the
+ * callback returns a "truthy" value, iteration will stop and the function
+ * will return the same value.
+ *
+ * @param {ol.Extent} extent Extent.
+ * @param {number} resolution Resolution.
+ * @param {function(this: T, ol.Feature): S} callback Called with each feature
+ *     whose bounding box intersects the provided extent.
+ * @param {T=} opt_this The object to use as `this` in the callback.
+ * @return {S|undefined} The return value from the last call to the callback.
+ * @template T,S
+ * @api
  */
 ol.source.TileVector.prototype.forEachFeatureInExtentAtResolution =
-    function(extent, resolution, f, opt_this) {
+    function(extent, resolution, callback, opt_this) {
   var tileGrid = this.tileGrid_;
   var tiles = this.tiles_;
   var z = tileGrid.getZForResolution(resolution);
@@ -171,9 +184,11 @@ ol.source.TileVector.prototype.forEachFeatureInExtentAtResolution =
       if (goog.isDef(features)) {
         var i, ii;
         for (i = 0, ii = features.length; i < ii; ++i) {
-          var result = f.call(opt_this, features[i]);
-          if (result) {
-            return result;
+          if (features[i].getGeometry().intersectsExtent(extent)) {
+            var result = callback.call(opt_this, features[i]);
+            if (result) {
+              return result;
+            }
           }
         }
       }


### PR DESCRIPTION
As I've written in #3830, I'm missing several ...AtResolution() functions:
- [ ] getClosestFeatureToCoordinateAtResolution()
- [ ] getFeatureByIdAtResolution()
- [x] getFeaturesAtResolution()
- [x] getFeaturesInExtentAtResolution()
also:
- [x] forEachFeatureAtResolution()
- [x] forEachFeatureInExtentAtResolution()

checked function names are already implemented by this pull request.

Now I'm a bit unsure how to proceed. I've seen that `getFeatureById()` and `getClosestFeatureToCoordinate()` use indexes. To also use these indexes for the ...AtResolution() functions, we should maybe add indexes per zoom level? Or shall I just iterate over all objects and ignore performance. The index could be added later on? The bounding box index could also be used by the forEachFeatureInExtentAtResolution() resp. getFeaturesInExtentAtResolution() functions.

If no one replies, I will just implement the iteration functions.