### PR TITLE
Move wrench node package to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "pixelworks": "1.0.0",
     "rbush": "1.3.5",
     "temp": "0.8.1",
-    "walk": "2.3.4",
-    "wrench": "1.5.8"
+    "walk": "2.3.4"
   },
   "devDependencies": {
     "clean-css": "2.2.16",
@@ -59,7 +58,8 @@
     "proj4": "2.3.6",
     "resemblejs": "1.2.0",
     "sinon": "1.10.3",
-    "slimerjs-edge": "0.10.0-pre-2"
+    "slimerjs-edge": "0.10.0-pre-2",
+    "wrench": "1.5.8"
   },
   "ext": [
     "rbush",


### PR DESCRIPTION
This package is only used by tasks/test-coverage.js (code coverage with istanbul)

Fixes #4048