### PR TITLE
Rebuild examples if package.json changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ host-libraries: build/timestamps/node-modules-timestamp
 	@mkdir -p $(BUILD_HOSTED)/ol.ext
 	@cp -r build/ol.ext/* $(BUILD_HOSTED)/ol.ext/
 
-$(BUILD_EXAMPLES): $(EXAMPLES)
+$(BUILD_EXAMPLES): $(EXAMPLES) package.json
 	@mkdir -p $(@D)
 	@node tasks/build-examples.js
 


### PR DESCRIPTION
Currently, `make examples` will do nothing when we update the version in `package.json`.  The `tasks/build-examples.js` script uses the version in `package.json` to write out the URLs to build artifacts.  So `package.json` needs to be listed as a dependency of any built example target.
