### PR TITLE
Use a more recent version of marked

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "graceful-fs": "3.0.2",
     "handlebars": "3.0.1",
     "jsdoc": "3.3.2",
-    "marked": "0.3.3",
+    "marked": "0.3.5",
     "metalsmith": "1.6.0",
     "metalsmith-templates": "0.7.0",
     "nomnom": "1.8.0",


### PR DESCRIPTION
Quoting from https://nodesecurity.io/advisories/marked_redos:

> Marked 0.3.3 and earlier is vulnerable to regular expression denial of
> service (ReDoS) when certain types of input are passed in to be parsed.