### PR TITLE
Ignore layer filter for unmanaged layers

### DIFF
--- a/src/ol/layer/layer.js
+++ b/src/ol/layer/layer.js
@@ -148,10 +148,13 @@ ol.layer.Layer.prototype.handleSourcePropertyChange_ = function() {
 
 /**
  * Sets the layer to be rendered on a map. The map will not manage this layer in
- * its layers collection, and the layer will be rendered on top. This is useful
- * for temporary layers. To remove an unmanaged layer from the map, use
- * `#setMap(null)`. To add the layer to a map and have it managed by the map,
- * use {@link ol.Map#addLayer} instead.
+ * its layers collection, layer filters in {@link ol.Map#forEachLayerAtPixel}
+ * will not filter the layer, and it will be rendered on top. This is useful for
+ * temporary layers. To remove an unmanaged layer from the map, use
+ * `#setMap(null)`.
+ *
+ * To add the layer to a map and have it managed by the map, use
+ * {@link ol.Map#addLayer} instead.
  * @param {ol.Map} map Map.
  * @api
  */

--- a/src/ol/renderer/maprenderer.js
+++ b/src/ol/renderer/maprenderer.js
@@ -167,8 +167,9 @@ ol.renderer.Map.prototype.forEachFeatureAtCoordinate =
   for (i = numLayers - 1; i >= 0; --i) {
     var layerState = layerStates[i];
     var layer = layerState.layer;
-    if (ol.layer.Layer.visibleAtResolution(layerState, viewResolution) &&
-        layerFilter.call(thisArg2, layer)) {
+    if (!layerState.managed ||
+        (ol.layer.Layer.visibleAtResolution(layerState, viewResolution) &&
+        layerFilter.call(thisArg2, layer))) {
       var layerRenderer = this.getLayerRenderer(layer);
       result = layerRenderer.forEachFeatureAtCoordinate(
           layer.getSource().getWrapX() ? translatedCoordinate : coordinate,

--- a/test/spec/ol/renderer/canvas/canvasmaprenderer.test.js
+++ b/test/spec/ol/renderer/canvas/canvasmaprenderer.test.js
@@ -14,6 +14,58 @@ describe('ol.renderer.canvas.Map', function() {
 
   });
 
+  describe('#forEachFeatureAtCoordinate', function() {
+
+    var layer, map, target;
+
+    beforeEach(function() {
+      target = document.createElement('div');
+      target.style.width = '100px';
+      target.style.height = '100px';
+      document.body.appendChild(target);
+      map = new ol.Map({
+        target: target,
+        view: new ol.View({
+          center: [0, 0],
+          zoom: 0
+        })
+      });
+      layer = new ol.layer.Vector({
+        source: new ol.source.Vector({
+          features: [
+            new ol.Feature({
+              geometry: new ol.geom.Point([0, 0])
+            })
+          ]
+        })
+      });
+    });
+
+    afterEach(function() {
+      map.setTarget(null);
+      document.body.removeChild(target);
+    });
+
+    it('always includes unmanaged layers', function() {
+      layer.setMap(map);
+      map.renderSync();
+      var cb = sinon.spy();
+      map.forEachFeatureAtPixel(map.getPixelFromCoordinate([0, 0]), cb, null,
+          function() { return false; });
+      expect(cb).to.be.called();
+    });
+
+    it('filters managed layers', function() {
+      map.addLayer(layer);
+      map.renderSync();
+      cb = sinon.spy();
+      map.forEachFeatureAtPixel(map.getPixelFromCoordinate([0, 0]), cb, null,
+          function() { return false; });
+      expect(cb).to.not.be.called();
+    });
+
+  });
+
   describe('#renderFrame()', function() {
     var layer, map, renderer;
 
@@ -36,8 +88,11 @@ describe('ol.renderer.canvas.Map', function() {
 });
 
 
-goog.require('ol.layer.Vector');
+goog.require('ol.Feature');
 goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.geom.Point');
+goog.require('ol.layer.Vector');
 goog.require('ol.renderer.canvas.Layer');
 goog.require('ol.renderer.canvas.Map');
 goog.require('ol.source.Vector');


### PR DESCRIPTION
To make unmanaged vector layers work like the removed ol.FeatureOverlay, the layer filter for ol.Map#forEachFeatureAtPixel needs to ignore unmanaged layers.

Fixes #3878.