### PR TITLE
Do not require projection extent for x-wrapping tile sources

### DIFF
--- a/src/ol/source/tilesource.js
+++ b/src/ol/source/tilesource.js
@@ -231,7 +231,7 @@ ol.source.Tile.prototype.getTileCoordForTileUrlFunction =
       opt_projection : this.getProjection();
   var tileGrid = this.getTileGridForProjection(projection);
   goog.asserts.assert(!goog.isNull(tileGrid), 'tile grid needed');
-  if (this.getWrapX() && projection.canWrapX()) {
+  if (this.getWrapX() && projection.isGlobal()) {
     tileCoord = ol.tilecoord.wrapX(tileCoord, tileGrid, projection);
   }
   return ol.tilecoord.withinExtentAndZ(tileCoord, tileGrid) ? tileCoord : null;

--- a/src/ol/source/tilevectorsource.js
+++ b/src/ol/source/tilevectorsource.js
@@ -254,7 +254,7 @@ ol.source.TileVector.prototype.getTileCoordForTileUrlFunction =
     function(tileCoord, projection) {
   var tileGrid = this.tileGrid_;
   goog.asserts.assert(!goog.isNull(tileGrid), 'tile grid needed');
-  if (this.getWrapX() && projection.canWrapX()) {
+  if (this.getWrapX() && projection.isGlobal()) {
     tileCoord = ol.tilecoord.wrapX(tileCoord, tileGrid, projection);
   }
   return ol.tilecoord.withinExtentAndZ(tileCoord, tileGrid) ?

--- a/test/spec/ol/source/tilesource.test.js
+++ b/test/spec/ol/source/tilesource.test.js
@@ -148,6 +148,20 @@ describe('ol.source.Tile', function() {
       tileCoord = tileSource.getTileCoordForTileUrlFunction([6, 97, -23]);
       expect(tileCoord).to.eql(null);
     });
+
+    it('works with wrapX and custom projection without extent', function() {
+      var tileSource = new ol.source.Tile({
+        projection: new ol.proj.Projection({
+          code: 'foo',
+          global: true,
+          units: 'm'
+        }),
+        wrapX: true
+      });
+
+      var tileCoord = tileSource.getTileCoordForTileUrlFunction([6, -31, -23]);
+      expect(tileCoord).to.eql([6, 33, -23]);
+    });
   });
 
 });
@@ -241,6 +255,7 @@ goog.require('ol.Tile');
 goog.require('ol.TileRange');
 goog.require('ol.TileState');
 goog.require('ol.proj');
+goog.require('ol.proj.Projection');
 goog.require('ol.source.Source');
 goog.require('ol.source.Tile');
 goog.require('ol.tilegrid.TileGrid');

--- a/test/spec/ol/source/tilevectorsource.test.js
+++ b/test/spec/ol/source/tilevectorsource.test.js
@@ -75,6 +75,25 @@ describe('ol.source.TileVector', function() {
           [6, 97, -23], projection);
       expect(tileCoord).to.eql(null);
     });
+
+    it('works with wrapX and custom projection without extent', function() {
+      var tileSource = new ol.source.TileVector({
+        format: new ol.format.TopoJSON(),
+        tileGrid: ol.tilegrid.createXYZ({
+          maxZoom: 19
+        }),
+        wrapX: true
+      });
+      var projection = new ol.proj.Projection({
+        code: 'foo',
+        global: true,
+        units: 'm'
+      });
+
+      var tileCoord = tileSource.getTileCoordForTileUrlFunction(
+          [6, -31, -23], projection);
+      expect(tileCoord).to.eql([6, 33, -23]);
+    });
   });
 
 });
@@ -82,4 +101,5 @@ describe('ol.source.TileVector', function() {
 
 goog.require('ol.format.TopoJSON');
 goog.require('ol.proj');
+goog.require('ol.proj.Projection');
 goog.require('ol.source.TileVector');


### PR DESCRIPTION
#3864 causes a regression, because a tile source now requires a projection with specified extent when `global` is set to true. This change fixes the regression.