### PR TITLE
Add an option to use the mouse's location as an anchor when zooming

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -2648,7 +2648,8 @@ olx.interaction.ModifyOptions.prototype.wrapX;
 
 
 /**
- * @typedef {{duration: (number|undefined)}}
+ * @typedef {{duration: (number|undefined),
+ *     useAnchor: (boolean|undefined)}}
  * @api
  */
 olx.interaction.MouseWheelZoomOptions;
@@ -2660,6 +2661,16 @@ olx.interaction.MouseWheelZoomOptions;
  * @api
  */
 olx.interaction.MouseWheelZoomOptions.prototype.duration;
+
+
+/**
+ * Enable zooming using the mouse's location as the anchor. Default is `true`.
+ * When set to false, zooming in and out will zoom to the center of the screen
+ * instead of zooming on the mouse's location.
+ * @type {boolean|undefined}
+ * @api
+ */
+olx.interaction.MouseWheelZoomOptions.prototype.useAnchor;
 
 
 /**

--- a/src/ol/interaction/mousewheelzoominteraction.js
+++ b/src/ol/interaction/mousewheelzoominteraction.js
@@ -41,6 +41,13 @@ ol.interaction.MouseWheelZoom = function(opt_options) {
 
   /**
    * @private
+   * @type {boolean}
+   */
+  this.useAnchor_ = goog.isDef(options.useAnchor) ?
+      options.useAnchor : true;
+
+  /**
+   * @private
    * @type {?ol.Coordinate}
    */
   this.lastAnchor_ = null;
@@ -78,7 +85,10 @@ ol.interaction.MouseWheelZoom.handleEvent = function(mapBrowserEvent) {
     goog.asserts.assertInstanceof(mouseWheelEvent, goog.events.MouseWheelEvent,
         'mouseWheelEvent should be of type MouseWheelEvent');
 
-    this.lastAnchor_ = mapBrowserEvent.coordinate;
+    if (this.useAnchor_) {
+      this.lastAnchor_ = mapBrowserEvent.coordinate;
+    }
+
     this.delta_ += mouseWheelEvent.deltaY;
 
     if (!goog.isDef(this.startTime_)) {
@@ -118,4 +128,18 @@ ol.interaction.MouseWheelZoom.prototype.doZoom_ = function(map) {
   this.lastAnchor_ = null;
   this.startTime_ = undefined;
   this.timeoutId_ = undefined;
+};
+
+
+/**
+ * Enable or disable using the mouse's location as an anchor when zooming
+ * @param {boolean} useAnchor true to zoom to the mouse's location, false
+ * to zoom to the center of the map
+ * @api
+ */
+ol.interaction.MouseWheelZoom.prototype.setMouseAnchor = function(useAnchor) {
+  this.useAnchor_ = useAnchor;
+  if (!useAnchor) {
+    this.lastAnchor_ = null;
+  }
 };

--- a/test/spec/ol/map.test.js
+++ b/test/spec/ol/map.test.js
@@ -243,6 +243,9 @@ describe('ol.Map', function() {
         var interactions = ol.interaction.defaults(options);
         expect(interactions.getLength()).to.eql(1);
         expect(interactions.item(0)).to.be.a(ol.interaction.MouseWheelZoom);
+        expect(interactions.item(0).useAnchor_).to.eql(true);
+        interactions.item(0).setMouseAnchor(false);
+        expect(interactions.item(0).useAnchor_).to.eql(false);
       });
     });
 


### PR DESCRIPTION
By default, zooming in or out zooms using the mouse's location as an anchor, which makes it possible to navigate the map using scrolling only, and makes zooming in more intuitive. 

This patch adds a new `useAnchor` option to the MouseWheelZoom interaction. It is enabled by default, which changes nothing to the current behavior of the interaction. When disabled, the interaction stops registering its lastAnchor_ value. This turns the zoom into a very basic one, that zooms to the center of the screen. 

The reason I am creating this patch is for a @mapgears project involving tracking points as they move on the map. We want to follow a point as it moves on the map, and stop the user from moving the map around as the point is followed. Leaving the zoom enabled would let the user move around using the mouse scroll, which could be confusing if they get lost and can't come back using panning.

A good example is [this demo](http://openlayers.org/en/master/examples/geolocation-orientation.html) on the openlayers website, where the same issue was solved by relocating to the point after zooming in or out.