### PR TITLE
Parse nested document tag

### DIFF
--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -1642,6 +1642,7 @@ ol.format.KML.prototype.readDocumentOrFolder_ = function(node, objectStack) {
   // FIXME use scope somehow
   var parsersNS = ol.xml.makeStructureNS(
       ol.format.KML.NAMESPACE_URIS_, {
+        'Document': ol.xml.makeArrayExtender(this.readDocumentOrFolder_, this),
         'Folder': ol.xml.makeArrayExtender(this.readDocumentOrFolder_, this),
         'Placemark': ol.xml.makeArrayPusher(this.readPlacemark_, this),
         'Style': goog.bind(this.readSharedStyle_, this),

--- a/test/spec/ol/format/kmlformat.test.js
+++ b/test/spec/ol/format/kmlformat.test.js
@@ -2102,6 +2102,19 @@ describe('ol.format.KML', function() {
         expect(fs[0]).to.be.an(ol.Feature);
       });
 
+      it('can read a single feature from nested Document', function() {
+        var text =
+            '<Document xmlns="http://earth.google.com/kml/2.2">' +
+            '  <Document>' +
+            '    <Placemark>' +
+            '    </Placemark>' +
+            '  </Document>' +
+            '</Document>';
+        var fs = format.readFeatures(text);
+        expect(fs).to.have.length(1);
+        expect(fs[0]).to.be.an(ol.Feature);
+      });
+
       it('can transform and read a single feature from a Document', function() {
         var text =
             '<Document xmlns="http://earth.google.com/kml/2.2">' +


### PR DESCRIPTION
Minor fix to allow parsing of nested document tag in KML format.