### PR TITLE
Simplify icon example and show popup at clicked position

### DIFF
--- a/examples/icon.css
+++ b/examples/icon.css
@@ -1,6 +1,3 @@
 #map {
   position: relative;
 }
-#popup {
-  padding-bottom: 45px;
-}

--- a/examples/icon.js
+++ b/examples/icon.js
@@ -71,9 +71,7 @@ map.on('click', function(evt) {
         return feature;
       });
   if (feature) {
-    var geometry = feature.getGeometry();
-    var coord = geometry.getCoordinates();
-    popup.setPosition(coord);
+    popup.setPosition(evt.coordinate);
     $(element).popover({
       'placement': 'top',
       'html': true,


### PR DESCRIPTION
By using the event's coordinate instead of the feature's, we make sure that the popup is shown where the user clicked when on a wrapped world.

Fixes #3944.