### PR TITLE
Release v3.8.1

### DIFF
--- a/changelog/v3.8.1.md
+++ b/changelog/v3.8.1.md
@@ -1,0 +1,7 @@
+# v3.8.1
+
+## Summary
+
+This is a patch release that updates the URL for builds shown in the examples.  Details below.
+
+ * [#3970](https://github.com/openlayers/ol3/pull/3970) - Pull builds from openlayers.org. ([@tschaub](https://github.com/tschaub))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlayers",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Build tools and sources for developing OpenLayers based mapping applications",
   "keywords": [
     "map",


### PR DESCRIPTION
This is a patch release that updates the URL for builds in the examples.  No code changes.