### PR TITLE
Simplify tileLoadFunction and crossOrigin handling

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -1,5 +1,14 @@
 ## Upgrade notes
 
+#### Changed return type of `ol.source.TileImage#getTileLoadFunction()`
+
+When no custom `tileLoadFunction` is configured, this method now returns `undefined`, and no longer the default, which is
+```js
+function(tile, src) {
+  tile.getImage().src = src;
+}
+```
+
 ### v3.8.0
 
 There should be nothing special required when upgrading from v3.7.0 to v3.8.0.

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -3899,19 +3899,18 @@ olx.source.TileUTFGridOptions.prototype.url;
 
 /**
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
- *            crossOrigin: (null|string|undefined),
- *            logo: (string|olx.LogoOptions|undefined),
- *            opaque: (boolean|undefined),
- *            projection: ol.proj.ProjectionLike,
- *            state: (ol.source.State|string|undefined),
- *            tileClass: (function(new: ol.ImageTile, ol.TileCoord,
- *                                 ol.TileState, string, ?string,
- *                                 ol.TileLoadFunctionType)|undefined),
- *            tileGrid: (ol.tilegrid.TileGrid|undefined),
- *            tileLoadFunction: (ol.TileLoadFunctionType|undefined),
- *            tilePixelRatio: (number|undefined),
- *            tileUrlFunction: (ol.TileUrlFunctionType|undefined),
- *            wrapX: (boolean|undefined)}}
+ *     crossOrigin: (string|undefined),
+ *     logo: (string|olx.LogoOptions|undefined),
+ *     opaque: (boolean|undefined),
+ *     projection: ol.proj.ProjectionLike,
+ *     state: (ol.source.State|string|undefined),
+ *     tileClass: (function(new: ol.ImageTile, ol.TileCoord, ol.TileState,
+ *         string, ol.TileLoadFunctionType=, string=)|undefined),
+ *     tileGrid: (ol.tilegrid.TileGrid|undefined),
+ *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
+ *     tilePixelRatio: (number|undefined),
+ *     tileUrlFunction: (ol.TileUrlFunctionType|undefined),
+ *     wrapX: (boolean|undefined)}}
  * @api
  */
 olx.source.TileImageOptions;
@@ -3931,7 +3930,7 @@ olx.source.TileImageOptions.prototype.attributions;
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- * @type {null|string|undefined}
+ * @type {string|undefined}
  * @api
  */
 olx.source.TileImageOptions.prototype.crossOrigin;
@@ -4184,7 +4183,7 @@ olx.source.ImageMapGuideOptions.prototype.projection;
 
 /**
  * Ratio. `1` means image requests are the size of the map viewport, `2` means
- * twice the width and height of the map viewport, and so on. Must be `1` or 
+ * twice the width and height of the map viewport, and so on. Must be `1` or
  * higher. Default is `1`.
  * @type {number|undefined}
  * @api stable
@@ -4309,7 +4308,8 @@ olx.source.OSMOptions.prototype.attributions;
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
  *
- * Default is `anonymous`.
+ * Default is `anonymous`. Set to `null` if your OSM server does not send
+ * CORS headers.
  * @type {null|string|undefined}
  * @api stable
  */
@@ -4467,7 +4467,7 @@ olx.source.ImageVectorOptions.prototype.projection;
 
 /**
  * Ratio. 1 means canvases are the size of the map viewport, 2 means twice the
- * width and height of the map viewport, and so on. Must be `1` or higher. 
+ * width and height of the map viewport, and so on. Must be `1` or higher.
  * Default is `1.5`.
  * @type {number|undefined}
  * @api
@@ -4562,7 +4562,7 @@ olx.source.RasterOptions.prototype.operationType;
 
 /**
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
- *     crossOrigin: (null|string|undefined),
+ *     crossOrigin: (string|undefined),
  *     hidpi: (boolean|undefined),
  *     serverType: (ol.source.wms.ServerType|string|undefined),
  *     logo: (string|olx.LogoOptions|undefined),
@@ -4591,7 +4591,7 @@ olx.source.ImageWMSOptions.prototype.attributions;
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- * @type {null|string|undefined}
+ * @type {string|undefined}
  * @api stable
  */
 olx.source.ImageWMSOptions.prototype.crossOrigin;
