### PR TITLE
Update to closure-util 1.7.0

### DIFF
--- a/externs/closure-compiler.js
+++ b/externs/closure-compiler.js
@@ -30,15 +30,3 @@ Touch.prototype.webkitRadiusX;
 
 /** @type {number} */
 Touch.prototype.webkitRadiusY;
-
-
-
-/**
- * @type {boolean}
- */
-WebGLContextAttributes.prototype.preferLowPowerToHighPerformance;
-
-/**
- * @type {boolean}
- */
-WebGLContextAttributes.prototype.failIfMajorPerformanceCaveat;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "async": "0.9.0",
     "browserify": "9.0.3",
-    "closure-util": "1.6.1",
+    "closure-util": "1.7.0",
     "fs-extra": "0.12.0",
     "glob": "5.0.3",
     "graceful-fs": "3.0.2",


### PR DESCRIPTION
With this PR we change from closure-util 1.6.1 to 1.7.0. This is to use the latest version of Closure Compiler (v20150729). See https://github.com/openlayers/closure-util/pull/67.