### PR TITLE
Add a getUrls Method to ol.source.XYZ

### DIFF
--- a/src/ol/source/xyzsource.js
+++ b/src/ol/source/xyzsource.js
@@ -38,6 +38,12 @@ ol.source.XYZ = function(options) {
         tileSize: options.tileSize
       });
 
+  /**
+   * @private
+   * @type {!Array.<string>|null}
+   */
+  this.urls_ = null;
+
   goog.base(this, {
     attributions: options.attributions,
     crossOrigin: options.crossOrigin,
@@ -63,6 +69,18 @@ goog.inherits(ol.source.XYZ, ol.source.TileImage);
 
 
 /**
+ * Return the URLs used for this XYZ source.
+ * When a tileUrlFunction is used instead of url or urls,
+ * null will be returned.
+ * @return {!Array.<string>|null} URLs.
+ * @api
+ */
+ol.source.XYZ.prototype.getUrls = function() {
+  return this.urls_;
+};
+
+
+/**
  * Set the URL to use for requests.
  * @param {string} url URL.
  * @api stable
@@ -70,6 +88,7 @@ goog.inherits(ol.source.XYZ, ol.source.TileImage);
 ol.source.XYZ.prototype.setUrl = function(url) {
   this.setTileUrlFunction(ol.TileUrlFunction.createFromTemplates(
       ol.TileUrlFunction.expandUrl(url)));
+  this.urls_ = [url];
 };
 
 
@@ -79,4 +98,5 @@ ol.source.XYZ.prototype.setUrl = function(url) {
  */
 ol.source.XYZ.prototype.setUrls = function(urls) {
   this.setTileUrlFunction(ol.TileUrlFunction.createFromTemplates(urls));
+  this.urls_ = urls;
 };

--- a/test/spec/ol/source/xyzsource.test.js
+++ b/test/spec/ol/source/xyzsource.test.js
@@ -115,6 +115,61 @@ describe('ol.source.XYZ', function() {
 
   });
 
+  describe('#getUrls', function() {
+
+    var sourceOptions;
+    var source;
+    var url = 'http://geo.nls.uk/maps/towns/glasgow1857/{z}/{x}/{-y}.png';
+
+    beforeEach(function() {
+      sourceOptions = {
+        projection: 'EPSG:4326'
+      };
+    });
+
+    describe('using a "url" option', function() {
+      beforeEach(function() {
+        sourceOptions.url = url;
+        source = new ol.source.XYZ(sourceOptions);
+      });
+
+      it('returns the XYZ URL', function() {
+        var urls = source.getUrls();
+        expect(urls).to.be.eql([url]);
+      });
+
+    });
+
+    describe('using a "urls" option', function() {
+      beforeEach(function() {
+        sourceOptions.urls = ['some_xyz_url1', 'some_xyz_url2'];
+        source = new ol.source.XYZ(sourceOptions);
+      });
+
+      it('returns the XYZ URLs', function() {
+        var urls = source.getUrls();
+        expect(urls).to.be.eql(['some_xyz_url1', 'some_xyz_url2']);
+      });
+
+    });
+
+    describe('using a "tileUrlFunction"', function() {
+      beforeEach(function() {
+        sourceOptions.tileUrlFunction = function() {
+          return 'some_xyz_url';
+        };
+        source = new ol.source.XYZ(sourceOptions);
+      });
+
+      it('returns null', function() {
+        var urls = source.getUrls();
+        expect(urls).to.be(null);
+      });
+
+    });
+
+  });
+
 });
 
 goog.require('ol.TileCoord');


### PR DESCRIPTION
added the `getUrls` method to get access to the `url` / `urls` property.
When using a `tileUrlFunction`, `getUrls` should return `null`.
This should fix issue #3886