### PR TITLE
Fix rotate buttons in animation example

### DIFF
--- a/examples/animation.html
+++ b/examples/animation.html
@@ -14,8 +14,8 @@ tags: "animation"
 </div>
 <div class="row-fluid">
   <div class="span12">
-    <button id="rotate-left"><i class="icon-arrow-left"></i></button>
-    <button id="rotate-right"><i class="icon-arrow-right"></i></button>
+    <button id="rotate-left" title="Rotate clockwise">↻</button>
+    <button id="rotate-right" title="Rotate counterclockwise">↺</button>
     <button id="rotate-around-rome">Rotate around Rome</button>
     <button id="pan-to-london">Pan to London</button>
     <button id="elastic-to-moscow">Elastic to Moscow</button>


### PR DESCRIPTION
The [animation-example](http://openlayers.org/en/v3.8.2/examples/animation.html) does not show icons for the rotate-buttons.

This PR suggests using two unicode characters for these buttons: [↻](http://www.fileformat.info/info/unicode/char/21bb/index.htm) and [↺](http://www.fileformat.info/info/unicode/char/21ba/index.htm).

I also added a `title`-attribute to the buttons.

* Before: 
![before](https://cloud.githubusercontent.com/assets/227934/9355947/b5994638-467d-11e5-983c-ec7976dce373.png)

* After:
![after](https://cloud.githubusercontent.com/assets/227934/9355949/b935f124-467d-11e5-8276-21298ded903f.png)

