### PR TITLE
Activate unknownDefines compiler check for the examples

### DIFF
--- a/config/example.json
+++ b/config/example.json
@@ -59,11 +59,9 @@
       "typeInvalidation",
       "undefinedNames",
       "undefinedVars",
+      "unknownDefines",
       "uselessCode",
       "visibility"
-    ],
-    "jscomp_off": [
-      "unknownDefines"
     ],
     "extra_annotation_name": [
       "api", "observable"


### PR DESCRIPTION
To have the same checks for all the builds