### PR TITLE
Do not overwrite projections in the registry simply by using `new ol.proj.Projection()`

### DIFF
--- a/src/ol/proj/proj.js
+++ b/src/ol/proj/proj.js
@@ -141,8 +141,10 @@ ol.proj.Projection = function(options) {
    */
   this.defaultTileGrid_ = null;
 
-  if (ol.ENABLE_PROJ4JS && typeof proj4 == 'function') {
-    var code = options.code;
+  var projections = ol.proj.projections_;
+  var code = options.code;
+  if (ol.ENABLE_PROJ4JS && typeof proj4 == 'function' &&
+      !goog.isDef(projections[code])) {
     var def = proj4.defs(code);
     if (goog.isDef(def)) {
       if (goog.isDef(def.axis) && !goog.isDef(options.axisOrientation)) {
@@ -158,7 +160,6 @@ ol.proj.Projection = function(options) {
         }
         this.units_ = units;
       }
-      var projections = ol.proj.projections_;
       var currentCode, currentDef, currentProj, proj4Transform;
       for (currentCode in projections) {
         currentDef = proj4.defs(currentCode);

--- a/test/spec/ol/proj/proj.test.js
+++ b/test/spec/ol/proj/proj.test.js
@@ -299,6 +299,16 @@ describe('ol.proj', function() {
       }
     });
 
+    it('does not overwrite existing projections in the registry', function() {
+      var epsg4326 = ol.proj.get('EPSG:4326');
+      new ol.proj.Projection({
+        code: 'EPSG:4326',
+        units: 'degrees',
+        extent: [-45, -45, 45, 45]
+      });
+      expect(ol.proj.get('EPSG:4326')).to.equal(epsg4326);
+    });
+
   });
 
   describe('ol.proj.getTransformFromProjections()', function() {


### PR DESCRIPTION
When proj4js is loaded, creating a projection with a SRS code that is already registered will cause the existing projection in the registry to be overwritten. This can become a problem e.g. when someone creates a projection object with a custom extent for use it in a specific context. That projection object with its custom extent would be set in the registry, causing it to be returned whenever `ol.proj.get()` is used with its SRS code.