### PR TITLE
Fix modify interaction event order

### DIFF
--- a/test/spec/ol/interaction/modifyinteraction.test.js
+++ b/test/spec/ol/interaction/modifyinteraction.test.js
@@ -156,13 +156,13 @@ describe('ol.interaction.Modify', function() {
       map.addInteraction(modify);
 
       var first = features[0];
-      var second = features[0];
+      var second = features[1];
 
       events = trackEvents(first, modify);
 
       expect(first.getGeometry().getRevision()).to.equal(1);
       expect(first.getGeometry().getCoordinates()[0]).to.have.length(5);
-      expect(second.getGeometry().getRevision()).to.equal(1);
+      expect(second.getGeometry().getRevision()).to.equal(2);
       expect(second.getGeometry().getCoordinates()[0]).to.have.length(5);
 
       simulateEvent('pointerdown', 10, -20, false, 0);
@@ -172,7 +172,7 @@ describe('ol.interaction.Modify', function() {
 
       expect(first.getGeometry().getRevision()).to.equal(2);
       expect(first.getGeometry().getCoordinates()[0]).to.have.length(4);
-      expect(second.getGeometry().getRevision()).to.equal(2);
+      expect(second.getGeometry().getRevision()).to.equal(3);
       expect(second.getGeometry().getCoordinates()[0]).to.have.length(4);
 
       validateEvents(events, features);

--- a/test/spec/ol/interaction/modifyinteraction.test.js
+++ b/test/spec/ol/interaction/modifyinteraction.test.js
@@ -78,6 +78,59 @@ describe('ol.interaction.Modify', function() {
     map.handleMapBrowserEvent(event);
   }
 
+  /**
+   * Tracks events triggered by the interaction as well as feature
+   * modifications. Helper function to
+   * @param {ol.Feature} feature Modified feature.
+   * @param {ol.interaction.Modify} interaction
+   * @return {Array<ol.ModifyEvent|string>} events
+   */
+  function trackEvents(feature, interaction) {
+    var events = [];
+    feature.on('change', function(event) {
+      events.push('change');
+    });
+    interaction.on('modifystart', function(event) {
+      events.push(event);
+    });
+    interaction.on('modifyend', function(event) {
+      events.push(event);
+    });
+    return events;
+  }
+
+  /**
+  * Validates the event array to verify proper event sequence. Checks
+  * that first and last event are correct ModifyEvents and that feature
+  * modifications event are in between.
+  * @param {Array<ol.ModifyEvent|string>} event
+  * @param {Array<ol.Feature>} features
+  */
+  function validateEvents(events, features) {
+
+    var startevent = events[0];
+    var endevent = events[events.length - 1];
+
+    // first event should be modifystary
+    expect(startevent).to.be.an(ol.ModifyEvent);
+    expect(startevent.type).to.eql('modifystart');
+
+    // last event should be modifyend
+    expect(endevent).to.be.an(ol.ModifyEvent);
+    expect(endevent.type).to.eql('modifyend');
+
+    // make sure we get change events to events array
+    expect(events.length > 2).to.be(true);
+    // middle events should be feature modification events
+    for (var i = 1; i < events.length - 2; i++) {
+      expect(events[i]).to.equal('change');
+    }
+
+    // ModifyEvents should include the expected features
+    expect(startevent.features.getArray()).to.eql(features);
+    expect(endevent.features.getArray()).to.eql(features);
+  }
+
   describe('constructor', function() {
     it('adds features to the RTree', function() {
       var feature = new ol.Feature(
@@ -105,6 +158,8 @@ describe('ol.interaction.Modify', function() {
       var first = features[0];
       var second = features[0];
 
+      events = trackEvents(first, modify);
+
       expect(first.getGeometry().getRevision()).to.equal(1);
       expect(first.getGeometry().getCoordinates()[0]).to.have.length(5);
       expect(second.getGeometry().getRevision()).to.equal(1);
@@ -119,20 +174,27 @@ describe('ol.interaction.Modify', function() {
       expect(first.getGeometry().getCoordinates()[0]).to.have.length(4);
       expect(second.getGeometry().getRevision()).to.equal(2);
       expect(second.getGeometry().getCoordinates()[0]).to.have.length(4);
+
+      validateEvents(events, features);
     });
 
   });
 
   describe('boundary modification', function() {
+    var modify, feature, events;
 
-    it('clicking vertex should delete it and +r1', function() {
-      var modify = new ol.interaction.Modify({
+    beforeEach(function() {
+      modify = new ol.interaction.Modify({
         features: new ol.Collection(features)
       });
       map.addInteraction(modify);
 
-      var feature = features[0];
+      feature = features[0];
 
+      events = trackEvents(feature, modify);
+    });
+
+    it('clicking vertex should delete it and +r1', function() {
       expect(feature.getGeometry().getRevision()).to.equal(1);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(5);
 
@@ -143,16 +205,11 @@ describe('ol.interaction.Modify', function() {
 
       expect(feature.getGeometry().getRevision()).to.equal(2);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(4);
+
+      validateEvents(events, [feature]);
     });
 
     it('single clicking boundary should add vertex and +r1', function() {
-      var modify = new ol.interaction.Modify({
-        features: new ol.Collection(features)
-      });
-      map.addInteraction(modify);
-
-      var feature = features[0];
-
       expect(feature.getGeometry().getRevision()).to.equal(1);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(5);
 
@@ -163,16 +220,11 @@ describe('ol.interaction.Modify', function() {
 
       expect(feature.getGeometry().getRevision()).to.equal(2);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(6);
+
+      validateEvents(events, [feature]);
     });
 
     it('single clicking on created vertex should delete it again', function() {
-      var modify = new ol.interaction.Modify({
-        features: new ol.Collection(features)
-      });
-      map.addInteraction(modify);
-
-      var feature = features[0];
-
       expect(feature.getGeometry().getRevision()).to.equal(1);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(5);
 
@@ -183,6 +235,9 @@ describe('ol.interaction.Modify', function() {
 
       expect(feature.getGeometry().getRevision()).to.equal(2);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(6);
+
+      validateEvents(events, [feature]);
+      events.length = 0;
 
       simulateEvent('pointerdown', 40, -20, false, 0);
       simulateEvent('pointerup', 40, -20, false, 0);
@@ -191,16 +246,11 @@ describe('ol.interaction.Modify', function() {
 
       expect(feature.getGeometry().getRevision()).to.equal(3);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(5);
+
+      validateEvents(events, [feature]);
     });
 
     it('clicking with drag should add vertex and +r3', function() {
-      var modify = new ol.interaction.Modify({
-        features: new ol.Collection(features)
-      });
-      map.addInteraction(modify);
-
-      var feature = features[0];
-
       expect(feature.getGeometry().getRevision()).to.equal(1);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(5);
 
@@ -212,19 +262,28 @@ describe('ol.interaction.Modify', function() {
 
       expect(feature.getGeometry().getRevision()).to.equal(4);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(6);
+
+      validateEvents(events, [feature]);
     });
   });
 
   describe('double click deleteCondition', function() {
 
-    it('should delete vertex on double click', function() {
-      var modify = new ol.interaction.Modify({
+    var modify, feature, events;
+
+    beforeEach(function() {
+      modify = new ol.interaction.Modify({
         features: new ol.Collection(features),
         deleteCondition: ol.events.condition.doubleClick
       });
       map.addInteraction(modify);
 
-      var feature = features[0];
+      feature = features[0];
+
+      events = trackEvents(feature, modify);
+    });
+
+    it('should delete vertex on double click', function() {
 
       expect(feature.getGeometry().getRevision()).to.equal(1);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(5);
@@ -239,16 +298,11 @@ describe('ol.interaction.Modify', function() {
 
       expect(feature.getGeometry().getRevision()).to.equal(2);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(4);
+
+      validateEvents(events, features);
     });
 
     it('should do nothing on single click', function() {
-      var modify = new ol.interaction.Modify({
-        features: new ol.Collection(features),
-        deleteCondition: ol.events.condition.doubleClick
-      });
-      map.addInteraction(modify);
-
-      var feature = features[0];
 
       expect(feature.getGeometry().getRevision()).to.equal(1);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(5);
@@ -260,6 +314,8 @@ describe('ol.interaction.Modify', function() {
 
       expect(feature.getGeometry().getRevision()).to.equal(1);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(5);
+
+      expect(events.length).to.eql(0);
     });
   });
 


### PR DESCRIPTION
`ol.interaction.Modify` emits `modifystart` and `modifyend` events. However, the timing of the events are not what would be expected.

Currently, the `modifystart` event is triggered at the `pointerdown` event (when on a feature). If the click is on a boundary (not a vertex), the down event also creates a new vertex. The `modifystart` event is triggered just after any new vertex is added. This PR changes this, so that the `modifystart` event is emitted before the geometries are modified. This event will be unchanged by this PR, except for the timing.

The `modifyend` event is currently triggered on the `pointerup` event, after the last drag event is handled. However, any potential vertex deletion is generally handled on the `click` events, after the `modifyend` has already been triggered. With this PR, the `modifyend` is not trigger until all geometry changes are done, including vertex deletions. A part from the timing, this PR will cause the `modifyend` to not always reference a `pointerup` event as it's `mapBrowserPointerEvent` attribute. If any vertex is deleted, the `modifyend` event will reference the event which triggered the deletion (generally a `click`, `singleclick` or `doubleclick`).

Fixes https://github.com/openlayers/ol3/issues/4022
