### PR TITLE
Clear features properly when there is no spatial index

### DIFF
--- a/src/ol/source/vectorsource.js
+++ b/src/ol/source/vectorsource.js
@@ -372,16 +372,14 @@ ol.source.Vector.prototype.bindFeaturesCollection_ = function(collection) {
  */
 ol.source.Vector.prototype.clear = function(opt_fast) {
   if (opt_fast) {
+    for (var featureId in this.featureChangeKeys_) {
+      var keys = this.featureChangeKeys_[featureId];
+      goog.array.forEach(keys, goog.events.unlistenByKey);
+    }
     if (goog.isNull(this.featuresCollection_)) {
-      for (var featureId in this.featureChangeKeys_) {
-        var keys = this.featureChangeKeys_[featureId];
-        goog.array.forEach(keys, goog.events.unlistenByKey);
-      }
       this.featureChangeKeys_ = {};
       this.idIndex_ = {};
       this.undefIdIndex_ = {};
-    } else {
-      this.featuresCollection_.clear();
     }
   } else {
     var rmFeatureInternal = this.removeFeatureInternal;
@@ -389,6 +387,9 @@ ol.source.Vector.prototype.clear = function(opt_fast) {
       this.featuresRtree_.forEach(rmFeatureInternal, this);
       goog.object.forEach(this.nullGeometryFeatures_, rmFeatureInternal, this);
     }
+  }
+  if (!goog.isNull(this.featuresCollection_)) {
+    this.featuresCollection_.clear();
   }
   goog.asserts.assert(goog.object.isEmpty(this.featureChangeKeys_),
       'featureChangeKeys is an empty object now');

--- a/test/spec/ol/source/vectorsource.test.js
+++ b/test/spec/ol/source/vectorsource.test.js
@@ -449,6 +449,53 @@ describe('ol.source.Vector', function() {
   describe('with a collection of features', function() {
     var collection, source;
     beforeEach(function() {
+      source = new ol.source.Vector({
+        useSpatialIndex: false
+      });
+      collection = source.getFeaturesCollection();
+    });
+
+    it('creates a features collection', function() {
+      expect(source.getFeaturesCollection()).to.not.be(null);
+    });
+
+    it('adding/removing features keeps the collection in sync', function() {
+      var feature = new ol.Feature();
+      source.addFeature(feature);
+      expect(collection.getLength()).to.be(1);
+      source.removeFeature(feature);
+      expect(collection.getLength()).to.be(0);
+    });
+
+    it('#clear() features keeps the collection in sync', function() {
+      var feature = new ol.Feature();
+      source.addFeatures([feature]);
+      expect(collection.getLength()).to.be(1);
+      source.clear();
+      expect(collection.getLength()).to.be(0);
+      source.addFeatures([feature]);
+      expect(collection.getLength()).to.be(1);
+      source.clear(true);
+      expect(collection.getLength()).to.be(0);
+    });
+
+    it('keeps the source\'s features in sync with the collection', function() {
+      var feature = new ol.Feature();
+      collection.push(feature);
+      expect(source.getFeatures().length).to.be(1);
+      collection.remove(feature);
+      expect(source.getFeatures().length).to.be(0);
+      collection.extend([feature]);
+      expect(source.getFeatures().length).to.be(1);
+      collection.clear();
+      expect(source.getFeatures().length).to.be(0);
+    });
+
+  });
+
+  describe('with a collection of features plus spatial index', function() {
+    var collection, source;
+    beforeEach(function() {
       collection = new ol.Collection();
       source = new ol.source.Vector({
         features: collection


### PR DESCRIPTION
Previously `#clear()` only kept the features collection in sync whern there was also a features RTree.

Fixes #3904.