### PR TITLE
Mark ol.style.Icon#load() @api

### DIFF
--- a/src/ol/style/iconstyle.js
+++ b/src/ol/style/iconstyle.js
@@ -347,6 +347,10 @@ ol.style.Icon.prototype.listenImageChange = function(listener, thisArg) {
 
 /**
  * Load not yet loaded URI.
+ * When rendering a feature with an icon style, the vector renderer will
+ * automatically call this method. However, you might want to call this
+ * method yourself for preloading or other purposes.
+ * @api
  */
 ol.style.Icon.prototype.load = function() {
   this.iconImage_.load();


### PR DESCRIPTION
We currently rely on the renderer to load the styles it intents to use.

In Ol3-Cesium we want to allow different styles for 3D and for 2D.
This commit fixes the issue by allowing application code to explicitely
initiate the loading process.