### PR TITLE
Do not add Style as a feature property

### DIFF
--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -289,28 +289,6 @@ ol.format.KML.ICON_ANCHOR_UNITS_MAP_ = {
  */
 ol.format.KML.createFeatureStyleFunction_ = function(
     style, styleUrl, defaultStyle, sharedStyles) {
-  var findStyle = (
-      /**
-       * @param {Array.<ol.style.Style>|string|undefined} styleValue Style
-       *     value.
-       * @return {Array.<ol.style.Style>} Style.
-       */
-      function(styleValue) {
-        if (goog.isArray(styleValue)) {
-          return styleValue;
-        } else if (goog.isString(styleValue)) {
-          // KML files in the wild occasionally forget the leading `#` on
-          // styleUrls defined in the same document.  Add a leading `#` if it
-          // enables to find a style.
-          if (!(styleValue in sharedStyles) &&
-              ('#' + styleValue in sharedStyles)) {
-            styleValue = '#' + styleValue;
-          }
-          return findStyle(sharedStyles[styleValue]);
-        } else {
-          return defaultStyle;
-        }
-      });
   return (
       /**
        * @param {number} resolution Resolution.
@@ -322,10 +300,36 @@ ol.format.KML.createFeatureStyleFunction_ = function(
           return style;
         }
         if (goog.isDef(styleUrl)) {
-          return findStyle(styleUrl);
+          return ol.format.KML.findStyle_(styleUrl, defaultStyle, sharedStyles);
         }
         return defaultStyle;
       });
+};
+
+
+/**
+ * @param {Array.<ol.style.Style>|string|undefined} styleValue Style value.
+ * @param {Array.<ol.style.Style>} defaultStyle Default style.
+ * @param {Object.<string, (Array.<ol.style.Style>|string)>} sharedStyles
+ * Shared styles.
+ * @return {Array.<ol.style.Style>} Style.
+ * @private
+ */
+ol.format.KML.findStyle_ = function(styleValue, defaultStyle, sharedStyles) {
+  if (goog.isArray(styleValue)) {
+    return styleValue;
+  } else if (goog.isString(styleValue)) {
+    // KML files in the wild occasionally forget the leading `#` on styleUrls
+    // defined in the same document.  Add a leading `#` if it enables to find
+    // a style.
+    if (!(styleValue in sharedStyles) && ('#' + styleValue in sharedStyles)) {
+      styleValue = '#' + styleValue;
+    }
+    return ol.format.KML.findStyle_(
+        sharedStyles[styleValue], defaultStyle, sharedStyles);
+  } else {
+    return defaultStyle;
+  }
 };
 
 

--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -77,33 +77,12 @@ ol.format.KML = function(opt_options) {
    */
   this.defaultDataProjection = ol.proj.get('EPSG:4326');
 
-  var defaultStyle = goog.isDef(options.defaultStyle) ?
+  /**
+   * @private
+   * @type {Array.<ol.style.Style>}
+   */
+  this.defaultStyle_ = goog.isDef(options.defaultStyle) ?
       options.defaultStyle : ol.format.KML.DEFAULT_STYLE_ARRAY_;
-
-  /** @type {Object.<string, (Array.<ol.style.Style>|string)>} */
-  var sharedStyles = {};
-
-  var findStyle =
-      /**
-       * @param {Array.<ol.style.Style>|string|undefined} styleValue Style
-       *     value.
-       * @return {Array.<ol.style.Style>} Style.
-       */
-      function(styleValue) {
-    if (goog.isArray(styleValue)) {
-      return styleValue;
-    } else if (goog.isString(styleValue)) {
-      // KML files in the wild occasionally forget the leading `#` on styleUrls
-      // defined in the same document.  Add a leading `#` if it enables to find
-      // a style.
-      if (!(styleValue in sharedStyles) && ('#' + styleValue in sharedStyles)) {
-        styleValue = '#' + styleValue;
-      }
-      return findStyle(sharedStyles[styleValue]);
-    } else {
-      return defaultStyle;
-    }
-  };
 
   /**
    * @private
@@ -116,30 +95,7 @@ ol.format.KML = function(opt_options) {
    * @private
    * @type {Object.<string, (Array.<ol.style.Style>|string)>}
    */
-  this.sharedStyles_ = sharedStyles;
-
-  /**
-   * @private
-   * @type {ol.FeatureStyleFunction}
-   */
-  this.featureStyleFunction_ =
-      /**
-       * @param {number} resolution Resolution.
-       * @return {Array.<ol.style.Style>} Style.
-       * @this {ol.Feature}
-       */
-      function(resolution) {
-    var style = /** @type {Array.<ol.style.Style>|undefined} */
-        (this.get('Style'));
-    if (goog.isDef(style)) {
-      return style;
-    }
-    var styleUrl = /** @type {string|undefined} */ (this.get('styleUrl'));
-    if (goog.isDef(styleUrl)) {
-      return findStyle(styleUrl);
-    }
-    return defaultStyle;
-  };
+  this.sharedStyles_ = {};
 
 };
 goog.inherits(ol.format.KML, ol.format.XMLFeature);
@@ -319,6 +275,57 @@ ol.format.KML.DEFAULT_STYLE_ARRAY_ = [ol.format.KML.DEFAULT_STYLE_];
 ol.format.KML.ICON_ANCHOR_UNITS_MAP_ = {
   'fraction': ol.style.IconAnchorUnits.FRACTION,
   'pixels': ol.style.IconAnchorUnits.PIXELS
+};
+
+
+/**
+ * @param {Array.<ol.style.Style>|undefined} style Style.
+ * @param {string} styleUrl Style URL.
+ * @param {Array.<ol.style.Style>} defaultStyle Default style.
+ * @param {Object.<string, (Array.<ol.style.Style>|string)>} sharedStyles
+ * Shared styles.
+ * @return {ol.FeatureStyleFunction} Feature style function.
+ * @private
+ */
+ol.format.KML.createFeatureStyleFunction_ = function(
+    style, styleUrl, defaultStyle, sharedStyles) {
+  var findStyle = (
+      /**
+       * @param {Array.<ol.style.Style>|string|undefined} styleValue Style
+       *     value.
+       * @return {Array.<ol.style.Style>} Style.
+       */
+      function(styleValue) {
+        if (goog.isArray(styleValue)) {
+          return styleValue;
+        } else if (goog.isString(styleValue)) {
+          // KML files in the wild occasionally forget the leading `#` on
+          // styleUrls defined in the same document.  Add a leading `#` if it
+          // enables to find a style.
+          if (!(styleValue in sharedStyles) &&
+              ('#' + styleValue in sharedStyles)) {
+            styleValue = '#' + styleValue;
+          }
+          return findStyle(sharedStyles[styleValue]);
+        } else {
+          return defaultStyle;
+        }
+      });
+  return (
+      /**
+       * @param {number} resolution Resolution.
+       * @return {Array.<ol.style.Style>} Style.
+       * @this {ol.Feature}
+       */
+      function(resolution) {
+        if (goog.isDef(style)) {
+          return style;
+        }
+        if (goog.isDef(styleUrl)) {
+          return findStyle(styleUrl);
+        }
+        return defaultStyle;
+      });
 };
 
 
@@ -1668,13 +1675,27 @@ ol.format.KML.prototype.readPlacemark_ = function(node, objectStack) {
     feature.setId(id);
   }
   var options = /** @type {olx.format.ReadOptions} */ (objectStack[0]);
-  if (goog.isDefAndNotNull(object.geometry)) {
-    ol.format.Feature.transformWithOptions(object.geometry, false, options);
+
+  var geometry = goog.object.get(object, 'geometry');
+  if (goog.isDefAndNotNull(geometry)) {
+    ol.format.Feature.transformWithOptions(geometry, false, options);
   }
-  feature.setProperties(object);
+  feature.setGeometry(geometry);
+  goog.object.remove(object, 'geometry');
+
   if (this.extractStyles_) {
-    feature.setStyle(this.featureStyleFunction_);
+    var style = goog.object.get(object, 'Style');
+    var styleUrl = goog.object.get(object, 'styleUrl');
+    var styleFunction = ol.format.KML.createFeatureStyleFunction_(
+        style, styleUrl, this.defaultStyle_, this.sharedStyles_);
+    feature.setStyle(styleFunction);
   }
+  goog.object.remove(object, 'Style');
+  // we do not remove the styleUrl property from the object, so it
+  // gets stored on feature when setProperties is called
+
+  feature.setProperties(object);
+
   return feature;
 };
 

--- a/test/spec/ol/format/kml/style.kml
+++ b/test/spec/ol/format/kml/style.kml
@@ -1,0 +1,37 @@
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 https://developers.google.com/kml/schema/kml22gx.xsd">
+    <Document>
+        <name>Drawing</name>
+        <Placemark id="linepolygon_1436780794279">
+            <Style>
+                <LineStyle>
+                    <color>ff0000ff</color>
+                    <width>3</width>
+                </LineStyle>
+                <PolyStyle>
+                    <color>660000ff</color>
+                </PolyStyle>
+            </Style>
+            <LineString>
+                <coordinates>7.282103855735575,47.252335388740185 7.286372432423239,47.23794977574282 7.353199702540651,47.23711986131712 7.287223923345992,47.26352553438413</coordinates>
+            </LineString>
+        </Placemark>
+        <Placemark id="linepolygon_1436780799384">
+            <Style>
+                <LineStyle>
+                    <color>ff0000ff</color>
+                    <width>3</width>
+                </LineStyle>
+                <PolyStyle>
+                    <color>660000ff</color>
+                </PolyStyle>
+            </Style>
+            <Polygon>
+                <outerBoundaryIs>
+                    <LinearRing>
+                        <coordinates>7.227134983319887,47.25587491183515 7.23801833800725,47.242582453518516 7.260803078150167,47.2619584739595 7.239912047946697,47.265971706882716 7.227134983319887,47.25587491183515</coordinates>
+                    </LinearRing>
+                </outerBoundaryIs>
+            </Polygon>
+        </Placemark>
+    </Document>
+</kml>

--- a/test/spec/ol/format/kmlformat.test.js
+++ b/test/spec/ol/format/kmlformat.test.js
@@ -2474,6 +2474,31 @@ describe('ol.format.KML', function() {
 
   });
 
+  describe('#JSONExport', function() {
+
+    var features;
+    before(function(done) {
+      afterLoadText('spec/ol/format/kml/style.kml', function(xml) {
+        try {
+          features = format.readFeatures(xml);
+        } catch (e) {
+          done(e);
+        }
+        done();
+      });
+    });
+
+    it('feature must not have a properties property', function() {
+      var geojsonFormat = new ol.format.GeoJSON();
+      features.forEach(function(feature) {
+        var geojsonFeature = geojsonFormat.writeFeatureObject(feature);
+        expect(geojsonFeature.properties).to.be(null);
+        JSON.stringify(geojsonFeature);
+      });
+    });
+
+  });
+
   describe('#readName', function() {
 
     it('returns undefined if there is no name', function() {
@@ -2578,6 +2603,7 @@ describe('ol.format.KML', function() {
 goog.require('goog.array');
 goog.require('goog.dom.xml');
 goog.require('ol.Feature');
+goog.require('ol.format.GeoJSON');
 goog.require('ol.format.KML');
 goog.require('ol.geom.GeometryCollection');
 goog.require('ol.geom.GeometryLayout');


### PR DESCRIPTION
This makes the KML format not add a Style property on features, as this may cause problems when serializing to another format such as JSON.

Close #3832 