### PR TITLE
Add parser for dimension property from WMTS Capabilities.xml

### DIFF
--- a/src/ol/format/wmtscapabilitiesformat.js
+++ b/src/ol/format/wmtscapabilitiesformat.js
@@ -160,6 +160,18 @@ ol.format.WMTSCapabilities.readTileMatrixSetLink_ = function(node,
  * @private
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
+ * @return {Object|undefined} Dimension object.
+ */
+ol.format.WMTSCapabilities.readDimensions_ = function(node, objectStack) {
+  return ol.xml.pushParseAndPop({},
+      ol.format.WMTSCapabilities.DIMENSION_PARSERS_, node, objectStack);
+};
+
+
+/**
+ * @private
+ * @param {Node} node Node.
+ * @param {Array.<*>} objectStack Object stack.
  * @return {Object|undefined} Resource URL object.
  */
 ol.format.WMTSCapabilities.readResourceUrl_ = function(node, objectStack) {
@@ -303,6 +315,8 @@ ol.format.WMTSCapabilities.LAYER_PARSERS_ = ol.xml.makeStructureNS(
           ol.format.XSD.readString),
       'TileMatrixSetLink': ol.xml.makeObjectPropertyPusher(
           ol.format.WMTSCapabilities.readTileMatrixSetLink_),
+      'Dimension': ol.xml.makeObjectPropertyPusher(
+          ol.format.WMTSCapabilities.readDimensions_),
       'ResourceURL': ol.xml.makeObjectPropertyPusher(
           ol.format.WMTSCapabilities.readResourceUrl_)
     }, ol.xml.makeStructureNS(ol.format.WMTSCapabilities.OWS_NAMESPACE_URIS_, {
@@ -344,6 +358,23 @@ ol.format.WMTSCapabilities.TMS_LINKS_PARSERS_ = ol.xml.makeStructureNS(
       'TileMatrixSet': ol.xml.makeObjectPropertySetter(
           ol.format.XSD.readString)
     });
+
+
+/**
+ * @const
+ * @type {Object.<string, Object.<string, ol.xml.Parser>>}
+ * @private
+ */
+ol.format.WMTSCapabilities.DIMENSION_PARSERS_ = ol.xml.makeStructureNS(
+    ol.format.WMTSCapabilities.NAMESPACE_URIS_, {
+      'Default': ol.xml.makeObjectPropertySetter(
+          ol.format.XSD.readString),
+      'Value': ol.xml.makeObjectPropertyPusher(
+          ol.format.XSD.readString)
+    }, ol.xml.makeStructureNS(ol.format.WMTSCapabilities.OWS_NAMESPACE_URIS_, {
+      'Identifier': ol.xml.makeObjectPropertySetter(
+          ol.format.XSD.readString)
+    }));
 
 
 /**

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -401,12 +401,12 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
   if ('Dimension' in l) {
     l['Dimension'].forEach(function(elt, index, array) {
       var key = elt['Identifier'];
-      var value = elt['default'];
+      var value = elt['Default'];
       if (value !== undefined) {
-        goog.asserts.assert(ol.array.includes(elt['values'], value),
+        goog.asserts.assert(ol.array.includes(elt['Value'], value),
             'default value contained in values');
       } else {
-        value = elt['values'][0];
+        value = elt['Value'][0];
       }
       goog.asserts.assert(value !== undefined, 'value could be found');
       dimensions[key] = value;

--- a/test/spec/ol/format/wmts/ogcsample.xml
+++ b/test/spec/ol/format/wmts/ogcsample.xml
@@ -94,6 +94,12 @@ access interface to some TileMatrixSets</ows:Abstract>
 			</TileMatrixSetLink>
 			<ResourceURL format="image/png" resourceType="tile" template="http://www.example.com/wmts/coastlines/{TileMatrix}/{TileRow}/{TileCol}.png"/>
 			<ResourceURL format="application/gml+xml; version=3.1" resourceType="FeatureInfo" template="http://www.example.com/wmts/coastlines/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}/{J}/{I}.xml"/>
+                        <Dimension>
+                                <ows:Identifier>Time</ows:Identifier>
+                                <Default>20110805</Default>
+                                <Value>20110805</Value>
+                                <Value>20081024</Value>
+                        </Dimension>
 		</Layer>
 		<TileMatrixSet>
 			<!-- -180 85.05112878 -->

--- a/test/spec/ol/format/wmtscapabilitiesformat.test.js
+++ b/test/spec/ol/format/wmtscapabilitiesformat.test.js
@@ -29,6 +29,15 @@ describe('ol.format.WMTSCapabilities', function() {
       expect(layer.Identifier).to.be.eql('BlueMarbleNextGeneration');
       expect(layer.Title).to.be.eql('Blue Marble Next Generation');
 
+      expect(layer.Dimension).to.be.an('array');
+      expect(layer.Dimension).to.have.length(1);
+      expect(layer.Dimension[0]).to.be.an('object');
+      expect(layer.Dimension[0].Identifier).to.be.eql('Time');
+      expect(layer.Dimension[0].Default).to.be.eql('20110805');
+      expect(layer.Dimension[0].Value).to.be.an('array');
+      expect(layer.Dimension[0].Value).to.have.length(2);
+      expect(layer.Dimension[0].Value[0]).to.be.eql('20110805');
+
       expect(layer.Format).to.be.an('array');
       expect(layer.Format).to.have.length(2);
       expect(layer.Format[0]).to.be.eql('image/jpeg');

--- a/test/spec/ol/source/wmtssource.test.js
+++ b/test/spec/ol/source/wmtssource.test.js
@@ -42,7 +42,7 @@ describe('ol.source.WMTS', function() {
 
           expect(options.style).to.be.eql('DarkBlue');
 
-          expect(options.dimensions).to.eql({});
+          expect(options.dimensions).to.eql({Time: '20110805'});
 
         });
 
@@ -73,7 +73,7 @@ describe('ol.source.WMTS', function() {
 
           expect(options.style).to.be.eql('DarkBlue');
 
-          expect(options.dimensions).to.eql({});
+          expect(options.dimensions).to.eql({Time: '20110805'});
 
         });
 


### PR DESCRIPTION
This add the possibility to parse the Dimension section of a WMTS Capabilities.xml with OpenLayers. I have a small question regarding tests: currently none of your xml used for testing have such a section. Should I add one with for instance:

```xml
<Dimension>
    <ows:Identifier>Time</ows:Identifier>
    <Default>20110805</Default>
    <Value>20110805</Value>
    <Value>20081024</Value>
</Dimension>
```

Or are these xml real xml from a server that shouldn't be modified?