### PR TITLE
Handle CDATA in attribute parsing for GML format

### DIFF
--- a/src/ol/format/gml/gmlbaseformat.js
+++ b/src/ol/format/gml/gmlbaseformat.js
@@ -203,10 +203,11 @@ ol.format.GMLBase.prototype.readFeatureElement = function(node, objectStack) {
       n = n.nextElementSibling) {
     var localName = ol.xml.getLocalName(n);
     // Assume attribute elements have one child node and that the child
-    // is a text node.  Otherwise assume it is a geometry node.
+    // is a text or CDATA node (to be treated as text).
+    // Otherwise assume it is a geometry node.
     if (n.childNodes.length === 0 ||
         (n.childNodes.length === 1 &&
-        n.firstChild.nodeType === 3)) {
+        (n.firstChild.nodeType === 3 || n.firstChild.nodeType === 4))) {
       var value = ol.xml.getAllTextContent(n, false);
       if (goog.string.isEmpty(value)) {
         value = undefined;

--- a/test/spec/ol/format/gmlformat.test.js
+++ b/test/spec/ol/format/gmlformat.test.js
@@ -907,6 +907,47 @@ describe('ol.format.GML3', function() {
     });
   });
 
+  describe('when parsing CDATA attribute', function() {
+    var features;
+    before(function(done) {
+      try {
+        var text =
+            '<gml:featureMembers xmlns:gml="http://www.opengis.net/gml">' +
+            '  <topp:gnis_pop gml:id="gnis_pop.148604" xmlns:topp="' +
+            'http://www.openplans.org/topp">' +
+            '    <gml:name>Aflu</gml:name>' +
+            '    <topp:the_geom>' +
+            '      <gml:Point srsName="urn:x-ogc:def:crs:EPSG:4326">' +
+            '        <gml:pos>34.12 2.09</gml:pos>' +
+            '      </gml:Point>' +
+            '    </topp:the_geom>' +
+            '    <topp:population>84683</topp:population>' +
+            '    <topp:country>Algeria</topp:country>' +
+            '    <topp:type>place</topp:type>' +
+            '    <topp:name>Aflu</topp:name>' +
+            '    <topp:cdata><![CDATA[<a>b</a>]]></topp:cdata>' +
+            '  </topp:gnis_pop>' +
+            '</gml:featureMembers>';
+        var config = {
+          'featureNS': 'http://www.openplans.org/topp',
+          'featureType': 'gnis_pop'
+        };
+        features = new ol.format.GML(config).readFeatures(text);
+      } catch (e) {
+        done(e);
+      }
+      done();
+    });
+
+    it('creates 1 feature', function() {
+      expect(features).to.have.length(1);
+    });
+
+    it('converts XML attribute to text', function() {
+      expect(features[0].get('cdata')).to.be('<a>b</a>');
+    });
+  });
+
   describe('when parsing TOPP states WFS with autoconfigure', function() {
     var features, text, gmlFormat;
     before(function(done) {


### PR DESCRIPTION
Following [3827](https://github.com/openlayers/ol3/issues/3827),
handle CDATA XML nodes in attribute parsing of GML data. Currently
such data will be expected to be a geometry, and will fail to parse.

Treating the CDATA node as text is the easiest way to handle such
an attribute.