### PR TITLE
Properly handle vertex deletion with multiple features

### DIFF
--- a/src/ol/interaction/modifyinteraction.js
+++ b/src/ol/interaction/modifyinteraction.js
@@ -888,8 +888,10 @@ ol.interaction.Modify.prototype.removeVertex_ = function() {
             newSegmentData);
         this.updateSegmentIndices_(geometry, index, segmentData.depth, -1);
 
-        this.overlay_.getSource().removeFeature(this.vertexFeature_);
-        this.vertexFeature_ = null;
+        if (!goog.isNull(this.vertexFeature_)) {
+          this.overlay_.getSource().removeFeature(this.vertexFeature_);
+          this.vertexFeature_ = null;
+        }
       }
     }
   }

--- a/test/spec/ol/interaction/modifyinteraction.test.js
+++ b/test/spec/ol/interaction/modifyinteraction.test.js
@@ -18,14 +18,13 @@ describe('ol.interaction.Modify', function() {
     style.height = height + 'px';
     document.body.appendChild(target);
 
-    var geometry = new ol.geom.Polygon([
-      [[0, 0], [10, 20], [0, 40], [40, 40], [40, 0]]]);
-
-    features = [];
-    features.push(
-        new ol.Feature({
-          geometry: geometry
-        }));
+    features = [
+      new ol.Feature({
+        geometry: new ol.geom.Polygon([
+          [[0, 0], [10, 20], [0, 40], [40, 40], [40, 0]]
+        ])
+      })
+    ];
 
     source = new ol.source.Vector({
       features: features
@@ -91,6 +90,37 @@ describe('ol.interaction.Modify', function() {
       expect(rbushEntries.length).to.be(1);
       expect(rbushEntries[0].feature).to.be(feature);
     });
+  });
+
+  describe('vertex deletion', function() {
+
+    it('works when clicking on a shared vertex', function() {
+      features.push(features[0].clone());
+
+      var modify = new ol.interaction.Modify({
+        features: new ol.Collection(features)
+      });
+      map.addInteraction(modify);
+
+      var first = features[0];
+      var second = features[0];
+
+      expect(first.getGeometry().getRevision()).to.equal(1);
+      expect(first.getGeometry().getCoordinates()[0]).to.have.length(5);
+      expect(second.getGeometry().getRevision()).to.equal(1);
+      expect(second.getGeometry().getCoordinates()[0]).to.have.length(5);
+
+      simulateEvent('pointerdown', 10, -20, false, 0);
+      simulateEvent('pointerup', 10, -20, false, 0);
+      simulateEvent('click', 10, -20, false, 0);
+      simulateEvent('singleclick', 10, -20, false, 0);
+
+      expect(first.getGeometry().getRevision()).to.equal(2);
+      expect(first.getGeometry().getCoordinates()[0]).to.have.length(4);
+      expect(second.getGeometry().getRevision()).to.equal(2);
+      expect(second.getGeometry().getCoordinates()[0]).to.have.length(4);
+    });
+
   });
 
   describe('boundary modification', function() {


### PR DESCRIPTION
When deleting a vertex shared by multiple features, we iterate through drag segments and only need to remove the vertex feature once.  Currently, we throw on the second drag segment because we try to call `source.removeFeature(null)`.

Fixes #3956.
