### PR TITLE
Fix WMTS TileMatrixSet lookup by SRS identifier

### DIFF
--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -351,19 +351,25 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
 
   goog.asserts.assert(l['TileMatrixSetLink'].length > 0,
       'layer has TileMatrixSetLink');
+  var tileMatrixSets = wmtsCap['Contents']['TileMatrixSet'];
   var idx, matrixSet;
   if (l['TileMatrixSetLink'].length > 1) {
-    idx = goog.array.findIndex(l['TileMatrixSetLink'],
-        function(elt, index, array) {
-          return elt['TileMatrixSet'] == config['matrixSet'];
-        });
-  } else if (goog.isDef(config['projection'])) {
-    idx = goog.array.findIndex(l['TileMatrixSetLink'],
-        function(elt, index, array) {
-          return elt['TileMatrixSet']['SupportedCRS'].replace(
-              /urn:ogc:def:crs:(\w+):(.*:)?(\w+)$/, '$1:$3'
-                 ) == config['projection'];
-        });
+    if (goog.isDef(config['projection'])) {
+      idx = goog.array.findIndex(l['TileMatrixSetLink'],
+          function(elt, index, array) {
+            var tileMatrixSet = goog.array.find(tileMatrixSets, function(el) {
+              return el['Identifier'] == elt['TileMatrixSet'];
+            });
+            return tileMatrixSet['SupportedCRS'].replace(
+                /urn:ogc:def:crs:(\w+):(.*:)?(\w+)$/, '$1:$3'
+                   ) == config['projection'];
+          });
+    } else {
+      idx = goog.array.findIndex(l['TileMatrixSetLink'],
+          function(elt, index, array) {
+            return elt['TileMatrixSet'] == config['matrixSet'];
+          });
+    }
   } else {
     idx = 0;
   }

--- a/test/spec/ol/source/wmtssource.test.js
+++ b/test/spec/ol/source/wmtssource.test.js
@@ -76,6 +76,16 @@ describe('ol.source.WMTS', function() {
           expect(options.dimensions).to.eql({});
 
         });
+
+    it('can find a MatrixSet by SRS identifier', function() {
+      var options = ol.source.WMTS.optionsFromCapabilities(
+          capabilities,
+          { layer: 'BlueMarbleNextGeneration', projection: 'EPSG:3857',
+            requestEncoding: 'REST' });
+
+      expect(options.matrixSet).to.be.eql('google3857');
+    });
+
   });
 
   describe('when creating tileUrlFunction', function() {


### PR DESCRIPTION
TileMatrixSet lookup by SRS identifier is completely broken. In addition to this fix, the whole `ol.source.WMTS#optionsFromCapabilities()` function could use an overhaul (see #3874).

cc @bartvde 
 
Fixes #3940.