### PR TITLE
Use goog.functions.identity instead of goog.identityFunction

### DIFF
--- a/test/spec/ol/structs/priorityqueue.test.js
+++ b/test/spec/ol/structs/priorityqueue.test.js
@@ -8,7 +8,7 @@ describe('ol.structs.PriorityQueue', function() {
     var pq;
     beforeEach(function() {
       pq = new ol.structs.PriorityQueue(
-          goog.identityFunction, goog.identityFunction);
+          goog.functions.identity, goog.functions.identity);
     });
 
     it('is valid', function() {
@@ -54,7 +54,7 @@ describe('ol.structs.PriorityQueue', function() {
     beforeEach(function() {
       elements = [];
       pq = new ol.structs.PriorityQueue(
-          goog.identityFunction, goog.identityFunction);
+          goog.functions.identity, goog.functions.identity);
       var element, i;
       for (i = 0; i < 32; ++i) {
         element = Math.random();
@@ -81,7 +81,7 @@ describe('ol.structs.PriorityQueue', function() {
       target = 0.5;
       pq = new ol.structs.PriorityQueue(function(element) {
         return Math.abs(element - target);
-      }, goog.identityFunction);
+      }, goog.functions.identity);
       var i;
       for (i = 0; i < 32; ++i) {
         pq.enqueue(Math.random());
@@ -138,7 +138,7 @@ describe('ol.structs.PriorityQueue', function() {
     var pq;
     beforeEach(function() {
       pq = new ol.structs.PriorityQueue(
-          goog.identityFunction, goog.identityFunction);
+          goog.functions.identity, goog.functions.identity);
       pq.enqueue('a');
       pq.enqueue('b');
       pq.enqueue('c');
@@ -183,4 +183,5 @@ describe('ol.structs.PriorityQueue', function() {
 });
 
 
+goog.require('goog.functions');
 goog.require('ol.structs.PriorityQueue');


### PR DESCRIPTION
`goog.identityFunction` was deprecated and has been removed from closure-library.