### PR TITLE
Use Travis CI cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 sudo: false
+cache:
+  directories:
+    - node_modules
 env:
   - DISPLAY=:99.0
 


### PR DESCRIPTION
Travis CI cache for dependencies is now available for container builds which ol3 recently switched to so perhaps it can be used? npm install seem to typically take about 100s.