@@ -4651,7 +4651,7 @@ olx.source.ImageWMSOptions.prototype.projection;
 
 /**
  * Ratio. `1` means image requests are the size of the map viewport, `2` means
- * twice the width and height of the map viewport, and so on. Must be `1` or 
+ * twice the width and height of the map viewport, and so on. Must be `1` or
  * higher. Default is `1.5`.
  * @type {number|undefined}
  * @api stable
@@ -4737,7 +4737,7 @@ olx.source.StamenOptions.prototype.url;
 
 /**
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
- *     crossOrigin: (null|string|undefined),
+ *     crossOrigin: (string|undefined),
  *     imageExtent: (ol.Extent),
  *     imageSize: (ol.Size|undefined),
  *     imageLoadFunction: (ol.ImageLoadFunctionType|undefined),
@@ -4763,7 +4763,7 @@ olx.source.ImageStaticOptions.prototype.attributions;
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- * @type {null|string|undefined}
+ * @type {string|undefined}
  * @api stable
  */
 olx.source.ImageStaticOptions.prototype.crossOrigin;
@@ -4820,7 +4820,7 @@ olx.source.ImageStaticOptions.prototype.url;
 
 /**
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
- *     crossOrigin: (null|string|undefined),
+ *     crossOrigin: (string|undefined),
  *     params: (Object.<string, *>|undefined),
  *     logo: (string|olx.LogoOptions|undefined),
  *     tileGrid: (ol.tilegrid.TileGrid|undefined),
@@ -4848,7 +4848,7 @@ olx.source.TileArcGISRestOptions.prototype.attributions;
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- * @type {null|string|undefined}
+ * @type {string|undefined}
  * @api
  */
 olx.source.TileArcGISRestOptions.prototype.crossOrigin;
@@ -4932,7 +4932,7 @@ olx.source.TileArcGISRestOptions.prototype.urls;
 
 /**
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
- *     crossOrigin: (null|string|undefined),
+ *     crossOrigin: (string|undefined),
  *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
  *     url: string,
  *     wrapX: (boolean|undefined)}}
@@ -4957,7 +4957,7 @@ olx.source.TileJSONOptions.prototype.attributions;
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- * @type {null|string|undefined}
+ * @type {string|undefined}
  * @api stable
  */
 olx.source.TileJSONOptions.prototype.crossOrigin;
@@ -4990,7 +4990,7 @@ olx.source.TileJSONOptions.prototype.wrapX;
 /**
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
  *     params: Object.<string,*>,
- *     crossOrigin: (null|string|undefined),
+ *     crossOrigin: (string|undefined),
  *     gutter: (number|undefined),
  *     hidpi: (boolean|undefined),
  *     logo: (string|olx.LogoOptions|undefined),
@@ -5031,7 +5031,7 @@ olx.source.TileWMSOptions.prototype.params;
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- * @type {null|string|undefined}
+ * @type {string|undefined}
  * @api stable
  */
 olx.source.TileWMSOptions.prototype.crossOrigin;
@@ -5256,7 +5256,7 @@ olx.source.VectorOptions.prototype.wrapX;
 
 /**
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
- *     crossOrigin: (string|null|undefined),
+ *     crossOrigin: (string|undefined),
  *     logo: (string|olx.LogoOptions|undefined),
  *     tileGrid: ol.tilegrid.WMTS,
  *     projection: ol.proj.ProjectionLike,
@@ -5295,7 +5295,7 @@ olx.source.WMTSOptions.prototype.attributions;
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- * @type {string|null|undefined}
+ * @type {string|undefined}
  * @api
  */
 olx.source.WMTSOptions.prototype.crossOrigin;
@@ -5448,7 +5448,7 @@ olx.source.WMTSOptions.prototype.wrapX;
 
 /**
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
- *     crossOrigin: (null|string|undefined),
+ *     crossOrigin: (string|undefined),
  *     logo: (string|olx.LogoOptions|undefined),
  *     projection: ol.proj.ProjectionLike,
  *     maxZoom: (number|undefined),
@@ -5480,7 +5480,7 @@ olx.source.XYZOptions.prototype.attributions;
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- * @type {null|string|undefined}
+ * @type {string|undefined}
  * @api stable
  */
 olx.source.XYZOptions.prototype.crossOrigin;
@@ -5590,7 +5590,7 @@ olx.source.XYZOptions.prototype.wrapX;
 
 /**
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
- *     crossOrigin: (null|string|undefined),
+ *     crossOrigin: (string|undefined),
  *     logo: (string|olx.LogoOptions|undefined),
  *     url: !string,
  *     tierSizeCalculation: (string|undefined),
@@ -5614,7 +5614,7 @@ olx.source.ZoomifyOptions.prototype.attributions;
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- * @type {null|string|undefined}
+ * @type {string|undefined}
  * @api stable
  */
 olx.source.ZoomifyOptions.prototype.crossOrigin;
