### PR TITLE
Fix bootstrap class name in examples

### DIFF
--- a/examples/brightness-contrast.html
+++ b/examples/brightness-contrast.html
@@ -10,7 +10,7 @@ tags: "brightness, contrast, webgl"
 <div class="row-fluid">
   <div class="span12">
     <div id="map" class="map"></div>
-    <div id="no-webgl" class="alert alert-error" style="display: none">
+    <div id="no-webgl" class="alert alert-danger" style="display: none">
       This example requires a browser that supports <a href="http://get.webgl.org/">WebGL</a>.
     </div>
     <div class="btn-group">

--- a/examples/export-map.html
+++ b/examples/export-map.html
@@ -9,7 +9,7 @@ tags: "export, png, openstreetmap"
 <div class="row-fluid">
   <div class="span12">
     <div id="map" class="map"></div>
-    <div id="no-download" class="alert alert-error" style="display: none">
+    <div id="no-download" class="alert alert-danger" style="display: none">
       This example requires a browser that supports the
       <a href="http://caniuse.com/#feat=download">link download</a> attribute.
     </div>

--- a/examples/geolocation.html
+++ b/examples/geolocation.html
@@ -10,7 +10,7 @@ tags: "geolocation, openstreetmap"
   <div class="span12">
     <div id="map" class="map"></div>
     <div class="span4 pull-right">
-      <div id="info" class="alert alert-error" style="display: none;"></div>
+      <div id="info" class="alert alert-danger" style="display: none;"></div>
     </div>
     <label class="checkbox" for="track">
       <input id="track" type="checkbox"/>track position

--- a/examples/hue-saturation.html
+++ b/examples/hue-saturation.html
@@ -9,7 +9,7 @@ tags: "custom, control"
 <div class="row-fluid">
   <div class="span12">
     <div id="map" class="map"></div>
-    <div id="no-webgl" class="alert alert-error" style="display: none">
+    <div id="no-webgl" class="alert alert-danger" style="display: none">
       This example requires a browser that supports <a href="http://get.webgl.org/">WebGL</a>.
     </div>
     <div class="btn-group">

--- a/examples/layer-clipping-webgl.html
+++ b/examples/layer-clipping-webgl.html
@@ -11,6 +11,6 @@ tags: "clipping, webgl, openstreetmap"
     <div id="map" class="map"></div>
   </div>
 </div>
-<div id="no-webgl" class="alert alert-error" style="display: none">
+<div id="no-webgl" class="alert alert-danger" style="display: none">
   This example requires a browser that supports <a href="http://get.webgl.org/">WebGL</a>.
 </div>

--- a/examples/side-by-side.html
+++ b/examples/side-by-side.html
@@ -14,7 +14,7 @@ tags: "side-by-side, canvas, webgl, dom, canvas, sync, object"
   <div class="span4">
     <h4>WebGL</h4>
     <div id="webglMap" class="map"></div>
-    <div id="no-webgl" class="alert alert-error" style="display: none">
+    <div id="no-webgl" class="alert alert-danger" style="display: none">
       This map requires a browser that supports <a href="http://get.webgl.org/">WebGL</a>.
     </div>
   </div>


### PR DESCRIPTION
`alert-error` was renamed to `alert-danger`