### PR TITLE
Skip features without geometry during webgl replay

### DIFF
--- a/src/ol/render/webgl/webglreplay.js
+++ b/src/ol/render/webgl/webglreplay.js
@@ -853,6 +853,7 @@ ol.render.webgl.ImageReplay.prototype.drawHitDetectionReplayOneByOne_ =
       featureUid = goog.getUid(feature).toString();
 
       if (!goog.isDef(skippedFeaturesHash[featureUid]) &&
+          goog.isDefAndNotNull(feature.getGeometry()) &&
           (!goog.isDef(opt_hitExtent) || ol.extent.intersects(
               opt_hitExtent, feature.getGeometry().getExtent()))) {
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);


### PR DESCRIPTION
Setting a feature geometry to null or undefined and triggering a hit
detection was throwing an exception.

This patch handles a batched feature without a geometry in the same
fashion as skipped features.

An equivalent patch has been applied to the canvas replay.