@@ -5739,7 +5739,7 @@ olx.style.FillOptions.prototype.color;
  *     anchorOrigin: (ol.style.IconOrigin|undefined),
  *     anchorXUnits: (ol.style.IconAnchorUnits|undefined),
  *     anchorYUnits: (ol.style.IconAnchorUnits|undefined),
- *     crossOrigin: (null|string|undefined),
+ *     crossOrigin: (string|undefined),
  *     img: (Image|undefined),
  *     offset: (Array.<number>|undefined),
  *     offsetOrigin: (ol.style.IconOrigin|undefined),
@@ -5799,7 +5799,7 @@ olx.style.IconOptions.prototype.anchorYUnits;
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- * @type {null|string|undefined}
+ * @type {string|undefined}
  * @api
  */
 olx.style.IconOptions.prototype.crossOrigin;

--- a/src/ol/imagetile.js
+++ b/src/ol/imagetile.js
@@ -18,10 +18,11 @@ goog.require('ol.TileState');
  * @param {ol.TileCoord} tileCoord Tile coordinate.
  * @param {ol.TileState} state State.
  * @param {string} src Image source URI.
- * @param {?string} crossOrigin Cross origin.
- * @param {ol.TileLoadFunctionType} tileLoadFunction Tile load function.
+ * @param {ol.TileLoadFunctionType=} opt_tileLoadFunction Tile load function.
+ * @param {string=} opt_crossOrigin Cross origin.
  */
