### PR TITLE
Fix drag zoom interaction: Choose proper anchor for zoom

### DIFF
--- a/test/spec/ol/interaction/dragzoominteraction.test.js
+++ b/test/spec/ol/interaction/dragzoominteraction.test.js
@@ -1,0 +1,68 @@
+goog.provide('ol.test.interaction.DragZoom');
+
+describe('ol.interaction.DragZoom', function() {
+
+  describe('constructor', function() {
+
+    it('can be constructed without arguments', function() {
+      var instance = new ol.interaction.DragZoom();
+      expect(instance).to.be.an(ol.interaction.DragZoom);
+    });
+
+  });
+
+  describe('ol.interaction.DragZoom.calculateAnchor', function() {
+
+    it('can calculate central x coordinate', function() {
+      var x = ol.interaction.DragZoom.calculateAnchor(
+          [0, NaN, 1000, NaN],
+          [400, NaN, 600, NaN],
+          0);
+      expect(x).to.eql(500);
+    });
+
+    it('can calculate central y coordinate', function() {
+      var x = ol.interaction.DragZoom.calculateAnchor(
+          [NaN, 0, NaN, 1000],
+          [NaN, 700, NaN, 900],
+          1);
+      expect(x).to.eql(875);
+    });
+
+    it('can handle equal lower extent', function() {
+      var x = ol.interaction.DragZoom.calculateAnchor(
+          [0, NaN, 1000, NaN],
+          [0, NaN, 600, NaN],
+          0);
+      expect(x).to.eql(0);
+    });
+
+    it('can handle equal higher extent', function() {
+      var x = ol.interaction.DragZoom.calculateAnchor(
+          [0, NaN, 1000, NaN],
+          [500, NaN, 1000, NaN],
+          0);
+      expect(x).to.eql(1000);
+    });
+
+    it('can calculate lower region coordinate', function() {
+      var x = ol.interaction.DragZoom.calculateAnchor(
+          [NaN, 0, NaN, 1200],
+          [NaN, 100, NaN, 500],
+          1);
+      expect(x).to.eql(150);
+    });
+
+    it('can calculate lower region coordinate', function() {
+      var x = ol.interaction.DragZoom.calculateAnchor(
+          [NaN, 0, NaN, 1200],
+          [NaN, 700, NaN, 1100],
+          1);
+      expect(x).to.eql(1050);
+    });
+
+  });
+
+});
+
+goog.require('ol.interaction.DragZoom');


### PR DESCRIPTION
Fixes https://github.com/openlayers/ol3/issues/4068

![dragzoom](https://cloud.githubusercontent.com/assets/1712882/9746899/dccbc7dc-567a-11e5-92af-e820cc7f3b7d.gif)

Before this PR, `ol.interaction.DragZoom` chose the proper resolution to zoom to, but always zoomed with the selected extent's center as anchor. This works fine as long as you select areas in the middle of the screen, but will focus om the wrong area when using it closer to the edges.

In this PR, I calculate an anchor which correlates to the selected area's position in the view.