### PR TITLE
Add assertion for required option 'code' on ol.proj.Projection

### DIFF
--- a/src/ol/proj/proj.js
+++ b/src/ol/proj/proj.js
@@ -143,6 +143,8 @@ ol.proj.Projection = function(options) {
 
   var projections = ol.proj.projections_;
   var code = options.code;
+  goog.asserts.assert(goog.isDef(code),
+      'Option "code" is required for constructing instance');
   if (ol.ENABLE_PROJ4JS && typeof proj4 == 'function' &&
       !goog.isDef(projections[code])) {
     var def = proj4.defs(code);


### PR DESCRIPTION
When using proj4js together with ol3 and instantiation of
ol.proj.Projection is made, the `code` property is required.
An empty string is enough though.

The reason can be found in the class ol.proj.Projection, starting in line 145:
https://github.com/openlayers/ol3/blob/master/src/ol/proj/proj.js#L145-L147

```javascript
var code = options.code;
  if (ol.ENABLE_PROJ4JS && typeof proj4 == 'function' &&
      !goog.isDef(projections[code])) {
...
```

Maybe an additional check if `code` is defined would make sense?

Problem can be observed in 
http://openlayers.org/en/master/examples/wms-image-custom-proj.html
by entering 

```javascript
new ol.proj.Projection({
    units: 'pixels'
});
```
in the console.