### PR TITLE
Insert quotes for correct output

### DIFF
--- a/src/ol/format/geojsonformat.js
+++ b/src/ol/format/geojsonformat.js
@@ -198,8 +198,8 @@ ol.format.GeoJSON.writeGeometry_ = function(geometry, opt_options) {
  */
 ol.format.GeoJSON.writeEmptyGeometryCollectionGeometry_ = function(geometry) {
   return /** @type {GeoJSONGeometryCollection} */ ({
-    type: 'GeometryCollection',
-    geometries: []
+    'type': 'GeometryCollection',
+    'geometries': []
   });
 };
 
@@ -219,8 +219,8 @@ ol.format.GeoJSON.writeGeometryCollectionGeometry_ = function(
         return ol.format.GeoJSON.writeGeometry_(geometry, opt_options);
       });
   return /** @type {GeoJSONGeometryCollection} */ ({
-    type: 'GeometryCollection',
-    geometries: geometries
+    'type': 'GeometryCollection',
+    'geometries': geometries
   });
 };
 
@@ -235,8 +235,8 @@ ol.format.GeoJSON.writeLineStringGeometry_ = function(geometry, opt_options) {
   goog.asserts.assertInstanceof(geometry, ol.geom.LineString,
       'geometry should be an ol.geom.LineString');
   return /** @type {GeoJSONGeometry} */ ({
-    type: 'LineString',
-    coordinates: geometry.getCoordinates()
+    'type': 'LineString',
+    'coordinates': geometry.getCoordinates()
   });
 };
 
@@ -252,8 +252,8 @@ ol.format.GeoJSON.writeMultiLineStringGeometry_ =
   goog.asserts.assertInstanceof(geometry, ol.geom.MultiLineString,
       'geometry should be an ol.geom.MultiLineString');
   return /** @type {GeoJSONGeometry} */ ({
-    type: 'MultiLineString',
-    coordinates: geometry.getCoordinates()
+    'type': 'MultiLineString',
+    'coordinates': geometry.getCoordinates()
   });
 };
 
@@ -268,8 +268,8 @@ ol.format.GeoJSON.writeMultiPointGeometry_ = function(geometry, opt_options) {
   goog.asserts.assertInstanceof(geometry, ol.geom.MultiPoint,
       'geometry should be an ol.geom.MultiPoint');
   return /** @type {GeoJSONGeometry} */ ({
-    type: 'MultiPoint',
-    coordinates: geometry.getCoordinates()
+    'type': 'MultiPoint',
+    'coordinates': geometry.getCoordinates()
   });
 };
 
@@ -288,8 +288,8 @@ ol.format.GeoJSON.writeMultiPolygonGeometry_ = function(geometry, opt_options) {
     right = opt_options.rightHanded;
   }
   return /** @type {GeoJSONGeometry} */ ({
-    type: 'MultiPolygon',
-    coordinates: geometry.getCoordinates(right)
+    'type': 'MultiPolygon',
+    'coordinates': geometry.getCoordinates(right)
   });
 };
 
@@ -304,8 +304,8 @@ ol.format.GeoJSON.writePointGeometry_ = function(geometry, opt_options) {
   goog.asserts.assertInstanceof(geometry, ol.geom.Point,
       'geometry should be an ol.geom.Point');
   return /** @type {GeoJSONGeometry} */ ({
-    type: 'Point',
-    coordinates: geometry.getCoordinates()
+    'type': 'Point',
+    'coordinates': geometry.getCoordinates()
   });
 };
 
@@ -324,8 +324,8 @@ ol.format.GeoJSON.writePolygonGeometry_ = function(geometry, opt_options) {
     right = opt_options.rightHanded;
   }
   return /** @type {GeoJSONGeometry} */ ({
-    type: 'Polygon',
-    coordinates: geometry.getCoordinates(right)
+    'type': 'Polygon',
+    'coordinates': geometry.getCoordinates(right)
   });
 };
 
@@ -584,8 +584,8 @@ ol.format.GeoJSON.prototype.writeFeaturesObject =
     objects.push(this.writeFeatureObject(features[i], opt_options));
   }
   return /** @type {GeoJSONFeatureCollection} */ ({
-    type: 'FeatureCollection',
-    features: objects
+    'type': 'FeatureCollection',
+    'features': objects
   });
 };
 


### PR DESCRIPTION
The quotes which have been removed in this commit:  https://github.com/openlayers/ol3/commit/0286564e8a4e19a67123fccae82ea7a18e524307

are necessary in order to get a correct output. Without the quotes, the names of the properties get minified.