### PR TITLE
Undo last points method to the draw interraction

### DIFF
--- a/src/ol/interaction/drawinteraction.js
+++ b/src/ol/interaction/drawinteraction.js
@@ -618,7 +618,7 @@ ol.interaction.Draw.prototype.addToDrawing_ = function(event) {
 
 
 /**
- * Remove last drawed point of the currently edited feature.
+ * Remove last point of the feature currently being drawn.
  * @api
  */
 ol.interaction.Draw.prototype.removeLastPoint = function() {

--- a/src/ol/interaction/drawinteraction.js
+++ b/src/ol/interaction/drawinteraction.js
@@ -640,7 +640,9 @@ ol.interaction.Draw.prototype.removeLastPoint = function() {
     this.geometryFunction_(this.sketchCoords_, geometry);
   }
 
-  if (coordinates.length === 0) this.finishCoordinate_ = null;
+  if (coordinates.length === 0) {
+    this.finishCoordinate_ = null;
+  }
 
   this.updateSketchFeatures_();
 };

--- a/src/ol/interaction/drawinteraction.js
+++ b/src/ol/interaction/drawinteraction.js
@@ -623,6 +623,8 @@ ol.interaction.Draw.prototype.addToDrawing_ = function(event) {
  */
 ol.interaction.Draw.prototype.removeLastPoint = function() {
   var geometry = this.sketchFeature_.getGeometry();
+  goog.asserts.assertInstanceof(geometry, ol.geom.SimpleGeometry,
+      'geometry must be an ol.geom.SimpleGeometry');
   var coordinates, sketchLineGeom;
   if (this.mode_ === ol.interaction.DrawMode.LINE_STRING) {
     coordinates = this.sketchCoords_;
@@ -632,6 +634,8 @@ ol.interaction.Draw.prototype.removeLastPoint = function() {
     coordinates = this.sketchCoords_[0];
     coordinates.splice(-2, 1);
     sketchLineGeom = this.sketchLine_.getGeometry();
+    goog.asserts.assertInstanceof(sketchLineGeom, ol.geom.LineString,
+        'sketchLineGeom must be an ol.geom.LineString');
     sketchLineGeom.setCoordinates(coordinates);
     this.geometryFunction_(this.sketchCoords_, geometry);
   }

--- a/src/ol/interaction/drawinteraction.js
+++ b/src/ol/interaction/drawinteraction.js
@@ -618,6 +618,31 @@ ol.interaction.Draw.prototype.addToDrawing_ = function(event) {
 
 
 /**
+ * Remove last drawed point of the currently edited feature.
+ * @api
+ */
+ol.interaction.Draw.prototype.removeLastPoint = function() {
+  var geometry = this.sketchFeature_.getGeometry();
+  var coordinates, sketchLineGeom;
+  if (this.mode_ === ol.interaction.DrawMode.LINE_STRING) {
+    coordinates = this.sketchCoords_;
+    coordinates.splice(-2, 1);
+    this.geometryFunction_(coordinates, geometry);
+  } else if (this.mode_ === ol.interaction.DrawMode.POLYGON) {
+    coordinates = this.sketchCoords_[0];
+    coordinates.splice(-2, 1);
+    sketchLineGeom = this.sketchLine_.getGeometry();
+    sketchLineGeom.setCoordinates(coordinates);
+    this.geometryFunction_(this.sketchCoords_, geometry);
+  }
+
+  if (coordinates.length === 0) this.finishCoordinate_ = null;
+
+  this.updateSketchFeatures_();
+};
+
+
+/**
  * Stop drawing and add the sketch feature to the target layer.
  * The {@link ol.interaction.DrawEventType.DRAWEND} event is dispatched before
  * inserting the feature.


### PR DESCRIPTION
The pull request adds the ability to delete the last segments added during editing with the draw interraction.

Usage sample  :

```

var draw_interaction = new ol.interaction.Draw( {
  type : "Polygon"
});

// Remove last point on "delete" key when drawing a feature.
var onKeyboardEvent = function(event) {
  if (draw_interaction && event.keyCode === 8) {
    draw_interaction.removeLastPoint();
    event.preventDefault();
  }
}

$document.bind('keydown', onKeyboardEvent);