### PR TITLE
Make the debug server work regardless of the current working directory

### DIFF
--- a/tasks/serve-lib.js
+++ b/tasks/serve-lib.js
@@ -22,7 +22,8 @@ var createServer = exports.createServer = function(callback) {
     lib: [
       'src/**/*.js',
       'build/ol.ext/*.js',
-    ]
+    ],
+    cwd: path.join(__dirname, '..')
   });
   manager.on('error', function(err) {
     if (server) {


### PR DESCRIPTION
With this change, you can run `serve-lib.js` from any directory, and it will provide a debug loader for the OpenLayers source files.  In addition, it will provide a static server for files in the current working directory.  This combination provides a zero config debug server for developing with the library (and is required for the workshop changes I'm making).
