### PR TITLE
Minor updates to release procedure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,7 @@ script: "make ci"
 after_success:
   - "make test-coverage"
   - "cat coverage/lcov.info | ./node_modules/.bin/coveralls"
+
+branches:
+  only:
+    - master

--- a/tasks/publish.sh
+++ b/tasks/publish.sh
@@ -95,6 +95,7 @@ main() {
   checkout_tag ${1}
   assert_version_match ${1}
   rm -rf ${BUILDS}
+  npm install
   build_js ${PROFILES}
   build_css
   npm publish


### PR DESCRIPTION
This makes sure the latest dependencies are installed before building release artifacts.  In addition, the `travis/push` job is configured to only build pushes to `master` (while this may look like a confusing change to `.travis.yml`, it doesn't affect the `travis/pr` job).