### PR TITLE
Use a blackish default for filling texts

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -4241,7 +4241,7 @@ olx.source.ImageMapGuideOptions.prototype.projection;
 
 /**
  * Ratio. `1` means image requests are the size of the map viewport, `2` means
- * twice the width and height of the map viewport, and so on. Must be `1` or 
+ * twice the width and height of the map viewport, and so on. Must be `1` or
  * higher. Default is `1`.
  * @type {number|undefined}
  * @api stable
@@ -4524,7 +4524,7 @@ olx.source.ImageVectorOptions.prototype.projection;
 
 /**
  * Ratio. 1 means canvases are the size of the map viewport, 2 means twice the
- * width and height of the map viewport, and so on. Must be `1` or higher. 
+ * width and height of the map viewport, and so on. Must be `1` or higher.
  * Default is `1.5`.
  * @type {number|undefined}
  * @api
@@ -4708,7 +4708,7 @@ olx.source.ImageWMSOptions.prototype.projection;
 
 /**
  * Ratio. `1` means image requests are the size of the map viewport, `2` means
- * twice the width and height of the map viewport, and so on. Must be `1` or 
+ * twice the width and height of the map viewport, and so on. Must be `1` or
  * higher. Default is `1.5`.
  * @type {number|undefined}
  * @api stable
@@ -6216,7 +6216,7 @@ olx.style.TextOptions.prototype.textBaseline;
 
 
 /**
- * Fill style.
+ * Fill style. If none is provided, we'll use a dark fill-style (#333).
  * @type {ol.style.Fill|undefined}
  * @api
  */

--- a/src/ol/style/textstyle.js
+++ b/src/ol/style/textstyle.js
@@ -1,6 +1,9 @@
 goog.provide('ol.style.Text');
 
 
+goog.require('ol.style.Fill');
+
+
 
 /**
  * @classdesc
@@ -54,7 +57,8 @@ ol.style.Text = function(opt_options) {
    * @private
    * @type {ol.style.Fill}
    */
-  this.fill_ = goog.isDef(options.fill) ? options.fill : null;
+  this.fill_ = goog.isDef(options.fill) ? options.fill :
+      new ol.style.Fill({color: ol.style.Text.DEFAULT_FILL_COLOR_});
 
   /**
    * @private
@@ -74,6 +78,16 @@ ol.style.Text = function(opt_options) {
    */
   this.offsetY_ = goog.isDef(options.offsetY) ? options.offsetY : 0;
 };
+
+
+/**
+ * The default fill color to use if no fill was set at construction time; a
+ * blackish `#333`.
+ *
+ * @const {string}
+ * @private
+ */
+ol.style.Text.DEFAULT_FILL_COLOR_ = '#333';
 
 
 /**

--- a/test/spec/ol/style/textstyle.test.js
+++ b/test/spec/ol/style/textstyle.test.js
@@ -1,0 +1,31 @@
+goog.provide('ol.test.style.Text');
+
+
+describe('ol.style.Text', function() {
+
+  describe('#constructor', function() {
+
+    it('uses a default fill style if none passed', function() {
+      var style = new ol.style.Text();
+      expect(style.getFill().getColor()).to.be('#333');
+    });
+
+    it('uses a provided fill style if one passed', function() {
+      var style = new ol.style.Text({
+        fill: new ol.style.Fill({color: '#123456'})
+      });
+      expect(style.getFill().getColor()).to.be('#123456');
+    });
+
+    it('can always be resetted to no color', function() {
+      var style = new ol.style.Text();
+      style.getFill().setColor();
+      expect(style.getFill().getColor()).to.be(undefined);
+    });
+
+  });
+
+});
+
+goog.require('ol.style.Fill');
+goog.require('ol.style.Text');


### PR DESCRIPTION
This suggests a blackish (`#333333`) default fill for `ol.style.Text` if they are constructed without actually specifying a fill. 

Please review.