### PR TITLE
SnapOptions: Fix typo in pixelTolerance JSDoc

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -2881,7 +2881,7 @@ olx.interaction.SnapOptions.prototype.features;
 
 /**
  * Pixel tolerance for considering the pointer close enough to a segment or
- * vertex for editing. Default is `10` pixels.
+ * vertex for snapping. Default is `10` pixels.
  * @type {number|undefined}
  * @api
  */


### PR DESCRIPTION
This was apparently copy-pasted from the `ModifyOptions` without adjustment