### PR TITLE
Remove invalid link to featureOverlay in API doc

### DIFF
--- a/config/jsdoc/api/index.md
+++ b/config/jsdoc/api/index.md
@@ -35,6 +35,5 @@ Interactions for [vector features](ol.Feature.html)
 <td><p>Changes to all [ol.Objects](ol.Object.html) can observed by calling the [object.on('propertychange')](ol.Object.html#on) method.  Listeners receive an [ol.ObjectEvent](ol.ObjectEvent.html) with information on the changed property and old value.</p>
 <td>[ol.DeviceOrientation](ol.DeviceOrientation.html)<br>
 [ol.Geolocation](ol.Geolocation.html)<br>
-[ol.Overlay](ol.Overlay.html)<br>
-[ol.FeatureOverlay](ol.FeatureOverlay.html)<br></td>
+[ol.Overlay](ol.Overlay.html)<br></td>
 </tr></table>


### PR DESCRIPTION
This PR removes a link to the `ol.FeatureOverlay` API documentation. `ol.FeatureOverlay` was removed with release 3.7.0 (see https://github.com/openlayers/ol3/releases/tag/v3.7.0), thus we have an invalid link on the API doc page: http://openlayers.org/en/v3.9.0/apidoc/