### PR TITLE
Fewer circle exports

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -1,5 +1,19 @@
 ## Upgrade notes
 
+### v3.9.0
+
+#### `ol.style.Circle` changes
+
+The experimental `getAnchor`, `getOrigin`, and `getSize` methods have been removed.  The anchor and origin of a circle symbolizer are not modifiable, so these properties should not need to be accessed.  The radius and stroke width can be used to calculate the rendered size of a circle symbolizer if needed:
+
+```js
+// calculate rendered size of a circle symbolizer
+var width = 2 * circle.getRadius();
+if (circle.getStroke()) {
+  width += circle.getStroke().getWidth() + 1;
+}
+```
+
 ### v3.8.0
 
 There should be nothing special required when upgrading from v3.7.0 to v3.8.0.

--- a/src/ol/style/circlestyle.js
+++ b/src/ol/style/circlestyle.js
@@ -116,7 +116,6 @@ goog.inherits(ol.style.Circle, ol.style.Image);
 
 /**
  * @inheritDoc
- * @api
  */
 ol.style.Circle.prototype.getAnchor = function() {
   return this.anchor_;
@@ -178,7 +177,6 @@ ol.style.Circle.prototype.getHitDetectionImageSize = function() {
 
 /**
  * @inheritDoc
- * @api
  */
 ol.style.Circle.prototype.getOrigin = function() {
   return this.origin_;
@@ -197,7 +195,6 @@ ol.style.Circle.prototype.getRadius = function() {
 
 /**
  * @inheritDoc
- * @api
  */
 ol.style.Circle.prototype.getSize = function() {
   return this.size_;


### PR DESCRIPTION
This removes the experimental `getAnchor`, `getOrigin`, and `getSize` methods from `ol.style.Circle`.  It is not possible to modify a circle's anchor or origin, so it should not be necessary to get these properties.  In addition, these properties and the size were not set until the circle was rendered.