### PR TITLE
Don't install python packages in before_install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ env:
   - DISPLAY=:99.0
 
 before_install:
-  - "pip install -r requirements.txt"
   - "npm install -g npm && npm install"
 
 before_script:


### PR DESCRIPTION
Travis already installs the packages by default.
See http://docs.travis-ci.com/user/languages/python/#Travis-CI-uses-pip