-ol.ImageTile = function(tileCoord, state, src, crossOrigin, tileLoadFunction) {
+ol.ImageTile = function(
+    tileCoord, state, src, opt_tileLoadFunction, opt_crossOrigin) {
 
   goog.base(this, tileCoord, state);
 
@@ -38,8 +39,8 @@ ol.ImageTile = function(tileCoord, state, src, crossOrigin, tileLoadFunction) {
    * @type {Image}
    */
   this.image_ = new Image();
-  if (!goog.isNull(crossOrigin)) {
-    this.image_.crossOrigin = crossOrigin;
+  if (goog.isDef(opt_crossOrigin)) {
+    this.image_.crossOrigin = opt_crossOrigin;
   }
 
   /**
@@ -58,7 +59,8 @@ ol.ImageTile = function(tileCoord, state, src, crossOrigin, tileLoadFunction) {
    * @private
    * @type {ol.TileLoadFunctionType}
    */
-  this.tileLoadFunction_ = tileLoadFunction;
+  this.tileLoadFunction_ = goog.isDef(opt_tileLoadFunction) ?
+      opt_tileLoadFunction : ol.ImageTile.defaultTileLoadFunction;
 
 };
 goog.inherits(ol.ImageTile, ol.Tile);
@@ -171,4 +173,13 @@ ol.ImageTile.prototype.unlistenImage_ = function() {
       'this.imageListenerKeys_ should not be null');
   goog.array.forEach(this.imageListenerKeys_, goog.events.unlistenByKey);
   this.imageListenerKeys_ = null;
+};
+
+
+/**
+ * @param {ol.ImageTile} imageTile Image tile.
+ * @param {string} src Source.
+ */
+ol.ImageTile.defaultTileLoadFunction = function(imageTile, src) {
+  imageTile.getImage().src = src;
 };

--- a/src/ol/source/osmsource.js
+++ b/src/ol/source/osmsource.js
@@ -26,7 +26,8 @@ ol.source.OSM = function(opt_options) {
   }
 
   var crossOrigin = goog.isDef(options.crossOrigin) ?
-      options.crossOrigin : 'anonymous';
+      (goog.isNull(options.crossOrigin) ? undefined : options.crossOrigin) :
+      'anonymous';
 
   var url = goog.isDef(options.url) ?
       options.url : 'https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png';

--- a/src/ol/source/tileimagesource.js
+++ b/src/ol/source/tileimagesource.js
@@ -49,37 +49,26 @@ ol.source.TileImage = function(options) {
 
   /**
    * @protected
-   * @type {?string}
+   * @type {string|undefined}
    */
-  this.crossOrigin =
-      goog.isDef(options.crossOrigin) ? options.crossOrigin : null;
+  this.crossOrigin = options.crossOrigin;
 
   /**
    * @protected
-   * @type {ol.TileLoadFunctionType}
+   * @type {ol.TileLoadFunctionType|undefined}
    */
-  this.tileLoadFunction = goog.isDef(options.tileLoadFunction) ?
-      options.tileLoadFunction : ol.source.TileImage.defaultTileLoadFunction;
+  this.tileLoadFunction = options.tileLoadFunction;
 
   /**
    * @protected
    * @type {function(new: ol.ImageTile, ol.TileCoord, ol.TileState, string,
-   *        ?string, ol.TileLoadFunctionType)}
+   *        ol.TileLoadFunctionType=, string=)}
    */
   this.tileClass = goog.isDef(options.tileClass) ?
       options.tileClass : ol.ImageTile;
 
 };
 goog.inherits(ol.source.TileImage, ol.source.Tile);
-
-
-/**
- * @param {ol.ImageTile} imageTile Image tile.
- * @param {string} src Source.
- */
-ol.source.TileImage.defaultTileLoadFunction = function(imageTile, src) {
-  imageTile.getImage().src = src;
-};
 
 
 /**
@@ -101,8 +90,8 @@ ol.source.TileImage.prototype.getTile =
         tileCoord,
         goog.isDef(tileUrl) ? ol.TileState.IDLE : ol.TileState.EMPTY,
         goog.isDef(tileUrl) ? tileUrl : '',
-        this.crossOrigin,
-        this.tileLoadFunction);
+        this.tileLoadFunction,
+        this.crossOrigin);
     goog.events.listen(tile, goog.events.EventType.CHANGE,
         this.handleTileChange_, false, this);
 
@@ -114,7 +103,7 @@ ol.source.TileImage.prototype.getTile =
 
 /**
  * Return the tile load function of the source.
- * @return {ol.TileLoadFunctionType} TileLoadFunction
+ * @return {ol.TileLoadFunctionType|undefined} TileLoadFunction
  * @api
  */
 ol.source.TileImage.prototype.getTileLoadFunction = function() {

--- a/src/ol/source/zoomifysource.js
+++ b/src/ol/source/zoomifysource.js
@@ -140,14 +140,14 @@ goog.inherits(ol.source.Zoomify, ol.source.TileImage);
  * @param {ol.TileCoord} tileCoord Tile coordinate.
  * @param {ol.TileState} state State.
  * @param {string} src Image source URI.
- * @param {?string} crossOrigin Cross origin.
- * @param {ol.TileLoadFunctionType} tileLoadFunction Tile load function.
+ * @param {ol.TileLoadFunctionType=} opt_tileLoadFunction Tile load function.
+ * @param {string=} opt_crossOrigin Cross origin.
  * @private
  */
 ol.source.ZoomifyTile_ = function(
-    tileCoord, state, src, crossOrigin, tileLoadFunction) {
+    tileCoord, state, src, opt_tileLoadFunction, opt_crossOrigin) {
 
-  goog.base(this, tileCoord, state, src, crossOrigin, tileLoadFunction);
+  goog.base(this, tileCoord, state, src, opt_tileLoadFunction, opt_crossOrigin);
 
   /**
    * @private

--- a/src/ol/tileloadfunction.js
+++ b/src/ol/tileloadfunction.js
@@ -3,10 +3,17 @@ goog.provide('ol.TileVectorLoadFunctionType');
 
 
 /**
- * A function that takes an {@link ol.ImageTile} for the image tile and a
- * `{string}` for the src as arguments.
+ * A function that takes an {@link ol.Tile} for the tile and a `{string}` for
+ * the tile url as arguments.
  *
- * @typedef {function(ol.ImageTile, string)}
+ * The default for {@link ol.ImageTile} is
+ * ```js
+ * function(tile, src) {
+ *   tile.getImage().src = src;
+ * }
+ * ```
+ *
+ * @typedef {function(ol.Tile, string)}
  * @api
  */
 ol.TileLoadFunctionType;

--- a/test/spec/ol/tilequeue.test.js
+++ b/test/spec/ol/tilequeue.test.js
@@ -21,8 +21,7 @@ describe('ol.TileQueue', function() {
     var src = 'data:image/gif;base64,R0lGODlhAQABAPAAAP8AAP///' +
         'yH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==#' + tileId;
 
-    return new ol.ImageTile(tileCoord, state, src, null,
-        ol.source.Image.defaultImageLoadFunction);
+    return new ol.ImageTile(tileCoord, state, src);
   }
 
   describe('#loadMoreTiles()', function() {
@@ -127,5 +126,4 @@ goog.require('ol.ImageTile');
 goog.require('ol.Tile');
 goog.require('ol.TileState');
 goog.require('ol.TileQueue');
-goog.require('ol.source.Image');
 goog.require('ol.structs.PriorityQueue');


### PR DESCRIPTION
It will be easier to work with tile classes other than `ol.ImageTile` when `crossOrigin` and `tileLoadFunction` are optional constructor parameters. In the case of the `tileLoadFunction`, the default should be provided by the tile class, not the tile source. And in the case of `crossOrigin`, providing `null` as value does not make sense, except for the OSM source, where uses must be able to unset the 'anonymous' default.

This change is a minor refactoring for introducing a new vector tile class, which I am currently working on.