### PR TITLE
Remove surnumerous '@api' annotations

### DIFF
--- a/src/ol/control/mousepositioncontrol.js
+++ b/src/ol/control/mousepositioncontrol.js
@@ -180,7 +180,6 @@ ol.control.MousePosition.prototype.handleMouseOut = function(browserEvent) {
 
 /**
  * @inheritDoc
- * @api stable
  */
 ol.control.MousePosition.prototype.setMap = function(map) {
   goog.base(this, 'setMap', map);

--- a/src/ol/control/overviewmapcontrol.js
+++ b/src/ol/control/overviewmapcontrol.js
@@ -147,7 +147,6 @@ goog.inherits(ol.control.OverviewMap, ol.control.Control);
 
 /**
  * @inheritDoc
- * @api
  */
 ol.control.OverviewMap.prototype.setMap = function(map) {
   var oldMap = this.getMap();

--- a/src/ol/source/tilevectorsource.js
+++ b/src/ol/source/tilevectorsource.js
@@ -199,7 +199,6 @@ ol.source.TileVector.prototype.getExtent = goog.abstractMethod;
 /**
  * Return the features of the TileVector source.
  * @inheritDoc
- * @api
  */
 ol.source.TileVector.prototype.getFeatures = function() {
   var tiles = this.tiles_;


### PR DESCRIPTION
This commit fixes duplicate functions in ol3/build/ol-externs.js.

ERROR - variable ol.source.TileVector.prototype.getFeatures redefined
ERROR - variable ol.control.MousePosition.prototype.setMap redefined
ERROR - variable ol.control.OverviewMap.prototype.setMap redefined