### PR TITLE
setOpacity of Image undefined

### DIFF
--- a/src/ol/style/imagestyle.js
+++ b/src/ol/style/imagestyle.js
@@ -176,6 +176,7 @@ ol.style.Image.prototype.getSize = goog.abstractMethod;
  * Set the opacity.
  *
  * @param {number} opacity Opacity.
+ * @api
  */
 ol.style.Image.prototype.setOpacity = function(opacity) {
   this.opacity_ = opacity;


### PR DESCRIPTION
V: 3.8.2
In the debug version I can use setOpacity of Image (which sets "opacity_") but in the min version, it's undefined (I have to set "v")

```javascript
ol.style.Image.prototype.setOpacity = function(opacity) {
  this.opacity_ = opacity;
};
```
