### PR TITLE
Update closure-library to latest commit

### DIFF
--- a/closure-util.json
+++ b/closure-util.json
@@ -1,3 +1,3 @@
 {
-  "library_url": "https://github.com/google/closure-library/archive/0011afd534469ba111786fe68300a634e08a4d80.zip"
+  "library_url": "https://github.com/google/closure-library/archive/a5f9b8a.zip"
 }

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -692,22 +692,8 @@ ol.Map.prototype.getEventCoordinate = function(event) {
  * @api stable
  */
 ol.Map.prototype.getEventPixel = function(event) {
-  // goog.style.getRelativePosition is based on event.targetTouches,
-  // but touchend and touchcancel events have no targetTouches when
-  // the last finger is removed from the screen.
-  // So we ourselves compute the position of touch events.
-  // See https://github.com/google/closure-library/pull/323
-  if (goog.isDef(event.changedTouches)) {
-    var touch = event.changedTouches[0];
-    var viewportPosition = goog.style.getClientPosition(this.viewport_);
-    return [
-      touch.clientX - viewportPosition.x,
-      touch.clientY - viewportPosition.y
-    ];
-  } else {
-    var eventPosition = goog.style.getRelativePosition(event, this.viewport_);
-    return [eventPosition.x, eventPosition.y];
-  }
+  var eventPosition = goog.style.getRelativePosition(event, this.viewport_);
+  return [eventPosition.x, eventPosition.y];
 };
 
 

--- a/test/spec/ol/map.test.js
+++ b/test/spec/ol/map.test.js
@@ -271,12 +271,54 @@ describe('ol.Map', function() {
         });
       });
     });
+
+    describe('#getEventPixel', function() {
+
+      var target;
+
+      beforeEach(function() {
+        target = document.createElement('div');
+        target.style.position = 'absolute';
+        target.style.top = '10px';
+        target.style.left = '20px';
+        target.style.width = '800px';
+        target.style.height = '400px';
+
+        document.body.appendChild(target);
+      });
+      afterEach(function() {
+        document.body.removeChild(target);
+      });
+
+      it('works with touchend events', function() {
+
+        var map = new ol.Map({
+          target: target
+        });
+
+        var browserEvent = new goog.events.BrowserEvent({
+          type: 'touchend',
+          target: target,
+          changedTouches: [{
+            clientX: 100,
+            clientY: 200
+          }]
+        });
+        var position = map.getEventPixel(browserEvent.getBrowserEvent());
+        // 80 = clientX - target.style.left
+        expect(position[0]).to.eql(80);
+        // 190 = clientY - target.style.top
+        expect(position[1]).to.eql(190);
+      });
+    });
+
   });
 
 });
 
 goog.require('goog.dispose');
 goog.require('goog.dom');
+goog.require('goog.events.BrowserEvent');
 goog.require('goog.events.EventType');
 goog.require('ol.Map');
 goog.require('ol.MapEvent');


### PR DESCRIPTION
And 	remove `goog.style.getRelativePosition` workaround in ol.Map (thanks to @elemoine for his work on this)

Fixes https://github.com/openlayers/ol3/pull/3316