### PR TITLE
Prevent page zoom on IE Edge

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -267,6 +267,7 @@ ol.Map = function(options) {
   this.viewport_.style.height = '100%';
   // prevent page zoom on IE >= 10 browsers
   this.viewport_.style.msTouchAction = 'none';
+  this.viewport_.style.touchAction = 'none';
   if (ol.has.TOUCH) {
     goog.dom.classlist.add(this.viewport_, 'ol-touch');
   }


### PR DESCRIPTION
The deprecated msTouchAction property was removed in IE Edge.

Fixes #4105