### PR TITLE
Add ol.interaction.Draw#continueDrawing

### DIFF
--- a/src/ol/interaction/drawinteraction.js
+++ b/src/ol/interaction/drawinteraction.js
@@ -715,6 +715,33 @@ ol.interaction.Draw.prototype.abortDrawing_ = function() {
 
 
 /**
+ * Extend an existing geometry by adding additional points. This only works
+ * on features with `LineString` geometries, where the interaction will
+ * extend lines by adding points to the end of the coordinates array.
+ * @param {!ol.Feature} feature Feature to be extended.
+ * @api
+ */
+ol.interaction.Draw.prototype.extend = function(feature) {
+  var geometry = feature.getGeometry();
+  goog.asserts.assert(this.mode_ == ol.interaction.DrawMode.LINE_STRING,
+      'interaction mode must be "line"');
+  goog.asserts.assert(goog.isDefAndNotNull(geometry),
+      'feature must have a geometry');
+  goog.asserts.assert(geometry.getType() == ol.geom.GeometryType.LINE_STRING,
+      'feature geometry must be a line string');
+  var lineString = /** @type {ol.geom.LineString} */ (geometry);
+  this.sketchFeature_ = feature;
+  this.sketchCoords_ = lineString.getCoordinates();
+  var last = this.sketchCoords_[this.sketchCoords_.length - 1];
+  this.finishCoordinate_ = last.slice();
+  this.sketchCoords_.push(last.slice());
+  this.updateSketchFeatures_();
+  this.dispatchEvent(new ol.interaction.DrawEvent(
+      ol.interaction.DrawEventType.DRAWSTART, this.sketchFeature_));
+};
+
+
+/**
  * @inheritDoc
  */
 ol.interaction.Draw.prototype.shouldStopEvent = goog.functions.FALSE;

--- a/test/spec/ol/interaction/drawinteraction.test.js
+++ b/test/spec/ol/interaction/drawinteraction.test.js
@@ -781,12 +781,43 @@ describe('ol.interaction.Draw', function() {
       expect(coordinates[0][0][1]).to.roughlyEqual(20, 1e-9);
     });
   });
+
+  describe('extend an existing feature', function() {
+    var draw;
+    var feature;
+
+    beforeEach(function() {
+      draw = new ol.interaction.Draw({
+        source: source,
+        type: ol.geom.GeometryType.LINE_STRING
+      });
+      map.addInteraction(draw);
+      feature = new ol.Feature(
+          new ol.geom.LineString([[0, 0], [1, 1], [2, 0]]));
+    });
+
+    it('sets the initial state', function() {
+      draw.extend(feature);
+      expect(draw.sketchCoords_).to.have.length(4);
+      expect(draw.sketchCoords_).to.eql([[0, 0], [1, 1], [2, 0], [2, 0]]);
+      expect(draw.finishCoordinate_).to.eql([2, 0]);
+    });
+
+    it('dispatches a drawstart event', function() {
+      var spy = sinon.spy();
+      goog.events.listen(draw, ol.interaction.DrawEventType.DRAWSTART, spy);
+      draw.extend(feature);
+      expect(spy.callCount).to.be(1);
+    });
+
+  });
 });
 
 goog.require('goog.dispose');
 goog.require('goog.events');
 goog.require('goog.events.BrowserEvent');
 goog.require('goog.style');
+goog.require('ol.Feature');
 goog.require('ol.Map');
 goog.require('ol.MapBrowserPointerEvent');
 goog.require('ol.View');


### PR DESCRIPTION
This commit adds a `continueDrawing` method to the draw interaction. This method makes it possible to continue the drawing a line string feature. It only works on line string features, where this functionality makes the most sense.

Here's an example on how to use `continueDrawing` to continue drawing a feature:

```js
var vectorSource = vectorLayer.getSource();
vectroSource.removeFeature(feature);
drawInteraction.continueDrawing(feature);
```