### PR TITLE
Provide a debug loader for the library

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "async": "0.9.0",
-    "closure-util": "1.4.0",
+    "closure-util": "1.5.0",
     "fs-extra": "0.12.0",
     "glob": "5.0.3",
     "graceful-fs": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "install": "node tasks/install.js",
     "postinstall": "closure-util update",
     "start": "node tasks/serve.js",
-    "test": "node tasks/test.js"
+    "test": "node tasks/test.js",
+    "debug-server": "node tasks/serve-lib.js"
   },
   "main": "dist/ol.js",
   "repository": {

--- a/tasks/.jshintrc
+++ b/tasks/.jshintrc
@@ -12,6 +12,7 @@
   "globals": {
     "Buffer": false,
     "__dirname": false,
+    "__filename": false,
     "exports": true,
     "module": false,
     "process": false,

--- a/tasks/serve-lib.js
+++ b/tasks/serve-lib.js
@@ -1,0 +1,83 @@
+/**
+ * This task starts a dev server that provides a script loader for the
+ * OpenLayers library.
+ */
+
+var path = require('path');
+var url = require('url');
+
+var closure = require('closure-util');
+var nomnom = require('nomnom');
+
+var log = closure.log;
+var name = path.basename(__filename, '.js');
+
+/**
+ * Create a debug server for the OpenLayers and Closure Library sources.
+ * @param {function(Error, closure.Server)} callback Callback.
+ */
+var createServer = exports.createServer = function(callback) {
+  var server;
+  var manager = new closure.Manager({
+    lib: [
+      'src/**/*.js',
+      'build/ol.ext/*.js',
+    ]
+  });
+  manager.on('error', function(err) {
+    if (server) {
+      log.error('serve', err.message);
+    } else {
+      callback(err);
+    }
+  });
+  manager.on('ready', function() {
+    server = new closure.Server({
+      manager: manager,
+      loader: '/loader.js'
+    });
+    callback(null, server);
+  });
+};
+
+/**
+ * If running this module directly start the server.
+ */
+if (require.main === module) {
+  var options = nomnom.options({
+    port: {
+      abbr: 'p',
+      default: 3001,
+      help: 'Port for incoming connections',
+      metavar: 'PORT'
+    },
+    loglevel: {
+      abbr: 'l',
+      choices: ['silly', 'verbose', 'info', 'warn', 'error'],
+      default: 'info',
+      help: 'Log level',
+      metavar: 'LEVEL'
+    }
+  }).parse();
+
+  /** @type {string} */
+  log.level = options.loglevel;
+
+  log.info(name, 'Parsing dependencies.');
+  createServer(function(err, server) {
+    if (err) {
+      log.error(name, 'Parsing failed');
+      log.error(name, err.message);
+      process.exit(1);
+    }
+    server.listen(options.port, function() {
+      log.info(name, 'Debug server running http://localhost:' +
+          options.port + '/loader.js (Ctrl+C to stop)');
+    });
+    server.on('error', function(err) {
+      log.error(name, 'Server failed to start: ' + err.message);
+      process.exit(1);
+    });
+  });
+
+}

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -31,8 +31,11 @@ function listen(min, max, server, callback) {
         callback(err);
       }
     });
-    server.listen(port, '127.0.0.1', callback);
+    server.listen(port, '127.0.0.1');
   }
+  server.once('listening', function() {
+    callback(null);
+  });
   _listen(min);
 }
 


### PR DESCRIPTION
This adds a simple task for serving just the library in debug mode.

The server can be started with:

    npm run debug-server

Depends on openlayers/closure-util#66.
