### PR TITLE
Modify 'url' option of ol.source.Vector to accept a function

### DIFF
--- a/examples/vector-osm.js
+++ b/examples/vector-osm.js
@@ -87,19 +87,13 @@ var styles = {
   }
 };
 
-var osmxmlFormat = new ol.format.OSMXML();
-
 var vectorSource = new ol.source.Vector({
-  loader: function(extent, resolution, projection) {
+  format: new ol.format.OSMXML(),
+  url: function(extent, resolution, projection) {
     var epsg4326Extent =
         ol.proj.transformExtent(extent, projection, 'EPSG:4326');
-    var url = 'http://overpass-api.de/api/xapi?map?bbox=' +
+    return 'http://overpass-api.de/api/xapi?map?bbox=' +
         epsg4326Extent.join(',');
-    $.ajax(url).then(function(response) {
-      var features = osmxmlFormat.readFeatures(response,
-          {featureProjection: projection});
-      vectorSource.addFeatures(features);
-    });
   },
   strategy: ol.loadingstrategy.tile(ol.tilegrid.createXYZ({
     maxZoom: 19

--- a/examples/vector-wfs.js
+++ b/examples/vector-wfs.js
@@ -10,32 +10,20 @@ goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
 
 
-// format used to parse WFS GetFeature responses
-var geojsonFormat = new ol.format.GeoJSON();
 
 var vectorSource = new ol.source.Vector({
-  loader: function(extent, resolution, projection) {
-    var url = 'http://demo.boundlessgeo.com/geoserver/wfs?service=WFS&' +
+  format: new ol.format.GeoJSON(),
+  url: function(extent, resolution, projection) {
+    return 'http://demo.boundlessgeo.com/geoserver/wfs?service=WFS&' +
         'version=1.1.0&request=GetFeature&typename=osm:water_areas&' +
-        'outputFormat=text/javascript&format_options=callback:loadFeatures' +
-        '&srsname=EPSG:3857&bbox=' + extent.join(',') + ',EPSG:3857';
-    // use jsonp: false to prevent jQuery from adding the "callback"
-    // parameter to the URL
-    $.ajax({url: url, dataType: 'jsonp', jsonp: false});
+        'outputFormat=application/json&srsname=EPSG:3857&' +
+        'bbox=' + extent.join(',') + ',EPSG:3857';
   },
   strategy: ol.loadingstrategy.tile(ol.tilegrid.createXYZ({
     maxZoom: 19
   }))
 });
 
-
-/**
- * JSONP WFS callback function.
- * @param {Object} response The response object.
- */
-window.loadFeatures = function(response) {
-  vectorSource.addFeatures(geojsonFormat.readFeatures(response));
-};
 
 var vector = new ol.layer.Vector({
   source: vectorSource,

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -5165,7 +5165,7 @@ olx.source.TileWMSOptions.prototype.wrapX;
  *     loader: (ol.FeatureLoader|undefined),
  *     logo: (string|olx.LogoOptions|undefined),
  *     strategy: (ol.LoadingStrategy|undefined),
- *     url: (string|undefined),
+ *     url: (string|ol.FeatureUrlFunction|undefined),
  *     useSpatialIndex: (boolean|undefined),
  *     wrapX: (boolean|undefined)}}
  * @api
@@ -5228,10 +5228,12 @@ olx.source.VectorOptions.prototype.strategy;
 
 /**
  * Setting this option instructs the source to use an XHR loader (see
- * {@link ol.featureloader.xhr}) and an {@link ol.loadingstrategy.all} for a
- * one-off download of all features from that URL.
+ * {@link ol.featureloader.xhr}). Use a `string` and an
+ * {@link ol.loadingstrategy.all} for a one-off download of all features from
+ * the given URL. Use a {@link ol.FeatureUrlFunction} to generate the url with
+ * other loading strategies.
  * Requires `format` to be set as well.
- * @type {string|undefined}
+ * @type {string|ol.FeatureUrlFunction|undefined}
  * @api
  */
 olx.source.VectorOptions.prototype.url;

--- a/test/spec/ol/featureloader.test.js
+++ b/test/spec/ol/featureloader.test.js
@@ -4,21 +4,52 @@ describe('ol.featureloader', function() {
   describe('ol.featureloader.xhr', function() {
     var loader;
     var source;
+    var url;
+    var format;
 
     beforeEach(function() {
-      var url = 'spec/ol/data/point.json';
-      var format = new ol.format.GeoJSON();
+      url = 'spec/ol/data/point.json';
+      format = new ol.format.GeoJSON();
 
-      loader = ol.featureloader.xhr(url, format);
       source = new ol.source.Vector();
     });
 
     it('adds features to the source', function(done) {
+      loader = ol.featureloader.xhr(url, format);
       source.on(ol.source.VectorEventType.ADDFEATURE, function(e) {
         expect(source.getFeatures().length).to.be.greaterThan(0);
         done();
       });
       loader.call(source, [], 1, 'EPSG:3857');
+    });
+
+    describe('when called with urlFunction', function() {
+      it('adds features to the source', function(done) {
+        url = function(extent, resolution, projection) {
+          return 'spec/ol/data/point.json';};
+        loader = ol.featureloader.xhr(url, format);
+
+        source.on(ol.source.VectorEventType.ADDFEATURE, function(e) {
+          expect(source.getFeatures().length).to.be.greaterThan(0);
+          done();
+        });
+        loader.call(source, [], 1, 'EPSG:3857');
+      });
+
+      it('sends the correct arguments to the urlFunction', function(done) {
+        var extent = [];
+        var resolution = 1;
+        var projection = 'EPSG:3857';
+        url = function(extent_, resolution_, projection_) {
+          expect(extent_).to.eql(extent);
+          expect(resolution_).to.eql(resolution);
+          expect(projection_).to.eql(projection);
+          done();
+          return 'spec/ol/data/point.json';
+        };
+        loader = ol.featureloader.xhr(url, format);
+        loader.call(source, [], 1, 'EPSG:3857');
+      });
     });
 
   });


### PR DESCRIPTION
Based on my observations/assumptions, many (most?) uses of custom loaders on Vector sources are all about dynamically creating the URL. The other parts of the loader (handling the ajax request, read the features through an ol.format and adding them to the source) are fairly standard and unnecessary in many cases.

This can be seen in two of our examples that uses a custom loader (the other two also did some error notifications).

This PR suggests accepting a function as the *url* option to ol.source.Vector, enabling users to provide custom urls (generally based on the extent) and still use ol.featureloader.xhr.