### PR TITLE
Make ol.has.* not depend on ol.ENABLE_*

### DIFF
--- a/src/ol/has.js
+++ b/src/ol/has.js
@@ -78,7 +78,7 @@ ol.has.GEOLOCATION = 'geolocation' in goog.global.navigator;
  * @type {boolean}
  * @api stable
  */
-ol.has.TOUCH = ol.ASSUME_TOUCH || 'ontouchstart' in goog.global;
+ol.has.TOUCH = 'ontouchstart' in goog.global;
 
 
 /**

--- a/src/ol/has.js
+++ b/src/ol/has.js
@@ -30,7 +30,7 @@ ol.has.CANVAS_LINE_DASH = false;
  * @type {boolean}
  * @api stable
  */
-ol.has.CANVAS = ol.ENABLE_CANVAS && (
+ol.has.CANVAS = (
     /**
      * @return {boolean} Canvas supported.
      */

--- a/src/ol/has.js
+++ b/src/ol/has.js
@@ -115,28 +115,26 @@ ol.has.WEBGL;
 
 
 (function() {
-  if (ol.ENABLE_WEBGL) {
-    var hasWebGL = false;
-    var textureSize;
-    var /** @type {Array.<string>} */ extensions = [];
+  var hasWebGL = false;
+  var textureSize;
+  var /** @type {Array.<string>} */ extensions = [];
 
-    if ('WebGLRenderingContext' in goog.global) {
-      try {
-        var canvas = /** @type {HTMLCanvasElement} */
-            (goog.dom.createElement(goog.dom.TagName.CANVAS));
-        var gl = ol.webgl.getContext(canvas, {
-          failIfMajorPerformanceCaveat: true
-        });
-        if (!goog.isNull(gl)) {
-          hasWebGL = true;
-          textureSize = /** @type {number} */
-              (gl.getParameter(gl.MAX_TEXTURE_SIZE));
-          extensions = gl.getSupportedExtensions();
-        }
-      } catch (e) {}
-    }
-    ol.has.WEBGL = hasWebGL;
-    ol.WEBGL_EXTENSIONS = extensions;
-    ol.WEBGL_MAX_TEXTURE_SIZE = textureSize;
+  if ('WebGLRenderingContext' in goog.global) {
+    try {
+      var canvas = /** @type {HTMLCanvasElement} */
+          (goog.dom.createElement(goog.dom.TagName.CANVAS));
+      var gl = ol.webgl.getContext(canvas, {
+        failIfMajorPerformanceCaveat: true
+      });
+      if (!goog.isNull(gl)) {
+        hasWebGL = true;
+        textureSize = /** @type {number} */
+            (gl.getParameter(gl.MAX_TEXTURE_SIZE));
+        extensions = gl.getSupportedExtensions();
+      }
+    } catch (e) {}
   }
+  ol.has.WEBGL = hasWebGL;
+  ol.WEBGL_EXTENSIONS = extensions;
+  ol.WEBGL_MAX_TEXTURE_SIZE = textureSize;
 })();

--- a/src/ol/has.js
+++ b/src/ol/has.js
@@ -64,14 +64,6 @@ ol.has.DEVICE_ORIENTATION = 'DeviceOrientationEvent' in goog.global;
 
 
 /**
- * True if browser supports DOM.
- * @const
- * @type {boolean}
- */
-ol.has.DOM = ol.ENABLE_DOM;
-
-
-/**
  * Is HTML5 geolocation supported in the current browser?
  * @const
  * @type {boolean}

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -266,7 +266,7 @@ ol.Map = function(options) {
   this.viewport_.style.height = '100%';
   // prevent page zoom on IE >= 10 browsers
   this.viewport_.style.msTouchAction = 'none';
-  if (ol.has.TOUCH) {
+  if (ol.ASSUME_TOUCH || ol.has.TOUCH) {
     goog.dom.classlist.add(this.viewport_, 'ol-touch');
   }
 

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -1534,10 +1534,8 @@ ol.Map.createOptionsInternal = function(options) {
         break;
       }
     } else if (ol.ENABLE_DOM && rendererType == ol.RendererType.DOM) {
-      if (ol.has.DOM) {
-        rendererConstructor = ol.renderer.dom.Map;
-        break;
-      }
+      rendererConstructor = ol.renderer.dom.Map;
+      break;
     } else if (ol.ENABLE_WEBGL && rendererType == ol.RendererType.WEBGL) {
       if (ol.has.WEBGL) {
         rendererConstructor = ol.renderer.webgl.Map;

--- a/src/ol/pointer/pointereventhandler.js
+++ b/src/ol/pointer/pointereventhandler.js
@@ -96,7 +96,7 @@ ol.pointer.PointerEventHandler.prototype.registerSources = function() {
     var mouseSource = new ol.pointer.MouseSource(this);
     this.registerSource('mouse', mouseSource);
 
-    if (ol.has.TOUCH) {
+    if (ol.ASSUME_TOUCH || ol.has.TOUCH) {
       this.registerSource('touch',
           new ol.pointer.TouchSource(this, mouseSource));
     }


### PR DESCRIPTION
With this PR `ol.has.WEBGL` does not depend on the value of the `ol.ENABLE_WEBGL` define variable. Same for `ol.has.CANVAS`, `ol.has.DOM` (which I completely removed) and `ol.has.TOUCH`.

`ol.has` is about the capabilities of the browser, so it doesn't make sense that variables set in `ol.has` depend on compilation settings (`@define`).

For example, currently, a custom build with `ol.ENABLE_WEBGL` set to `false` will have `ol.has.WEBGL` set to `false` as well, even if the browser does support WebGL. And if the user also generates a debug build (with no `compile` section in the json config) then `ol.ENABLE_WEBGL` will be `true` and `ol.has.WEBGL`  will be `false` only if the browser does not support WebGL. This PR fixes that inconsistency issue.

With `ol.ENABLE_WEBGL` set to `false` the build is slightly bigger with my changes (131660 bytes versus 131841 bytes compressed, see below). This is because, with my changes, the build always includes the code that tests whether the browser supports WebGL.

Please review.

----

Full build size with `ol.ENABLE_WEBGL` and `ol.ENABLE_DOM` set to `false`. First is `master` branch. Second is `has` branch.

```bash
[wrk12 ol3 (master *$% u+1196)]$ make build/ol.js
node tasks/build.js config/ol.json build/ol.js
info ol Parsing dependencies
info ol Compiling 356 sources
uncompressed: 441277 bytes
  compressed: 131660 bytes
``` 

```bash
[wrk12 ol3 (has *$%)]$ make build/ol.js
node tasks/build.js config/ol.json build/ol.js
info ol Parsing dependencies
info ol Compiling 356 sources
uncompressed: 441523 bytes
  compressed: 131841 bytes
```