### PR TITLE
Install Python dependencies without sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
+language: python
+sudo: false
 env:
   - DISPLAY=:99.0
 
 before_install:
-  - "sudo pip install -r requirements.txt"
+  - "pip install -r requirements.txt"
   - "npm install -g npm && npm install"
 
 before_script:


### PR DESCRIPTION
This should allow us to use the [container based infrastructure](http://docs.travis-ci.com/user/migrating-from-legacy/) on Travis.

Fixes #3893.