### PR TITLE
Check projection.canWrapX() before wrapping tiles

### DIFF
--- a/src/ol/source/tilesource.js
+++ b/src/ol/source/tilesource.js
@@ -231,7 +231,7 @@ ol.source.Tile.prototype.getTileCoordForTileUrlFunction =
       opt_projection : this.getProjection();
   var tileGrid = this.getTileGridForProjection(projection);
   goog.asserts.assert(!goog.isNull(tileGrid), 'tile grid needed');
-  if (this.getWrapX()) {
+  if (this.getWrapX() && projection.canWrapX()) {
     tileCoord = ol.tilecoord.wrapX(tileCoord, tileGrid, projection);
   }
   return ol.tilecoord.withinExtentAndZ(tileCoord, tileGrid) ? tileCoord : null;

--- a/src/ol/source/tilevectorsource.js
+++ b/src/ol/source/tilevectorsource.js
@@ -254,7 +254,7 @@ ol.source.TileVector.prototype.getTileCoordForTileUrlFunction =
     function(tileCoord, projection) {
   var tileGrid = this.tileGrid_;
   goog.asserts.assert(!goog.isNull(tileGrid), 'tile grid needed');
-  if (this.getWrapX()) {
+  if (this.getWrapX() && projection.canWrapX()) {
     tileCoord = ol.tilecoord.wrapX(tileCoord, tileGrid, projection);
   }
   return ol.tilecoord.withinExtentAndZ(tileCoord, tileGrid) ?


### PR DESCRIPTION
EDIT: see below for better solution

It probably does not make sense to have `wrapX:true` as default on `ol.source.XYZ` if the projection is not global (therefore `projection.canWrapX()` returns false).

This can lead to some strange behavior when the projection has `extent` defined (example: http://jsfiddle.net/30wjhq38/). It can be solved by manually specifying `wrapX: false` as the constructor option, but it should not be required if the projection can not wrap X.