### PR TITLE
Clarify drag interaction example to inform about ol.interaction.Translate

### DIFF
--- a/examples/drag-features.html
+++ b/examples/drag-features.html
@@ -1,10 +1,11 @@
 ---
 template: example.html
-title: Drag features example
-shortdesc: Example of a drag features interaction.
+title: Custom interaction example
+shortdesc: Example of a custom drag features interaction.
 docs: >
-  The drag features interaction can be used to drag features to a new position.
-tags: "drag, feature, vector, editing"
+  This example demonstrates using a custom interaction with OpenLayers, by subclassing `ol.interaction.Pointer`.
+  Note that the built in interaction `ol.interaction.Translate` might be a better option for moving features.
+tags: "drag, feature, vector, editing, custom, interaction"
 ---
 <div class="row-fluid">
   <div class="span12">


### PR DESCRIPTION
The example http://openlayers.org/en/v3.8.2/examples/drag-features.html is more or less a duplicate of ol.interaction.Translate from https://github.com/openlayers/ol3/pull/4008

Ideally, the example should probably be replaced by an example of using a custom interaction that is not implemented in the library. This PR only modifies the description, to inform the reader of ol.interaction.Translate and to focus a little bit more about it being a custom interaction than about the actual dragging.