### PR TITLE
Remove reference to vbarray.js

### DIFF
--- a/config/example.json
+++ b/config/example.json
@@ -20,8 +20,7 @@
       "externs/jquery-1.9.js",
       "externs/proj4js.js",
       "externs/tilejson.js",
-      "externs/topojson.js",
-      "externs/vbarray.js"
+      "externs/topojson.js"
     ],
     "define": [
       "goog.array.ASSUME_NATIVE_FUNCTIONS=true",


### PR DESCRIPTION
This file was removed with https://github.com/openlayers/ol3/pull/3516.

Fixes #3702.