### PR TITLE
Serialize properly ol.style.Circle to KML

### DIFF
--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -31,6 +31,7 @@ goog.require('ol.geom.MultiPolygon');
 goog.require('ol.geom.Point');
 goog.require('ol.geom.Polygon');
 goog.require('ol.proj');
+goog.require('ol.style.Circle');
 goog.require('ol.style.Fill');
 goog.require('ol.style.Icon');
 goog.require('ol.style.IconAnchorUnits');
@@ -2067,45 +2068,51 @@ ol.format.KML.writeIcon_ = function(node, icon, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {ol.style.Icon} style Icon style.
+ * @param {ol.style.Image} style Image style.
  * @param {Array.<*>} objectStack Object stack.
  * @private
  */
 ol.format.KML.writeIconStyle_ = function(node, style, objectStack) {
   var /** @type {ol.xml.NodeStackItem} */ context = {node: node};
   var properties = {};
-  var src = style.getSrc();
-  var size = style.getSize();
-  var iconImageSize = style.getImageSize();
-  var iconProperties = {
-    'href': src
-  };
 
-  if (!goog.isNull(size)) {
-    iconProperties['w'] = size[0];
-    iconProperties['h'] = size[1];
-    var anchor = style.getAnchor(); // top-left
-    var origin = style.getOrigin(); // top-left
+  if (style instanceof ol.style.Icon) {
+    var src = style.getSrc();
+    var size = style.getSize();
+    var iconImageSize = style.getImageSize();
+    var iconProperties = {
+      'href': src
+    };
 
-    if (!goog.isNull(origin) && !goog.isNull(iconImageSize) &&
-        origin[0] !== 0 && origin[1] !== size[1]) {
-      iconProperties['x'] = origin[0];
-      iconProperties['y'] = iconImageSize[1] - (origin[1] + size[1]);
+    if (!goog.isNull(size)) {
+      iconProperties['w'] = size[0];
+      iconProperties['h'] = size[1];
+      var anchor = style.getAnchor(); // top-left
+      var origin = style.getOrigin(); // top-left
+
+      if (!goog.isNull(origin) && !goog.isNull(iconImageSize) &&
+          origin[0] !== 0 && origin[1] !== size[1]) {
+        iconProperties['x'] = origin[0];
+        iconProperties['y'] = iconImageSize[1] - (origin[1] + size[1]);
+      }
+
+      if (!goog.isNull(anchor) &&
+          anchor[0] !== 0 && anchor[1] !== size[1]) {
+        var /** @type {ol.format.KMLVec2_} */ hotSpot = {
+          x: anchor[0],
+          xunits: ol.style.IconAnchorUnits.PIXELS,
+          y: size[1] - anchor[1],
+          yunits: ol.style.IconAnchorUnits.PIXELS
+        };
+        properties['hotSpot'] = hotSpot;
+      }
     }
 
-    if (!goog.isNull(anchor) &&
-        anchor[0] !== 0 && anchor[1] !== size[1]) {
-      var /** @type {ol.format.KMLVec2_} */ hotSpot = {
-        x: anchor[0],
-        xunits: ol.style.IconAnchorUnits.PIXELS,
-        y: size[1] - anchor[1],
-        yunits: ol.style.IconAnchorUnits.PIXELS
-      };
-      properties['hotSpot'] = hotSpot;
-    }
+    properties['Icon'] = iconProperties;
+  } else if (style instanceof ol.style.Circle) {
+    properties['color'] = style.getFill() ? style.getFill().getColor() :
+        'ffffffff';
   }
-
-  properties['Icon'] = iconProperties;
 
   var scale = style.getScale();
   if (scale !== 1) {
@@ -2485,7 +2492,7 @@ ol.format.KML.ICON_SERIALIZERS_ = ol.xml.makeStructureNS(
  */
 ol.format.KML.ICON_STYLE_SEQUENCE_ = ol.xml.makeStructureNS(
     ol.format.KML.NAMESPACE_URIS_, [
-      'scale', 'heading', 'Icon', 'hotSpot'
+      'color', 'scale', 'heading', 'Icon', 'hotSpot'
     ]);
 
 
@@ -2499,7 +2506,8 @@ ol.format.KML.ICON_STYLE_SERIALIZERS_ = ol.xml.makeStructureNS(
       'Icon': ol.xml.makeChildAppender(ol.format.KML.writeIcon_),
       'heading': ol.xml.makeChildAppender(ol.format.XSD.writeDecimalTextNode),
       'hotSpot': ol.xml.makeChildAppender(ol.format.KML.writeVec2_),
-      'scale': ol.xml.makeChildAppender(ol.format.KML.writeScaleTextNode_)
+      'scale': ol.xml.makeChildAppender(ol.format.KML.writeScaleTextNode_),
+      'color': ol.xml.makeChildAppender(ol.format.KML.writeColorTextNode_)
     });
 
 

--- a/test/spec/ol/format/kmlformat.test.js
+++ b/test/spec/ol/format/kmlformat.test.js
@@ -1681,6 +1681,41 @@ describe('ol.format.KML', function() {
         expect(node).to.xmleql(ol.xml.parse(text));
       });
 
+      it('can write an feature\'s icon style with Circle style', function() {
+        var fill = new ol.style.Fill({
+          color: 'rgba(225,109,0,0.4)'
+        });
+        var stroke = new ol.style.Stroke({
+          color: '#3399CC',
+          width: 1.25
+        });
+        var style = new ol.style.Style({
+          image: new ol.style.Circle({
+            fill: fill,
+            stroke: stroke,
+            radius: 5
+          })
+        });
+        var feature = new ol.Feature();
+        feature.setStyle([style]);
+        var node = format.writeFeaturesNode([feature]);
+        var text =
+            '<kml xmlns="http://www.opengis.net/kml/2.2"' +
+            ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
+            ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"' +
+            ' xsi:schemaLocation="http://www.opengis.net/kml/2.2' +
+            ' https://developers.google.com/kml/schema/kml22gx.xsd">' +
+            '  <Placemark>' +
+            '    <Style>' +
+            '      <IconStyle>' +
+            '        <color>66006de1</color>' +
+            '      </IconStyle>' +
+            '    </Style>' +
+            '  </Placemark>' +
+            '</kml>';
+        expect(node).to.xmleql(ol.xml.parse(text));
+      });
+
       it('can write an feature\'s text style', function() {
         var style = new ol.style.Style({
           text: new ol.style.Text({
@@ -2588,6 +2623,7 @@ goog.require('ol.geom.MultiPoint');
 goog.require('ol.geom.MultiPolygon');
 goog.require('ol.geom.Point');
 goog.require('ol.geom.Polygon');
+goog.require('ol.style.Circle');
 goog.require('ol.style.Fill');
 goog.require('ol.style.Icon');
 goog.require('ol.style.IconOrigin');


### PR DESCRIPTION
This PR fixes #3882.

While serializing `ol.geom.Point`, current KML format assumes to find an `IconStyle` which is not always the case,iIt could also be an `ol.style.Circle`

This PR allows to serialize an `ol.style.Circle`. It simply takes the `ol.style.Fill` color. It might not be the best serialization but at least it prevents errors and does not mess up the KML export.