### PR TITLE
Rework the tile queue for multiple queues

### DIFF
--- a/src/ol/tilequeue.js
+++ b/src/ol/tilequeue.js
@@ -94,9 +94,11 @@ ol.TileQueue.prototype.loadMoreTiles = function(maxTotalLoading, maxNewLoads) {
   var i, tile;
   for (i = 0; i < newLoads; ++i) {
     tile = /** @type {ol.Tile} */ (this.dequeue()[0]);
-    goog.events.listen(tile, goog.events.EventType.CHANGE,
-        this.handleTileChange, false, this);
-    tile.load();
+    if (tile.getState() === ol.TileState.IDLE) {
+      goog.events.listen(tile, goog.events.EventType.CHANGE,
+          this.handleTileChange, false, this);
+      tile.load();
+      ++this.tilesLoading_;
+    }
   }
-  this.tilesLoading_ += newLoads;
 };

--- a/src/ol/tilequeue.js
+++ b/src/ol/tilequeue.js
@@ -89,16 +89,17 @@ ol.TileQueue.prototype.handleTileChange = function(event) {
  * @param {number} maxNewLoads Maximum number of new tiles to load.
  */
 ol.TileQueue.prototype.loadMoreTiles = function(maxTotalLoading, maxNewLoads) {
-  var newLoads = Math.min(
-      maxTotalLoading - this.getTilesLoading(), maxNewLoads, this.getCount());
-  var i, tile;
-  for (i = 0; i < newLoads; ++i) {
+  var newLoads = 0;
+  var tile;
+  while (this.tilesLoading_ < maxTotalLoading && newLoads < maxNewLoads &&
+         this.getCount() > 0) {
     tile = /** @type {ol.Tile} */ (this.dequeue()[0]);
     if (tile.getState() === ol.TileState.IDLE) {
       goog.events.listen(tile, goog.events.EventType.CHANGE,
           this.handleTileChange, false, this);
       tile.load();
       ++this.tilesLoading_;
+      ++newLoads;
     }
   }
 };

--- a/test/spec/ol/tilequeue.test.js
+++ b/test/spec/ol/tilequeue.test.js
@@ -39,6 +39,10 @@ describe('ol.TileQueue', function() {
         q2.enqueue([tile]);
       }
 
+      // Initially, both have all tiles.
+      expect(q1.getCount()).to.equal(numTiles);
+      expect(q2.getCount()).to.equal(numTiles);
+
       var maxLoading = numTiles / 2;
 
       expect(q1.getTilesLoading()).to.equal(0);
@@ -52,9 +56,17 @@ describe('ol.TileQueue', function() {
       expect(q1.getTilesLoading()).to.equal(maxLoading);
       expect(q2.getTilesLoading()).to.equal(0);
 
+      // however, both queues will be reduced
+      expect(q1.getCount()).to.equal(numTiles - maxLoading);
+      expect(q2.getCount()).to.equal(numTiles - maxLoading);
+
       // ask both to load more
       q1.loadMoreTiles(maxLoading, maxLoading);
       q2.loadMoreTiles(maxLoading, maxLoading);
+
+      // now the second queue will be empty
+      expect(q1.getCount()).to.equal(numTiles - maxLoading);
+      expect(q2.getCount()).to.equal(0);
 
       // after the first is saturated, the second should start loading
       expect(q1.getTilesLoading()).to.equal(maxLoading);
@@ -64,6 +76,14 @@ describe('ol.TileQueue', function() {
       setTimeout(function() {
         expect(q1.getTilesLoading()).to.equal(0);
         expect(q2.getTilesLoading()).to.equal(0);
+
+        // load again, which will clear the first queue
+        q1.loadMoreTiles(maxLoading, maxLoading);
+        q2.loadMoreTiles(maxLoading, maxLoading);
+
+        expect(q1.getCount()).to.equal(0);
+        expect(q2.getCount()).to.equal(0);
+
         done();
       }, 20);
 

--- a/test/spec/ol/tilequeue.test.js
+++ b/test/spec/ol/tilequeue.test.js
@@ -45,6 +45,7 @@ describe('ol.TileQueue', function() {
 
       var maxLoading = numTiles / 2;
 
+      // and nothing is loading
       expect(q1.getTilesLoading()).to.equal(0);
       expect(q2.getTilesLoading()).to.equal(0);
 
@@ -52,32 +53,20 @@ describe('ol.TileQueue', function() {
       q1.loadMoreTiles(maxLoading, maxLoading);
       q2.loadMoreTiles(maxLoading, maxLoading);
 
-      // since tiles can only load once, we expect one queue to load them
-      expect(q1.getTilesLoading()).to.equal(maxLoading);
-      expect(q2.getTilesLoading()).to.equal(0);
-
-      // however, both queues will be reduced
-      expect(q1.getCount()).to.equal(numTiles - maxLoading);
-      expect(q2.getCount()).to.equal(numTiles - maxLoading);
-
-      // ask both to load more
-      q1.loadMoreTiles(maxLoading, maxLoading);
-      q2.loadMoreTiles(maxLoading, maxLoading);
-
-      // now the second queue will be empty
-      expect(q1.getCount()).to.equal(numTiles - maxLoading);
-      expect(q2.getCount()).to.equal(0);
-
-      // after the first is saturated, the second should start loading
+      // both tiles will be loading the max
       expect(q1.getTilesLoading()).to.equal(maxLoading);
       expect(q2.getTilesLoading()).to.equal(maxLoading);
+
+      // the second queue will be empty now
+      expect(q1.getCount()).to.equal(numTiles - maxLoading);
+      expect(q2.getCount()).to.equal(0);
 
       // let all tiles load
       setTimeout(function() {
         expect(q1.getTilesLoading()).to.equal(0);
         expect(q2.getTilesLoading()).to.equal(0);
 
-        // load again, which will clear the first queue
+        // ask both to load, this should clear q1
         q1.loadMoreTiles(maxLoading, maxLoading);
         q2.loadMoreTiles(maxLoading, maxLoading);
 


### PR DESCRIPTION
This fixes https://github.com/openlayers/ol3/issues/3889, which has a good explanation of the issue.

Re: Greediness. Before [this change](https://github.com/openlayers/ol3/commit/2142b538ac7b7aafdbae37d58613454f5f5baab5), the implementation of the queue would calculate the amount of tiles to load before dequeuing / loading. In the multiple queue case, after https://github.com/planetlabs/ol3/commit/b57cdb730c5b57450a2f9adcca44038994181165 this could cause a queue to not be fully utilized. For instance, if a queue were to be requested to load N new tiles, and had the capacity for it, if any of the dequeued tiles were in a state other than IDLE the total number of tiles that would start loading would be less than what had been requested. 
This change makes the queue always try to load tiles at its maximum capacity. 