### PR TITLE
Clarify documentation of Image source ratio option.

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -4184,7 +4184,8 @@ olx.source.ImageMapGuideOptions.prototype.projection;
 
 /**
  * Ratio. `1` means image requests are the size of the map viewport, `2` means
- * twice the size of the map viewport, and so on. Default is `1`.
+ * twice the width and height of the map viewport, and so on. Must be `1` or 
+ * higher. Default is `1`.
  * @type {number|undefined}
  * @api stable
  */
@@ -4402,7 +4403,8 @@ olx.source.ImageCanvasOptions.prototype.projection;
 
 /**
  * Ratio. 1 means canvases are the size of the map viewport, 2 means twice the
- * size of the map viewport, and so on. Default is `1.5`.
+ * width and height of the map viewport, and so on. Must be `1` or higher.
+ * Default is `1.5`.
  * @type {number|undefined}
  * @api
  */
@@ -4465,7 +4467,8 @@ olx.source.ImageVectorOptions.prototype.projection;
 
 /**
  * Ratio. 1 means canvases are the size of the map viewport, 2 means twice the
- * size of the map viewport, and so on. Default is `1.5`.
+ * width and height of the map viewport, and so on. Must be `1` or higher. 
+ * Default is `1.5`.
  * @type {number|undefined}
  * @api
  */
@@ -4589,7 +4592,8 @@ olx.source.ImageWMSOptions.prototype.projection;
 
 /**
  * Ratio. `1` means image requests are the size of the map viewport, `2` means
- * twice the size of the map viewport, and so on. Default is `1.5`.
+ * twice the width and height of the map viewport, and so on. Must be `1` or 
+ * higher. Default is `1.5`.
  * @type {number|undefined}
  * @api stable
  */


### PR DESCRIPTION
Clarifies documentation for the *ratio* option of ImageWMS, ImageMapGuide, ImageVector and ImageCanvas. Should make it clear that the ratio should be at least *1*, and that the ratio is in relation to width/height (not area).

Fixes https://github.com/openlayers/ol3/issues/3926