### PR TITLE
Update link to workshop

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Documentation
 
-Check out the [hosted examples](http://openlayers.org/en/master/examples/), the [workshop](http://openlayers.org/ol3-workshop/) or [API docs](http://openlayers.org/en/master/apidoc/).
+Check out the [hosted examples](http://openlayers.org/en/master/examples/), the [workshop](http://openlayers.org/workshop/) or [API docs](http://openlayers.org/en/master/apidoc/).
 
 ## Bugs
 

--- a/doc/index.hbs
+++ b/doc/index.hbs
@@ -9,7 +9,7 @@ If you're eager to get your first OpenLayers 3 map on a page, dive into the [qui
 
 For a more in-depth overview of OpenLayers 3 core concepts, check out the [tutorials](tutorials/).
 
-Make sure to also check out the [OpenLayers 3 workshop](../../../ol3-workshop/).
+Make sure to also check out the [OpenLayers 3 workshop](/workshop/).
 
 Find additional reference material in the [API docs](../apidoc).
 


### PR DESCRIPTION
The latest workshop will now be hosted here: http://openlayers.org/workshop/
