### PR TITLE
Correct documentation for ol.FeatureStyleFunction

### DIFF
--- a/src/ol/feature.js
+++ b/src/ol/feature.js
@@ -283,8 +283,9 @@ ol.Feature.prototype.setGeometryName = function(name) {
 
 
 /**
- * A function that returns a style given a resolution. The `this` keyword inside
- * the function references the {@link ol.Feature} to be styled.
+ * A function that returns an array of {@link ol.style.Style styles} given a
+ * resolution. The `this` keyword inside the function references the
+ * {@link ol.Feature} to be styled.
  *
  * @typedef {function(this: ol.Feature, number): Array.<ol.style.Style>}
  * @api stable


### PR DESCRIPTION
Any `ol.FeatureStyleFunction` should return an array of styles, not a single style. The docs should be better here.

**Before:**

![before](https://cloud.githubusercontent.com/assets/227934/9379282/6f6a4008-4728-11e5-84bd-82521094e7b6.png)

**After**

![after](https://cloud.githubusercontent.com/assets/227934/9379285/75b9ae58-4728-11e5-9e10-cfe996a3b3de.png)