### PR TITLE
Release v3.8.2

### DIFF
--- a/changelog/v3.8.2.md
+++ b/changelog/v3.8.2.md
@@ -1,0 +1,7 @@
+# v3.8.2
+
+## Summary
+
+This is a patch release that corrects the URL for builds shown in the examples.  Details below.
+
+ * [#3979](https://github.com/openlayers/ol3/pull/3979) - Fix URLs for openlayers.org resources. ([@tschaub](https://github.com/tschaub))

--- a/config/examples/example.html
+++ b/config/examples/example.html
@@ -44,7 +44,7 @@
           <textarea class="hidden" name="css">{{ css.source }}</textarea>
           <textarea class="hidden" name="html">{{ contents }}</textarea>
           <input type="hidden" name="wrap" value="l">
-          <input type="hidden" name="resources" value="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css,https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js,http://openlayers.org/en/{{ olVersion }}/css/ol.css,http://openlayers.org/en/{{ olVersion }}/build/ol.js">
+          <input type="hidden" name="resources" value="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css,https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js,http://openlayers.org/en/v{{ olVersion }}/css/ol.css,http://openlayers.org/en/v{{ olVersion }}/build/ol.js">
           <pre><code id="example-source" class="language-markup">&lt;!DOCTYPE html&gt;
 &lt;html&gt;
 &lt;head&gt;
@@ -52,8 +52,8 @@
 &lt;script src="https://code.jquery.com/jquery-1.11.2.min.js"&gt;&lt;/script&gt;
 &lt;link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css"&gt;
 &lt;script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"&gt;&lt;/script&gt;
-&lt;link rel="stylesheet" href="http://openlayers.org/en/{{ olVersion }}/css/ol.css" type="text/css"&gt;
-&lt;script src="http://openlayers.org/en/{{ olVersion }}/build/ol.js"&gt;&lt;/script&gt;
+&lt;link rel="stylesheet" href="http://openlayers.org/en/v{{ olVersion }}/css/ol.css" type="text/css"&gt;
+&lt;script src="http://openlayers.org/en/v{{ olVersion }}/build/ol.js"&gt;&lt;/script&gt;
 {{ extraHead }}
 {{#if css.source}}
 &lt;style&gt;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlayers",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "description": "Build tools and sources for developing OpenLayers based mapping applications",
   "keywords": [
     "map",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlayers",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Build tools and sources for developing OpenLayers based mapping applications",
   "keywords": [
     "map",


### PR DESCRIPTION
Yet another patch release to fix build URLs in examples.

Thanks @ahocevar for the catch.
