### PR TITLE
Do not provide an AMD environment to ol.ext modules

### DIFF
--- a/tasks/build-ext.js
+++ b/tasks/build-ext.js
@@ -50,6 +50,7 @@ function wrapModule(mod, callback) {
         '(function() {\n' +
         'var exports = {};\n' +
         'var module = {exports: exports};\n' +
+        'var define;\n' +
         '/**\n' +
         ' * @fileoverview\n' +
         ' * @suppress {accessControls, ambiguousFunctionDecl, ' +


### PR DESCRIPTION
This fixes issues with `ol.source.Vector` being unable to use `ol.ext.rbush`, but it also means that potential future external modules without node module loader support will not work (which they apparently don't do now either). If we ever depend on such a module, we can replace `var define;` with a minimal AMD define shim.

With #3848 also fixed, OpenLayers should finally work fine with RequireJS after this change.

Fixes #3155.