### PR TITLE
Remove use of goog.isDef

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -1996,6 +1996,25 @@ olx.format.WFSWriteGetFeatureOptions.prototype.propertyNames;
 
 
 /**
+ * Start index to use for WFS paging. This is a WFS 2.0 feature backported to
+ * WFS 1.1.0 by some Web Feature Services.
+ * @type {number|undefined}
+ * @api
+ */
+olx.format.WFSWriteGetFeatureOptions.prototype.startIndex;
+
+
+/**
+ * Number of features to retrieve when paging. This is a WFS 2.0 feature
+ * backported to WFS 1.1.0 by some Web Feature Services. Please note that some
+ * Web Feature Services have repurposed `maxfeatures` instead.
+ * @type {number|undefined}
+ * @api
+ */
+olx.format.WFSWriteGetFeatureOptions.prototype.count;
+
+
+/**
  * Extent to use for the BBOX filter.
  * @type {ol.Extent|undefined}
  * @api

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -1914,6 +1914,8 @@ olx.format.WFSOptions.prototype.schemaLocation;
  *     maxFeatures: (number|undefined),
  *     geometryName: (string|undefined),
  *     propertyNames: (Array.<string>|undefined),
+ *     startIndex: (number|undefined),
+ *     count: (number|undefined),
  *     bbox: (ol.Extent|undefined)}}
  * @api
  */

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -1291,7 +1291,7 @@ olx.control.ScaleLineOptions.prototype.units;
 /**
  * @typedef {{duration: (number|undefined),
  *     className: (string|undefined),
- *     label: (string|Node|undefined),
+ *     label: (string|Element|undefined),
  *     tipLabel: (string|undefined),
  *     target: (Element|undefined),
  *     render: (function(ol.MapEvent)|undefined),

--- a/src/ol/animation.js
+++ b/src/ol/animation.js
@@ -17,8 +17,7 @@ goog.require('ol.easing');
 ol.animation.bounce = function(options) {
   var resolution = options.resolution;
   var start = options.start ? options.start : goog.now();
-  var duration = ol.isDef(options.duration) ?
-      /** @type {number} */ (options.duration) : 1000;
+  var duration = options.duration !== undefined ? options.duration : 1000;
   var easing = options.easing ?
       options.easing : ol.easing.upAndDown;
   return (
@@ -56,8 +55,7 @@ ol.animation.pan = function(options) {
   var start = options.start ? options.start : goog.now();
   var sourceX = source[0];
   var sourceY = source[1];
-  var duration = ol.isDef(options.duration) ?
-      /** @type {number} */ (options.duration) : 1000;
+  var duration = options.duration !== undefined ? options.duration : 1000;
   var easing = options.easing ?
       options.easing : ol.easing.inAndOut;
   return (
@@ -95,8 +93,7 @@ ol.animation.pan = function(options) {
 ol.animation.rotate = function(options) {
   var sourceRotation = options.rotation ? options.rotation : 0;
   var start = options.start ? options.start : goog.now();
-  var duration = ol.isDef(options.duration) ?
-      /** @type {number} */ (options.duration) : 1000;
+  var duration = options.duration !== undefined ? options.duration : 1000;
   var easing = options.easing ?
       options.easing : ol.easing.inAndOut;
   var anchor = options.anchor ?
@@ -142,8 +139,7 @@ ol.animation.rotate = function(options) {
 ol.animation.zoom = function(options) {
   var sourceResolution = options.resolution;
   var start = options.start ? options.start : goog.now();
-  var duration = ol.isDef(options.duration) ?
-      /** @type {number} */ (options.duration) : 1000;
+  var duration = options.duration !== undefined ? options.duration : 1000;
   var easing = options.easing ?
       options.easing : ol.easing.inAndOut;
   return (

--- a/src/ol/animation.js
+++ b/src/ol/animation.js
@@ -17,7 +17,8 @@ goog.require('ol.easing');
 ol.animation.bounce = function(options) {
   var resolution = options.resolution;
   var start = options.start ? options.start : goog.now();
-  var duration = ol.isDef(options.duration) ? options.duration : 1000;
+  var duration = ol.isDef(options.duration) ?
+      /** @type {number} */ (options.duration) : 1000;
   var easing = options.easing ?
       options.easing : ol.easing.upAndDown;
   return (
@@ -55,7 +56,8 @@ ol.animation.pan = function(options) {
   var start = options.start ? options.start : goog.now();
   var sourceX = source[0];
   var sourceY = source[1];
-  var duration = ol.isDef(options.duration) ? options.duration : 1000;
+  var duration = ol.isDef(options.duration) ?
+      /** @type {number} */ (options.duration) : 1000;
   var easing = options.easing ?
       options.easing : ol.easing.inAndOut;
   return (
@@ -93,7 +95,8 @@ ol.animation.pan = function(options) {
 ol.animation.rotate = function(options) {
   var sourceRotation = options.rotation ? options.rotation : 0;
   var start = options.start ? options.start : goog.now();
-  var duration = ol.isDef(options.duration) ? options.duration : 1000;
+  var duration = ol.isDef(options.duration) ?
+      /** @type {number} */ (options.duration) : 1000;
   var easing = options.easing ?
       options.easing : ol.easing.inAndOut;
   var anchor = options.anchor ?
@@ -139,7 +142,8 @@ ol.animation.rotate = function(options) {
 ol.animation.zoom = function(options) {
   var sourceResolution = options.resolution;
   var start = options.start ? options.start : goog.now();
-  var duration = ol.isDef(options.duration) ? options.duration : 1000;
+  var duration = ol.isDef(options.duration) ?
+      /** @type {number} */ (options.duration) : 1000;
   var easing = options.easing ?
       options.easing : ol.easing.inAndOut;
   return (

--- a/src/ol/animation.js
+++ b/src/ol/animation.js
@@ -1,5 +1,6 @@
 goog.provide('ol.animation');
 
+goog.require('ol');
 goog.require('ol.PreRenderFunction');
 goog.require('ol.ViewHint');
 goog.require('ol.coordinate');
@@ -16,7 +17,7 @@ goog.require('ol.easing');
 ol.animation.bounce = function(options) {
   var resolution = options.resolution;
   var start = options.start ? options.start : goog.now();
-  var duration = options.duration ? options.duration : 1000;
+  var duration = ol.isDef(options.duration) ? options.duration : 1000;
   var easing = options.easing ?
       options.easing : ol.easing.upAndDown;
   return (
@@ -54,7 +55,7 @@ ol.animation.pan = function(options) {
   var start = options.start ? options.start : goog.now();
   var sourceX = source[0];
   var sourceY = source[1];
-  var duration = options.duration ? options.duration : 1000;
+  var duration = ol.isDef(options.duration) ? options.duration : 1000;
   var easing = options.easing ?
       options.easing : ol.easing.inAndOut;
   return (
@@ -92,7 +93,7 @@ ol.animation.pan = function(options) {
 ol.animation.rotate = function(options) {
   var sourceRotation = options.rotation ? options.rotation : 0;
   var start = options.start ? options.start : goog.now();
-  var duration = options.duration ? options.duration : 1000;
+  var duration = ol.isDef(options.duration) ? options.duration : 1000;
   var easing = options.easing ?
       options.easing : ol.easing.inAndOut;
   var anchor = options.anchor ?
@@ -138,7 +139,7 @@ ol.animation.rotate = function(options) {
 ol.animation.zoom = function(options) {
   var sourceResolution = options.resolution;
   var start = options.start ? options.start : goog.now();
-  var duration = options.duration ? options.duration : 1000;
+  var duration = ol.isDef(options.duration) ? options.duration : 1000;
   var easing = options.easing ?
       options.easing : ol.easing.inAndOut;
   return (

--- a/src/ol/animation.js
+++ b/src/ol/animation.js
@@ -15,9 +15,9 @@ goog.require('ol.easing');
  */
 ol.animation.bounce = function(options) {
   var resolution = options.resolution;
-  var start = goog.isDef(options.start) ? options.start : goog.now();
-  var duration = goog.isDef(options.duration) ? options.duration : 1000;
-  var easing = goog.isDef(options.easing) ?
+  var start = options.start ? options.start : goog.now();
+  var duration = options.duration ? options.duration : 1000;
+  var easing = options.easing ?
       options.easing : ol.easing.upAndDown;
   return (
       /**
@@ -51,11 +51,11 @@ ol.animation.bounce = function(options) {
  */
 ol.animation.pan = function(options) {
   var source = options.source;
-  var start = goog.isDef(options.start) ? options.start : goog.now();
+  var start = options.start ? options.start : goog.now();
   var sourceX = source[0];
   var sourceY = source[1];
-  var duration = goog.isDef(options.duration) ? options.duration : 1000;
-  var easing = goog.isDef(options.easing) ?
+  var duration = options.duration ? options.duration : 1000;
+  var easing = options.easing ?
       options.easing : ol.easing.inAndOut;
   return (
       /**
@@ -90,12 +90,12 @@ ol.animation.pan = function(options) {
  * @api
  */
 ol.animation.rotate = function(options) {
-  var sourceRotation = goog.isDef(options.rotation) ? options.rotation : 0;
-  var start = goog.isDef(options.start) ? options.start : goog.now();
-  var duration = goog.isDef(options.duration) ? options.duration : 1000;
-  var easing = goog.isDef(options.easing) ?
+  var sourceRotation = options.rotation ? options.rotation : 0;
+  var start = options.start ? options.start : goog.now();
+  var duration = options.duration ? options.duration : 1000;
+  var easing = options.easing ?
       options.easing : ol.easing.inAndOut;
-  var anchor = goog.isDef(options.anchor) ?
+  var anchor = options.anchor ?
       options.anchor : null;
 
   return (
@@ -137,9 +137,9 @@ ol.animation.rotate = function(options) {
  */
 ol.animation.zoom = function(options) {
   var sourceResolution = options.resolution;
-  var start = goog.isDef(options.start) ? options.start : goog.now();
-  var duration = goog.isDef(options.duration) ? options.duration : 1000;
-  var easing = goog.isDef(options.easing) ?
+  var start = options.start ? options.start : goog.now();
+  var duration = options.duration ? options.duration : 1000;
+  var easing = options.easing ?
       options.easing : ol.easing.inAndOut;
   return (
       /**

--- a/src/ol/attribution.js
+++ b/src/ol/attribution.js
@@ -38,8 +38,7 @@ ol.Attribution = function(options) {
    * @private
    * @type {Object.<string, Array.<ol.TileRange>>}
    */
-  this.tileRanges_ = goog.isDef(options.tileRanges) ?
-      options.tileRanges : null;
+  this.tileRanges_ = options.tileRanges ? options.tileRanges : null;
 
 };
 

--- a/src/ol/centerconstraint.js
+++ b/src/ol/centerconstraint.js
@@ -21,7 +21,7 @@ ol.CenterConstraint.createExtent = function(extent) {
        * @return {ol.Coordinate|undefined} Center.
        */
       function(center) {
-        if (goog.isDef(center)) {
+        if (center) {
           return [
             goog.math.clamp(center[0], extent[0], extent[2]),
             goog.math.clamp(center[1], extent[1], extent[3])

--- a/src/ol/collection.js
+++ b/src/ol/collection.js
@@ -91,7 +91,7 @@ ol.Collection = function(opt_array) {
    * @private
    * @type {!Array.<T>}
    */
-  this.array_ = goog.isDef(opt_array) ? opt_array : [];
+  this.array_ = opt_array ? opt_array : [];
 
   this.updateLength_();
 

--- a/src/ol/color/color.js
+++ b/src/ol/color/color.js
@@ -62,7 +62,7 @@ ol.color.rgbaColorRe_ =
 ol.color.blend = function(dst, src, opt_color) {
   // http://en.wikipedia.org/wiki/Alpha_compositing
   // FIXME do we need to scale by 255?
-  var out = goog.isDef(opt_color) ? opt_color : [];
+  var out = opt_color ? opt_color : [];
   var dstA = dst[3];
   var srcA = src[3];
   if (dstA == 1) {
@@ -271,7 +271,7 @@ ol.color.isValid = function(color) {
  * @return {ol.Color} Clamped color.
  */
 ol.color.normalize = function(color, opt_color) {
-  var result = goog.isDef(opt_color) ? opt_color : [];
+  var result = opt_color ? opt_color : [];
   result[0] = goog.math.clamp((color[0] + 0.5) | 0, 0, 255);
   result[1] = goog.math.clamp((color[1] + 0.5) | 0, 0, 255);
   result[2] = goog.math.clamp((color[2] + 0.5) | 0, 0, 255);
@@ -309,7 +309,7 @@ ol.color.toString = function(color) {
  * @return {ol.Color} Transformed color.
  */
 ol.color.transform = function(color, transform, opt_color) {
-  var result = goog.isDef(opt_color) ? opt_color : [];
+  var result = opt_color ? opt_color : [];
   result = goog.vec.Mat4.multVec3(transform, color, result);
   goog.asserts.assert(goog.isArray(result), 'result should be an array');
   result[3] = color[3];

--- a/src/ol/color/colormatrix.js
+++ b/src/ol/color/colormatrix.js
@@ -166,24 +166,24 @@ ol.color.Matrix.makeSaturation = function(matrix, value) {
 ol.color.Matrix.prototype.getMatrix = function(
     brightness, contrast, hue, saturation) {
   var colorMatrixDirty = false;
-  if (ol.isDef(brightness) && brightness !== this.brightness_) {
+  if (brightness !== undefined && brightness !== this.brightness_) {
     ol.color.Matrix.makeBrightness(this.brightnessMatrix_,
         /** @type {number} */ (brightness));
     this.brightness_ = brightness;
     colorMatrixDirty = true;
   }
-  if (ol.isDef(contrast) && contrast !== this.contrast_) {
+  if (contrast !== undefined && contrast !== this.contrast_) {
     ol.color.Matrix.makeContrast(this.contrastMatrix_,
         /** @type {number} */ (contrast));
     this.contrast_ = contrast;
     colorMatrixDirty = true;
   }
-  if (ol.isDef(hue) && hue !== this.hue_) {
+  if (hue !== undefined && hue !== this.hue_) {
     ol.color.Matrix.makeHue(this.hueMatrix_, /** @type {number} */ (hue));
     this.hue_ = hue;
     colorMatrixDirty = true;
   }
-  if (ol.isDef(saturation) && saturation !== this.saturation_) {
+  if (saturation !== undefined && saturation !== this.saturation_) {
     ol.color.Matrix.makeSaturation(this.saturationMatrix_,
         /** @type {number} */ (saturation));
     this.saturation_ = saturation;
@@ -192,16 +192,16 @@ ol.color.Matrix.prototype.getMatrix = function(
   if (colorMatrixDirty) {
     var colorMatrix = this.colorMatrix_;
     goog.vec.Mat4.makeIdentity(colorMatrix);
-    if (ol.isDef(contrast)) {
+    if (contrast !== undefined) {
       goog.vec.Mat4.multMat(colorMatrix, this.contrastMatrix_, colorMatrix);
     }
-    if (ol.isDef(brightness)) {
+    if (brightness !== undefined) {
       goog.vec.Mat4.multMat(colorMatrix, this.brightnessMatrix_, colorMatrix);
     }
-    if (ol.isDef(saturation)) {
+    if (saturation !== undefined) {
       goog.vec.Mat4.multMat(colorMatrix, this.saturationMatrix_, colorMatrix);
     }
-    if (ol.isDef(hue)) {
+    if (hue !== undefined) {
       goog.vec.Mat4.multMat(colorMatrix, this.hueMatrix_, colorMatrix);
     }
   }

--- a/src/ol/color/colormatrix.js
+++ b/src/ol/color/colormatrix.js
@@ -1,6 +1,7 @@
 goog.provide('ol.color.Matrix');
 
 goog.require('goog.vec.Mat4');
+goog.require('ol');
 
 
 
@@ -165,39 +166,42 @@ ol.color.Matrix.makeSaturation = function(matrix, value) {
 ol.color.Matrix.prototype.getMatrix = function(
     brightness, contrast, hue, saturation) {
   var colorMatrixDirty = false;
-  if (goog.isDef(brightness) && brightness !== this.brightness_) {
-    ol.color.Matrix.makeBrightness(this.brightnessMatrix_, brightness);
+  if (ol.isDef(brightness) && brightness !== this.brightness_) {
+    ol.color.Matrix.makeBrightness(this.brightnessMatrix_,
+        /** @type {number} */ (brightness));
     this.brightness_ = brightness;
     colorMatrixDirty = true;
   }
-  if (goog.isDef(contrast) && contrast !== this.contrast_) {
-    ol.color.Matrix.makeContrast(this.contrastMatrix_, contrast);
+  if (ol.isDef(contrast) && contrast !== this.contrast_) {
+    ol.color.Matrix.makeContrast(this.contrastMatrix_,
+        /** @type {number} */ (contrast));
     this.contrast_ = contrast;
     colorMatrixDirty = true;
   }
-  if (goog.isDef(hue) && hue !== this.hue_) {
-    ol.color.Matrix.makeHue(this.hueMatrix_, hue);
+  if (ol.isDef(hue) && hue !== this.hue_) {
+    ol.color.Matrix.makeHue(this.hueMatrix_, /** @type {number} */ (hue));
     this.hue_ = hue;
     colorMatrixDirty = true;
   }
-  if (goog.isDef(saturation) && saturation !== this.saturation_) {
-    ol.color.Matrix.makeSaturation(this.saturationMatrix_, saturation);
+  if (ol.isDef(saturation) && saturation !== this.saturation_) {
+    ol.color.Matrix.makeSaturation(this.saturationMatrix_,
+        /** @type {number} */ (saturation));
     this.saturation_ = saturation;
     colorMatrixDirty = true;
   }
   if (colorMatrixDirty) {
     var colorMatrix = this.colorMatrix_;
     goog.vec.Mat4.makeIdentity(colorMatrix);
-    if (goog.isDef(contrast)) {
+    if (ol.isDef(contrast)) {
       goog.vec.Mat4.multMat(colorMatrix, this.contrastMatrix_, colorMatrix);
     }
-    if (goog.isDef(brightness)) {
+    if (ol.isDef(brightness)) {
       goog.vec.Mat4.multMat(colorMatrix, this.brightnessMatrix_, colorMatrix);
     }
-    if (goog.isDef(saturation)) {
+    if (ol.isDef(saturation)) {
       goog.vec.Mat4.multMat(colorMatrix, this.saturationMatrix_, colorMatrix);
     }
-    if (goog.isDef(hue)) {
+    if (ol.isDef(hue)) {
       goog.vec.Mat4.multMat(colorMatrix, this.hueMatrix_, colorMatrix);
     }
   }

--- a/src/ol/control/attributioncontrol.js
+++ b/src/ol/control/attributioncontrol.js
@@ -10,6 +10,7 @@ goog.require('goog.events');
 goog.require('goog.events.EventType');
 goog.require('goog.object');
 goog.require('goog.style');
+goog.require('ol');
 goog.require('ol.Attribution');
 goog.require('ol.control.Control');
 goog.require('ol.css');
@@ -31,7 +32,7 @@ goog.require('ol.source.Tile');
  */
 ol.control.Attribution = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   /**
    * @private
@@ -52,27 +53,25 @@ ol.control.Attribution = function(opt_options) {
    * @private
    * @type {boolean}
    */
-  this.collapsed_ = goog.isDef(options.collapsed) ? options.collapsed : true;
+  this.collapsed_ = ol.isDef(options.collapsed) ?
+      /** @type {boolean} */ (options.collapsed) : true;
 
   /**
    * @private
    * @type {boolean}
    */
-  this.collapsible_ = goog.isDef(options.collapsible) ?
-      options.collapsible : true;
+  this.collapsible_ = ol.isDef(options.collapsible) ?
+      /** @type {boolean} */ (options.collapsible) : true;
 
   if (!this.collapsible_) {
     this.collapsed_ = false;
   }
 
-  var className = goog.isDef(options.className) ?
-      options.className : 'ol-attribution';
+  var className = options.className ? options.className : 'ol-attribution';
 
-  var tipLabel = goog.isDef(options.tipLabel) ?
-      options.tipLabel : 'Attributions';
+  var tipLabel = options.tipLabel ? options.tipLabel : 'Attributions';
 
-  var collapseLabel = goog.isDef(options.collapseLabel) ?
-      options.collapseLabel : '\u00BB';
+  var collapseLabel = options.collapseLabel ? options.collapseLabel : '\u00BB';
 
   /**
    * @private
@@ -82,7 +81,7 @@ ol.control.Attribution = function(opt_options) {
       goog.dom.createDom(goog.dom.TagName.SPAN, {}, collapseLabel) :
       collapseLabel);
 
-  var label = goog.isDef(options.label) ? options.label : 'i';
+  var label = options.label ? options.label : 'i';
 
   /**
    * @private
@@ -116,8 +115,7 @@ ol.control.Attribution = function(opt_options) {
   var element = goog.dom.createDom(goog.dom.TagName.DIV,
       cssClasses, this.ulElement_, button);
 
-  var render = goog.isDef(options.render) ?
-      options.render : ol.control.Attribution.render;
+  var render = options.render ? options.render : ol.control.Attribution.render;
 
   goog.base(this, {
     element: element,
@@ -185,7 +183,7 @@ ol.control.Attribution.prototype.getSourceAttributions = function(frameState) {
         continue;
       }
       tileRanges = frameState.usedTiles[sourceKey];
-      if (goog.isDef(tileRanges)) {
+      if (tileRanges) {
         goog.asserts.assertInstanceof(source, ol.source.Tile,
             'source should be an ol.source.Tile');
         var tileGrid = source.getTileGridForProjection(projection);

--- a/src/ol/control/attributioncontrol.js
+++ b/src/ol/control/attributioncontrol.js
@@ -53,15 +53,14 @@ ol.control.Attribution = function(opt_options) {
    * @private
    * @type {boolean}
    */
-  this.collapsed_ = ol.isDef(options.collapsed) ?
-      /** @type {boolean} */ (options.collapsed) : true;
+  this.collapsed_ = options.collapsed !== undefined ? options.collapsed : true;
 
   /**
    * @private
    * @type {boolean}
    */
-  this.collapsible_ = ol.isDef(options.collapsible) ?
-      /** @type {boolean} */ (options.collapsible) : true;
+  this.collapsible_ = options.collapsible !== undefined ?
+      options.collapsible : true;
 
   if (!this.collapsible_) {
     this.collapsed_ = false;

--- a/src/ol/control/control.js
+++ b/src/ol/control/control.js
@@ -45,7 +45,7 @@ ol.control.Control = function(options) {
    * @protected
    * @type {Element}
    */
-  this.element = goog.isDef(options.element) ? options.element : null;
+  this.element = options.element ? options.element : null;
 
   /**
    * @private
@@ -68,9 +68,9 @@ ol.control.Control = function(options) {
   /**
    * @type {function(ol.MapEvent)}
    */
-  this.render = goog.isDef(options.render) ? options.render : goog.nullFunction;
+  this.render = options.render ? options.render : goog.nullFunction;
 
-  if (goog.isDef(options.target)) {
+  if (options.target) {
     this.setTarget(options.target);
   }
 

--- a/src/ol/control/controldefaults.js
+++ b/src/ol/control/controldefaults.js
@@ -25,19 +25,17 @@ ol.control.defaults = function(opt_options) {
 
   var controls = new ol.Collection();
 
-  var zoomControl = ol.isDef(options.zoom) ?
-      options.zoom : true;
+  var zoomControl = options.zoom !== undefined ? options.zoom : true;
   if (zoomControl) {
     controls.push(new ol.control.Zoom(options.zoomOptions));
   }
 
-  var rotateControl = ol.isDef(options.rotate) ?
-      options.rotate : true;
+  var rotateControl = options.rotate !== undefined ? options.rotate : true;
   if (rotateControl) {
     controls.push(new ol.control.Rotate(options.rotateOptions));
   }
 
-  var attributionControl = ol.isDef(options.attribution) ?
+  var attributionControl = options.attribution !== undefined ?
       options.attribution : true;
   if (attributionControl) {
     controls.push(new ol.control.Attribution(options.attributionOptions));

--- a/src/ol/control/controldefaults.js
+++ b/src/ol/control/controldefaults.js
@@ -1,5 +1,6 @@
 goog.provide('ol.control');
 
+goog.require('ol');
 goog.require('ol.Collection');
 goog.require('ol.control.Attribution');
 goog.require('ol.control.Rotate');
@@ -20,23 +21,23 @@ goog.require('ol.control.Zoom');
  */
 ol.control.defaults = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   var controls = new ol.Collection();
 
-  var zoomControl = goog.isDef(options.zoom) ?
+  var zoomControl = ol.isDef(options.zoom) ?
       options.zoom : true;
   if (zoomControl) {
     controls.push(new ol.control.Zoom(options.zoomOptions));
   }
 
-  var rotateControl = goog.isDef(options.rotate) ?
+  var rotateControl = ol.isDef(options.rotate) ?
       options.rotate : true;
   if (rotateControl) {
     controls.push(new ol.control.Rotate(options.rotateOptions));
   }
 
-  var attributionControl = goog.isDef(options.attribution) ?
+  var attributionControl = ol.isDef(options.attribution) ?
       options.attribution : true;
   if (attributionControl) {
     controls.push(new ol.control.Attribution(options.attributionOptions));

--- a/src/ol/control/fullscreencontrol.js
+++ b/src/ol/control/fullscreencontrol.js
@@ -83,8 +83,7 @@ ol.control.FullScreen = function(opt_options) {
    * @private
    * @type {boolean}
    */
-  this.keys_ = ol.isDef(options.keys) ?
-      /** @type {boolean} */ (options.keys) : false;
+  this.keys_ = options.keys !== undefined ? options.keys : false;
 
 };
 goog.inherits(ol.control.FullScreen, ol.control.Control);

--- a/src/ol/control/fullscreencontrol.js
+++ b/src/ol/control/fullscreencontrol.js
@@ -8,6 +8,7 @@ goog.require('goog.dom.fullscreen');
 goog.require('goog.dom.fullscreen.EventType');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
+goog.require('ol');
 goog.require('ol.control.Control');
 goog.require('ol.css');
 
@@ -28,16 +29,15 @@ goog.require('ol.css');
  */
 ol.control.FullScreen = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   /**
    * @private
    * @type {string}
    */
-  this.cssClassName_ = goog.isDef(options.className) ?
-      options.className : 'ol-full-screen';
+  this.cssClassName_ = options.className ? options.className : 'ol-full-screen';
 
-  var label = goog.isDef(options.label) ? options.label : '\u2194';
+  var label = options.label ? options.label : '\u2194';
 
   /**
    * @private
@@ -46,8 +46,7 @@ ol.control.FullScreen = function(opt_options) {
   this.labelNode_ = /** @type {Node} */ (goog.isString(label) ?
           goog.dom.createTextNode(label) : label);
 
-  var labelActive = goog.isDef(options.labelActive) ?
-      options.labelActive : '\u00d7';
+  var labelActive = options.labelActive ? options.labelActive : '\u00d7';
 
   /**
    * @private
@@ -56,8 +55,7 @@ ol.control.FullScreen = function(opt_options) {
   this.labelActiveNode_ = /** @type {Node} */ (goog.isString(labelActive) ?
           goog.dom.createTextNode(labelActive) : labelActive);
 
-  var tipLabel = goog.isDef(options.tipLabel) ?
-      options.tipLabel : 'Toggle full-screen';
+  var tipLabel = options.tipLabel ? options.tipLabel : 'Toggle full-screen';
   var button = goog.dom.createDom(goog.dom.TagName.BUTTON, {
     'class': this.cssClassName_ + '-' + goog.dom.fullscreen.isFullScreen(),
     'type': 'button',
@@ -85,7 +83,8 @@ ol.control.FullScreen = function(opt_options) {
    * @private
    * @type {boolean}
    */
-  this.keys_ = goog.isDef(options.keys) ? options.keys : false;
+  this.keys_ = ol.isDef(options.keys) ?
+      /** @type {boolean} */ (options.keys) : false;
 
 };
 goog.inherits(ol.control.FullScreen, ol.control.Control);

--- a/src/ol/control/mousepositioncontrol.js
+++ b/src/ol/control/mousepositioncontrol.js
@@ -40,14 +40,13 @@ ol.control.MousePositionProperty = {
  */
 ol.control.MousePosition = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
-  var className = goog.isDef(options.className) ?
-      options.className : 'ol-mouse-position';
+  var className = options.className ? options.className : 'ol-mouse-position';
 
   var element = goog.dom.createDom(goog.dom.TagName.DIV, className);
 
-  var render = goog.isDef(options.render) ?
+  var render = options.render ?
       options.render : ol.control.MousePosition.render;
 
   goog.base(this, {
@@ -60,10 +59,10 @@ ol.control.MousePosition = function(opt_options) {
       ol.Object.getChangeEventType(ol.control.MousePositionProperty.PROJECTION),
       this.handleProjectionChanged_, false, this);
 
-  if (goog.isDef(options.coordinateFormat)) {
+  if (options.coordinateFormat) {
     this.setCoordinateFormat(options.coordinateFormat);
   }
-  if (goog.isDef(options.projection)) {
+  if (options.projection) {
     this.setProjection(ol.proj.get(options.projection));
   }
 
@@ -71,8 +70,7 @@ ol.control.MousePosition = function(opt_options) {
    * @private
    * @type {string}
    */
-  this.undefinedHTML_ = goog.isDef(options.undefinedHTML) ?
-      options.undefinedHTML : '';
+  this.undefinedHTML_ = options.undefinedHTML ? options.undefinedHTML : '';
 
   /**
    * @private
@@ -229,7 +227,7 @@ ol.control.MousePosition.prototype.updateHTML_ = function(pixel) {
   if (!goog.isNull(pixel) && !goog.isNull(this.mapProjection_)) {
     if (goog.isNull(this.transform_)) {
       var projection = this.getProjection();
-      if (goog.isDef(projection)) {
+      if (projection) {
         this.transform_ = ol.proj.getTransformFromProjections(
             this.mapProjection_, projection);
       } else {
@@ -241,14 +239,14 @@ ol.control.MousePosition.prototype.updateHTML_ = function(pixel) {
     if (!goog.isNull(coordinate)) {
       this.transform_(coordinate, coordinate);
       var coordinateFormat = this.getCoordinateFormat();
-      if (goog.isDef(coordinateFormat)) {
+      if (coordinateFormat) {
         html = coordinateFormat(coordinate);
       } else {
         html = coordinate.toString();
       }
     }
   }
-  if (!goog.isDef(this.renderedHTML_) || html != this.renderedHTML_) {
+  if (!this.renderedHTML_ || html != this.renderedHTML_) {
     this.element.innerHTML = html;
     this.renderedHTML_ = html;
   }

--- a/src/ol/control/overviewmapcontrol.js
+++ b/src/ol/control/overviewmapcontrol.js
@@ -41,15 +41,14 @@ ol.control.OverviewMap = function(opt_options) {
    * @type {boolean}
    * @private
    */
-  this.collapsed_ = ol.isDef(options.collapsed) ?
-      /** @type {boolean} */ (options.collapsed) : true;
+  this.collapsed_ = options.collapsed !== undefined ? options.collapsed : true;
 
   /**
    * @private
    * @type {boolean}
    */
-  this.collapsible_ = ol.isDef(options.collapsible) ?
-      /** @type {boolean} */ (options.collapsible) : true;
+  this.collapsible_ = options.collapsible !== undefined ?
+      options.collapsible : true;
 
   if (!this.collapsible_) {
     this.collapsed_ = false;
@@ -382,7 +381,7 @@ ol.control.OverviewMap.prototype.updateBox_ = function() {
   goog.asserts.assertArray(ovmapSize, 'ovmapSize should be an array');
 
   var rotation = view.getRotation();
-  goog.asserts.assert(ol.isDef(rotation), 'rotation should be defined');
+  goog.asserts.assert(rotation !== undefined, 'rotation should be defined');
 
   var overlay = this.boxOverlay_;
   var box = this.boxOverlay_.getElement();

--- a/src/ol/control/overviewmapcontrol.js
+++ b/src/ol/control/overviewmapcontrol.js
@@ -8,6 +8,7 @@ goog.require('goog.events');
 goog.require('goog.events.EventType');
 goog.require('goog.math.Size');
 goog.require('goog.style');
+goog.require('ol');
 goog.require('ol.Collection');
 goog.require('ol.Map');
 goog.require('ol.MapEventType');
@@ -34,33 +35,31 @@ goog.require('ol.extent');
  */
 ol.control.OverviewMap = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   /**
    * @type {boolean}
    * @private
    */
-  this.collapsed_ = goog.isDef(options.collapsed) ? options.collapsed : true;
+  this.collapsed_ = ol.isDef(options.collapsed) ?
+      /** @type {boolean} */ (options.collapsed) : true;
 
   /**
    * @private
    * @type {boolean}
    */
-  this.collapsible_ = goog.isDef(options.collapsible) ?
-      options.collapsible : true;
+  this.collapsible_ = ol.isDef(options.collapsible) ?
+      /** @type {boolean} */ (options.collapsible) : true;
 
   if (!this.collapsible_) {
     this.collapsed_ = false;
   }
 
-  var className = goog.isDef(options.className) ?
-      options.className : 'ol-overviewmap';
+  var className = options.className ? options.className : 'ol-overviewmap';
 
-  var tipLabel = goog.isDef(options.tipLabel) ?
-      options.tipLabel : 'Overview map';
+  var tipLabel = options.tipLabel ? options.tipLabel : 'Overview map';
 
-  var collapseLabel = goog.isDef(options.collapseLabel) ?
-      options.collapseLabel : '\u00AB';
+  var collapseLabel = options.collapseLabel ? options.collapseLabel : '\u00AB';
 
   /**
    * @private
@@ -70,7 +69,7 @@ ol.control.OverviewMap = function(opt_options) {
       goog.dom.createDom(goog.dom.TagName.SPAN, {}, collapseLabel) :
       collapseLabel);
 
-  var label = goog.isDef(options.label) ? options.label : '\u00BB';
+  var label = options.label ? options.label : '\u00BB';
 
   /**
    * @private
@@ -103,7 +102,7 @@ ol.control.OverviewMap = function(opt_options) {
   });
   var ovmap = this.ovmap_;
 
-  if (goog.isDef(options.layers)) {
+  if (options.layers) {
     options.layers.forEach(
         /**
        * @param {ol.layer.Layer} layer Layer.
@@ -133,8 +132,7 @@ ol.control.OverviewMap = function(opt_options) {
   var element = goog.dom.createDom(goog.dom.TagName.DIV,
       cssClasses, ovmapDiv, button);
 
-  var render = goog.isDef(options.render) ?
-      options.render : ol.control.OverviewMap.render;
+  var render = options.render ? options.render : ol.control.OverviewMap.render;
 
   goog.base(this, {
     element: element,
@@ -271,14 +269,14 @@ ol.control.OverviewMap.prototype.validateExtent_ = function() {
   goog.asserts.assertArray(mapSize, 'mapSize should be an array');
 
   var view = map.getView();
-  goog.asserts.assert(goog.isDef(view), 'view should be defined');
+  goog.asserts.assert(view, 'view should be defined');
   var extent = view.calculateExtent(mapSize);
 
   var ovmapSize = ovmap.getSize();
   goog.asserts.assertArray(ovmapSize, 'ovmapSize should be an array');
 
   var ovview = ovmap.getView();
-  goog.asserts.assert(goog.isDef(ovview), 'ovview should be defined');
+  goog.asserts.assert(ovview, 'ovview should be defined');
   var ovextent = ovview.calculateExtent(ovmapSize);
 
   var topLeftPixel =
@@ -320,14 +318,14 @@ ol.control.OverviewMap.prototype.resetExtent_ = function() {
   goog.asserts.assertArray(mapSize, 'mapSize should be an array');
 
   var view = map.getView();
-  goog.asserts.assert(goog.isDef(view), 'view should be defined');
+  goog.asserts.assert(view, 'view should be defined');
   var extent = view.calculateExtent(mapSize);
 
   var ovmapSize = ovmap.getSize();
   goog.asserts.assertArray(ovmapSize, 'ovmapSize should be an array');
 
   var ovview = ovmap.getView();
-  goog.asserts.assert(goog.isDef(ovview), 'ovview should be defined');
+  goog.asserts.assert(ovview, 'ovview should be defined');
 
   // get how many times the current map overview could hold different
   // box sizes using the min and max ratio, pick the step in the middle used
@@ -350,10 +348,10 @@ ol.control.OverviewMap.prototype.recenter_ = function() {
   var ovmap = this.ovmap_;
 
   var view = map.getView();
-  goog.asserts.assert(goog.isDef(view), 'view should be defined');
+  goog.asserts.assert(view, 'view should be defined');
 
   var ovview = ovmap.getView();
-  goog.asserts.assert(goog.isDef(ovview), 'ovview should be defined');
+  goog.asserts.assert(ovview, 'ovview should be defined');
 
   ovview.setCenter(view.getCenter());
 };
@@ -375,16 +373,16 @@ ol.control.OverviewMap.prototype.updateBox_ = function() {
   goog.asserts.assertArray(mapSize, 'mapSize should be an array');
 
   var view = map.getView();
-  goog.asserts.assert(goog.isDef(view), 'view should be defined');
+  goog.asserts.assert(view, 'view should be defined');
 
   var ovview = ovmap.getView();
-  goog.asserts.assert(goog.isDef(ovview), 'ovview should be defined');
+  goog.asserts.assert(ovview, 'ovview should be defined');
 
   var ovmapSize = ovmap.getSize();
   goog.asserts.assertArray(ovmapSize, 'ovmapSize should be an array');
 
   var rotation = view.getRotation();
-  goog.asserts.assert(goog.isDef(rotation), 'rotation should be defined');
+  goog.asserts.assert(ol.isDef(rotation), 'rotation should be defined');
 
   var overlay = this.boxOverlay_;
   var box = this.boxOverlay_.getElement();
@@ -419,11 +417,11 @@ ol.control.OverviewMap.prototype.calculateCoordinateRotate_ = function(
 
   var map = this.getMap();
   var view = map.getView();
-  goog.asserts.assert(goog.isDef(view), 'view should be defined');
+  goog.asserts.assert(view, 'view should be defined');
 
   var currentCenter = view.getCenter();
 
-  if (goog.isDef(currentCenter)) {
+  if (currentCenter) {
     coordinateRotate = [
       coordinate[0] - currentCenter[0],
       coordinate[1] - currentCenter[1]

--- a/src/ol/control/rotatecontrol.js
+++ b/src/ol/control/rotatecontrol.js
@@ -6,6 +6,7 @@ goog.require('goog.dom.classlist');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
 goog.require('goog.math');
+goog.require('ol');
 goog.require('ol.animation');
 goog.require('ol.control.Control');
 goog.require('ol.css');
@@ -26,16 +27,15 @@ goog.require('ol.easing');
  */
 ol.control.Rotate = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
-  var className = goog.isDef(options.className) ?
+  var className = options.className ?
       options.className : 'ol-rotate';
 
-  var label = goog.isDef(options.label) ?
-      options.label : '\u21E7';
+  var label = options.label ? options.label : '\u21E7';
 
   /**
-   * @type {Node}
+   * @type {Element}
    * @private
    */
   this.label_ = null;
@@ -48,8 +48,7 @@ ol.control.Rotate = function(opt_options) {
     goog.dom.classlist.add(this.label_, 'ol-compass');
   }
 
-  var tipLabel = goog.isDef(options.tipLabel) ?
-      options.tipLabel : 'Reset rotation';
+  var tipLabel = options.tipLabel ? options.tipLabel : 'Reset rotation';
 
   var button = goog.dom.createDom(goog.dom.TagName.BUTTON, {
     'class': className + '-reset',
@@ -64,8 +63,7 @@ ol.control.Rotate = function(opt_options) {
       ol.css.CLASS_CONTROL;
   var element = goog.dom.createDom(goog.dom.TagName.DIV, cssClasses, button);
 
-  var render = goog.isDef(options.render) ?
-      options.render : ol.control.Rotate.render;
+  var render = options.render ? options.render : ol.control.Rotate.render;
 
   goog.base(this, {
     element: element,
@@ -77,13 +75,14 @@ ol.control.Rotate = function(opt_options) {
    * @type {number}
    * @private
    */
-  this.duration_ = goog.isDef(options.duration) ? options.duration : 250;
+  this.duration_ = options.duration ? options.duration : 250;
 
   /**
    * @type {boolean}
    * @private
    */
-  this.autoHide_ = goog.isDef(options.autoHide) ? options.autoHide : true;
+  this.autoHide_ = ol.isDef(options.autoHide) ?
+      /** @type {boolean} */ (options.autoHide) : true;
 
   /**
    * @private
@@ -127,7 +126,7 @@ ol.control.Rotate.prototype.resetNorth_ = function() {
   while (currentRotation > Math.PI) {
     currentRotation -= 2 * Math.PI;
   }
-  if (goog.isDef(currentRotation)) {
+  if (ol.isDef(currentRotation)) {
     if (this.duration_ > 0) {
       map.beforeRender(ol.animation.rotate({
         rotation: currentRotation,

--- a/src/ol/control/rotatecontrol.js
+++ b/src/ol/control/rotatecontrol.js
@@ -81,8 +81,7 @@ ol.control.Rotate = function(opt_options) {
    * @type {boolean}
    * @private
    */
-  this.autoHide_ = ol.isDef(options.autoHide) ?
-      /** @type {boolean} */ (options.autoHide) : true;
+  this.autoHide_ = options.autoHide !== undefined ? options.autoHide : true;
 
   /**
    * @private
@@ -126,7 +125,7 @@ ol.control.Rotate.prototype.resetNorth_ = function() {
   while (currentRotation > Math.PI) {
     currentRotation -= 2 * Math.PI;
   }
-  if (ol.isDef(currentRotation)) {
+  if (currentRotation !== undefined) {
     if (this.duration_ > 0) {
       map.beforeRender(ol.animation.rotate({
         rotation: currentRotation,

--- a/src/ol/control/scalelinecontrol.js
+++ b/src/ol/control/scalelinecontrol.js
@@ -87,8 +87,7 @@ ol.control.ScaleLine = function(opt_options) {
    * @private
    * @type {number}
    */
-  this.minWidth_ = ol.isDef(options.minWidth) ?
-      /** @type {number} */ (options.minWidth) : 64;
+  this.minWidth_ = options.minWidth !== undefined ? options.minWidth : 64;
 
   /**
    * @private

--- a/src/ol/control/scalelinecontrol.js
+++ b/src/ol/control/scalelinecontrol.js
@@ -8,6 +8,7 @@ goog.require('goog.dom.TagName');
 goog.require('goog.events');
 goog.require('goog.math');
 goog.require('goog.style');
+goog.require('ol');
 goog.require('ol.Object');
 goog.require('ol.TransformFunction');
 goog.require('ol.control.Control');
@@ -58,10 +59,9 @@ ol.control.ScaleLineUnits = {
  */
 ol.control.ScaleLine = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
-  var className = goog.isDef(options.className) ?
-      options.className : 'ol-scale-line';
+  var className = options.className ? options.className : 'ol-scale-line';
 
   /**
    * @private
@@ -87,7 +87,8 @@ ol.control.ScaleLine = function(opt_options) {
    * @private
    * @type {number}
    */
-  this.minWidth_ = goog.isDef(options.minWidth) ? options.minWidth : 64;
+  this.minWidth_ = ol.isDef(options.minWidth) ?
+      /** @type {number} */ (options.minWidth) : 64;
 
   /**
    * @private
@@ -113,8 +114,7 @@ ol.control.ScaleLine = function(opt_options) {
    */
   this.toEPSG4326_ = null;
 
-  var render = goog.isDef(options.render) ?
-      options.render : ol.control.ScaleLine.render;
+  var render = options.render ? options.render : ol.control.ScaleLine.render;
 
   goog.base(this, {
     element: this.element_,
@@ -233,7 +233,7 @@ ol.control.ScaleLine.prototype.updateElement_ = function() {
     }
     cosLatitude = Math.cos(goog.math.toRadians(this.toEPSG4326_(center)[1]));
     var radius = ol.sphere.NORMAL.radius;
-    goog.asserts.assert(goog.isDef(ol.proj.METERS_PER_UNIT[projectionUnits]),
+    goog.asserts.assert(ol.proj.METERS_PER_UNIT[projectionUnits],
         'Meters per unit should be defined for the projection unit');
     radius /= ol.proj.METERS_PER_UNIT[projectionUnits];
     pointResolution *= 180 / (Math.PI * cosLatitude * radius);

--- a/src/ol/control/zoomcontrol.js
+++ b/src/ol/control/zoomcontrol.js
@@ -24,20 +24,18 @@ goog.require('ol.easing');
  */
 ol.control.Zoom = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
-  var className = goog.isDef(options.className) ? options.className : 'ol-zoom';
+  var className = options.className ? options.className : 'ol-zoom';
 
-  var delta = goog.isDef(options.delta) ? options.delta : 1;
+  var delta = options.delta ? options.delta : 1;
 
-  var zoomInLabel = goog.isDef(options.zoomInLabel) ?
-      options.zoomInLabel : '+';
-  var zoomOutLabel = goog.isDef(options.zoomOutLabel) ?
-      options.zoomOutLabel : '\u2212';
+  var zoomInLabel = options.zoomInLabel ? options.zoomInLabel : '+';
+  var zoomOutLabel = options.zoomOutLabel ? options.zoomOutLabel : '\u2212';
 
-  var zoomInTipLabel = goog.isDef(options.zoomInTipLabel) ?
+  var zoomInTipLabel = options.zoomInTipLabel ?
       options.zoomInTipLabel : 'Zoom in';
-  var zoomOutTipLabel = goog.isDef(options.zoomOutTipLabel) ?
+  var zoomOutTipLabel = options.zoomOutTipLabel ?
       options.zoomOutTipLabel : 'Zoom out';
 
   var inElement = goog.dom.createDom(goog.dom.TagName.BUTTON, {
@@ -81,7 +79,7 @@ ol.control.Zoom = function(opt_options) {
    * @type {number}
    * @private
    */
-  this.duration_ = goog.isDef(options.duration) ? options.duration : 250;
+  this.duration_ = options.duration ? options.duration : 250;
 
 };
 goog.inherits(ol.control.Zoom, ol.control.Control);
@@ -111,7 +109,7 @@ ol.control.Zoom.prototype.zoomByDelta_ = function(delta) {
     return;
   }
   var currentResolution = view.getResolution();
-  if (goog.isDef(currentResolution)) {
+  if (currentResolution) {
     if (this.duration_ > 0) {
       map.beforeRender(ol.animation.zoom({
         resolution: currentResolution,

--- a/src/ol/control/zoomslidercontrol.js
+++ b/src/ol/control/zoomslidercontrol.js
@@ -38,7 +38,7 @@ goog.require('ol.easing');
  */
 ol.control.ZoomSlider = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   /**
    * Will hold the current resolution of the view.
@@ -76,10 +76,9 @@ ol.control.ZoomSlider = function(opt_options) {
    * @private
    * @type {number}
    */
-  this.duration_ = goog.isDef(options.duration) ? options.duration : 200;
+  this.duration_ = options.duration ? options.duration : 200;
 
-  var className = goog.isDef(options.className) ?
-      options.className : 'ol-zoomslider';
+  var className = options.className ? options.className : 'ol-zoomslider';
   var thumbElement = goog.dom.createDom(goog.dom.TagName.DIV,
       [className + '-thumb', ol.css.CLASS_UNSELECTABLE]);
   var containerElement = goog.dom.createDom(goog.dom.TagName.DIV,
@@ -105,8 +104,7 @@ ol.control.ZoomSlider = function(opt_options) {
   goog.events.listen(thumbElement, goog.events.EventType.CLICK,
       goog.events.Event.stopPropagation);
 
-  var render = goog.isDef(options.render) ?
-      options.render : ol.control.ZoomSlider.render;
+  var render = options.render ? options.render : ol.control.ZoomSlider.render;
 
   goog.base(this, {
     element: containerElement,
@@ -205,7 +203,7 @@ ol.control.ZoomSlider.prototype.handleContainerClick_ = function(browserEvent) {
   var map = this.getMap();
   var view = map.getView();
   var currentResolution = view.getResolution();
-  goog.asserts.assert(goog.isDef(currentResolution),
+  goog.asserts.assert(currentResolution,
       'currentResolution should be defined');
   map.beforeRender(ol.animation.zoom({
     resolution: currentResolution,
@@ -252,7 +250,7 @@ ol.control.ZoomSlider.prototype.handleDraggerEnd_ = function(event) {
   var map = this.getMap();
   var view = map.getView();
   view.setHint(ol.ViewHint.INTERACTING, -1);
-  goog.asserts.assert(goog.isDef(this.currentResolution_),
+  goog.asserts.assert(this.currentResolution_,
       'this.currentResolution_ should be defined');
   map.beforeRender(ol.animation.zoom({
     resolution: this.currentResolution_,

--- a/src/ol/control/zoomtoextentcontrol.js
+++ b/src/ol/control/zoomtoextentcontrol.js
@@ -21,19 +21,19 @@ goog.require('ol.css');
  * @api stable
  */
 ol.control.ZoomToExtent = function(opt_options) {
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   /**
    * @type {ol.Extent}
    * @private
    */
-  this.extent_ = goog.isDef(options.extent) ? options.extent : null;
+  this.extent_ = options.extent ? options.extent : null;
 
-  var className = goog.isDef(options.className) ? options.className :
+  var className = options.className ? options.className :
       'ol-zoom-extent';
 
-  var label = goog.isDef(options.label) ? options.label : 'E';
-  var tipLabel = goog.isDef(options.tipLabel) ?
+  var label = options.label ? options.label : 'E';
+  var tipLabel = options.tipLabel ?
       options.tipLabel : 'Fit to extent';
   var button = goog.dom.createDom(goog.dom.TagName.BUTTON, {
     'type': 'button',
@@ -74,6 +74,6 @@ ol.control.ZoomToExtent.prototype.handleZoomToExtent_ = function() {
   var extent = goog.isNull(this.extent_) ?
       view.getProjection().getExtent() : this.extent_;
   var size = map.getSize();
-  goog.asserts.assert(goog.isDef(size), 'size should be defined');
+  goog.asserts.assert(size, 'size should be defined');
   view.fit(extent, size);
 };

--- a/src/ol/coordinate.js
+++ b/src/ol/coordinate.js
@@ -164,7 +164,7 @@ ol.coordinate.degreesToStringHDMS_ = function(degrees, hemispheres) {
  * @api stable
  */
 ol.coordinate.format = function(coordinate, template, opt_fractionDigits) {
-  if (goog.isDef(coordinate)) {
+  if (coordinate) {
     return template
       .replace('{x}', coordinate[0].toFixed(opt_fractionDigits))
       .replace('{y}', coordinate[1].toFixed(opt_fractionDigits));
@@ -295,7 +295,7 @@ ol.coordinate.squaredDistanceToSegment = function(coordinate, segment) {
  * @api stable
  */
 ol.coordinate.toStringHDMS = function(coordinate) {
-  if (goog.isDef(coordinate)) {
+  if (coordinate) {
     return ol.coordinate.degreesToStringHDMS_(coordinate[1], 'NS') + ' ' +
         ol.coordinate.degreesToStringHDMS_(coordinate[0], 'EW');
   } else {

--- a/src/ol/deviceorientation.js
+++ b/src/ol/deviceorientation.js
@@ -92,8 +92,7 @@ ol.DeviceOrientation = function(opt_options) {
       ol.Object.getChangeEventType(ol.DeviceOrientationProperty.TRACKING),
       this.handleTrackingChanged_, false, this);
 
-  this.setTracking(ol.isDef(options.tracking) ?
-      /** @type {boolean} */ (options.tracking) : false);
+  this.setTracking(options.tracking !== undefined ? options.tracking : false);
 
 };
 goog.inherits(ol.DeviceOrientation, ol.Object);

--- a/src/ol/deviceorientation.js
+++ b/src/ol/deviceorientation.js
@@ -3,6 +3,7 @@ goog.provide('ol.DeviceOrientationProperty');
 
 goog.require('goog.events');
 goog.require('goog.math');
+goog.require('ol');
 goog.require('ol.Object');
 goog.require('ol.has');
 
@@ -79,7 +80,7 @@ ol.DeviceOrientation = function(opt_options) {
 
   goog.base(this);
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   /**
    * @private
@@ -91,7 +92,8 @@ ol.DeviceOrientation = function(opt_options) {
       ol.Object.getChangeEventType(ol.DeviceOrientationProperty.TRACKING),
       this.handleTrackingChanged_, false, this);
 
-  this.setTracking(goog.isDef(options.tracking) ? options.tracking : false);
+  this.setTracking(ol.isDef(options.tracking) ?
+      /** @type {boolean} */ (options.tracking) : false);
 
 };
 goog.inherits(ol.DeviceOrientation, ol.Object);

--- a/src/ol/dom/dom.js
+++ b/src/ol/dom/dom.js
@@ -19,10 +19,10 @@ goog.require('ol');
  */
 ol.dom.createCanvasContext2D = function(opt_width, opt_height) {
   var canvas = goog.dom.createElement(goog.dom.TagName.CANVAS);
-  if (goog.isDef(opt_width)) {
+  if (opt_width) {
     canvas.width = opt_width;
   }
-  if (goog.isDef(opt_height)) {
+  if (opt_height) {
     canvas.height = opt_height;
   }
   return canvas.getContext('2d');
@@ -47,7 +47,7 @@ ol.dom.BrowserFeature = {
 ol.dom.canUseCssTransform = (function() {
   var canUseCssTransform;
   return function() {
-    if (!goog.isDef(canUseCssTransform)) {
+    if (!ol.isDef(canUseCssTransform)) {
       goog.asserts.assert(!goog.isNull(document.body),
           'document.body should not be null');
       if (!goog.global.getComputedStyle) {
@@ -90,7 +90,7 @@ ol.dom.canUseCssTransform = (function() {
 ol.dom.canUseCssTransform3D = (function() {
   var canUseCssTransform3D;
   return function() {
-    if (!goog.isDef(canUseCssTransform3D)) {
+    if (!ol.isDef(canUseCssTransform3D)) {
       goog.asserts.assert(!goog.isNull(document.body),
           'document.body should not be null');
       if (!goog.global.getComputedStyle) {
@@ -224,7 +224,7 @@ ol.dom.transformElement2D =
   if (ol.dom.canUseCssTransform3D()) {
     var value3D;
 
-    if (goog.isDef(opt_precision)) {
+    if (ol.isDef(opt_precision)) {
       /** @type {Array.<string>} */
       var strings3D = new Array(16);
       for (i = 0; i < 16; ++i) {
@@ -246,7 +246,7 @@ ol.dom.transformElement2D =
       goog.vec.Mat4.getElement(transform, 1, 3)
     ];
     var value2D;
-    if (goog.isDef(opt_precision)) {
+    if (ol.isDef(opt_precision)) {
       /** @type {Array.<string>} */
       var strings2D = new Array(6);
       for (i = 0; i < 6; ++i) {

--- a/src/ol/dom/dom.js
+++ b/src/ol/dom/dom.js
@@ -47,7 +47,7 @@ ol.dom.BrowserFeature = {
 ol.dom.canUseCssTransform = (function() {
   var canUseCssTransform;
   return function() {
-    if (!ol.isDef(canUseCssTransform)) {
+    if (canUseCssTransform === undefined) {
       goog.asserts.assert(!goog.isNull(document.body),
           'document.body should not be null');
       if (!goog.global.getComputedStyle) {
@@ -90,7 +90,7 @@ ol.dom.canUseCssTransform = (function() {
 ol.dom.canUseCssTransform3D = (function() {
   var canUseCssTransform3D;
   return function() {
-    if (!ol.isDef(canUseCssTransform3D)) {
+    if (canUseCssTransform3D === undefined) {
       goog.asserts.assert(!goog.isNull(document.body),
           'document.body should not be null');
       if (!goog.global.getComputedStyle) {
@@ -224,7 +224,7 @@ ol.dom.transformElement2D =
   if (ol.dom.canUseCssTransform3D()) {
     var value3D;
 
-    if (ol.isDef(opt_precision)) {
+    if (opt_precision !== undefined) {
       /** @type {Array.<string>} */
       var strings3D = new Array(16);
       for (i = 0; i < 16; ++i) {
@@ -246,7 +246,7 @@ ol.dom.transformElement2D =
       goog.vec.Mat4.getElement(transform, 1, 3)
     ];
     var value2D;
-    if (ol.isDef(opt_precision)) {
+    if (opt_precision !== undefined) {
       /** @type {Array.<string>} */
       var strings2D = new Array(6);
       for (i = 0; i < 6; ++i) {

--- a/src/ol/extent.js
+++ b/src/ol/extent.js
@@ -87,7 +87,7 @@ ol.extent.boundingExtentXYs_ = function(xs, ys, opt_extent) {
  * @api stable
  */
 ol.extent.buffer = function(extent, value, opt_extent) {
-  if (goog.isDef(opt_extent)) {
+  if (opt_extent) {
     opt_extent[0] = extent[0] - value;
     opt_extent[1] = extent[1] - value;
     opt_extent[2] = extent[2] + value;
@@ -112,7 +112,7 @@ ol.extent.buffer = function(extent, value, opt_extent) {
  * @return {ol.Extent} The clone.
  */
 ol.extent.clone = function(extent, opt_extent) {
-  if (goog.isDef(opt_extent)) {
+  if (opt_extent) {
     opt_extent[0] = extent[0];
     opt_extent[1] = extent[1];
     opt_extent[2] = extent[2];
@@ -247,7 +247,7 @@ ol.extent.createEmpty = function() {
  * @return {ol.Extent} Extent.
  */
 ol.extent.createOrUpdate = function(minX, minY, maxX, maxY, opt_extent) {
-  if (goog.isDef(opt_extent)) {
+  if (opt_extent) {
     opt_extent[0] = minX;
     opt_extent[1] = minY;
     opt_extent[2] = maxX;
@@ -545,7 +545,7 @@ ol.extent.getCorner = function(extent, corner) {
   } else {
     goog.asserts.fail('Invalid corner: %s', corner);
   }
-  goog.asserts.assert(goog.isDef(coordinate), 'coordinate should be defined');
+  goog.asserts.assert(coordinate, 'coordinate should be defined');
   return coordinate;
 };
 
@@ -624,8 +624,7 @@ ol.extent.getIntersectionArea = function(extent1, extent2) {
  * @api stable
  */
 ol.extent.getIntersection = function(extent1, extent2, opt_extent) {
-  var intersection = goog.isDef(opt_extent) ?
-      opt_extent : ol.extent.createEmpty();
+  var intersection = opt_extent ? opt_extent : ol.extent.createEmpty();
   if (ol.extent.intersects(extent1, extent2)) {
     if (extent1[0] > extent2[0]) {
       intersection[0] = extent1[0];
@@ -760,7 +759,7 @@ ol.extent.normalize = function(extent, coordinate) {
  * @return {ol.Extent} Extent.
  */
 ol.extent.returnOrUpdate = function(extent, opt_extent) {
-  if (goog.isDef(opt_extent)) {
+  if (opt_extent) {
     opt_extent[0] = extent[0];
     opt_extent[1] = extent[1];
     opt_extent[2] = extent[2];
@@ -886,7 +885,7 @@ ol.extent.applyTransform = function(extent, transformFn, opt_extent) {
  * @return {ol.Extent} The transformed extent.
  */
 ol.extent.transform2D = function(extent, transform, opt_extent) {
-  var dest = goog.isDef(opt_extent) ? opt_extent : [];
+  var dest = opt_extent ? opt_extent : [];
   var m00 = goog.vec.Mat4.getElement(transform, 0, 0);
   var m10 = goog.vec.Mat4.getElement(transform, 1, 0);
   var m01 = goog.vec.Mat4.getElement(transform, 0, 1);

--- a/src/ol/feature.js
+++ b/src/ol/feature.js
@@ -97,7 +97,7 @@ ol.Feature = function(opt_geometryOrProperties) {
       this, ol.Object.getChangeEventType(this.geometryName_),
       this.handleGeometryChanged_, false, this);
 
-  if (ol.isDef(opt_geometryOrProperties)) {
+  if (opt_geometryOrProperties !== undefined) {
     if (opt_geometryOrProperties instanceof ol.geom.Geometry ||
         goog.isNull(opt_geometryOrProperties)) {
       var geometry = /** @type {ol.geom.Geometry} */ (opt_geometryOrProperties);

--- a/src/ol/feature.js
+++ b/src/ol/feature.js
@@ -5,6 +5,7 @@ goog.require('goog.asserts');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
 goog.require('goog.functions');
+goog.require('ol');
 goog.require('ol.Object');
 goog.require('ol.geom.Geometry');
 goog.require('ol.style.Style');
@@ -96,7 +97,7 @@ ol.Feature = function(opt_geometryOrProperties) {
       this, ol.Object.getChangeEventType(this.geometryName_),
       this.handleGeometryChanged_, false, this);
 
-  if (goog.isDef(opt_geometryOrProperties)) {
+  if (ol.isDef(opt_geometryOrProperties)) {
     if (opt_geometryOrProperties instanceof ol.geom.Geometry ||
         goog.isNull(opt_geometryOrProperties)) {
       var geometry = /** @type {ol.geom.Geometry} */ (opt_geometryOrProperties);

--- a/src/ol/format/esrijsonformat.js
+++ b/src/ol/format/esrijsonformat.js
@@ -32,7 +32,7 @@ goog.require('ol.proj');
  */
 ol.format.EsriJSON = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   goog.base(this);
 
@@ -80,9 +80,9 @@ ol.format.EsriJSON.readGeometry_ = function(object, opt_options) {
       object.rings = rings;
     }
   }
-  goog.asserts.assert(goog.isDef(type), 'geometry type should be defined');
+  goog.asserts.assert(type, 'geometry type should be defined');
   var geometryReader = ol.format.EsriJSON.GEOMETRY_READERS_[type];
-  goog.asserts.assert(goog.isDef(geometryReader),
+  goog.asserts.assert(geometryReader,
       'geometryReader should be defined');
   return /** @type {ol.geom.Geometry} */ (
       ol.format.Feature.transformWithOptions(
@@ -490,19 +490,19 @@ ol.format.EsriJSON.prototype.readFeatureFromObject = function(
   var geometry = ol.format.EsriJSON.readGeometry_(esriJSONFeature.geometry,
       opt_options);
   var feature = new ol.Feature();
-  if (goog.isDef(this.geometryName_)) {
+  if (this.geometryName_) {
     feature.setGeometryName(this.geometryName_);
   }
   feature.setGeometry(geometry);
-  if (goog.isDef(opt_options) && goog.isDef(opt_options.idField) &&
-      goog.isDef(esriJSONFeature.attributes[opt_options.idField])) {
+  if (opt_options && opt_options.idField &&
+      esriJSONFeature.attributes[opt_options.idField]) {
     goog.asserts.assert(
         goog.isNumber(esriJSONFeature.attributes[opt_options.idField]),
         'objectIdFieldName value should be a number');
     feature.setId(/** @type {number} */(
         esriJSONFeature.attributes[opt_options.idField]));
   }
-  if (goog.isDef(esriJSONFeature.attributes)) {
+  if (esriJSONFeature.attributes) {
     feature.setProperties(esriJSONFeature.attributes);
   }
   return feature;
@@ -515,7 +515,7 @@ ol.format.EsriJSON.prototype.readFeatureFromObject = function(
 ol.format.EsriJSON.prototype.readFeaturesFromObject = function(
     object, opt_options) {
   var esriJSONObject = /** @type {EsriJSONObject} */ (object);
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
   if (goog.isDefAndNotNull(esriJSONObject.features)) {
     var esriJSONFeatureCollection = /** @type {EsriJSONFeatureCollection} */
         (object);
@@ -591,8 +591,7 @@ ol.format.EsriJSON.prototype.readProjectionFromObject = function(object) {
  */
 ol.format.EsriJSON.writeGeometry_ = function(geometry, opt_options) {
   var geometryWriter = ol.format.EsriJSON.GEOMETRY_WRITERS_[geometry.getType()];
-  goog.asserts.assert(goog.isDef(geometryWriter),
-      'geometryWriter should be defined');
+  goog.asserts.assert(geometryWriter, 'geometryWriter should be defined');
   return geometryWriter(/** @type {ol.geom.Geometry} */ (
       ol.format.Feature.transformWithOptions(geometry, true, opt_options)),
       opt_options);
@@ -662,7 +661,7 @@ ol.format.EsriJSON.prototype.writeFeatureObject = function(
   } else {
     object['attributes'] = {};
   }
-  if (goog.isDef(opt_options) && goog.isDef(opt_options.featureProjection)) {
+  if (opt_options && opt_options.featureProjection) {
     object['spatialReference'] = /** @type {EsriJSONCRS} */({
       wkid: ol.proj.get(
           opt_options.featureProjection).getCode().split(':').pop()

--- a/src/ol/format/featureformat.js
+++ b/src/ol/format/featureformat.js
@@ -42,9 +42,9 @@ ol.format.Feature.prototype.getExtensions = goog.abstractMethod;
  */
 ol.format.Feature.prototype.getReadOptions = function(source, opt_options) {
   var options;
-  if (goog.isDef(opt_options)) {
+  if (opt_options) {
     options = {
-      dataProjection: goog.isDef(opt_options.dataProjection) ?
+      dataProjection: opt_options.dataProjection ?
           opt_options.dataProjection : this.readProjection(source),
       featureProjection: opt_options.featureProjection
     };
@@ -64,7 +64,7 @@ ol.format.Feature.prototype.getReadOptions = function(source, opt_options) {
  */
 ol.format.Feature.prototype.adaptOptions = function(options) {
   var updatedOptions;
-  if (goog.isDef(options)) {
+  if (options) {
     updatedOptions = {
       featureProjection: options.featureProjection,
       dataProjection: goog.isDefAndNotNull(options.dataProjection) ?
@@ -161,9 +161,9 @@ ol.format.Feature.prototype.writeGeometry = goog.abstractMethod;
  */
 ol.format.Feature.transformWithOptions = function(
     geometry, write, opt_options) {
-  var featureProjection = goog.isDef(opt_options) ?
+  var featureProjection = opt_options ?
       ol.proj.get(opt_options.featureProjection) : null;
-  var dataProjection = goog.isDef(opt_options) ?
+  var dataProjection = opt_options ?
       ol.proj.get(opt_options.dataProjection) : null;
   if (!goog.isNull(featureProjection) && !goog.isNull(dataProjection) &&
       !ol.proj.equivalent(featureProjection, dataProjection)) {

--- a/src/ol/format/geojsonformat.js
+++ b/src/ol/format/geojsonformat.js
@@ -31,7 +31,7 @@ goog.require('ol.proj');
  */
 ol.format.GeoJSON = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   goog.base(this);
 
@@ -73,8 +73,7 @@ ol.format.GeoJSON.readGeometry_ = function(object, opt_options) {
     return null;
   }
   var geometryReader = ol.format.GeoJSON.GEOMETRY_READERS_[object.type];
-  goog.asserts.assert(goog.isDef(geometryReader),
-      'geometryReader should be defined');
+  goog.asserts.assert(geometryReader, 'geometryReader should be defined');
   return /** @type {ol.geom.Geometry} */ (
       ol.format.Feature.transformWithOptions(
           geometryReader(object), false, opt_options));
@@ -183,8 +182,7 @@ ol.format.GeoJSON.readPolygonGeometry_ = function(object) {
  */
 ol.format.GeoJSON.writeGeometry_ = function(geometry, opt_options) {
   var geometryWriter = ol.format.GeoJSON.GEOMETRY_WRITERS_[geometry.getType()];
-  goog.asserts.assert(goog.isDef(geometryWriter),
-      'geometryWriter should be defined');
+  goog.asserts.assert(geometryWriter, 'geometryWriter should be defined');
   return geometryWriter(/** @type {ol.geom.Geometry} */ (
       ol.format.Feature.transformWithOptions(geometry, true, opt_options)),
       opt_options);
@@ -284,7 +282,7 @@ ol.format.GeoJSON.writeMultiPolygonGeometry_ = function(geometry, opt_options) {
   goog.asserts.assertInstanceof(geometry, ol.geom.MultiPolygon,
       'geometry should be an ol.geom.MultiPolygon');
   var right;
-  if (goog.isDef(opt_options)) {
+  if (opt_options) {
     right = opt_options.rightHanded;
   }
   return /** @type {GeoJSONGeometry} */ ({
@@ -320,7 +318,7 @@ ol.format.GeoJSON.writePolygonGeometry_ = function(geometry, opt_options) {
   goog.asserts.assertInstanceof(geometry, ol.geom.Polygon,
       'geometry should be an ol.geom.Polygon');
   var right;
-  if (goog.isDef(opt_options)) {
+  if (opt_options) {
     right = opt_options.rightHanded;
   }
   return /** @type {GeoJSONGeometry} */ ({
@@ -408,14 +406,14 @@ ol.format.GeoJSON.prototype.readFeatureFromObject = function(
   var geometry = ol.format.GeoJSON.readGeometry_(geoJSONFeature.geometry,
       opt_options);
   var feature = new ol.Feature();
-  if (goog.isDef(this.geometryName_)) {
+  if (this.geometryName_) {
     feature.setGeometryName(this.geometryName_);
   }
   feature.setGeometry(geometry);
-  if (goog.isDef(geoJSONFeature.id)) {
+  if (geoJSONFeature.id) {
     feature.setId(geoJSONFeature.id);
   }
-  if (goog.isDef(geoJSONFeature.properties)) {
+  if (geoJSONFeature.properties) {
     feature.setProperties(geoJSONFeature.properties);
   }
   return feature;

--- a/src/ol/format/gml/gml2format.js
+++ b/src/ol/format/gml/gml2format.js
@@ -22,7 +22,7 @@ goog.require('ol.xml');
  */
 ol.format.GML2 = function(opt_options) {
   var options = /** @type {olx.format.GMLOptions} */
-      (goog.isDef(opt_options) ? opt_options : {});
+      (opt_options ? opt_options : {});
 
   goog.base(this, options);
 
@@ -33,7 +33,7 @@ ol.format.GML2 = function(opt_options) {
   /**
    * @inheritDoc
    */
-  this.schemaLocation = goog.isDef(options.schemaLocation) ?
+  this.schemaLocation = options.schemaLocation ?
       options.schemaLocation : ol.format.GML2.schemaLocation_;
 
 };
@@ -127,7 +127,7 @@ ol.format.GML2.prototype.innerBoundaryIsParser_ =
   var flatLinearRing = ol.xml.pushParseAndPop(
       /** @type {Array.<number>|undefined} */ (undefined),
       this.RING_PARSERS, node, objectStack, this);
-  if (goog.isDef(flatLinearRing)) {
+  if (flatLinearRing) {
     var flatLinearRings = /** @type {Array.<Array.<number>>} */
         (objectStack[objectStack.length - 1]);
     goog.asserts.assert(goog.isArray(flatLinearRings),
@@ -153,7 +153,7 @@ ol.format.GML2.prototype.outerBoundaryIsParser_ =
   var flatLinearRing = ol.xml.pushParseAndPop(
       /** @type {Array.<number>|undefined} */ (undefined),
       this.RING_PARSERS, node, objectStack, this);
-  if (goog.isDef(flatLinearRing)) {
+  if (flatLinearRing) {
     var flatLinearRings = /** @type {Array.<Array.<number>>} */
         (objectStack[objectStack.length - 1]);
     goog.asserts.assert(goog.isArray(flatLinearRings),

--- a/src/ol/format/gml/gml3format.js
+++ b/src/ol/format/gml/gml3format.js
@@ -5,6 +5,7 @@ goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.dom.NodeType');
 goog.require('goog.object');
+goog.require('ol');
 goog.require('ol.Feature');
 goog.require('ol.extent');
 goog.require('ol.format.Feature');
@@ -37,7 +38,7 @@ goog.require('ol.xml');
  */
 ol.format.GML3 = function(opt_options) {
   var options = /** @type {olx.format.GMLOptions} */
-      (goog.isDef(opt_options) ? opt_options : {});
+      (opt_options ? opt_options : {});
 
   goog.base(this, options);
 
@@ -45,34 +46,34 @@ ol.format.GML3 = function(opt_options) {
    * @private
    * @type {boolean}
    */
-  this.surface_ = goog.isDef(options.surface) ?
-      options.surface : false;
+  this.surface_ = ol.isDef(options.surface) ?
+      /** @type {boolean} */ (options.surface) : false;
 
   /**
    * @private
    * @type {boolean}
    */
-  this.curve_ = goog.isDef(options.curve) ?
-      options.curve : false;
+  this.curve_ = ol.isDef(options.curve) ?
+      /** @type {boolean} */ (options.curve) : false;
 
   /**
    * @private
    * @type {boolean}
    */
-  this.multiCurve_ = goog.isDef(options.multiCurve) ?
-      options.multiCurve : true;
+  this.multiCurve_ = ol.isDef(options.multiCurve) ?
+      /** @type {boolean} */ (options.multiCurve) : true;
 
   /**
    * @private
    * @type {boolean}
    */
-  this.multiSurface_ = goog.isDef(options.multiSurface) ?
-      options.multiSurface : true;
+  this.multiSurface_ = ol.isDef(options.multiSurface) ?
+      /** @type {boolean} */ (options.multiSurface) : true;
 
   /**
    * @inheritDoc
    */
-  this.schemaLocation = goog.isDef(options.schemaLocation) ?
+  this.schemaLocation = options.schemaLocation ?
       options.schemaLocation : ol.format.GML3.schemaLocation_;
 
 };
@@ -103,7 +104,7 @@ ol.format.GML3.prototype.readMultiCurve_ = function(node, objectStack) {
   var lineStrings = ol.xml.pushParseAndPop(
       /** @type {Array.<ol.geom.LineString>} */ ([]),
       this.MULTICURVE_PARSERS_, node, objectStack, this);
-  if (goog.isDef(lineStrings)) {
+  if (lineStrings) {
     var multiLineString = new ol.geom.MultiLineString(null);
     multiLineString.setLineStrings(lineStrings);
     return multiLineString;
@@ -127,7 +128,7 @@ ol.format.GML3.prototype.readMultiSurface_ = function(node, objectStack) {
   var polygons = ol.xml.pushParseAndPop(
       /** @type {Array.<ol.geom.Polygon>} */ ([]),
       this.MULTISURFACE_PARSERS_, node, objectStack, this);
-  if (goog.isDef(polygons)) {
+  if (polygons) {
     var multiPolygon = new ol.geom.MultiPolygon(null);
     multiPolygon.setPolygons(polygons);
     return multiPolygon;
@@ -251,7 +252,7 @@ ol.format.GML3.prototype.interiorParser_ = function(node, objectStack) {
   var flatLinearRing = ol.xml.pushParseAndPop(
       /** @type {Array.<number>|undefined} */ (undefined),
       this.RING_PARSERS, node, objectStack, this);
-  if (goog.isDef(flatLinearRing)) {
+  if (flatLinearRing) {
     var flatLinearRings = /** @type {Array.<Array.<number>>} */
         (objectStack[objectStack.length - 1]);
     goog.asserts.assert(goog.isArray(flatLinearRings),
@@ -276,7 +277,7 @@ ol.format.GML3.prototype.exteriorParser_ = function(node, objectStack) {
   var flatLinearRing = ol.xml.pushParseAndPop(
       /** @type {Array.<number>|undefined} */ (undefined),
       this.RING_PARSERS, node, objectStack, this);
-  if (goog.isDef(flatLinearRing)) {
+  if (flatLinearRing) {
     var flatLinearRings = /** @type {Array.<Array.<number>>} */
         (objectStack[objectStack.length - 1]);
     goog.asserts.assert(goog.isArray(flatLinearRings),
@@ -302,8 +303,7 @@ ol.format.GML3.prototype.readSurface_ = function(node, objectStack) {
   var flatLinearRings = ol.xml.pushParseAndPop(
       /** @type {Array.<Array.<number>>} */ ([null]),
       this.SURFACE_PARSERS_, node, objectStack, this);
-  if (goog.isDef(flatLinearRings) &&
-      !goog.isNull(flatLinearRings[0])) {
+  if (flatLinearRings && !goog.isNull(flatLinearRings[0])) {
     var polygon = new ol.geom.Polygon(null);
     var flatCoordinates = flatLinearRings[0];
     var ends = [flatCoordinates.length];
@@ -334,7 +334,7 @@ ol.format.GML3.prototype.readCurve_ = function(node, objectStack) {
   var flatCoordinates = ol.xml.pushParseAndPop(
       /** @type {Array.<number>} */ ([null]),
       this.CURVE_PARSERS_, node, objectStack, this);
-  if (goog.isDef(flatCoordinates)) {
+  if (flatCoordinates) {
     var lineString = new ol.geom.LineString(null);
     lineString.setFlatCoordinates(ol.geom.GeometryLayout.XYZ, flatCoordinates);
     return lineString;
@@ -741,7 +741,7 @@ ol.format.GML3.prototype.writeEnvelope = function(node, extent, objectStack) {
   var context = objectStack[objectStack.length - 1];
   goog.asserts.assert(goog.isObject(context), 'context should be an Object');
   var srsName = context['srsName'];
-  if (goog.isDef(srsName)) {
+  if (srsName) {
     node.setAttribute('srsName', srsName);
   }
   var keys = ['lowerCorner', 'upperCorner'];
@@ -787,11 +787,11 @@ ol.format.GML3.prototype.RING_NODE_FACTORY_ =
   var parentNode = context.node;
   goog.asserts.assert(goog.isObject(context), 'context should be an Object');
   var exteriorWritten = context['exteriorWritten'];
-  if (!goog.isDef(exteriorWritten)) {
+  if (!ol.isDef(exteriorWritten)) {
     context['exteriorWritten'] = true;
   }
   return ol.xml.createElementNS(parentNode.namespaceURI,
-      goog.isDef(exteriorWritten) ? 'interior' : 'exterior');
+      ol.isDef(exteriorWritten) ? 'interior' : 'exterior');
 };
 
 
@@ -947,7 +947,7 @@ ol.format.GML3.prototype.writeSurfaceOrPolygonMember_ =
   goog.asserts.assert(goog.isObject(context), 'context should be an Object');
   var child = this.GEOMETRY_NODE_FACTORY_(
       polygon, objectStack);
-  if (goog.isDef(child)) {
+  if (child) {
     node.appendChild(child);
     this.writeSurfaceOrPolygon_(child, polygon, objectStack);
   }
@@ -979,7 +979,7 @@ ol.format.GML3.prototype.writeLineStringOrCurveMember_ =
   var context = objectStack[objectStack.length - 1];
   goog.asserts.assert(goog.isObject(context), 'context should be an Object');
   var child = this.GEOMETRY_NODE_FACTORY_(line, objectStack);
-  if (goog.isDef(child)) {
+  if (child) {
     node.appendChild(child);
     this.writeCurveOrLineString_(child, line, objectStack);
   }
@@ -1028,7 +1028,7 @@ ol.format.GML3.prototype.writeGeometryElement =
   item.node = node;
   var value;
   if (goog.isArray(geometry)) {
-    if (goog.isDef(context.dataProjection)) {
+    if (context.dataProjection) {
       value = ol.proj.transformExtent(
           geometry, context.featureProjection, context.dataProjection);
     } else {
@@ -1055,14 +1055,14 @@ ol.format.GML3.prototype.writeGeometryElement =
 ol.format.GML3.prototype.writeFeatureElement =
     function(node, feature, objectStack) {
   var fid = feature.getId();
-  if (goog.isDef(fid)) {
+  if (fid) {
     node.setAttribute('fid', fid);
   }
   var context = objectStack[objectStack.length - 1];
   goog.asserts.assert(goog.isObject(context), 'context should be an Object');
   var featureNS = context['featureNS'];
   var geometryName = feature.getGeometryName();
-  if (!goog.isDef(context.serializers)) {
+  if (!context.serializers) {
     context.serializers = {};
     context.serializers[featureNS] = {};
   }
@@ -1293,7 +1293,7 @@ ol.format.GML3.prototype.writeGeometryNode = function(geometry, opt_options) {
   var context = {node: geom, srsName: this.srsName,
     curve: this.curve_, surface: this.surface_,
     multiSurface: this.multiSurface_, multiCurve: this.multiCurve_};
-  if (goog.isDef(opt_options)) {
+  if (opt_options) {
     goog.object.extend(context, opt_options);
   }
   this.writeGeometryElement(geom, geometry, [context]);
@@ -1336,7 +1336,7 @@ ol.format.GML3.prototype.writeFeaturesNode = function(features, opt_options) {
     featureNS: this.featureNS,
     featureType: this.featureType
   };
-  if (goog.isDef(opt_options)) {
+  if (opt_options) {
     goog.object.extend(context, opt_options);
   }
   this.writeFeatureMembers_(node, features, [context]);

--- a/src/ol/format/gml/gml3format.js
+++ b/src/ol/format/gml/gml3format.js
@@ -46,28 +46,26 @@ ol.format.GML3 = function(opt_options) {
    * @private
    * @type {boolean}
    */
-  this.surface_ = ol.isDef(options.surface) ?
-      /** @type {boolean} */ (options.surface) : false;
+  this.surface_ = options.surface !== undefined ? options.surface : false;
 
   /**
    * @private
    * @type {boolean}
    */
-  this.curve_ = ol.isDef(options.curve) ?
-      /** @type {boolean} */ (options.curve) : false;
+  this.curve_ = options.curve !== undefined ? options.curve : false;
 
   /**
    * @private
    * @type {boolean}
    */
-  this.multiCurve_ = ol.isDef(options.multiCurve) ?
-      /** @type {boolean} */ (options.multiCurve) : true;
+  this.multiCurve_ = options.multiCurve !== undefined ?
+      options.multiCurve : true;
 
   /**
    * @private
    * @type {boolean}
    */
-  this.multiSurface_ = ol.isDef(options.multiSurface) ?
+  this.multiSurface_ = options.multiSurface !== undefined ?
       /** @type {boolean} */ (options.multiSurface) : true;
 
   /**
@@ -787,11 +785,11 @@ ol.format.GML3.prototype.RING_NODE_FACTORY_ =
   var parentNode = context.node;
   goog.asserts.assert(goog.isObject(context), 'context should be an Object');
   var exteriorWritten = context['exteriorWritten'];
-  if (!ol.isDef(exteriorWritten)) {
+  if (exteriorWritten === undefined) {
     context['exteriorWritten'] = true;
   }
   return ol.xml.createElementNS(parentNode.namespaceURI,
-      ol.isDef(exteriorWritten) ? 'interior' : 'exterior');
+      exteriorWritten !== undefined ? 'interior' : 'exterior');
 };
 
 

--- a/src/ol/format/gml/gmlbaseformat.js
+++ b/src/ol/format/gml/gmlbaseformat.js
@@ -41,7 +41,7 @@ goog.require('ol.xml');
  */
 ol.format.GMLBase = function(opt_options) {
   var options = /** @type {olx.format.GMLOptions} */
-      (goog.isDef(opt_options) ? opt_options : {});
+      (opt_options ? opt_options : {});
 
   /**
    * @protected
@@ -116,7 +116,7 @@ ol.format.GMLBase.prototype.readFeaturesInternal = function(node, objectStack) {
     var featureType = context['featureType'];
     var featureNS = context['featureNS'];
     var i, ii, prefix = 'p', defaultPrefix = 'p0';
-    if (!goog.isDef(featureType) && goog.isDefAndNotNull(node.childNodes)) {
+    if (!featureType && goog.isDefAndNotNull(node.childNodes)) {
       featureType = [], featureNS = {};
       for (i = 0, ii = node.childNodes.length; i < ii; ++i) {
         var child = node.childNodes[i];
@@ -162,7 +162,7 @@ ol.format.GMLBase.prototype.readFeaturesInternal = function(node, objectStack) {
     }
     features = ol.xml.pushParseAndPop([], parsersNS, node, objectStack);
   }
-  if (!goog.isDef(features)) {
+  if (!features) {
     features = [];
   }
   return features;
@@ -222,7 +222,7 @@ ol.format.GMLBase.prototype.readFeatureElement = function(node, objectStack) {
     }
   }
   var feature = new ol.Feature(values);
-  if (goog.isDef(geometryName)) {
+  if (geometryName) {
     feature.setGeometryName(geometryName);
   }
   if (fid) {
@@ -266,7 +266,7 @@ ol.format.GMLBase.prototype.readMultiPoint = function(node, objectStack) {
   var coordinates = ol.xml.pushParseAndPop(
       /** @type {Array.<Array.<number>>} */ ([]),
       this.MULTIPOINT_PARSERS_, node, objectStack, this);
-  if (goog.isDef(coordinates)) {
+  if (coordinates) {
     return new ol.geom.MultiPoint(coordinates);
   } else {
     return undefined;
@@ -287,7 +287,7 @@ ol.format.GMLBase.prototype.readMultiLineString = function(node, objectStack) {
   var lineStrings = ol.xml.pushParseAndPop(
       /** @type {Array.<ol.geom.LineString>} */ ([]),
       this.MULTILINESTRING_PARSERS_, node, objectStack, this);
-  if (goog.isDef(lineStrings)) {
+  if (lineStrings) {
     var multiLineString = new ol.geom.MultiLineString(null);
     multiLineString.setLineStrings(lineStrings);
     return multiLineString;
@@ -310,7 +310,7 @@ ol.format.GMLBase.prototype.readMultiPolygon = function(node, objectStack) {
   var polygons = ol.xml.pushParseAndPop(
       /** @type {Array.<ol.geom.Polygon>} */ ([]),
       this.MULTIPOLYGON_PARSERS_, node, objectStack, this);
-  if (goog.isDef(polygons)) {
+  if (polygons) {
     var multiPolygon = new ol.geom.MultiPolygon(null);
     multiPolygon.setPolygons(polygons);
     return multiPolygon;
@@ -426,7 +426,7 @@ ol.format.GMLBase.prototype.readLinearRing = function(node, objectStack) {
       'localName should be LinearRing');
   var flatCoordinates =
       this.readFlatCoordinatesFromNode_(node, objectStack);
-  if (goog.isDef(flatCoordinates)) {
+  if (flatCoordinates) {
     var ring = new ol.geom.LinearRing(null);
     ring.setFlatCoordinates(ol.geom.GeometryLayout.XYZ, flatCoordinates);
     return ring;
@@ -449,7 +449,7 @@ ol.format.GMLBase.prototype.readPolygon = function(node, objectStack) {
   var flatLinearRings = ol.xml.pushParseAndPop(
       /** @type {Array.<Array.<number>>} */ ([null]),
       this.FLAT_LINEAR_RINGS_PARSERS_, node, objectStack, this);
-  if (goog.isDef(flatLinearRings) &&
+  if (flatLinearRings &&
       !goog.isNull(flatLinearRings[0])) {
     var polygon = new ol.geom.Polygon(null);
     var flatCoordinates = flatLinearRings[0];
@@ -588,8 +588,8 @@ ol.format.GMLBase.prototype.RING_PARSERS = Object({
 ol.format.GMLBase.prototype.readGeometryFromNode =
     function(node, opt_options) {
   var geometry = this.readGeometryElement(node,
-      [this.getReadOptions(node, goog.isDef(opt_options) ? opt_options : {})]);
-  return goog.isDef(geometry) ? geometry : null;
+      [this.getReadOptions(node, opt_options ? opt_options : {})]);
+  return geometry ? geometry : null;
 };
 
 
@@ -614,7 +614,7 @@ ol.format.GMLBase.prototype.readFeaturesFromNode =
     featureType: this.featureType,
     featureNS: this.featureNS
   };
-  if (goog.isDef(opt_options)) {
+  if (opt_options) {
     goog.object.extend(options, this.getReadOptions(node, opt_options));
   }
   return this.readFeaturesInternal(node, [options]);
@@ -625,6 +625,6 @@ ol.format.GMLBase.prototype.readFeaturesFromNode =
  * @inheritDoc
  */
 ol.format.GMLBase.prototype.readProjectionFromNode = function(node) {
-  return ol.proj.get(goog.isDef(this.srsName_) ? this.srsName_ :
+  return ol.proj.get(this.srsName_ ? this.srsName_ :
       node.firstElementChild.getAttribute('srsName'));
 };

--- a/src/ol/format/gpxformat.js
+++ b/src/ol/format/gpxformat.js
@@ -27,7 +27,7 @@ goog.require('ol.xml');
  */
 ol.format.GPX = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   goog.base(this);
 
@@ -130,7 +130,7 @@ ol.format.GPX.parseRtePt_ = function(node, objectStack) {
   goog.asserts.assert(node.localName == 'rtept', 'localName should be rtept');
   var values = ol.xml.pushParseAndPop(
       {}, ol.format.GPX.RTEPT_PARSERS_, node, objectStack);
-  if (goog.isDef(values)) {
+  if (values) {
     var rteValues = /** @type {Object} */ (objectStack[objectStack.length - 1]);
     var flatCoordinates = /** @type {Array.<number>} */
         (rteValues['flatCoordinates']);
@@ -150,7 +150,7 @@ ol.format.GPX.parseTrkPt_ = function(node, objectStack) {
   goog.asserts.assert(node.localName == 'trkpt', 'localName should be trkpt');
   var values = ol.xml.pushParseAndPop(
       {}, ol.format.GPX.TRKPT_PARSERS_, node, objectStack);
-  if (goog.isDef(values)) {
+  if (values) {
     var trkValues = /** @type {Object} */ (objectStack[objectStack.length - 1]);
     var flatCoordinates = /** @type {Array.<number>} */
         (trkValues['flatCoordinates']);
@@ -192,7 +192,7 @@ ol.format.GPX.readRte_ = function(node, objectStack) {
   var values = ol.xml.pushParseAndPop({
     'flatCoordinates': []
   }, ol.format.GPX.RTE_PARSERS_, node, objectStack);
-  if (!goog.isDef(values)) {
+  if (!values) {
     return undefined;
   }
   var flatCoordinates = /** @type {Array.<number>} */
@@ -222,7 +222,7 @@ ol.format.GPX.readTrk_ = function(node, objectStack) {
     'flatCoordinates': [],
     'ends': []
   }, ol.format.GPX.TRK_PARSERS_, node, objectStack);
-  if (!goog.isDef(values)) {
+  if (!values) {
     return undefined;
   }
   var flatCoordinates = /** @type {Array.<number>} */
@@ -253,7 +253,7 @@ ol.format.GPX.readWpt_ = function(node, objectStack) {
   var options = /** @type {olx.format.ReadOptions} */ (objectStack[0]);
   var values = ol.xml.pushParseAndPop(
       {}, ol.format.GPX.WPT_PARSERS_, node, objectStack);
-  if (!goog.isDef(values)) {
+  if (!values) {
     return undefined;
   }
   var coordinates = ol.format.GPX.appendCoordinate_([], node, values);
@@ -422,7 +422,7 @@ ol.format.GPX.prototype.handleReadExtensions_ = function(features) {
   }
   for (var i = 0, ii = features.length; i < ii; ++i) {
     var feature = features[i];
-    if (goog.isDef(this.readExtensions_)) {
+    if (this.readExtensions_) {
       var extensionsNode = feature.get('extensionsNode_') || null;
       this.readExtensions_(feature, extensionsNode);
     }
@@ -453,11 +453,11 @@ ol.format.GPX.prototype.readFeatureFromNode = function(node, opt_options) {
     return null;
   }
   var featureReader = ol.format.GPX.FEATURE_READER_[node.localName];
-  if (!goog.isDef(featureReader)) {
+  if (!featureReader) {
     return null;
   }
   var feature = featureReader(node, [this.getReadOptions(node, opt_options)]);
-  if (!goog.isDef(feature)) {
+  if (!feature) {
     return null;
   }
   this.handleReadExtensions_([feature]);
@@ -490,7 +490,7 @@ ol.format.GPX.prototype.readFeaturesFromNode = function(node, opt_options) {
     var features = ol.xml.pushParseAndPop(
         /** @type {Array.<ol.Feature>} */ ([]), ol.format.GPX.GPX_PARSERS_,
         node, [this.getReadOptions(node, opt_options)]);
-    if (goog.isDef(features)) {
+    if (features) {
       this.handleReadExtensions_(features);
       return features;
     } else {
@@ -588,7 +588,7 @@ ol.format.GPX.writeRte_ = function(node, feature, objectStack) {
   var properties = feature.getProperties();
   var context = {node: node, 'properties': properties};
   var geometry = feature.getGeometry();
-  if (goog.isDef(geometry)) {
+  if (geometry) {
     goog.asserts.assertInstanceof(geometry, ol.geom.LineString,
         'geometry should be an ol.geom.LineString');
     geometry = /** @type {ol.geom.LineString} */
@@ -616,7 +616,7 @@ ol.format.GPX.writeTrk_ = function(node, feature, objectStack) {
   var properties = feature.getProperties();
   var context = {node: node, 'properties': properties};
   var geometry = feature.getGeometry();
-  if (goog.isDef(geometry)) {
+  if (geometry) {
     goog.asserts.assertInstanceof(geometry, ol.geom.MultiLineString,
         'geometry should be an ol.geom.MultiLineString');
     geometry = /** @type {ol.geom.MultiLineString} */
@@ -659,7 +659,7 @@ ol.format.GPX.writeWpt_ = function(node, feature, objectStack) {
   goog.asserts.assert(goog.isObject(context), 'context should be an Object');
   context['properties'] = feature.getProperties();
   var geometry = feature.getGeometry();
-  if (goog.isDef(geometry)) {
+  if (geometry) {
     goog.asserts.assertInstanceof(geometry, ol.geom.Point,
         'geometry should be an ol.geom.Point');
     geometry = /** @type {ol.geom.Point} */
@@ -838,7 +838,7 @@ ol.format.GPX.GPX_NODE_FACTORY_ = function(value, objectStack, opt_nodeName) {
   goog.asserts.assertInstanceof(value, ol.Feature,
       'value should be an ol.Feature');
   var geometry = value.getGeometry();
-  if (goog.isDef(geometry)) {
+  if (geometry) {
     var parentNode = objectStack[objectStack.length - 1].node;
     goog.asserts.assert(ol.xml.isNode(parentNode),
         'parentNode should be an XML node');

--- a/src/ol/format/igcformat.js
+++ b/src/ol/format/igcformat.js
@@ -36,7 +36,7 @@ ol.format.IGCZ = {
  */
 ol.format.IGC = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   goog.base(this);
 
@@ -49,7 +49,7 @@ ol.format.IGC = function(opt_options) {
    * @private
    * @type {ol.format.IGCZ}
    */
-  this.altitudeMode_ = goog.isDef(options.altitudeMode) ?
+  this.altitudeMode_ = options.altitudeMode ?
       options.altitudeMode : ol.format.IGCZ.NONE;
 
 };

--- a/src/ol/format/jsonfeatureformat.js
+++ b/src/ol/format/jsonfeatureformat.js
@@ -32,7 +32,7 @@ ol.format.JSONFeature.prototype.getObject_ = function(source) {
     return source;
   } else if (goog.isString(source)) {
     var object = goog.json.parse(source);
-    return goog.isDef(object) ? object : null;
+    return object ? object : null;
   } else {
     goog.asserts.fail();
     return null;

--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -89,8 +89,8 @@ ol.format.KML = function(opt_options) {
    * @private
    * @type {boolean}
    */
-  this.extractStyles_ = ol.isDef(options.extractStyles) ?
-      /** @type {boolean} */ (options.extractStyles) : true;
+  this.extractStyles_ = options.extractStyles !== undefined ?
+      options.extractStyles : true;
 
   /**
    * @private
@@ -441,7 +441,7 @@ ol.format.KML.readVec2_ = function(node) {
  */
 ol.format.KML.readScale_ = function(node) {
   var number = ol.format.XSD.readDecimal(node);
-  if (ol.isDef(number)) {
+  if (number !== undefined) {
     return Math.sqrt(number);
   } else {
     return undefined;
@@ -517,7 +517,7 @@ ol.format.KML.IconStyleParser_ = function(node, objectStack) {
       (IconObject['x']);
   var y = /** @type {number|undefined} */
       (IconObject['y']);
-  if (ol.isDef(x) && ol.isDef(y)) {
+  if (x !== undefined && y !== undefined) {
     offset = [x, y];
   }
 
@@ -526,14 +526,14 @@ ol.format.KML.IconStyleParser_ = function(node, objectStack) {
       (IconObject['w']);
   var h = /** @type {number|undefined} */
       (IconObject['h']);
-  if (ol.isDef(w) && ol.isDef(h)) {
+  if (w !== undefined && h !== undefined) {
     size = [w, h];
   }
 
   var rotation;
   var heading = /** @type {number} */
       (object['heading']);
-  if (ol.isDef(heading)) {
+  if (heading !== undefined) {
     rotation = goog.math.toRadians(heading);
   }
 
@@ -648,12 +648,12 @@ ol.format.KML.PolyStyleParser_ = function(node, objectStack) {
   });
   styleObject['fillStyle'] = fillStyle;
   var fill = /** @type {boolean|undefined} */ (object['fill']);
-  if (ol.isDef(fill)) {
+  if (fill !== undefined) {
     styleObject['fill'] = fill;
   }
   var outline =
       /** @type {boolean|undefined} */ (object['outline']);
-  if (ol.isDef(outline)) {
+  if (outline !== undefined) {
     styleObject['outline'] = outline;
   }
 };
@@ -1018,7 +1018,7 @@ ol.format.KML.readStyle_ = function(node, objectStack) {
       styleObject, 'fillStyle', ol.format.KML.DEFAULT_FILL_STYLE_));
   var fill = /** @type {boolean|undefined} */
       (styleObject['fill']);
-  if (ol.isDef(fill) && !fill) {
+  if (fill !== undefined && !fill) {
     fillStyle = null;
   }
   var imageStyle = /** @type {ol.style.Image} */ (goog.object.get(
@@ -1029,7 +1029,7 @@ ol.format.KML.readStyle_ = function(node, objectStack) {
       styleObject, 'strokeStyle', ol.format.KML.DEFAULT_STROKE_STYLE_));
   var outline = /** @type {boolean|undefined} */
       (styleObject['outline']);
-  if (ol.isDef(outline) && !outline) {
+  if (outline !== undefined && !outline) {
     strokeStyle = null;
   }
   return [new ol.style.Style({
@@ -1061,7 +1061,7 @@ ol.format.KML.setCommonGeometryProperties_ = function(multiGeometry,
     geometry = geometries[i];
     extrudes[i] = geometry.get('extrude');
     altitudeModes[i] = geometry.get('altitudeMode');
-    hasExtrude = hasExtrude || ol.isDef(extrudes[i]);
+    hasExtrude = hasExtrude || extrudes[i] !== undefined;
     hasAltitudeMode = hasAltitudeMode || altitudeModes[i];
   }
   if (hasExtrude) {

--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -13,6 +13,7 @@ goog.require('goog.dom.NodeType');
 goog.require('goog.math');
 goog.require('goog.object');
 goog.require('goog.string');
+goog.require('ol');
 goog.require('ol.Feature');
 goog.require('ol.FeatureStyleFunction');
 goog.require('ol.color');
@@ -68,7 +69,7 @@ ol.format.KMLGxTrackObject_;
  */
 ol.format.KML = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   goog.base(this);
 
@@ -81,15 +82,15 @@ ol.format.KML = function(opt_options) {
    * @private
    * @type {Array.<ol.style.Style>}
    */
-  this.defaultStyle_ = goog.isDef(options.defaultStyle) ?
+  this.defaultStyle_ = options.defaultStyle ?
       options.defaultStyle : ol.format.KML.DEFAULT_STYLE_ARRAY_;
 
   /**
    * @private
    * @type {boolean}
    */
-  this.extractStyles_ = goog.isDef(options.extractStyles) ?
-      options.extractStyles : true;
+  this.extractStyles_ = ol.isDef(options.extractStyles) ?
+      /** @type {boolean} */ (options.extractStyles) : true;
 
   /**
    * @private
@@ -296,10 +297,10 @@ ol.format.KML.createFeatureStyleFunction_ = function(
        * @this {ol.Feature}
        */
       function(resolution) {
-        if (goog.isDef(style)) {
+        if (style) {
           return style;
         }
-        if (goog.isDef(styleUrl)) {
+        if (styleUrl) {
           return ol.format.KML.findStyle_(styleUrl, defaultStyle, sharedStyles);
         }
         return defaultStyle;
@@ -440,7 +441,7 @@ ol.format.KML.readVec2_ = function(node) {
  */
 ol.format.KML.readScale_ = function(node) {
   var number = ol.format.XSD.readDecimal(node);
-  if (goog.isDef(number)) {
+  if (ol.isDef(number)) {
     return Math.sqrt(number);
   } else {
     return undefined;
@@ -479,7 +480,7 @@ ol.format.KML.IconStyleParser_ = function(node, objectStack) {
   // FIXME httpQuery
   var object = ol.xml.pushParseAndPop(
       {}, ol.format.KML.ICON_STYLE_PARSERS_, node, objectStack);
-  if (!goog.isDef(object)) {
+  if (!object) {
     return;
   }
   var styleObject = /** @type {Object} */ (objectStack[objectStack.length - 1]);
@@ -489,7 +490,7 @@ ol.format.KML.IconStyleParser_ = function(node, objectStack) {
   var src;
   var href = /** @type {string|undefined} */
       (IconObject['href']);
-  if (goog.isDef(href)) {
+  if (href) {
     src = href;
   } else {
     src = ol.format.KML.DEFAULT_IMAGE_STYLE_SRC_;
@@ -497,7 +498,7 @@ ol.format.KML.IconStyleParser_ = function(node, objectStack) {
   var anchor, anchorXUnits, anchorYUnits;
   var hotSpot = /** @type {ol.format.KMLVec2_|undefined} */
       (object['hotSpot']);
-  if (goog.isDef(hotSpot)) {
+  if (hotSpot) {
     anchor = [hotSpot.x, hotSpot.y];
     anchorXUnits = hotSpot.xunits;
     anchorYUnits = hotSpot.yunits;
@@ -516,7 +517,7 @@ ol.format.KML.IconStyleParser_ = function(node, objectStack) {
       (IconObject['x']);
   var y = /** @type {number|undefined} */
       (IconObject['y']);
-  if (goog.isDef(x) && goog.isDef(y)) {
+  if (ol.isDef(x) && ol.isDef(y)) {
     offset = [x, y];
   }
 
@@ -525,14 +526,14 @@ ol.format.KML.IconStyleParser_ = function(node, objectStack) {
       (IconObject['w']);
   var h = /** @type {number|undefined} */
       (IconObject['h']);
-  if (goog.isDef(w) && goog.isDef(h)) {
+  if (ol.isDef(w) && ol.isDef(h)) {
     size = [w, h];
   }
 
   var rotation;
-  var heading = /** @type {number|undefined} */
+  var heading = /** @type {number} */
       (object['heading']);
-  if (goog.isDef(heading)) {
+  if (ol.isDef(heading)) {
     rotation = goog.math.toRadians(heading);
   }
 
@@ -572,7 +573,7 @@ ol.format.KML.LabelStyleParser_ = function(node, objectStack) {
   // FIXME colorMode
   var object = ol.xml.pushParseAndPop(
       {}, ol.format.KML.LABEL_STYLE_PARSERS_, node, objectStack);
-  if (!goog.isDef(object)) {
+  if (!object) {
     return;
   }
   var styleObject = objectStack[objectStack.length - 1];
@@ -607,7 +608,7 @@ ol.format.KML.LineStyleParser_ = function(node, objectStack) {
   // FIXME gx:labelVisibility
   var object = ol.xml.pushParseAndPop(
       {}, ol.format.KML.LINE_STYLE_PARSERS_, node, objectStack);
-  if (!goog.isDef(object)) {
+  if (!object) {
     return;
   }
   var styleObject = objectStack[objectStack.length - 1];
@@ -635,7 +636,7 @@ ol.format.KML.PolyStyleParser_ = function(node, objectStack) {
   // FIXME colorMode
   var object = ol.xml.pushParseAndPop(
       {}, ol.format.KML.POLY_STYLE_PARSERS_, node, objectStack);
-  if (!goog.isDef(object)) {
+  if (!object) {
     return;
   }
   var styleObject = objectStack[objectStack.length - 1];
@@ -647,12 +648,12 @@ ol.format.KML.PolyStyleParser_ = function(node, objectStack) {
   });
   styleObject['fillStyle'] = fillStyle;
   var fill = /** @type {boolean|undefined} */ (object['fill']);
-  if (goog.isDef(fill)) {
+  if (ol.isDef(fill)) {
     styleObject['fill'] = fill;
   }
   var outline =
       /** @type {boolean|undefined} */ (object['outline']);
-  if (goog.isDef(outline)) {
+  if (ol.isDef(outline)) {
     styleObject['outline'] = outline;
   }
 };
@@ -723,7 +724,7 @@ ol.format.KML.readGxMultiTrack_ = function(node, objectStack) {
   var lineStrings = ol.xml.pushParseAndPop(
       /** @type {Array.<ol.geom.LineString>} */ ([]),
       ol.format.KML.GX_MULTITRACK_GEOMETRY_PARSERS_, node, objectStack);
-  if (!goog.isDef(lineStrings)) {
+  if (!lineStrings) {
     return undefined;
   }
   var multiLineString = new ol.geom.MultiLineString(null);
@@ -750,7 +751,7 @@ ol.format.KML.readGxTrack_ = function(node, objectStack) {
         flatCoordinates: [],
         whens: []
       }), ol.format.KML.GX_TRACK_PARSERS_, node, objectStack);
-  if (!goog.isDef(gxTrackObject)) {
+  if (!gxTrackObject) {
     return undefined;
   }
   var flatCoordinates = gxTrackObject.flatCoordinates;
@@ -781,7 +782,7 @@ ol.format.KML.readIcon_ = function(node, objectStack) {
   goog.asserts.assert(node.localName == 'Icon', 'localName should be Icon');
   var iconObject = ol.xml.pushParseAndPop(
       {}, ol.format.KML.ICON_PARSERS_, node, objectStack);
-  if (goog.isDef(iconObject)) {
+  if (iconObject) {
     return iconObject;
   } else {
     return null;
@@ -819,7 +820,7 @@ ol.format.KML.readLineString_ = function(node, objectStack) {
       objectStack);
   var flatCoordinates =
       ol.format.KML.readFlatCoordinatesFromNode_(node, objectStack);
-  if (goog.isDef(flatCoordinates)) {
+  if (flatCoordinates) {
     var lineString = new ol.geom.LineString(null);
     lineString.setFlatCoordinates(ol.geom.GeometryLayout.XYZ, flatCoordinates);
     lineString.setProperties(properties);
@@ -846,7 +847,7 @@ ol.format.KML.readLinearRing_ = function(node, objectStack) {
       objectStack);
   var flatCoordinates =
       ol.format.KML.readFlatCoordinatesFromNode_(node, objectStack);
-  if (goog.isDef(flatCoordinates)) {
+  if (flatCoordinates) {
     var polygon = new ol.geom.Polygon(null);
     polygon.setFlatCoordinates(ol.geom.GeometryLayout.XYZ, flatCoordinates,
         [flatCoordinates.length]);
@@ -872,7 +873,7 @@ ol.format.KML.readMultiGeometry_ = function(node, objectStack) {
   var geometries = ol.xml.pushParseAndPop(
       /** @type {Array.<ol.geom.Geometry>} */ ([]),
       ol.format.KML.MULTI_GEOMETRY_PARSERS_, node, objectStack);
-  if (!goog.isDef(geometries)) {
+  if (!geometries) {
     return null;
   }
   if (geometries.length === 0) {
@@ -1010,14 +1011,14 @@ ol.format.KML.readStyle_ = function(node, objectStack) {
   goog.asserts.assert(node.localName == 'Style', 'localName should be Style');
   var styleObject = ol.xml.pushParseAndPop(
       {}, ol.format.KML.STYLE_PARSERS_, node, objectStack);
-  if (!goog.isDef(styleObject)) {
+  if (!styleObject) {
     return null;
   }
   var fillStyle = /** @type {ol.style.Fill} */ (goog.object.get(
       styleObject, 'fillStyle', ol.format.KML.DEFAULT_FILL_STYLE_));
   var fill = /** @type {boolean|undefined} */
       (styleObject['fill']);
-  if (goog.isDef(fill) && !fill) {
+  if (ol.isDef(fill) && !fill) {
     fillStyle = null;
   }
   var imageStyle = /** @type {ol.style.Image} */ (goog.object.get(
@@ -1028,7 +1029,7 @@ ol.format.KML.readStyle_ = function(node, objectStack) {
       styleObject, 'strokeStyle', ol.format.KML.DEFAULT_STROKE_STYLE_));
   var outline = /** @type {boolean|undefined} */
       (styleObject['outline']);
-  if (goog.isDef(outline) && !outline) {
+  if (ol.isDef(outline) && !outline) {
     strokeStyle = null;
   }
   return [new ol.style.Style({
@@ -1060,8 +1061,8 @@ ol.format.KML.setCommonGeometryProperties_ = function(multiGeometry,
     geometry = geometries[i];
     extrudes[i] = geometry.get('extrude');
     altitudeModes[i] = geometry.get('altitudeMode');
-    hasExtrude = hasExtrude || goog.isDef(extrudes[i]);
-    hasAltitudeMode = hasAltitudeMode || goog.isDef(altitudeModes[i]);
+    hasExtrude = hasExtrude || ol.isDef(extrudes[i]);
+    hasAltitudeMode = hasAltitudeMode || altitudeModes[i];
   }
   if (hasExtrude) {
     multiGeometry.set('extrude', extrudes);
@@ -1085,7 +1086,7 @@ ol.format.KML.DataParser_ = function(node, objectStack) {
   if (!goog.isNull(name)) {
     var data = ol.xml.pushParseAndPop(
         undefined, ol.format.KML.DATA_PARSERS_, node, objectStack);
-    if (goog.isDef(data)) {
+    if (data) {
       var featureObject =
           /** @type {Object} */ (objectStack[objectStack.length - 1]);
       goog.asserts.assert(goog.isObject(featureObject),
@@ -1121,20 +1122,20 @@ ol.format.KML.PairDataParser_ = function(node, objectStack) {
   goog.asserts.assert(node.localName == 'Pair', 'localName should be Pair');
   var pairObject = ol.xml.pushParseAndPop(
       {}, ol.format.KML.PAIR_PARSERS_, node, objectStack);
-  if (!goog.isDef(pairObject)) {
+  if (!pairObject) {
     return;
   }
   var key = /** @type {string|undefined} */
       (pairObject['key']);
-  if (goog.isDef(key) && key == 'normal') {
+  if (key && key == 'normal') {
     var styleUrl = /** @type {string|undefined} */
         (pairObject['styleUrl']);
-    if (goog.isDef(styleUrl)) {
+    if (styleUrl) {
       objectStack[objectStack.length - 1] = styleUrl;
     }
     var Style = /** @type {ol.style.Style} */
         (pairObject['Style']);
-    if (goog.isDef(Style)) {
+    if (Style) {
       objectStack[objectStack.length - 1] = Style;
     }
   }
@@ -1152,7 +1153,7 @@ ol.format.KML.PlacemarkStyleMapParser_ = function(node, objectStack) {
   goog.asserts.assert(node.localName == 'StyleMap',
       'localName should be StyleMap');
   var styleMapValue = ol.format.KML.readStyleMapValue_(node, objectStack);
-  if (!goog.isDef(styleMapValue)) {
+  if (!styleMapValue) {
     return;
   }
   var placemarkObject = objectStack[objectStack.length - 1];
@@ -1215,7 +1216,7 @@ ol.format.KML.innerBoundaryIsParser_ = function(node, objectStack) {
   var flatLinearRing = ol.xml.pushParseAndPop(
       /** @type {Array.<number>|undefined} */ (undefined),
       ol.format.KML.INNER_BOUNDARY_IS_PARSERS_, node, objectStack);
-  if (goog.isDef(flatLinearRing)) {
+  if (flatLinearRing) {
     var flatLinearRings = /** @type {Array.<Array.<number>>} */
         (objectStack[objectStack.length - 1]);
     goog.asserts.assert(goog.isArray(flatLinearRings),
@@ -1240,7 +1241,7 @@ ol.format.KML.outerBoundaryIsParser_ = function(node, objectStack) {
   var flatLinearRing = ol.xml.pushParseAndPop(
       /** @type {Array.<number>|undefined} */ (undefined),
       ol.format.KML.OUTER_BOUNDARY_IS_PARSERS_, node, objectStack);
-  if (goog.isDef(flatLinearRing)) {
+  if (flatLinearRing) {
     var flatLinearRings = /** @type {Array.<Array.<number>>} */
         (objectStack[objectStack.length - 1]);
     goog.asserts.assert(goog.isArray(flatLinearRings),
@@ -1285,16 +1286,16 @@ ol.format.KML.whenParser_ = function(node, objectStack) {
   var m = re.exec(s);
   if (m) {
     var year = parseInt(m[1], 10);
-    var month = goog.isDef(m[3]) ? parseInt(m[3], 10) - 1 : 0;
-    var day = goog.isDef(m[5]) ? parseInt(m[5], 10) : 1;
-    var hour = goog.isDef(m[7]) ? parseInt(m[7], 10) : 0;
-    var minute = goog.isDef(m[8]) ? parseInt(m[8], 10) : 0;
-    var second = goog.isDef(m[9]) ? parseInt(m[9], 10) : 0;
+    var month = m[3] ? parseInt(m[3], 10) - 1 : 0;
+    var day = m[5] ? parseInt(m[5], 10) : 1;
+    var hour = m[7] ? parseInt(m[7], 10) : 0;
+    var minute = m[8] ? parseInt(m[8], 10) : 0;
+    var second = m[9] ? parseInt(m[9], 10) : 0;
     var when = Date.UTC(year, month, day, hour, minute, second);
-    if (goog.isDef(m[10]) && m[10] != 'Z') {
+    if (m[10] && m[10] != 'Z') {
       var sign = m[11] == '-' ? -1 : 1;
       when += sign * 60 * parseInt(m[12], 10);
-      if (goog.isDef(m[13])) {
+      if (m[13]) {
         when += sign * 60 * 60 * parseInt(m[13], 10);
       }
     }
@@ -1650,7 +1651,7 @@ ol.format.KML.prototype.readDocumentOrFolder_ = function(node, objectStack) {
       });
   var features = ol.xml.pushParseAndPop(/** @type {Array.<ol.Feature>} */ ([]),
       parsersNS, node, objectStack, this);
-  if (goog.isDef(features)) {
+  if (features) {
     return features;
   } else {
     return undefined;
@@ -1671,7 +1672,7 @@ ol.format.KML.prototype.readPlacemark_ = function(node, objectStack) {
       'localName should be Placemark');
   var object = ol.xml.pushParseAndPop({'geometry': null},
       ol.format.KML.PLACEMARK_PARSERS_, node, objectStack);
-  if (!goog.isDef(object)) {
+  if (!object) {
     return undefined;
   }
   var feature = new ol.Feature();
@@ -1717,7 +1718,7 @@ ol.format.KML.prototype.readSharedStyle_ = function(node, objectStack) {
   var id = node.getAttribute('id');
   if (!goog.isNull(id)) {
     var style = ol.format.KML.readStyle_(node, objectStack);
-    if (goog.isDef(style)) {
+    if (style) {
       var styleUri;
       if (goog.isDefAndNotNull(node.baseURI)) {
         styleUri = goog.Uri.resolve(node.baseURI, '#' + id).toString();
@@ -1745,7 +1746,7 @@ ol.format.KML.prototype.readSharedStyleMap_ = function(node, objectStack) {
     return;
   }
   var styleMapValue = ol.format.KML.readStyleMapValue_(node, objectStack);
-  if (!goog.isDef(styleMapValue)) {
+  if (!styleMapValue) {
     return;
   }
   var styleUri;
@@ -1783,7 +1784,7 @@ ol.format.KML.prototype.readFeatureFromNode = function(node, opt_options) {
       'localName should be Placemark');
   var feature = this.readPlacemark_(
       node, [this.getReadOptions(node, opt_options)]);
-  if (goog.isDef(feature)) {
+  if (feature) {
     return feature;
   } else {
     return null;
@@ -1817,7 +1818,7 @@ ol.format.KML.prototype.readFeaturesFromNode = function(node, opt_options) {
   if (localName == 'Document' || localName == 'Folder') {
     features = this.readDocumentOrFolder_(
         node, [this.getReadOptions(node, opt_options)]);
-    if (goog.isDef(features)) {
+    if (features) {
       return features;
     } else {
       return [];
@@ -1825,7 +1826,7 @@ ol.format.KML.prototype.readFeaturesFromNode = function(node, opt_options) {
   } else if (localName == 'Placemark') {
     var feature = this.readPlacemark_(
         node, [this.getReadOptions(node, opt_options)]);
-    if (goog.isDef(feature)) {
+    if (feature) {
       return [feature];
     } else {
       return [];
@@ -1836,7 +1837,7 @@ ol.format.KML.prototype.readFeaturesFromNode = function(node, opt_options) {
     for (n = node.firstElementChild; !goog.isNull(n);
          n = n.nextElementSibling) {
       var fs = this.readFeaturesFromNode(n, opt_options);
-      if (goog.isDef(fs)) {
+      if (fs) {
         goog.array.extend(features, fs);
       }
     }
@@ -1878,7 +1879,7 @@ ol.format.KML.prototype.readNameFromDocument = function(doc) {
   for (n = doc.firstChild; !goog.isNull(n); n = n.nextSibling) {
     if (n.nodeType == goog.dom.NodeType.ELEMENT) {
       var name = this.readNameFromNode(n);
-      if (goog.isDef(name)) {
+      if (name) {
         return name;
       }
     }
@@ -1907,7 +1908,7 @@ ol.format.KML.prototype.readNameFromNode = function(node) {
          localName == 'Placemark' ||
          localName == 'kml')) {
       var name = this.readNameFromNode(n);
-      if (goog.isDef(name)) {
+      if (name) {
         return name;
       }
     }
@@ -2165,7 +2166,7 @@ ol.format.KML.writeLabelStyle_ = function(node, style, objectStack) {
     properties['color'] = fill.getColor();
   }
   var scale = style.getScale();
-  if (goog.isDef(scale) && scale !== 1) {
+  if (scale && scale !== 1) {
     properties['scale'] = scale;
   }
   var parentNode = objectStack[objectStack.length - 1].node;
@@ -2272,7 +2273,7 @@ ol.format.KML.writePlacemark_ = function(node, feature, objectStack) {
   // serialize properties (properties unknown to KML are not serialized)
   var properties = feature.getProperties();
   var styleFunction = feature.getStyleFunction();
-  if (goog.isDef(styleFunction)) {
+  if (styleFunction) {
     // FIXME the styles returned by the style function are supposed to be
     // resolution-independent here
     var styles = styleFunction.call(feature, 0);

--- a/src/ol/format/osmxmlformat.js
+++ b/src/ol/format/osmxmlformat.js
@@ -223,7 +223,7 @@ ol.format.OSMXML.prototype.readFeaturesFromNode = function(node, opt_options) {
       nodes: {},
       features: []
     }, ol.format.OSMXML.PARSERS_, node, [options]);
-    if (goog.isDef(state.features)) {
+    if (state.features) {
       return state.features;
     }
   }

--- a/src/ol/format/owsformat.js
+++ b/src/ol/format/owsformat.js
@@ -44,7 +44,7 @@ ol.format.OWS.prototype.readFromNode = function(node) {
       'node.nodeType should be ELEMENT');
   var owsObject = ol.xml.pushParseAndPop({},
       ol.format.OWS.PARSERS_, node, []);
-  return goog.isDef(owsObject) ? owsObject : null;
+  return owsObject ? owsObject : null;
 };
 
 
@@ -92,7 +92,7 @@ ol.format.OWS.readConstraint_ = function(node, objectStack) {
   goog.asserts.assert(node.localName == 'Constraint',
       'localName should be Constraint');
   var name = node.getAttribute('name');
-  if (!goog.isDef(name)) {
+  if (!name) {
     return undefined;
   }
   return ol.xml.pushParseAndPop({'name': name},
@@ -143,7 +143,7 @@ ol.format.OWS.readGet_ = function(node, objectStack) {
       'node.nodeType should be ELEMENT');
   goog.asserts.assert(node.localName == 'Get', 'localName should be Get');
   var href = ol.format.XLink.readHref(node);
-  if (!goog.isDef(href)) {
+  if (!href) {
     return undefined;
   }
   return ol.xml.pushParseAndPop({'href': href},
@@ -180,7 +180,7 @@ ol.format.OWS.readOperation_ = function(node, objectStack) {
   var name = node.getAttribute('name');
   var value = ol.xml.pushParseAndPop({},
       ol.format.OWS.OPERATION_PARSERS_, node, objectStack);
-  if (!goog.isDef(value)) {
+  if (!value) {
     return undefined;
   }
   var object = /** @type {Object} */

--- a/src/ol/format/polylineformat.js
+++ b/src/ol/format/polylineformat.js
@@ -26,7 +26,7 @@ goog.require('ol.proj');
  */
 ol.format.Polyline = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   goog.base(this);
 
@@ -39,13 +39,13 @@ ol.format.Polyline = function(opt_options) {
    * @private
    * @type {number}
    */
-  this.factor_ = goog.isDef(options.factor) ? options.factor : 1e5;
+  this.factor_ = options.factor ? options.factor : 1e5;
 
   /**
    * @private
    * @type {ol.geom.GeometryLayout}
    */
-  this.geometryLayout_ = goog.isDef(options.geometryLayout) ?
+  this.geometryLayout_ = options.geometryLayout ?
       options.geometryLayout : ol.geom.GeometryLayout.XY;
 };
 goog.inherits(ol.format.Polyline, ol.format.TextFeature);
@@ -65,7 +65,7 @@ goog.inherits(ol.format.Polyline, ol.format.TextFeature);
  * @api
  */
 ol.format.Polyline.encodeDeltas = function(numbers, stride, opt_factor) {
-  var factor = goog.isDef(opt_factor) ? opt_factor : 1e5;
+  var factor = opt_factor ? opt_factor : 1e5;
   var d;
 
   var lastNumbers = new Array(stride);
@@ -100,7 +100,7 @@ ol.format.Polyline.encodeDeltas = function(numbers, stride, opt_factor) {
  * @api
  */
 ol.format.Polyline.decodeDeltas = function(encoded, stride, opt_factor) {
-  var factor = goog.isDef(opt_factor) ? opt_factor : 1e5;
+  var factor = opt_factor ? opt_factor : 1e5;
   var d;
 
   /** @type {Array.<number>} */
@@ -137,7 +137,7 @@ ol.format.Polyline.decodeDeltas = function(encoded, stride, opt_factor) {
  * @api
  */
 ol.format.Polyline.encodeFloats = function(numbers, opt_factor) {
-  var factor = goog.isDef(opt_factor) ? opt_factor : 1e5;
+  var factor = opt_factor ? opt_factor : 1e5;
   var i, ii;
   for (i = 0, ii = numbers.length; i < ii; ++i) {
     numbers[i] = Math.round(numbers[i] * factor);
@@ -157,7 +157,7 @@ ol.format.Polyline.encodeFloats = function(numbers, opt_factor) {
  * @api
  */
 ol.format.Polyline.decodeFloats = function(encoded, opt_factor) {
-  var factor = goog.isDef(opt_factor) ? opt_factor : 1e5;
+  var factor = opt_factor ? opt_factor : 1e5;
   var numbers = ol.format.Polyline.decodeSignedIntegers(encoded);
   var i, ii;
   for (i = 0, ii = numbers.length; i < ii; ++i) {

--- a/src/ol/format/topojsonformat.js
+++ b/src/ol/format/topojsonformat.js
@@ -26,7 +26,7 @@ goog.require('ol.proj');
  */
 ol.format.TopoJSON = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   goog.base(this);
 
@@ -251,8 +251,7 @@ ol.format.TopoJSON.readFeatureFromGeometry_ = function(object, arcs,
   var geometry;
   var type = object.type;
   var geometryReader = ol.format.TopoJSON.GEOMETRY_READERS_[type];
-  goog.asserts.assert(goog.isDef(geometryReader),
-      'geometryReader should be defined');
+  goog.asserts.assert(geometryReader, 'geometryReader should be defined');
   if ((type === 'Point') || (type === 'MultiPoint')) {
     geometry = geometryReader(object, scale, translate);
   } else {
@@ -261,10 +260,10 @@ ol.format.TopoJSON.readFeatureFromGeometry_ = function(object, arcs,
   var feature = new ol.Feature();
   feature.setGeometry(/** @type {ol.geom.Geometry} */ (
       ol.format.Feature.transformWithOptions(geometry, false, opt_options)));
-  if (goog.isDef(object.id)) {
+  if (object.id) {
     feature.setId(object.id);
   }
-  if (goog.isDef(object.properties)) {
+  if (object.properties) {
     feature.setProperties(object.properties);
   }
   return feature;
@@ -290,13 +289,13 @@ ol.format.TopoJSON.prototype.readFeaturesFromObject = function(
   if (object.type == 'Topology') {
     var topoJSONTopology = /** @type {TopoJSONTopology} */ (object);
     var transform, scale = null, translate = null;
-    if (goog.isDef(topoJSONTopology.transform)) {
+    if (topoJSONTopology.transform) {
       transform = topoJSONTopology.transform;
       scale = transform.scale;
       translate = transform.translate;
     }
     var arcs = topoJSONTopology.arcs;
-    if (goog.isDef(transform)) {
+    if (transform) {
       ol.format.TopoJSON.transformArcs_(arcs, scale, translate);
     }
     /** @type {Array.<ol.Feature>} */

--- a/src/ol/format/wfsformat.js
+++ b/src/ol/format/wfsformat.js
@@ -3,6 +3,7 @@ goog.provide('ol.format.WFS');
 goog.require('goog.asserts');
 goog.require('goog.dom.NodeType');
 goog.require('goog.object');
+goog.require('ol');
 goog.require('ol.format.GML3');
 goog.require('ol.format.GMLBase');
 goog.require('ol.format.XMLFeature');
@@ -27,7 +28,7 @@ goog.require('ol.xml');
  * @api stable
  */
 ol.format.WFS = function(opt_options) {
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   /**
    * @private
@@ -45,14 +46,14 @@ ol.format.WFS = function(opt_options) {
    * @private
    * @type {ol.format.GMLBase}
    */
-  this.gmlFormat_ = goog.isDef(options.gmlFormat) ?
+  this.gmlFormat_ = options.gmlFormat ?
       options.gmlFormat : new ol.format.GML3();
 
   /**
    * @private
    * @type {string}
    */
-  this.schemaLocation_ = goog.isDef(options.schemaLocation) ?
+  this.schemaLocation_ = options.schemaLocation ?
       options.schemaLocation : ol.format.WFS.SCHEMA_LOCATION;
 
   goog.base(this);
@@ -123,7 +124,7 @@ ol.format.WFS.prototype.readFeaturesFromNode = function(node, opt_options) {
     'featureNS': this.featureNS_
   };
   goog.object.extend(context, this.getReadOptions(node,
-      goog.isDef(opt_options) ? opt_options : {}));
+      opt_options ? opt_options : {}));
   var objectStack = [context];
   this.gmlFormat_.FEATURE_COLLECTION_PARSERS[ol.format.GMLBase.GMLNS][
       'featureMember'] =
@@ -131,7 +132,7 @@ ol.format.WFS.prototype.readFeaturesFromNode = function(node, opt_options) {
   var features = ol.xml.pushParseAndPop([],
       this.gmlFormat_.FEATURE_COLLECTION_PARSERS, node,
       objectStack, this.gmlFormat_);
-  if (!goog.isDef(features)) {
+  if (!features) {
     features = [];
   }
   return features;
@@ -414,14 +415,14 @@ ol.format.WFS.writeDelete_ = function(node, feature, objectStack) {
   goog.asserts.assert(goog.isObject(context), 'context should be an Object');
   var featureType = context['featureType'];
   var featurePrefix = context['featurePrefix'];
-  featurePrefix = goog.isDef(featurePrefix) ? featurePrefix :
+  featurePrefix = featurePrefix ? featurePrefix :
       ol.format.WFS.FEATURE_PREFIX;
   var featureNS = context['featureNS'];
   node.setAttribute('typeName', featurePrefix + ':' + featureType);
   ol.xml.setAttributeNS(node, ol.format.WFS.XMLNS, 'xmlns:' + featurePrefix,
       featureNS);
   var fid = feature.getId();
-  if (goog.isDef(fid)) {
+  if (fid) {
     ol.format.WFS.writeOgcFidFilter_(node, fid, objectStack);
   }
 };
@@ -438,19 +439,19 @@ ol.format.WFS.writeUpdate_ = function(node, feature, objectStack) {
   goog.asserts.assert(goog.isObject(context), 'context should be an Object');
   var featureType = context['featureType'];
   var featurePrefix = context['featurePrefix'];
-  featurePrefix = goog.isDef(featurePrefix) ? featurePrefix :
+  featurePrefix = featurePrefix ? featurePrefix :
       ol.format.WFS.FEATURE_PREFIX;
   var featureNS = context['featureNS'];
   node.setAttribute('typeName', featurePrefix + ':' + featureType);
   ol.xml.setAttributeNS(node, ol.format.WFS.XMLNS, 'xmlns:' + featurePrefix,
       featureNS);
   var fid = feature.getId();
-  if (goog.isDef(fid)) {
+  if (fid) {
     var keys = feature.getKeys();
     var values = [];
     for (var i = 0, ii = keys.length; i < ii; i++) {
       var value = feature.get(keys[i]);
-      if (goog.isDef(value)) {
+      if (ol.isDef(value)) {
         values.push({name: keys[i], value: value});
       }
     }
@@ -495,13 +496,13 @@ ol.format.WFS.writeProperty_ = function(node, pair, objectStack) {
  * @private
  */
 ol.format.WFS.writeNative_ = function(node, nativeElement, objectStack) {
-  if (goog.isDef(nativeElement.vendorId)) {
+  if (nativeElement.vendorId) {
     node.setAttribute('vendorId', nativeElement.vendorId);
   }
-  if (goog.isDef(nativeElement.safeToIgnore)) {
+  if (ol.isDef(nativeElement.safeToIgnore)) {
     node.setAttribute('safeToIgnore', nativeElement.safeToIgnore);
   }
-  if (goog.isDef(nativeElement.value)) {
+  if (ol.isDef(nativeElement.value)) {
     ol.format.XSD.writeStringTextNode(node, nativeElement.value);
   }
 };
@@ -535,12 +536,12 @@ ol.format.WFS.writeQuery_ = function(node, featureType, objectStack) {
   var featureNS = context['featureNS'];
   var propertyNames = context['propertyNames'];
   var srsName = context['srsName'];
-  var prefix = goog.isDef(featurePrefix) ? featurePrefix + ':' : '';
+  var prefix = featurePrefix ? featurePrefix + ':' : '';
   node.setAttribute('typeName', prefix + featureType);
-  if (goog.isDef(srsName)) {
+  if (srsName) {
     node.setAttribute('srsName', srsName);
   }
-  if (goog.isDef(featureNS)) {
+  if (featureNS) {
     ol.xml.setAttributeNS(node, ol.format.WFS.XMLNS, 'xmlns:' + featurePrefix,
         featureNS);
   }
@@ -551,7 +552,7 @@ ol.format.WFS.writeQuery_ = function(node, featureType, objectStack) {
       ol.xml.makeSimpleNodeFactory('PropertyName'), propertyNames,
       objectStack);
   var bbox = context['bbox'];
-  if (goog.isDef(bbox)) {
+  if (bbox) {
     var child = ol.xml.createElementNS('http://www.opengis.net/ogc', 'Filter');
     ol.format.WFS.writeOgcBBOX_(child, bbox, objectStack);
     node.appendChild(child);
@@ -632,23 +633,23 @@ ol.format.WFS.prototype.writeGetFeature = function(options) {
       'GetFeature');
   node.setAttribute('service', 'WFS');
   node.setAttribute('version', '1.1.0');
-  if (goog.isDef(options)) {
-    if (goog.isDef(options.handle)) {
+  if (options) {
+    if (options.handle) {
       node.setAttribute('handle', options.handle);
     }
-    if (goog.isDef(options.outputFormat)) {
+    if (options.outputFormat) {
       node.setAttribute('outputFormat', options.outputFormat);
     }
-    if (goog.isDef(options.maxFeatures)) {
+    if (ol.isDef(options.maxFeatures)) {
       node.setAttribute('maxFeatures', options.maxFeatures);
     }
-    if (goog.isDef(options.resultType)) {
+    if (options.resultType) {
       node.setAttribute('resultType', options.resultType);
     }
-    if (goog.isDef(options.startIndex)) {
+    if (ol.isDef(options.startIndex)) {
       node.setAttribute('startIndex', options.startIndex);
     }
-    if (goog.isDef(options.count)) {
+    if (ol.isDef(options.count)) {
       node.setAttribute('count', options.count);
     }
   }
@@ -657,13 +658,11 @@ ol.format.WFS.prototype.writeGetFeature = function(options) {
   var context = {
     node: node,
     srsName: options.srsName,
-    featureNS: goog.isDef(options.featureNS) ?
-        options.featureNS : this.featureNS_,
+    featureNS: options.featureNS ? options.featureNS : this.featureNS_,
     featurePrefix: options.featurePrefix,
     geometryName: options.geometryName,
     bbox: options.bbox,
-    propertyNames: goog.isDef(options.propertyNames) ?
-        options.propertyNames : []
+    propertyNames: options.propertyNames ? options.propertyNames : []
   };
   goog.asserts.assert(goog.isArray(options.featureTypes),
       'options.featureTypes should be an array');
@@ -690,9 +689,9 @@ ol.format.WFS.prototype.writeTransaction = function(inserts, updates, deletes,
   node.setAttribute('service', 'WFS');
   node.setAttribute('version', '1.1.0');
   var baseObj, obj;
-  if (goog.isDef(options)) {
-    baseObj = goog.isDef(options.gmlOptions) ? options.gmlOptions : {};
-    if (goog.isDef(options.handle)) {
+  if (options) {
+    baseObj = options.gmlOptions ? options.gmlOptions : {};
+    if (options.handle) {
       node.setAttribute('handle', options.handle);
     }
   }
@@ -723,7 +722,7 @@ ol.format.WFS.prototype.writeTransaction = function(inserts, updates, deletes,
     ol.xml.makeSimpleNodeFactory('Delete'), deletes,
     objectStack);
   }
-  if (goog.isDef(options.nativeElements)) {
+  if (options.nativeElements) {
     ol.xml.pushSerializeAndPop({node: node, featureNS: options.featureNS,
       featureType: options.featureType, featurePrefix: options.featurePrefix},
     ol.format.WFS.TRANSACTION_SERIALIZERS_,

--- a/src/ol/format/wfsformat.js
+++ b/src/ol/format/wfsformat.js
@@ -451,7 +451,7 @@ ol.format.WFS.writeUpdate_ = function(node, feature, objectStack) {
     var values = [];
     for (var i = 0, ii = keys.length; i < ii; i++) {
       var value = feature.get(keys[i]);
-      if (ol.isDef(value)) {
+      if (value !== undefined) {
         values.push({name: keys[i], value: value});
       }
     }
@@ -499,10 +499,10 @@ ol.format.WFS.writeNative_ = function(node, nativeElement, objectStack) {
   if (nativeElement.vendorId) {
     node.setAttribute('vendorId', nativeElement.vendorId);
   }
-  if (ol.isDef(nativeElement.safeToIgnore)) {
+  if (nativeElement.safeToIgnore !== undefined) {
     node.setAttribute('safeToIgnore', nativeElement.safeToIgnore);
   }
-  if (ol.isDef(nativeElement.value)) {
+  if (nativeElement.value !== undefined) {
     ol.format.XSD.writeStringTextNode(node, nativeElement.value);
   }
 };
@@ -640,16 +640,16 @@ ol.format.WFS.prototype.writeGetFeature = function(options) {
     if (options.outputFormat) {
       node.setAttribute('outputFormat', options.outputFormat);
     }
-    if (ol.isDef(options.maxFeatures)) {
+    if (options.maxFeatures !== undefined) {
       node.setAttribute('maxFeatures', options.maxFeatures);
     }
     if (options.resultType) {
       node.setAttribute('resultType', options.resultType);
     }
-    if (ol.isDef(options.startIndex)) {
+    if (options.startIndex !== undefined) {
       node.setAttribute('startIndex', options.startIndex);
     }
-    if (ol.isDef(options.count)) {
+    if (options.count !== undefined) {
       node.setAttribute('count', options.count);
     }
   }

--- a/src/ol/format/wktformat.js
+++ b/src/ol/format/wktformat.js
@@ -38,8 +38,8 @@ ol.format.WKT = function(opt_options) {
    * @type {boolean}
    * @private
    */
-  this.splitCollection_ = ol.isDef(options.splitCollection) ?
-      /** @type {boolean} */ (options.splitCollection) : false;
+  this.splitCollection_ = options.splitCollection !== undefined ?
+      options.splitCollection : false;
 
 };
 goog.inherits(ol.format.WKT, ol.format.TextFeature);
@@ -427,7 +427,7 @@ ol.format.WKT.Lexer.prototype.isAlpha_ = function(c) {
  * @private
  */
 ol.format.WKT.Lexer.prototype.isNumeric_ = function(c, opt_decimal) {
-  var decimal = ol.isDef(opt_decimal) ? opt_decimal : false;
+  var decimal = opt_decimal !== undefined ? opt_decimal : false;
   return c >= '0' && c <= '9' || c == '.' && !decimal;
 };
 

--- a/src/ol/format/wktformat.js
+++ b/src/ol/format/wktformat.js
@@ -1,6 +1,7 @@
 goog.provide('ol.format.WKT');
 
 goog.require('goog.asserts');
+goog.require('ol');
 goog.require('ol.Feature');
 goog.require('ol.format.Feature');
 goog.require('ol.format.TextFeature');
@@ -28,7 +29,7 @@ goog.require('ol.geom.Polygon');
  */
 ol.format.WKT = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   goog.base(this);
 
@@ -37,8 +38,8 @@ ol.format.WKT = function(opt_options) {
    * @type {boolean}
    * @private
    */
-  this.splitCollection_ = goog.isDef(options.splitCollection) ?
-      options.splitCollection : false;
+  this.splitCollection_ = ol.isDef(options.splitCollection) ?
+      /** @type {boolean} */ (options.splitCollection) : false;
 
 };
 goog.inherits(ol.format.WKT, ol.format.TextFeature);
@@ -167,8 +168,7 @@ ol.format.WKT.encodeMultiPolygonGeometry_ = function(geom) {
 ol.format.WKT.encode_ = function(geom) {
   var type = geom.getType();
   var geometryEncoder = ol.format.WKT.GeometryEncoder_[type];
-  goog.asserts.assert(goog.isDef(geometryEncoder),
-      'geometryEncoder should be defined');
+  goog.asserts.assert(geometryEncoder, 'geometryEncoder should be defined');
   var enc = geometryEncoder(geom);
   type = type.toUpperCase();
   if (enc.length === 0) {
@@ -225,7 +225,7 @@ ol.format.WKT.prototype.readFeature;
  */
 ol.format.WKT.prototype.readFeatureFromText = function(text, opt_options) {
   var geom = this.readGeometryFromText(text, opt_options);
-  if (goog.isDef(geom)) {
+  if (geom) {
     var feature = new ol.Feature();
     feature.setGeometry(geom);
     return feature;
@@ -286,7 +286,7 @@ ol.format.WKT.prototype.readGeometry;
  */
 ol.format.WKT.prototype.readGeometryFromText = function(text, opt_options) {
   var geometry = this.parse_(text);
-  if (goog.isDef(geometry)) {
+  if (geometry) {
     return /** @type {ol.geom.Geometry} */ (
         ol.format.Feature.transformWithOptions(geometry, false, opt_options));
   } else {
@@ -312,7 +312,7 @@ ol.format.WKT.prototype.writeFeature;
  */
 ol.format.WKT.prototype.writeFeatureText = function(feature, opt_options) {
   var geometry = feature.getGeometry();
-  if (goog.isDef(geometry)) {
+  if (geometry) {
     return this.writeGeometryText(geometry, opt_options);
   }
   return '';
@@ -427,7 +427,7 @@ ol.format.WKT.Lexer.prototype.isAlpha_ = function(c) {
  * @private
  */
 ol.format.WKT.Lexer.prototype.isNumeric_ = function(c, opt_decimal) {
-  var decimal = goog.isDef(opt_decimal) ? opt_decimal : false;
+  var decimal = ol.isDef(opt_decimal) ? opt_decimal : false;
   return c >= '0' && c <= '9' || c == '.' && !decimal;
 };
 
@@ -603,7 +603,7 @@ ol.format.WKT.Parser.prototype.parseGeometry_ = function() {
     } else {
       var parser = ol.format.WKT.Parser.GeometryParser_[geomType];
       var ctor = ol.format.WKT.Parser.GeometryConstructor_[geomType];
-      if (!goog.isDef(parser) || !goog.isDef(ctor)) {
+      if (!parser || !ctor) {
         throw new Error('Invalid geometry type: ' + geomType);
       }
       var coordinates = parser.call(this);

--- a/src/ol/format/wmscapabilitiesformat.js
+++ b/src/ol/format/wmscapabilitiesformat.js
@@ -5,6 +5,7 @@ goog.require('goog.asserts');
 goog.require('goog.dom.NodeType');
 goog.require('goog.object');
 goog.require('goog.string');
+goog.require('ol');
 goog.require('ol.format.XLink');
 goog.require('ol.format.XML');
 goog.require('ol.format.XSD');
@@ -74,7 +75,7 @@ ol.format.WMSCapabilities.prototype.readFromNode = function(node) {
   var wmsCapabilityObject = ol.xml.pushParseAndPop({
     'version': this.version
   }, ol.format.WMSCapabilities.PARSERS_, node, []);
-  return goog.isDef(wmsCapabilityObject) ? wmsCapabilityObject : null;
+  return wmsCapabilityObject ? wmsCapabilityObject : null;
 };
 
 
@@ -142,7 +143,7 @@ ol.format.WMSCapabilities.readEXGeographicBoundingBox_ =
       {},
       ol.format.WMSCapabilities.EX_GEOGRAPHIC_BOUNDING_BOX_PARSERS_,
       node, objectStack);
-  if (!goog.isDef(geographicBoundingBox)) {
+  if (!geographicBoundingBox) {
     return undefined;
   }
   var westBoundLongitude = /** @type {number|undefined} */
@@ -153,8 +154,8 @@ ol.format.WMSCapabilities.readEXGeographicBoundingBox_ =
       (geographicBoundingBox['eastBoundLongitude']);
   var northBoundLatitude = /** @type {number|undefined} */
       (geographicBoundingBox['northBoundLatitude']);
-  if (!goog.isDef(westBoundLongitude) || !goog.isDef(southBoundLatitude) ||
-      !goog.isDef(eastBoundLongitude) || !goog.isDef(northBoundLatitude)) {
+  if (!ol.isDef(westBoundLongitude) || !ol.isDef(southBoundLatitude) ||
+      !ol.isDef(eastBoundLongitude) || !ol.isDef(northBoundLatitude)) {
     return undefined;
   }
   return /** @type {ol.Extent} */ ([
@@ -297,46 +298,46 @@ ol.format.WMSCapabilities.readLayer_ = function(node, objectStack) {
   var layerObject = /**  @type {Object.<string,*>} */ (ol.xml.pushParseAndPop(
       {}, ol.format.WMSCapabilities.LAYER_PARSERS_, node, objectStack));
 
-  if (!goog.isDef(layerObject)) {
+  if (!layerObject) {
     return undefined;
   }
   var queryable =
       ol.format.XSD.readBooleanString(node.getAttribute('queryable'));
-  if (!goog.isDef(queryable)) {
+  if (!ol.isDef(queryable)) {
     queryable = parentLayerObject['queryable'];
   }
-  layerObject['queryable'] = goog.isDef(queryable) ? queryable : false;
+  layerObject['queryable'] = ol.isDef(queryable) ? queryable : false;
 
   var cascaded = ol.format.XSD.readNonNegativeIntegerString(
       node.getAttribute('cascaded'));
-  if (!goog.isDef(cascaded)) {
+  if (!ol.isDef(cascaded)) {
     cascaded = parentLayerObject['cascaded'];
   }
   layerObject['cascaded'] = cascaded;
 
   var opaque = ol.format.XSD.readBooleanString(node.getAttribute('opaque'));
-  if (!goog.isDef(opaque)) {
+  if (!ol.isDef(opaque)) {
     opaque = parentLayerObject['opaque'];
   }
-  layerObject['opaque'] = goog.isDef(opaque) ? opaque : false;
+  layerObject['opaque'] = ol.isDef(opaque) ? opaque : false;
 
   var noSubsets =
       ol.format.XSD.readBooleanString(node.getAttribute('noSubsets'));
-  if (!goog.isDef(noSubsets)) {
+  if (!ol.isDef(noSubsets)) {
     noSubsets = parentLayerObject['noSubsets'];
   }
-  layerObject['noSubsets'] = goog.isDef(noSubsets) ? noSubsets : false;
+  layerObject['noSubsets'] = ol.isDef(noSubsets) ? noSubsets : false;
 
   var fixedWidth =
       ol.format.XSD.readDecimalString(node.getAttribute('fixedWidth'));
-  if (!goog.isDef(fixedWidth)) {
+  if (!fixedWidth) {
     fixedWidth = parentLayerObject['fixedWidth'];
   }
   layerObject['fixedWidth'] = fixedWidth;
 
   var fixedHeight =
       ol.format.XSD.readDecimalString(node.getAttribute('fixedHeight'));
-  if (!goog.isDef(fixedHeight)) {
+  if (!fixedHeight) {
     fixedHeight = parentLayerObject['fixedHeight'];
   }
   layerObject['fixedHeight'] = fixedHeight;
@@ -344,10 +345,9 @@ ol.format.WMSCapabilities.readLayer_ = function(node, objectStack) {
   // See 7.2.4.8
   var addKeys = ['Style', 'CRS', 'AuthorityURL'];
   goog.array.forEach(addKeys, function(key) {
-    var parentValue = parentLayerObject[key];
-    if (goog.isDef(parentValue)) {
+    if (key in parentLayerObject) {
       var childValue = goog.object.setIfUndefined(layerObject, key, []);
-      childValue = childValue.concat(parentValue);
+      childValue = childValue.concat(parentLayerObject[key]);
       layerObject[key] = childValue;
     }
   });
@@ -355,8 +355,7 @@ ol.format.WMSCapabilities.readLayer_ = function(node, objectStack) {
   var replaceKeys = ['EX_GeographicBoundingBox', 'BoundingBox', 'Dimension',
     'Attribution', 'MinScaleDenominator', 'MaxScaleDenominator'];
   goog.array.forEach(replaceKeys, function(key) {
-    var childValue = layerObject[key];
-    if (!goog.isDef(childValue)) {
+    if (!(key in layerObject)) {
       var parentValue = parentLayerObject[key];
       layerObject[key] = parentValue;
     }
@@ -482,7 +481,7 @@ ol.format.WMSCapabilities.readSizedFormatOnlineresource_ =
       'node.nodeType should be ELEMENT');
   var formatOnlineresource =
       ol.format.WMSCapabilities.readFormatOnlineresource_(node, objectStack);
-  if (goog.isDef(formatOnlineresource)) {
+  if (formatOnlineresource) {
     var size = [
       ol.format.XSD.readNonNegativeIntegerString(node.getAttribute('width')),
       ol.format.XSD.readNonNegativeIntegerString(node.getAttribute('height'))
@@ -507,7 +506,7 @@ ol.format.WMSCapabilities.readAuthorityURL_ = function(node, objectStack) {
       'localName should be AuthorityURL');
   var authorityObject =
       ol.format.WMSCapabilities.readFormatOnlineresource_(node, objectStack);
-  if (goog.isDef(authorityObject)) {
+  if (authorityObject) {
     authorityObject['name'] = node.getAttribute('name');
     return authorityObject;
   }
@@ -528,7 +527,7 @@ ol.format.WMSCapabilities.readMetadataURL_ = function(node, objectStack) {
       'localName should be MetadataURL');
   var metadataObject =
       ol.format.WMSCapabilities.readFormatOnlineresource_(node, objectStack);
-  if (goog.isDef(metadataObject)) {
+  if (metadataObject) {
     metadataObject['type'] = node.getAttribute('type');
     return metadataObject;
   }

--- a/src/ol/format/wmscapabilitiesformat.js
+++ b/src/ol/format/wmscapabilitiesformat.js
@@ -154,8 +154,8 @@ ol.format.WMSCapabilities.readEXGeographicBoundingBox_ =
       (geographicBoundingBox['eastBoundLongitude']);
   var northBoundLatitude = /** @type {number|undefined} */
       (geographicBoundingBox['northBoundLatitude']);
-  if (!ol.isDef(westBoundLongitude) || !ol.isDef(southBoundLatitude) ||
-      !ol.isDef(eastBoundLongitude) || !ol.isDef(northBoundLatitude)) {
+  if (westBoundLongitude === undefined || southBoundLatitude === undefined ||
+      eastBoundLongitude === undefined || northBoundLatitude === undefined) {
     return undefined;
   }
   return /** @type {ol.Extent} */ ([
@@ -303,30 +303,30 @@ ol.format.WMSCapabilities.readLayer_ = function(node, objectStack) {
   }
   var queryable =
       ol.format.XSD.readBooleanString(node.getAttribute('queryable'));
-  if (!ol.isDef(queryable)) {
+  if (queryable === undefined) {
     queryable = parentLayerObject['queryable'];
   }
-  layerObject['queryable'] = ol.isDef(queryable) ? queryable : false;
+  layerObject['queryable'] = queryable !== undefined ? queryable : false;
 
   var cascaded = ol.format.XSD.readNonNegativeIntegerString(
       node.getAttribute('cascaded'));
-  if (!ol.isDef(cascaded)) {
+  if (cascaded === undefined) {
     cascaded = parentLayerObject['cascaded'];
   }
   layerObject['cascaded'] = cascaded;
 
   var opaque = ol.format.XSD.readBooleanString(node.getAttribute('opaque'));
-  if (!ol.isDef(opaque)) {
+  if (opaque === undefined) {
     opaque = parentLayerObject['opaque'];
   }
-  layerObject['opaque'] = ol.isDef(opaque) ? opaque : false;
+  layerObject['opaque'] = opaque !== undefined ? opaque : false;
 
   var noSubsets =
       ol.format.XSD.readBooleanString(node.getAttribute('noSubsets'));
-  if (!ol.isDef(noSubsets)) {
+  if (noSubsets === undefined) {
     noSubsets = parentLayerObject['noSubsets'];
   }
-  layerObject['noSubsets'] = ol.isDef(noSubsets) ? noSubsets : false;
+  layerObject['noSubsets'] = noSubsets !== undefined ? noSubsets : false;
 
   var fixedWidth =
       ol.format.XSD.readDecimalString(node.getAttribute('fixedWidth'));

--- a/src/ol/format/wmsgetfeatureinfoformat.js
+++ b/src/ol/format/wmsgetfeatureinfoformat.js
@@ -102,7 +102,7 @@ ol.format.WMSGetFeatureInfo.prototype.readFeatures_ =
       layer.namespaceURI = this.featureNS_;
       var layerFeatures = ol.xml.pushParseAndPop(
           [], parsersNS, layer, objectStack, this.gmlFormat_);
-      if (goog.isDef(layerFeatures)) {
+      if (layerFeatures) {
         goog.array.extend(features, layerFeatures);
       }
     }, this);
@@ -111,7 +111,7 @@ ol.format.WMSGetFeatureInfo.prototype.readFeatures_ =
     var gmlFeatures = ol.xml.pushParseAndPop([],
         this.gmlFormat_.FEATURE_COLLECTION_PARSERS, node,
         [{}], this.gmlFormat_);
-    if (goog.isDef(gmlFeatures)) {
+    if (gmlFeatures) {
       features = gmlFeatures;
     }
   }
@@ -140,7 +140,7 @@ ol.format.WMSGetFeatureInfo.prototype.readFeaturesFromNode =
     'featureType': this.featureType,
     'featureNS': this.featureNS
   };
-  if (goog.isDef(opt_options)) {
+  if (opt_options) {
     goog.object.extend(options, this.getReadOptions(node, opt_options));
   }
   return this.readFeatures_(node, [options]);

--- a/src/ol/format/wmtscapabilitiesformat.js
+++ b/src/ol/format/wmtscapabilitiesformat.js
@@ -71,13 +71,13 @@ ol.format.WMTSCapabilities.prototype.readFromNode = function(node) {
   this.version = goog.string.trim(node.getAttribute('version'));
   goog.asserts.assertString(this.version, 'this.version should be a string');
   var WMTSCapabilityObject = this.owsParser_.readFromNode(node);
-  if (!goog.isDef(WMTSCapabilityObject)) {
+  if (!WMTSCapabilityObject) {
     return null;
   }
   WMTSCapabilityObject['version'] = this.version;
   WMTSCapabilityObject = ol.xml.pushParseAndPop(WMTSCapabilityObject,
       ol.format.WMTSCapabilities.PARSERS_, node, []);
-  return goog.isDef(WMTSCapabilityObject) ? WMTSCapabilityObject : null;
+  return WMTSCapabilityObject ? WMTSCapabilityObject : null;
 };
 
 
@@ -134,7 +134,7 @@ ol.format.WMTSCapabilities.readTileMatrixSet_ = function(node, objectStack) {
 ol.format.WMTSCapabilities.readStyle_ = function(node, objectStack) {
   var style = ol.xml.pushParseAndPop({},
       ol.format.WMTSCapabilities.STYLE_PARSERS_, node, objectStack);
-  if (!goog.isDef(style)) {
+  if (!style) {
     return undefined;
   }
   var isDefault = node.getAttribute('isDefault') === 'true';
@@ -168,13 +168,13 @@ ol.format.WMTSCapabilities.readResourceUrl_ = function(node, objectStack) {
   var template = node.getAttribute('template');
   var resourceType = node.getAttribute('resourceType');
   var resource = {};
-  if (goog.isDef(format)) {
+  if (format) {
     resource['format'] = format;
   }
-  if (goog.isDef(template)) {
+  if (template) {
     resource['template'] = template;
   }
-  if (goog.isDef(resourceType)) {
+  if (resourceType) {
     resource['resourceType'] = resourceType;
   }
   return resource;
@@ -219,7 +219,7 @@ ol.format.WMTSCapabilities.readLegendUrl_ = function(node, objectStack) {
  */
 ol.format.WMTSCapabilities.readCoordinates_ = function(node, objectStack) {
   var coordinates = ol.format.XSD.readString(node).split(' ');
-  if (!goog.isDef(coordinates) || coordinates.length != 2) {
+  if (!coordinates || coordinates.length != 2) {
     return undefined;
   }
   var x = +coordinates[0];

--- a/src/ol/format/xsdformat.js
+++ b/src/ol/format/xsdformat.js
@@ -2,6 +2,7 @@ goog.provide('ol.format.XSD');
 
 goog.require('goog.asserts');
 goog.require('goog.string');
+goog.require('ol');
 goog.require('ol.xml');
 
 
@@ -29,7 +30,7 @@ ol.format.XSD.readBoolean = function(node) {
 ol.format.XSD.readBooleanString = function(string) {
   var m = /^\s*(true|1)|(false|0)\s*$/.exec(string);
   if (m) {
-    return goog.isDef(m[1]) || false;
+    return ol.isDef(m[1]) || false;
   } else {
     return undefined;
   }
@@ -56,7 +57,7 @@ ol.format.XSD.readDateTime = function(node) {
     if (m[7] != 'Z') {
       var sign = m[8] == '-' ? -1 : 1;
       dateTime += sign * 60 * parseInt(m[9], 10);
-      if (goog.isDef(m[10])) {
+      if (ol.isDef(m[10])) {
         dateTime += sign * 60 * 60 * parseInt(m[10], 10);
       }
     }

--- a/src/ol/format/xsdformat.js
+++ b/src/ol/format/xsdformat.js
@@ -30,7 +30,7 @@ ol.format.XSD.readBoolean = function(node) {
 ol.format.XSD.readBooleanString = function(string) {
   var m = /^\s*(true|1)|(false|0)\s*$/.exec(string);
   if (m) {
-    return ol.isDef(m[1]) || false;
+    return m[1] !== undefined || false;
   } else {
     return undefined;
   }
@@ -57,7 +57,7 @@ ol.format.XSD.readDateTime = function(node) {
     if (m[7] != 'Z') {
       var sign = m[8] == '-' ? -1 : 1;
       dateTime += sign * 60 * parseInt(m[9], 10);
-      if (ol.isDef(m[10])) {
+      if (m[10] !== undefined) {
         dateTime += sign * 60 * 60 * parseInt(m[10], 10);
       }
     }

--- a/src/ol/geolocation.js
+++ b/src/ol/geolocation.js
@@ -134,7 +134,7 @@ ol.Geolocation.prototype.handleProjectionChanged_ = function() {
 ol.Geolocation.prototype.handleTrackingChanged_ = function() {
   if (ol.has.GEOLOCATION) {
     var tracking = this.getTracking();
-    if (tracking && !goog.isDef(this.watchId_)) {
+    if (tracking && this.watchId_ === undefined) {
       this.watchId_ = goog.global.navigator.geolocation.watchPosition(
           goog.bind(this.positionChange_, this),
           goog.bind(this.positionError_, this),

--- a/src/ol/geolocation.js
+++ b/src/ol/geolocation.js
@@ -62,7 +62,7 @@ ol.Geolocation = function(opt_options) {
 
   goog.base(this);
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options || {};
 
   /**
    * The unprojected (EPSG:4326) device position.

--- a/src/ol/geolocation.js
+++ b/src/ol/geolocation.js
@@ -97,7 +97,7 @@ ol.Geolocation = function(opt_options) {
     this.setTrackingOptions(options.trackingOptions);
   }
 
-  this.setTracking(goog.isDef(options.tracking) ? options.tracking : false);
+  this.setTracking(options.tracking !== undefined ? options.tracking : false);
 
 };
 goog.inherits(ol.Geolocation, ol.Object);
@@ -139,7 +139,7 @@ ol.Geolocation.prototype.handleTrackingChanged_ = function() {
           goog.bind(this.positionChange_, this),
           goog.bind(this.positionError_, this),
           this.getTrackingOptions());
-    } else if (!tracking && goog.isDef(this.watchId_)) {
+    } else if (!tracking && this.watchId_ !== undefined) {
       goog.global.navigator.geolocation.clearWatch(this.watchId_);
       this.watchId_ = undefined;
     }

--- a/src/ol/geolocation.js
+++ b/src/ol/geolocation.js
@@ -90,10 +90,10 @@ ol.Geolocation = function(opt_options) {
       this, ol.Object.getChangeEventType(ol.GeolocationProperty.TRACKING),
       this.handleTrackingChanged_, false, this);
 
-  if (goog.isDef(options.projection)) {
+  if (options.projection !== undefined) {
     this.setProjection(ol.proj.get(options.projection));
   }
-  if (goog.isDef(options.trackingOptions)) {
+  if (options.trackingOptions !== undefined) {
     this.setTrackingOptions(options.trackingOptions);
   }
 

--- a/src/ol/geom/circle.js
+++ b/src/ol/geom/circle.js
@@ -23,7 +23,7 @@ goog.require('ol.proj');
  */
 ol.geom.Circle = function(center, opt_radius, opt_layout) {
   goog.base(this);
-  var radius = goog.isDef(opt_radius) ? opt_radius : 0;
+  var radius = opt_radius ? opt_radius : 0;
   this.setCenterAndRadius(center, radius, opt_layout);
 };
 goog.inherits(ol.geom.Circle, ol.geom.SimpleGeometry);

--- a/src/ol/geom/flat/closestflatgeom.js
+++ b/src/ol/geom/flat/closestflatgeom.js
@@ -154,7 +154,7 @@ ol.geom.flat.closest.getClosestPoint = function(flatCoordinates, offset, end,
     }
   }
   goog.asserts.assert(maxDelta > 0, 'maxDelta should be larger than 0');
-  var tmpPoint = goog.isDef(opt_tmpPoint) ? opt_tmpPoint : [NaN, NaN];
+  var tmpPoint = opt_tmpPoint ? opt_tmpPoint : [NaN, NaN];
   var index = offset + stride;
   while (index < end) {
     ol.geom.flat.closest.point(
@@ -217,7 +217,7 @@ ol.geom.flat.closest.getClosestPoint = function(flatCoordinates, offset, end,
 ol.geom.flat.closest.getsClosestPoint = function(flatCoordinates, offset, ends,
     stride, maxDelta, isRing, x, y, closestPoint, minSquaredDistance,
     opt_tmpPoint) {
-  var tmpPoint = goog.isDef(opt_tmpPoint) ? opt_tmpPoint : [NaN, NaN];
+  var tmpPoint = opt_tmpPoint ? opt_tmpPoint : [NaN, NaN];
   var i, ii;
   for (i = 0, ii = ends.length; i < ii; ++i) {
     var end = ends[i];
@@ -247,7 +247,7 @@ ol.geom.flat.closest.getsClosestPoint = function(flatCoordinates, offset, ends,
 ol.geom.flat.closest.getssClosestPoint = function(flatCoordinates, offset,
     endss, stride, maxDelta, isRing, x, y, closestPoint, minSquaredDistance,
     opt_tmpPoint) {
-  var tmpPoint = goog.isDef(opt_tmpPoint) ? opt_tmpPoint : [NaN, NaN];
+  var tmpPoint = opt_tmpPoint ? opt_tmpPoint : [NaN, NaN];
   var i, ii;
   for (i = 0, ii = endss.length; i < ii; ++i) {
     var ends = endss[i];

--- a/src/ol/geom/flat/deflateflatgeom.js
+++ b/src/ol/geom/flat/deflateflatgeom.js
@@ -55,7 +55,7 @@ ol.geom.flat.deflate.coordinates =
  */
 ol.geom.flat.deflate.coordinatess =
     function(flatCoordinates, offset, coordinatess, stride, opt_ends) {
-  var ends = goog.isDef(opt_ends) ? opt_ends : [];
+  var ends = opt_ends ? opt_ends : [];
   var i = 0;
   var j, jj;
   for (j = 0, jj = coordinatess.length; j < jj; ++j) {
@@ -79,7 +79,7 @@ ol.geom.flat.deflate.coordinatess =
  */
 ol.geom.flat.deflate.coordinatesss =
     function(flatCoordinates, offset, coordinatesss, stride, opt_endss) {
-  var endss = goog.isDef(opt_endss) ? opt_endss : [];
+  var endss = opt_endss ? opt_endss : [];
   var i = 0;
   var j, jj;
   for (j = 0, jj = coordinatesss.length; j < jj; ++j) {

--- a/src/ol/geom/flat/flipflatgeom.js
+++ b/src/ol/geom/flat/flipflatgeom.js
@@ -17,7 +17,7 @@ ol.geom.flat.flip.flipXY =
   var dest, destOffset;
   if (opt_dest !== undefined) {
     dest = opt_dest;
-    destOffset = goog.isDef(opt_destOffset) ? opt_destOffset : 0;
+    destOffset = opt_destOffset !== undefined ? opt_destOffset : 0;
   } else {
     goog.asserts.assert(opt_destOffset === undefined,
         'opt_destOffSet should be defined');

--- a/src/ol/geom/flat/flipflatgeom.js
+++ b/src/ol/geom/flat/flipflatgeom.js
@@ -15,7 +15,7 @@ goog.require('goog.asserts');
 ol.geom.flat.flip.flipXY =
     function(flatCoordinates, offset, end, stride, opt_dest, opt_destOffset) {
   var dest, destOffset;
-  if (goog.isDef(opt_dest)) {
+  if (opt_dest !== undefined) {
     dest = opt_dest;
     destOffset = goog.isDef(opt_destOffset) ? opt_destOffset : 0;
   } else {

--- a/src/ol/geom/flat/flipflatgeom.js
+++ b/src/ol/geom/flat/flipflatgeom.js
@@ -19,7 +19,7 @@ ol.geom.flat.flip.flipXY =
     dest = opt_dest;
     destOffset = goog.isDef(opt_destOffset) ? opt_destOffset : 0;
   } else {
-    goog.asserts.assert(!goog.isDef(opt_destOffset),
+    goog.asserts.assert(opt_destOffset === undefined,
         'opt_destOffSet should be defined');
     dest = [];
     destOffset = 0;

--- a/src/ol/geom/flat/inflateflatgeom.js
+++ b/src/ol/geom/flat/inflateflatgeom.js
@@ -11,7 +11,7 @@ goog.provide('ol.geom.flat.inflate');
  */
 ol.geom.flat.inflate.coordinates =
     function(flatCoordinates, offset, end, stride, opt_coordinates) {
-  var coordinates = goog.isDef(opt_coordinates) ? opt_coordinates : [];
+  var coordinates = opt_coordinates !== undefined ? opt_coordinates : [];
   var i = 0;
   var j;
   for (j = offset; j < end; j += stride) {
@@ -32,7 +32,7 @@ ol.geom.flat.inflate.coordinates =
  */
 ol.geom.flat.inflate.coordinatess =
     function(flatCoordinates, offset, ends, stride, opt_coordinatess) {
-  var coordinatess = goog.isDef(opt_coordinatess) ? opt_coordinatess : [];
+  var coordinatess = opt_coordinatess !== undefined ? opt_coordinatess : [];
   var i = 0;
   var j, jj;
   for (j = 0, jj = ends.length; j < jj; ++j) {
@@ -57,7 +57,7 @@ ol.geom.flat.inflate.coordinatess =
  */
 ol.geom.flat.inflate.coordinatesss =
     function(flatCoordinates, offset, endss, stride, opt_coordinatesss) {
-  var coordinatesss = goog.isDef(opt_coordinatesss) ? opt_coordinatesss : [];
+  var coordinatesss = opt_coordinatesss !== undefined ? opt_coordinatesss : [];
   var i = 0;
   var j, jj;
   for (j = 0, jj = endss.length; j < jj; ++j) {

--- a/src/ol/geom/flat/interiorpointflatgeom.js
+++ b/src/ol/geom/flat/interiorpointflatgeom.js
@@ -60,7 +60,7 @@ ol.geom.flat.interiorpoint.linearRings = function(flatCoordinates, offset,
     // ring.  Use the center of the the linear ring's extent.
     pointX = flatCenters[flatCentersOffset];
   }
-  if (goog.isDef(opt_dest)) {
+  if (opt_dest) {
     opt_dest.push(pointX, y);
     return opt_dest;
   } else {

--- a/src/ol/geom/flat/orientflatgeom.js
+++ b/src/ol/geom/flat/orientflatgeom.js
@@ -1,5 +1,6 @@
 goog.provide('ol.geom.flat.orient');
 
+goog.require('ol');
 goog.require('ol.geom.flat.reverse');
 
 
@@ -43,7 +44,7 @@ ol.geom.flat.orient.linearRingIsClockwise =
  */
 ol.geom.flat.orient.linearRingsAreOriented =
     function(flatCoordinates, offset, ends, stride, opt_right) {
-  var right = goog.isDef(opt_right) ? opt_right : false;
+  var right = ol.isDef(opt_right) ? opt_right : false;
   var i, ii;
   for (i = 0, ii = ends.length; i < ii; ++i) {
     var end = ends[i];
@@ -105,7 +106,7 @@ ol.geom.flat.orient.linearRingssAreOriented =
  */
 ol.geom.flat.orient.orientLinearRings =
     function(flatCoordinates, offset, ends, stride, opt_right) {
-  var right = goog.isDef(opt_right) ? opt_right : false;
+  var right = ol.isDef(opt_right) ? opt_right : false;
   var i, ii;
   for (i = 0, ii = ends.length; i < ii; ++i) {
     var end = ends[i];

--- a/src/ol/geom/flat/orientflatgeom.js
+++ b/src/ol/geom/flat/orientflatgeom.js
@@ -44,7 +44,7 @@ ol.geom.flat.orient.linearRingIsClockwise =
  */
 ol.geom.flat.orient.linearRingsAreOriented =
     function(flatCoordinates, offset, ends, stride, opt_right) {
-  var right = ol.isDef(opt_right) ? opt_right : false;
+  var right = opt_right !== undefined ? opt_right : false;
   var i, ii;
   for (i = 0, ii = ends.length; i < ii; ++i) {
     var end = ends[i];
@@ -106,7 +106,7 @@ ol.geom.flat.orient.linearRingssAreOriented =
  */
 ol.geom.flat.orient.orientLinearRings =
     function(flatCoordinates, offset, ends, stride, opt_right) {
-  var right = ol.isDef(opt_right) ? opt_right : false;
+  var right = opt_right !== undefined ? opt_right : false;
   var i, ii;
   for (i = 0, ii = ends.length; i < ii; ++i) {
     var end = ends[i];

--- a/src/ol/geom/flat/simplifyflatgeom.js
+++ b/src/ol/geom/flat/simplifyflatgeom.js
@@ -42,7 +42,7 @@ goog.require('ol.math');
  */
 ol.geom.flat.simplify.lineString = function(flatCoordinates, offset, end,
     stride, squaredTolerance, highQuality, opt_simplifiedFlatCoordinates) {
-  var simplifiedFlatCoordinates = goog.isDef(opt_simplifiedFlatCoordinates) ?
+  var simplifiedFlatCoordinates = opt_simplifiedFlatCoordinates !== undefined ?
       opt_simplifiedFlatCoordinates : [];
   if (!highQuality) {
     end = ol.geom.flat.simplify.radialDistance(flatCoordinates, offset, end,

--- a/src/ol/geom/flat/transformflatgeom.js
+++ b/src/ol/geom/flat/transformflatgeom.js
@@ -20,7 +20,7 @@ ol.geom.flat.transform.transform2D =
   var m11 = goog.vec.Mat4.getElement(transform, 1, 1);
   var m03 = goog.vec.Mat4.getElement(transform, 0, 3);
   var m13 = goog.vec.Mat4.getElement(transform, 1, 3);
-  var dest = goog.isDef(opt_dest) ? opt_dest : [];
+  var dest = opt_dest ? opt_dest : [];
   var i = 0;
   var j;
   for (j = offset; j < end; j += stride) {
@@ -29,7 +29,7 @@ ol.geom.flat.transform.transform2D =
     dest[i++] = m00 * x + m01 * y + m03;
     dest[i++] = m10 * x + m11 * y + m13;
   }
-  if (goog.isDef(opt_dest) && dest.length != i) {
+  if (opt_dest && dest.length != i) {
     dest.length = i;
   }
   return dest;
@@ -48,7 +48,7 @@ ol.geom.flat.transform.transform2D =
  */
 ol.geom.flat.transform.translate =
     function(flatCoordinates, offset, end, stride, deltaX, deltaY, opt_dest) {
-  var dest = goog.isDef(opt_dest) ? opt_dest : [];
+  var dest = opt_dest ? opt_dest : [];
   var i = 0;
   var j, k;
   for (j = offset; j < end; j += stride) {
@@ -58,7 +58,7 @@ ol.geom.flat.transform.translate =
       dest[i++] = flatCoordinates[k];
     }
   }
-  if (goog.isDef(opt_dest) && dest.length != i) {
+  if (opt_dest && dest.length != i) {
     dest.length = i;
   }
   return dest;

--- a/src/ol/geom/geometry.js
+++ b/src/ol/geom/geometry.js
@@ -122,8 +122,7 @@ ol.geom.Geometry.prototype.closestPointXY = goog.abstractMethod;
  * @api stable
  */
 ol.geom.Geometry.prototype.getClosestPoint = function(point, opt_closestPoint) {
-  var closestPoint = goog.isDef(opt_closestPoint) ?
-      opt_closestPoint : [NaN, NaN];
+  var closestPoint = opt_closestPoint ? opt_closestPoint : [NaN, NaN];
   this.closestPointXY(point[0], point[1], closestPoint, Infinity);
   return closestPoint;
 };

--- a/src/ol/geom/geometrycollection.js
+++ b/src/ol/geom/geometrycollection.js
@@ -26,7 +26,7 @@ ol.geom.GeometryCollection = function(opt_geometries) {
    * @private
    * @type {Array.<ol.geom.Geometry>}
    */
-  this.geometries_ = goog.isDef(opt_geometries) ? opt_geometries : null;
+  this.geometries_ = opt_geometries ? opt_geometries : null;
 
   this.listenGeometriesChange_();
 };

--- a/src/ol/geom/linestring.js
+++ b/src/ol/geom/linestring.js
@@ -148,7 +148,7 @@ ol.geom.LineString.prototype.getCoordinateAtM = function(m, opt_extrapolate) {
       this.layout != ol.geom.GeometryLayout.XYZM) {
     return null;
   }
-  var extrapolate = goog.isDef(opt_extrapolate) ? opt_extrapolate : false;
+  var extrapolate = opt_extrapolate ? opt_extrapolate : false;
   return ol.geom.flat.lineStringCoordinateAtM(this.flatCoordinates, 0,
       this.flatCoordinates.length, this.stride, m, extrapolate);
 };

--- a/src/ol/geom/linestring.js
+++ b/src/ol/geom/linestring.js
@@ -2,6 +2,7 @@ goog.provide('ol.geom.LineString');
 
 goog.require('goog.array');
 goog.require('goog.asserts');
+goog.require('ol');
 goog.require('ol.extent');
 goog.require('ol.geom.GeometryLayout');
 goog.require('ol.geom.GeometryType');
@@ -148,7 +149,8 @@ ol.geom.LineString.prototype.getCoordinateAtM = function(m, opt_extrapolate) {
       this.layout != ol.geom.GeometryLayout.XYZM) {
     return null;
   }
-  var extrapolate = opt_extrapolate ? opt_extrapolate : false;
+  var extrapolate = ol.isDef(opt_extrapolate) ?
+      /** @type {boolean} */ (opt_extrapolate) : false;
   return ol.geom.flat.lineStringCoordinateAtM(this.flatCoordinates, 0,
       this.flatCoordinates.length, this.stride, m, extrapolate);
 };

--- a/src/ol/geom/linestring.js
+++ b/src/ol/geom/linestring.js
@@ -149,8 +149,7 @@ ol.geom.LineString.prototype.getCoordinateAtM = function(m, opt_extrapolate) {
       this.layout != ol.geom.GeometryLayout.XYZM) {
     return null;
   }
-  var extrapolate = ol.isDef(opt_extrapolate) ?
-      /** @type {boolean} */ (opt_extrapolate) : false;
+  var extrapolate = opt_extrapolate !== undefined ? opt_extrapolate : false;
   return ol.geom.flat.lineStringCoordinateAtM(this.flatCoordinates, 0,
       this.flatCoordinates.length, this.stride, m, extrapolate);
 };

--- a/src/ol/geom/multilinestring.js
+++ b/src/ol/geom/multilinestring.js
@@ -136,10 +136,8 @@ ol.geom.MultiLineString.prototype.getCoordinateAtM =
       this.flatCoordinates.length === 0) {
     return null;
   }
-  var extrapolate = ol.isDef(opt_extrapolate) ?
-      /** @type {boolean} */ (opt_extrapolate) : false;
-  var interpolate = ol.isDef(opt_interpolate) ?
-      /** @type {boolean} */ (opt_interpolate) : false;
+  var extrapolate = opt_extrapolate !== undefined ? opt_extrapolate : false;
+  var interpolate = opt_interpolate !== undefined ? opt_interpolate : false;
   return ol.geom.flat.lineStringsCoordinateAtM(this.flatCoordinates, 0,
       this.ends_, this.stride, m, extrapolate, interpolate);
 };

--- a/src/ol/geom/multilinestring.js
+++ b/src/ol/geom/multilinestring.js
@@ -2,6 +2,7 @@ goog.provide('ol.geom.MultiLineString');
 
 goog.require('goog.array');
 goog.require('goog.asserts');
+goog.require('ol');
 goog.require('ol.extent');
 goog.require('ol.geom.GeometryLayout');
 goog.require('ol.geom.GeometryType');
@@ -135,8 +136,10 @@ ol.geom.MultiLineString.prototype.getCoordinateAtM =
       this.flatCoordinates.length === 0) {
     return null;
   }
-  var extrapolate = goog.isDef(opt_extrapolate) ? opt_extrapolate : false;
-  var interpolate = goog.isDef(opt_interpolate) ? opt_interpolate : false;
+  var extrapolate = ol.isDef(opt_extrapolate) ?
+      /** @type {boolean} */ (opt_extrapolate) : false;
+  var interpolate = ol.isDef(opt_interpolate) ?
+      /** @type {boolean} */ (opt_interpolate) : false;
   return ol.geom.flat.lineStringsCoordinateAtM(this.flatCoordinates, 0,
       this.ends_, this.stride, m, extrapolate, interpolate);
 };

--- a/src/ol/geom/multipolygon.js
+++ b/src/ol/geom/multipolygon.js
@@ -183,7 +183,7 @@ ol.geom.MultiPolygon.prototype.getArea = function() {
  */
 ol.geom.MultiPolygon.prototype.getCoordinates = function(opt_right) {
   var flatCoordinates;
-  if (ol.isDef(opt_right)) {
+  if (opt_right !== undefined) {
     flatCoordinates = this.getOrientedFlatCoordinates().slice();
     ol.geom.flat.orient.orientLinearRingss(
         flatCoordinates, 0, this.endss_, this.stride, opt_right);

--- a/src/ol/geom/multipolygon.js
+++ b/src/ol/geom/multipolygon.js
@@ -3,6 +3,7 @@ goog.provide('ol.geom.MultiPolygon');
 goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.object');
+goog.require('ol');
 goog.require('ol.extent');
 goog.require('ol.geom.GeometryLayout');
 goog.require('ol.geom.GeometryType');
@@ -182,7 +183,7 @@ ol.geom.MultiPolygon.prototype.getArea = function() {
  */
 ol.geom.MultiPolygon.prototype.getCoordinates = function(opt_right) {
   var flatCoordinates;
-  if (goog.isDef(opt_right)) {
+  if (ol.isDef(opt_right)) {
     flatCoordinates = this.getOrientedFlatCoordinates().slice();
     ol.geom.flat.orient.orientLinearRingss(
         flatCoordinates, 0, this.endss_, this.stride, opt_right);

--- a/src/ol/geom/polygon.js
+++ b/src/ol/geom/polygon.js
@@ -3,6 +3,7 @@ goog.provide('ol.geom.Polygon');
 goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.math');
+goog.require('ol');
 goog.require('ol.extent');
 goog.require('ol.geom.GeometryLayout');
 goog.require('ol.geom.GeometryType');
@@ -169,7 +170,7 @@ ol.geom.Polygon.prototype.getArea = function() {
  */
 ol.geom.Polygon.prototype.getCoordinates = function(opt_right) {
   var flatCoordinates;
-  if (goog.isDef(opt_right)) {
+  if (ol.isDef(opt_right)) {
     flatCoordinates = this.getOrientedFlatCoordinates().slice();
     ol.geom.flat.orient.orientLinearRings(
         flatCoordinates, 0, this.ends_, this.stride, opt_right);
@@ -388,7 +389,7 @@ ol.geom.Polygon.prototype.setFlatCoordinates =
  * @api stable
  */
 ol.geom.Polygon.circular = function(sphere, center, radius, opt_n) {
-  var n = goog.isDef(opt_n) ? opt_n : 32;
+  var n = opt_n ? opt_n : 32;
   /** @type {Array.<number>} */
   var flatCoordinates = [];
   var i;
@@ -434,7 +435,7 @@ ol.geom.Polygon.fromExtent = function(extent) {
  * @api
  */
 ol.geom.Polygon.fromCircle = function(circle, opt_sides, opt_angle) {
-  var sides = goog.isDef(opt_sides) ? opt_sides : 32;
+  var sides = opt_sides ? opt_sides : 32;
   var stride = circle.getStride();
   var layout = circle.getLayout();
   var polygon = new ol.geom.Polygon(null, layout);
@@ -462,7 +463,7 @@ ol.geom.Polygon.makeRegular = function(polygon, center, radius, opt_angle) {
   var ends = polygon.getEnds();
   goog.asserts.assert(ends.length === 1, 'only 1 ring is supported');
   var sides = flatCoordinates.length / stride - 1;
-  var startAngle = goog.isDef(opt_angle) ? opt_angle : 0;
+  var startAngle = opt_angle ? opt_angle : 0;
   var angle, coord, offset;
   for (var i = 0; i <= sides; ++i) {
     offset = i * stride;

--- a/src/ol/geom/polygon.js
+++ b/src/ol/geom/polygon.js
@@ -170,7 +170,7 @@ ol.geom.Polygon.prototype.getArea = function() {
  */
 ol.geom.Polygon.prototype.getCoordinates = function(opt_right) {
   var flatCoordinates;
-  if (ol.isDef(opt_right)) {
+  if (opt_right !== undefined) {
     flatCoordinates = this.getOrientedFlatCoordinates().slice();
     ol.geom.flat.orient.orientLinearRings(
         flatCoordinates, 0, this.ends_, this.stride, opt_right);

--- a/src/ol/geom/simplegeometry.js
+++ b/src/ol/geom/simplegeometry.js
@@ -232,7 +232,7 @@ ol.geom.SimpleGeometry.prototype.setLayout =
     function(layout, coordinates, nesting) {
   /** @type {number} */
   var stride;
-  if (goog.isDef(layout)) {
+  if (layout) {
     stride = ol.geom.SimpleGeometry.getStrideForLayout(layout);
   } else {
     var i;

--- a/src/ol/graticule.js
+++ b/src/ol/graticule.js
@@ -346,7 +346,7 @@ ol.Graticule.prototype.getMeridian_ = function(lon, minLat, maxLat,
       minLat, maxLat, this.projection_, squaredTolerance);
   goog.asserts.assert(flatCoordinates.length > 0,
       'flatCoordinates cannot be empty');
-  var lineString = goog.isDef(this.meridians_[index]) ?
+  var lineString = this.meridians_[index] !== undefined ?
       this.meridians_[index] : new ol.geom.LineString(null);
   lineString.setFlatCoordinates(ol.geom.GeometryLayout.XY, flatCoordinates);
   return lineString;
@@ -382,7 +382,7 @@ ol.Graticule.prototype.getParallel_ = function(lat, minLon, maxLon,
       this.minLon_, this.maxLon_, this.projection_, squaredTolerance);
   goog.asserts.assert(flatCoordinates.length > 0,
       'flatCoordinates cannot be empty');
-  var lineString = goog.isDef(this.parallels_[index]) ?
+  var lineString = this.parallels_[index] !== undefined ?
       this.parallels_[index] : new ol.geom.LineString(null);
   lineString.setFlatCoordinates(ol.geom.GeometryLayout.XY, flatCoordinates);
   return lineString;

--- a/src/ol/graticule.js
+++ b/src/ol/graticule.js
@@ -463,18 +463,18 @@ ol.Graticule.prototype.updateProjectionInfo_ = function(projection) {
   var minLonP = worldExtentP[0];
 
   goog.asserts.assert(!goog.isNull(extent), 'extent cannot be null');
-  goog.asserts.assert(goog.isDef(maxLat), 'maxLat should be defined');
-  goog.asserts.assert(goog.isDef(maxLon), 'maxLon should be defined');
-  goog.asserts.assert(goog.isDef(minLat), 'minLat should be defined');
-  goog.asserts.assert(goog.isDef(minLon), 'minLon should be defined');
+  goog.asserts.assert(maxLat !== undefined, 'maxLat should be defined');
+  goog.asserts.assert(maxLon !== undefined, 'maxLon should be defined');
+  goog.asserts.assert(minLat !== undefined, 'minLat should be defined');
+  goog.asserts.assert(minLon !== undefined, 'minLon should be defined');
 
-  goog.asserts.assert(goog.isDef(maxLatP),
+  goog.asserts.assert(maxLatP !== undefined,
       'projected maxLat should be defined');
-  goog.asserts.assert(goog.isDef(maxLonP),
+  goog.asserts.assert(maxLonP !== undefined,
       'projected maxLon should be defined');
-  goog.asserts.assert(goog.isDef(minLatP),
+  goog.asserts.assert(minLatP !== undefined,
       'projected minLat should be defined');
-  goog.asserts.assert(goog.isDef(minLonP),
+  goog.asserts.assert(minLonP !== undefined,
       'projected minLon should be defined');
 
   this.maxLat_ = maxLat;

--- a/src/ol/graticule.js
+++ b/src/ol/graticule.js
@@ -86,14 +86,14 @@ ol.Graticule = function(opt_options) {
    * @type {number}
    * @private
    */
-  this.targetSize_ = goog.isDef(options.targetSize) ?
+  this.targetSize_ = options.targetSize !== undefined ?
       options.targetSize : 100;
 
   /**
    * @type {number}
    * @private
    */
-  this.maxLines_ = goog.isDef(options.maxLines) ? options.maxLines : 100;
+  this.maxLines_ = options.maxLines !== undefined ? options.maxLines : 100;
   goog.asserts.assert(this.maxLines_ > 0,
       'this.maxLines_ should be more than 0');
 
@@ -113,7 +113,7 @@ ol.Graticule = function(opt_options) {
    * @type {ol.style.Stroke}
    * @private
    */
-  this.strokeStyle_ = goog.isDef(options.strokeStyle) ?
+  this.strokeStyle_ = options.strokeStyle !== undefined ?
       options.strokeStyle : ol.Graticule.DEFAULT_STROKE_STYLE_;
 
   /**
@@ -134,7 +134,7 @@ ol.Graticule = function(opt_options) {
    */
   this.projectionCenterLonLat_ = null;
 
-  this.setMap(goog.isDef(options.map) ? options.map : null);
+  this.setMap(options.map !== undefined ? options.map : null);
 };
 
 

--- a/src/ol/graticule.js
+++ b/src/ol/graticule.js
@@ -20,7 +20,7 @@ goog.require('ol.style.Stroke');
  */
 ol.Graticule = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options || {};
 
   /**
    * @type {ol.Map}

--- a/src/ol/has.js
+++ b/src/ol/has.js
@@ -44,7 +44,7 @@ ol.has.CANVAS = ol.ENABLE_CANVAS && (
         if (goog.isNull(context)) {
           return false;
         } else {
-          if (goog.isDef(context.setLineDash)) {
+          if (context.setLineDash !== undefined) {
             ol.has.CANVAS_LINE_DASH = true;
           }
           return true;

--- a/src/ol/image.js
+++ b/src/ol/image.js
@@ -114,7 +114,7 @@ ol.Image.prototype.handleImageError_ = function() {
  * @private
  */
 ol.Image.prototype.handleImageLoad_ = function() {
-  if (!goog.isDef(this.resolution)) {
+  if (this.resolution === undefined) {
     this.resolution = ol.extent.getHeight(this.extent) / this.image_.height;
   }
   this.state = ol.ImageState.LOADED;

--- a/src/ol/image.js
+++ b/src/ol/image.js
@@ -78,7 +78,7 @@ goog.inherits(ol.Image, ol.ImageBase);
  * @api
  */
 ol.Image.prototype.getImage = function(opt_context) {
-  if (goog.isDef(opt_context)) {
+  if (opt_context !== undefined) {
     var image;
     var key = goog.getUid(opt_context);
     if (key in this.imageByContext_) {

--- a/src/ol/imagebase.js
+++ b/src/ol/imagebase.js
@@ -110,7 +110,7 @@ ol.ImageBase.prototype.getPixelRatio = function() {
  * @return {number} Resolution.
  */
 ol.ImageBase.prototype.getResolution = function() {
-  goog.asserts.assert(goog.isDef(this.resolution), 'resolution not yet set');
+  goog.asserts.assert(this.resolution !== undefined, 'resolution not yet set');
   return this.resolution;
 };
 

--- a/src/ol/imagecanvas.js
+++ b/src/ol/imagecanvas.js
@@ -25,9 +25,9 @@ ol.ImageCanvas = function(extent, resolution, pixelRatio, attributions,
    * @type {?ol.ImageCanvasLoader}
    * @private
    */
-  this.loader_ = goog.isDef(opt_loader) ? opt_loader : null;
+  this.loader_ = opt_loader !== undefined ? opt_loader : null;
 
-  var state = goog.isDef(opt_loader) ?
+  var state = opt_loader !== undefined ?
       ol.ImageState.IDLE : ol.ImageState.LOADED;
 
   goog.base(this, extent, resolution, pixelRatio, state, attributions);

--- a/src/ol/imagetile.js
+++ b/src/ol/imagetile.js
@@ -126,7 +126,7 @@ ol.ImageTile.prototype.handleImageError_ = function() {
  */
 ol.ImageTile.prototype.handleImageLoad_ = function() {
   if (ol.LEGACY_IE_SUPPORT && ol.IS_LEGACY_IE) {
-    if (!goog.isDef(this.image_.naturalWidth)) {
+    if (this.image_.naturalWidth === undefined) {
       this.image_.naturalWidth = this.image_.width;
       this.image_.naturalHeight = this.image_.height;
     }

--- a/src/ol/imagetile.js
+++ b/src/ol/imagetile.js
@@ -81,7 +81,7 @@ ol.ImageTile.prototype.disposeInternal = function() {
  * @api
  */
 ol.ImageTile.prototype.getImage = function(opt_context) {
-  if (goog.isDef(opt_context)) {
+  if (opt_context !== undefined) {
     var image;
     var key = goog.getUid(opt_context);
     if (key in this.imageByContext_) {

--- a/src/ol/interaction/doubleclickzoominteraction.js
+++ b/src/ol/interaction/doubleclickzoominteraction.js
@@ -18,13 +18,13 @@ goog.require('ol.interaction.Interaction');
  */
 ol.interaction.DoubleClickZoom = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   /**
    * @private
    * @type {number}
    */
-  this.delta_ = goog.isDef(options.delta) ? options.delta : 1;
+  this.delta_ = options.delta ? options.delta : 1;
 
   goog.base(this, {
     handleEvent: ol.interaction.DoubleClickZoom.handleEvent
@@ -34,7 +34,7 @@ ol.interaction.DoubleClickZoom = function(opt_options) {
    * @private
    * @type {number}
    */
-  this.duration_ = goog.isDef(options.duration) ? options.duration : 250;
+  this.duration_ = options.duration ? options.duration : 250;
 
 };
 goog.inherits(ol.interaction.DoubleClickZoom, ol.interaction.Interaction);

--- a/src/ol/interaction/draganddropinteraction.js
+++ b/src/ol/interaction/draganddropinteraction.js
@@ -27,7 +27,7 @@ goog.require('ol.proj');
  */
 ol.interaction.DragAndDrop = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   goog.base(this, {
     handleEvent: ol.interaction.DragAndDrop.handleEvent
@@ -37,14 +37,14 @@ ol.interaction.DragAndDrop = function(opt_options) {
    * @private
    * @type {Array.<function(new: ol.format.Feature)>}
    */
-  this.formatConstructors_ = goog.isDef(options.formatConstructors) ?
+  this.formatConstructors_ = options.formatConstructors ?
       options.formatConstructors : [];
 
   /**
    * @private
    * @type {ol.proj.Projection}
    */
-  this.projection_ = goog.isDef(options.projection) ?
+  this.projection_ = options.projection ?
       ol.proj.get(options.projection) : null;
 
   /**
@@ -67,7 +67,7 @@ goog.inherits(ol.interaction.DragAndDrop, ol.interaction.Interaction);
  * @inheritDoc
  */
 ol.interaction.DragAndDrop.prototype.disposeInternal = function() {
-  if (goog.isDef(this.dropListenKey_)) {
+  if (this.dropListenKey_) {
     goog.events.unlistenByKey(this.dropListenKey_);
   }
   goog.base(this, 'disposeInternal');
@@ -104,7 +104,7 @@ ol.interaction.DragAndDrop.prototype.handleResult_ = function(file, result) {
     var view = map.getView();
     goog.asserts.assert(!goog.isNull(view), 'view should not be null');
     projection = view.getProjection();
-    goog.asserts.assert(goog.isDef(projection),
+    goog.asserts.assert(projection !== undefined,
         'projection should be defined');
   }
   var formatConstructors = this.formatConstructors_;
@@ -150,7 +150,7 @@ ol.interaction.DragAndDrop.handleEvent = goog.functions.TRUE;
  * @inheritDoc
  */
 ol.interaction.DragAndDrop.prototype.setMap = function(map) {
-  if (goog.isDef(this.dropListenKey_)) {
+  if (this.dropListenKey_) {
     goog.events.unlistenByKey(this.dropListenKey_);
     this.dropListenKey_ = undefined;
   }
@@ -158,7 +158,7 @@ ol.interaction.DragAndDrop.prototype.setMap = function(map) {
     goog.dispose(this.fileDropHandler_);
     this.fileDropHandler_ = null;
   }
-  goog.asserts.assert(!goog.isDef(this.dropListenKey_),
+  goog.asserts.assert(this.dropListenKey_ === undefined,
       'this.dropListenKey_ should be undefined');
   goog.base(this, 'setMap', map);
   if (!goog.isNull(map)) {

--- a/src/ol/interaction/dragboxinteraction.js
+++ b/src/ol/interaction/dragboxinteraction.js
@@ -91,13 +91,13 @@ ol.interaction.DragBox = function(opt_options) {
     handleUpEvent: ol.interaction.DragBox.handleUpEvent_
   });
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   /**
    * @private
    * @type {ol.style.Style}
    */
-  var style = goog.isDef(options.style) ? options.style : null;
+  var style = options.style ? options.style : null;
 
   /**
    * @type {ol.render.Box}
@@ -115,7 +115,7 @@ ol.interaction.DragBox = function(opt_options) {
    * @private
    * @type {ol.events.ConditionType}
    */
-  this.condition_ = goog.isDef(options.condition) ?
+  this.condition_ = options.condition ?
       options.condition : ol.events.condition.always;
 
 };

--- a/src/ol/interaction/dragpaninteraction.js
+++ b/src/ol/interaction/dragpaninteraction.js
@@ -28,7 +28,7 @@ ol.interaction.DragPan = function(opt_options) {
     handleUpEvent: ol.interaction.DragPan.handleUpEvent_
   });
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   /**
    * @private
@@ -51,7 +51,7 @@ ol.interaction.DragPan = function(opt_options) {
    * @private
    * @type {ol.events.ConditionType}
    */
-  this.condition_ = goog.isDef(options.condition) ?
+  this.condition_ = options.condition ?
       options.condition : ol.events.condition.noModifierKeys;
 
   /**
@@ -109,7 +109,7 @@ ol.interaction.DragPan.handleUpEvent_ = function(mapBrowserEvent) {
       var distance = this.kinetic_.getDistance();
       var angle = this.kinetic_.getAngle();
       var center = view.getCenter();
-      goog.asserts.assert(goog.isDef(center), 'center should be defined');
+      goog.asserts.assert(center !== undefined, 'center should be defined');
       this.kineticPreRenderFn_ = this.kinetic_.pan(center);
       map.beforeRender(this.kineticPreRenderFn_);
       var centerpx = map.getPixelFromCoordinate(center);

--- a/src/ol/interaction/dragrotateandzoominteraction.js
+++ b/src/ol/interaction/dragrotateandzoominteraction.js
@@ -26,7 +26,7 @@ goog.require('ol.interaction.Pointer');
  */
 ol.interaction.DragRotateAndZoom = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   goog.base(this, {
     handleDownEvent: ol.interaction.DragRotateAndZoom.handleDownEvent_,
@@ -38,7 +38,7 @@ ol.interaction.DragRotateAndZoom = function(opt_options) {
    * @private
    * @type {ol.events.ConditionType}
    */
-  this.condition_ = goog.isDef(options.condition) ?
+  this.condition_ = options.condition ?
       options.condition : ol.events.condition.shiftKeyOnly;
 
   /**
@@ -63,7 +63,7 @@ ol.interaction.DragRotateAndZoom = function(opt_options) {
    * @private
    * @type {number}
    */
-  this.duration_ = goog.isDef(options.duration) ? options.duration : 400;
+  this.duration_ = options.duration ? options.duration : 400;
 
 };
 goog.inherits(ol.interaction.DragRotateAndZoom, ol.interaction.Pointer);
@@ -89,17 +89,17 @@ ol.interaction.DragRotateAndZoom.handleDragEvent_ = function(mapBrowserEvent) {
   var magnitude = delta.magnitude();
   var view = map.getView();
   map.render();
-  if (goog.isDef(this.lastAngle_)) {
+  if (this.lastAngle_ !== undefined) {
     var angleDelta = theta - this.lastAngle_;
     ol.interaction.Interaction.rotateWithoutConstraints(
         map, view, view.getRotation() - angleDelta);
   }
   this.lastAngle_ = theta;
-  if (goog.isDef(this.lastMagnitude_)) {
+  if (this.lastMagnitude_ !== undefined) {
     var resolution = this.lastMagnitude_ * (view.getResolution() / magnitude);
     ol.interaction.Interaction.zoomWithoutConstraints(map, view, resolution);
   }
-  if (goog.isDef(this.lastMagnitude_)) {
+  if (this.lastMagnitude_ !== undefined) {
     this.lastScaleDelta_ = this.lastMagnitude_ / magnitude;
   }
   this.lastMagnitude_ = magnitude;

--- a/src/ol/interaction/dragrotateandzoominteraction.js
+++ b/src/ol/interaction/dragrotateandzoominteraction.js
@@ -90,17 +90,17 @@ ol.interaction.DragRotateAndZoom.handleDragEvent_ = function(mapBrowserEvent) {
   var magnitude = delta.magnitude();
   var view = map.getView();
   map.render();
-  if (ol.isDef(this.lastAngle_)) {
+  if (this.lastAngle_ !== undefined) {
     var angleDelta = theta - this.lastAngle_;
     ol.interaction.Interaction.rotateWithoutConstraints(
         map, view, view.getRotation() - angleDelta);
   }
   this.lastAngle_ = theta;
-  if (ol.isDef(this.lastMagnitude_)) {
+  if (this.lastMagnitude_ !== undefined) {
     var resolution = this.lastMagnitude_ * (view.getResolution() / magnitude);
     ol.interaction.Interaction.zoomWithoutConstraints(map, view, resolution);
   }
-  if (ol.isDef(this.lastMagnitude_)) {
+  if (this.lastMagnitude_ !== undefined) {
     this.lastScaleDelta_ = this.lastMagnitude_ / magnitude;
   }
   this.lastMagnitude_ = magnitude;

--- a/src/ol/interaction/dragrotateandzoominteraction.js
+++ b/src/ol/interaction/dragrotateandzoominteraction.js
@@ -1,6 +1,7 @@
 goog.provide('ol.interaction.DragRotateAndZoom');
 
 goog.require('goog.math.Vec2');
+goog.require('ol');
 goog.require('ol.ViewHint');
 goog.require('ol.events.ConditionType');
 goog.require('ol.events.condition');
@@ -89,17 +90,17 @@ ol.interaction.DragRotateAndZoom.handleDragEvent_ = function(mapBrowserEvent) {
   var magnitude = delta.magnitude();
   var view = map.getView();
   map.render();
-  if (this.lastAngle_ !== undefined) {
+  if (ol.isDef(this.lastAngle_)) {
     var angleDelta = theta - this.lastAngle_;
     ol.interaction.Interaction.rotateWithoutConstraints(
         map, view, view.getRotation() - angleDelta);
   }
   this.lastAngle_ = theta;
-  if (this.lastMagnitude_ !== undefined) {
+  if (ol.isDef(this.lastMagnitude_)) {
     var resolution = this.lastMagnitude_ * (view.getResolution() / magnitude);
     ol.interaction.Interaction.zoomWithoutConstraints(map, view, resolution);
   }
-  if (this.lastMagnitude_ !== undefined) {
+  if (ol.isDef(this.lastMagnitude_)) {
     this.lastScaleDelta_ = this.lastMagnitude_ / magnitude;
   }
   this.lastMagnitude_ = magnitude;

--- a/src/ol/interaction/dragrotateinteraction.js
+++ b/src/ol/interaction/dragrotateinteraction.js
@@ -69,7 +69,7 @@ ol.interaction.DragRotate.handleDragEvent_ = function(mapBrowserEvent) {
   var offset = mapBrowserEvent.pixel;
   var theta =
       Math.atan2(size[1] / 2 - offset[1], offset[0] - size[0] / 2);
-  if (ol.isDef(this.lastAngle_)) {
+  if (this.lastAngle_ !== undefined) {
     var delta = theta - this.lastAngle_;
     var view = map.getView();
     var rotation = view.getRotation();

--- a/src/ol/interaction/dragrotateinteraction.js
+++ b/src/ol/interaction/dragrotateinteraction.js
@@ -1,5 +1,6 @@
 goog.provide('ol.interaction.DragRotate');
 
+goog.require('ol');
 goog.require('ol.ViewHint');
 goog.require('ol.events.ConditionType');
 goog.require('ol.events.condition');
@@ -68,7 +69,7 @@ ol.interaction.DragRotate.handleDragEvent_ = function(mapBrowserEvent) {
   var offset = mapBrowserEvent.pixel;
   var theta =
       Math.atan2(size[1] / 2 - offset[1], offset[0] - size[0] / 2);
-  if (this.lastAngle_ !== undefined) {
+  if (ol.isDef(this.lastAngle_)) {
     var delta = theta - this.lastAngle_;
     var view = map.getView();
     var rotation = view.getRotation();

--- a/src/ol/interaction/dragrotateinteraction.js
+++ b/src/ol/interaction/dragrotateinteraction.js
@@ -23,7 +23,7 @@ goog.require('ol.interaction.Pointer');
  */
 ol.interaction.DragRotate = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   goog.base(this, {
     handleDownEvent: ol.interaction.DragRotate.handleDownEvent_,
@@ -35,7 +35,7 @@ ol.interaction.DragRotate = function(opt_options) {
    * @private
    * @type {ol.events.ConditionType}
    */
-  this.condition_ = goog.isDef(options.condition) ?
+  this.condition_ = options.condition ?
       options.condition : ol.events.condition.altShiftKeysOnly;
 
   /**
@@ -48,7 +48,7 @@ ol.interaction.DragRotate = function(opt_options) {
    * @private
    * @type {number}
    */
-  this.duration_ = goog.isDef(options.duration) ? options.duration : 250;
+  this.duration_ = options.duration ? options.duration : 250;
 };
 goog.inherits(ol.interaction.DragRotate, ol.interaction.Pointer);
 
@@ -68,7 +68,7 @@ ol.interaction.DragRotate.handleDragEvent_ = function(mapBrowserEvent) {
   var offset = mapBrowserEvent.pixel;
   var theta =
       Math.atan2(size[1] / 2 - offset[1], offset[0] - size[0] / 2);
-  if (goog.isDef(this.lastAngle_)) {
+  if (this.lastAngle_ !== undefined) {
     var delta = theta - this.lastAngle_;
     var view = map.getView();
     var rotation = view.getRotation();

--- a/src/ol/interaction/dragzoominteraction.js
+++ b/src/ol/interaction/dragzoominteraction.js
@@ -23,22 +23,22 @@ goog.require('ol.style.Style');
  * @api stable
  */
 ol.interaction.DragZoom = function(opt_options) {
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
-  var condition = goog.isDef(options.condition) ?
+  var condition = options.condition ?
       options.condition : ol.events.condition.shiftKeyOnly;
 
   /**
    * @private
    * @type {number}
    */
-  this.duration_ = goog.isDef(options.duration) ? options.duration : 200;
+  this.duration_ = options.duration ? options.duration : 200;
 
   /**
    * @private
    * @type {ol.style.Style}
    */
-  var style = goog.isDef(options.style) ?
+  var style = options.style ?
       options.style : new ol.style.Style({
         stroke: new ol.style.Stroke({
           color: [0, 0, 255, 1]
@@ -64,7 +64,7 @@ ol.interaction.DragZoom.prototype.onBoxEnd = function() {
   goog.asserts.assert(!goog.isNull(view), 'view should not be null');
 
   var size = map.getSize();
-  goog.asserts.assert(goog.isDef(size), 'size should be defined');
+  goog.asserts.assert(size !== undefined, 'size should be defined');
 
   var extent = this.getGeometry().getExtent();
 
@@ -72,10 +72,10 @@ ol.interaction.DragZoom.prototype.onBoxEnd = function() {
       view.getResolutionForExtent(extent, size));
 
   var currentResolution = view.getResolution();
-  goog.asserts.assert(goog.isDef(currentResolution), 'res should be defined');
+  goog.asserts.assert(currentResolution !== undefined, 'res should be defined');
 
   var currentCenter = view.getCenter();
-  goog.asserts.assert(goog.isDef(currentCenter), 'center should be defined');
+  goog.asserts.assert(currentCenter !== undefined, 'center should be defined');
 
   map.beforeRender(ol.animation.zoom({
     resolution: currentResolution,

--- a/src/ol/interaction/drawinteraction.js
+++ b/src/ol/interaction/drawinteraction.js
@@ -112,22 +112,21 @@ ol.interaction.Draw = function(options) {
    * @type {ol.source.Vector}
    * @private
    */
-  this.source_ = goog.isDef(options.source) ? options.source : null;
+  this.source_ = options.source ? options.source : null;
 
   /**
    * Target collection for drawn features.
    * @type {ol.Collection.<ol.Feature>}
    * @private
    */
-  this.features_ = goog.isDef(options.features) ? options.features : null;
+  this.features_ = options.features ? options.features : null;
 
   /**
    * Pixel distance for snapping.
    * @type {number}
    * @private
    */
-  this.snapTolerance_ = goog.isDef(options.snapTolerance) ?
-      options.snapTolerance : 12;
+  this.snapTolerance_ = options.snapTolerance ? options.snapTolerance : 12;
 
   /**
    * Geometry type.
@@ -150,7 +149,7 @@ ol.interaction.Draw = function(options) {
    * @type {number}
    * @private
    */
-  this.minPoints_ = goog.isDef(options.minPoints) ?
+  this.minPoints_ = options.minPoints ?
       options.minPoints :
       (this.mode_ === ol.interaction.DrawMode.POLYGON ? 3 : 2);
 
@@ -160,11 +159,10 @@ ol.interaction.Draw = function(options) {
    * @type {number}
    * @private
    */
-  this.maxPoints_ = goog.isDef(options.maxPoints) ?
-      options.maxPoints : Infinity;
+  this.maxPoints_ = options.maxPoints ? options.maxPoints : Infinity;
 
   var geometryFunction = options.geometryFunction;
-  if (!goog.isDef(geometryFunction)) {
+  if (!geometryFunction) {
     if (this.type_ === ol.geom.GeometryType.CIRCLE) {
       /**
        * @param {ol.Coordinate|Array.<ol.Coordinate>|Array.<Array.<ol.Coordinate>>} coordinates
@@ -172,7 +170,7 @@ ol.interaction.Draw = function(options) {
        * @return {ol.geom.SimpleGeometry}
        */
       geometryFunction = function(coordinates, opt_geometry) {
-        var circle = goog.isDef(opt_geometry) ? opt_geometry :
+        var circle = opt_geometry ? opt_geometry :
             new ol.geom.Circle([NaN, NaN]);
         goog.asserts.assertInstanceof(circle, ol.geom.Circle,
             'geometry must be an ol.geom.Circle');
@@ -198,7 +196,7 @@ ol.interaction.Draw = function(options) {
        */
       geometryFunction = function(coordinates, opt_geometry) {
         var geometry = opt_geometry;
-        if (goog.isDef(geometry)) {
+        if (geometry) {
           geometry.setCoordinates(coordinates);
         } else {
           geometry = new Constructor(coordinates);
@@ -264,7 +262,7 @@ ol.interaction.Draw = function(options) {
    * @type {number}
    * @private
    */
-  this.squaredClickTolerance_ = goog.isDef(options.clickTolerance) ?
+  this.squaredClickTolerance_ = options.clickTolerance ?
       options.clickTolerance * options.clickTolerance : 36;
 
   /**
@@ -275,10 +273,10 @@ ol.interaction.Draw = function(options) {
   this.overlay_ = new ol.layer.Vector({
     source: new ol.source.Vector({
       useSpatialIndex: false,
-      wrapX: goog.isDef(options.wrapX) ? options.wrapX : false
+      wrapX: options.wrapX ? options.wrapX : false
     }),
-    style: goog.isDef(options.style) ?
-        options.style : ol.interaction.Draw.getDefaultStyleFunction()
+    style: options.style ? options.style :
+        ol.interaction.Draw.getDefaultStyleFunction()
   });
 
   /**
@@ -292,14 +290,14 @@ ol.interaction.Draw = function(options) {
    * @private
    * @type {ol.events.ConditionType}
    */
-  this.condition_ = goog.isDef(options.condition) ?
+  this.condition_ = options.condition ?
       options.condition : ol.events.condition.noModifierKeys;
 
   /**
    * @private
    * @type {ol.events.ConditionType}
    */
-  this.freehandCondition_ = goog.isDef(options.freehandCondition) ?
+  this.freehandCondition_ = options.freehandCondition ?
       options.freehandCondition : ol.events.condition.shiftKeyOnly;
 
   goog.events.listen(this,
@@ -512,9 +510,9 @@ ol.interaction.Draw.prototype.startDrawing_ = function(event) {
         new ol.geom.LineString(this.sketchLineCoords_));
   }
   var geometry = this.geometryFunction_(this.sketchCoords_);
-  goog.asserts.assert(goog.isDef(geometry), 'geometry should be defined');
+  goog.asserts.assert(geometry !== undefined, 'geometry should be defined');
   this.sketchFeature_ = new ol.Feature();
-  if (goog.isDef(this.geometryName_)) {
+  if (this.geometryName_) {
     this.sketchFeature_.setGeometryName(this.geometryName_);
   }
   this.sketchFeature_.setGeometry(geometry);
@@ -806,11 +804,11 @@ ol.interaction.Draw.createRegularPolygon = function(opt_sides, opt_angle) {
         var end = coordinates[1];
         var radius = Math.sqrt(
             ol.coordinate.squaredDistance(center, end));
-        var geometry = goog.isDef(opt_geometry) ? opt_geometry :
+        var geometry = opt_geometry ? opt_geometry :
             ol.geom.Polygon.fromCircle(new ol.geom.Circle(center), opt_sides);
         goog.asserts.assertInstanceof(geometry, ol.geom.Polygon,
             'geometry must be a polygon');
-        var angle = goog.isDef(opt_angle) ? opt_angle :
+        var angle = opt_angle ? opt_angle :
             Math.atan((end[1] - center[1]) / (end[0] - center[0]));
         ol.geom.Polygon.makeRegular(geometry, center, radius, angle);
         return geometry;
@@ -840,7 +838,7 @@ ol.interaction.Draw.getMode_ = function(type) {
   } else if (type === ol.geom.GeometryType.CIRCLE) {
     mode = ol.interaction.DrawMode.CIRCLE;
   }
-  goog.asserts.assert(goog.isDef(mode), 'mode should be defined');
+  goog.asserts.assert(mode !== undefined, 'mode should be defined');
   return mode;
 };
 

--- a/src/ol/interaction/interaction.js
+++ b/src/ol/interaction/interaction.js
@@ -107,8 +107,8 @@ ol.interaction.Interaction.prototype.setMap = function(map) {
  */
 ol.interaction.Interaction.pan = function(map, view, delta, opt_duration) {
   var currentCenter = view.getCenter();
-  if (goog.isDef(currentCenter)) {
-    if (goog.isDef(opt_duration) && opt_duration > 0) {
+  if (currentCenter) {
+    if (opt_duration && opt_duration > 0) {
       map.beforeRender(ol.animation.pan({
         source: currentCenter,
         duration: opt_duration,
@@ -149,14 +149,14 @@ ol.interaction.Interaction.rotateWithoutConstraints =
   if (goog.isDefAndNotNull(rotation)) {
     var currentRotation = view.getRotation();
     var currentCenter = view.getCenter();
-    if (goog.isDef(currentRotation) && goog.isDef(currentCenter) &&
-        goog.isDef(opt_duration) && opt_duration > 0) {
+    if (currentRotation !== undefined && currentCenter &&
+        opt_duration && opt_duration > 0) {
       map.beforeRender(ol.animation.rotate({
         rotation: currentRotation,
         duration: opt_duration,
         easing: ol.easing.easeOut
       }));
-      if (goog.isDef(opt_anchor)) {
+      if (opt_anchor) {
         map.beforeRender(ol.animation.pan({
           source: currentCenter,
           duration: opt_duration,
@@ -220,14 +220,14 @@ ol.interaction.Interaction.zoomWithoutConstraints =
   if (goog.isDefAndNotNull(resolution)) {
     var currentResolution = view.getResolution();
     var currentCenter = view.getCenter();
-    if (goog.isDef(currentResolution) && goog.isDef(currentCenter) &&
-        goog.isDef(opt_duration) && opt_duration > 0) {
+    if (currentResolution !== undefined && currentCenter &&
+        opt_duration && opt_duration > 0) {
       map.beforeRender(ol.animation.zoom({
         resolution: currentResolution,
         duration: opt_duration,
         easing: ol.easing.easeOut
       }));
-      if (goog.isDef(opt_anchor)) {
+      if (opt_anchor) {
         map.beforeRender(ol.animation.pan({
           source: currentCenter,
           duration: opt_duration,

--- a/src/ol/interaction/interaction.js
+++ b/src/ol/interaction/interaction.js
@@ -150,7 +150,7 @@ ol.interaction.Interaction.rotateWithoutConstraints =
   if (goog.isDefAndNotNull(rotation)) {
     var currentRotation = view.getRotation();
     var currentCenter = view.getCenter();
-    if (ol.isDef(currentRotation) && currentCenter &&
+    if (currentRotation !== undefined && currentCenter &&
         opt_duration && opt_duration > 0) {
       map.beforeRender(ol.animation.rotate({
         rotation: currentRotation,
@@ -221,7 +221,7 @@ ol.interaction.Interaction.zoomWithoutConstraints =
   if (goog.isDefAndNotNull(resolution)) {
     var currentResolution = view.getResolution();
     var currentCenter = view.getCenter();
-    if (ol.isDef(currentResolution) && currentCenter &&
+    if (currentResolution !== undefined && currentCenter &&
         opt_duration && opt_duration > 0) {
       map.beforeRender(ol.animation.zoom({
         resolution: /** @type {number} */ (currentResolution),

--- a/src/ol/interaction/interaction.js
+++ b/src/ol/interaction/interaction.js
@@ -3,6 +3,7 @@
 goog.provide('ol.interaction.Interaction');
 goog.provide('ol.interaction.InteractionProperty');
 
+goog.require('ol');
 goog.require('ol.MapBrowserEvent');
 goog.require('ol.Object');
 goog.require('ol.animation');
@@ -149,7 +150,7 @@ ol.interaction.Interaction.rotateWithoutConstraints =
   if (goog.isDefAndNotNull(rotation)) {
     var currentRotation = view.getRotation();
     var currentCenter = view.getCenter();
-    if (currentRotation !== undefined && currentCenter &&
+    if (ol.isDef(currentRotation) && currentCenter &&
         opt_duration && opt_duration > 0) {
       map.beforeRender(ol.animation.rotate({
         rotation: currentRotation,
@@ -220,10 +221,10 @@ ol.interaction.Interaction.zoomWithoutConstraints =
   if (goog.isDefAndNotNull(resolution)) {
     var currentResolution = view.getResolution();
     var currentCenter = view.getCenter();
-    if (currentResolution !== undefined && currentCenter &&
+    if (ol.isDef(currentResolution) && currentCenter &&
         opt_duration && opt_duration > 0) {
       map.beforeRender(ol.animation.zoom({
-        resolution: currentResolution,
+        resolution: /** @type {number} */ (currentResolution),
         duration: opt_duration,
         easing: ol.easing.easeOut
       }));

--- a/src/ol/interaction/interactiondefaults.js
+++ b/src/ol/interaction/interactiondefaults.js
@@ -41,19 +41,19 @@ goog.require('ol.interaction.PinchZoom');
  */
 ol.interaction.defaults = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   var interactions = new ol.Collection();
 
   var kinetic = new ol.Kinetic(-0.005, 0.05, 100);
 
-  var altShiftDragRotate = goog.isDef(options.altShiftDragRotate) ?
+  var altShiftDragRotate = options.altShiftDragRotate !== undefined ?
       options.altShiftDragRotate : true;
   if (altShiftDragRotate) {
     interactions.push(new ol.interaction.DragRotate());
   }
 
-  var doubleClickZoom = goog.isDef(options.doubleClickZoom) ?
+  var doubleClickZoom = options.doubleClickZoom !== undefined ?
       options.doubleClickZoom : true;
   if (doubleClickZoom) {
     interactions.push(new ol.interaction.DoubleClickZoom({
@@ -62,30 +62,27 @@ ol.interaction.defaults = function(opt_options) {
     }));
   }
 
-  var dragPan = goog.isDef(options.dragPan) ?
-      options.dragPan : true;
+  var dragPan = options.dragPan !== undefined ? options.dragPan : true;
   if (dragPan) {
     interactions.push(new ol.interaction.DragPan({
       kinetic: kinetic
     }));
   }
 
-  var pinchRotate = goog.isDef(options.pinchRotate) ?
-      options.pinchRotate : true;
+  var pinchRotate = options.pinchRotate !== undefined ? options.pinchRotate :
+      true;
   if (pinchRotate) {
     interactions.push(new ol.interaction.PinchRotate());
   }
 
-  var pinchZoom = goog.isDef(options.pinchZoom) ?
-      options.pinchZoom : true;
+  var pinchZoom = options.pinchZoom !== undefined ? options.pinchZoom : true;
   if (pinchZoom) {
     interactions.push(new ol.interaction.PinchZoom({
       duration: options.zoomDuration
     }));
   }
 
-  var keyboard = goog.isDef(options.keyboard) ?
-      options.keyboard : true;
+  var keyboard = options.keyboard !== undefined ? options.keyboard : true;
   if (keyboard) {
     interactions.push(new ol.interaction.KeyboardPan());
     interactions.push(new ol.interaction.KeyboardZoom({
@@ -94,7 +91,7 @@ ol.interaction.defaults = function(opt_options) {
     }));
   }
 
-  var mouseWheelZoom = goog.isDef(options.mouseWheelZoom) ?
+  var mouseWheelZoom = options.mouseWheelZoom !== undefined ?
       options.mouseWheelZoom : true;
   if (mouseWheelZoom) {
     interactions.push(new ol.interaction.MouseWheelZoom({
@@ -102,7 +99,7 @@ ol.interaction.defaults = function(opt_options) {
     }));
   }
 
-  var shiftDragZoom = goog.isDef(options.shiftDragZoom) ?
+  var shiftDragZoom = options.shiftDragZoom !== undefined ?
       options.shiftDragZoom : true;
   if (shiftDragZoom) {
     interactions.push(new ol.interaction.DragZoom());

--- a/src/ol/interaction/interactiondefaults.js
+++ b/src/ol/interaction/interactiondefaults.js
@@ -1,5 +1,6 @@
 goog.provide('ol.interaction');
 
+goog.require('ol');
 goog.require('ol.Collection');
 goog.require('ol.Kinetic');
 goog.require('ol.interaction.DoubleClickZoom');
@@ -47,13 +48,13 @@ ol.interaction.defaults = function(opt_options) {
 
   var kinetic = new ol.Kinetic(-0.005, 0.05, 100);
 
-  var altShiftDragRotate = options.altShiftDragRotate !== undefined ?
+  var altShiftDragRotate = ol.isDef(options.altShiftDragRotate) ?
       options.altShiftDragRotate : true;
   if (altShiftDragRotate) {
     interactions.push(new ol.interaction.DragRotate());
   }
 
-  var doubleClickZoom = options.doubleClickZoom !== undefined ?
+  var doubleClickZoom = ol.isDef(options.doubleClickZoom) ?
       options.doubleClickZoom : true;
   if (doubleClickZoom) {
     interactions.push(new ol.interaction.DoubleClickZoom({
@@ -62,27 +63,27 @@ ol.interaction.defaults = function(opt_options) {
     }));
   }
 
-  var dragPan = options.dragPan !== undefined ? options.dragPan : true;
+  var dragPan = ol.isDef(options.dragPan) ? options.dragPan : true;
   if (dragPan) {
     interactions.push(new ol.interaction.DragPan({
       kinetic: kinetic
     }));
   }
 
-  var pinchRotate = options.pinchRotate !== undefined ? options.pinchRotate :
+  var pinchRotate = ol.isDef(options.pinchRotate) ? options.pinchRotate :
       true;
   if (pinchRotate) {
     interactions.push(new ol.interaction.PinchRotate());
   }
 
-  var pinchZoom = options.pinchZoom !== undefined ? options.pinchZoom : true;
+  var pinchZoom = ol.isDef(options.pinchZoom) ? options.pinchZoom : true;
   if (pinchZoom) {
     interactions.push(new ol.interaction.PinchZoom({
       duration: options.zoomDuration
     }));
   }
 
-  var keyboard = options.keyboard !== undefined ? options.keyboard : true;
+  var keyboard = ol.isDef(options.keyboard) ? options.keyboard : true;
   if (keyboard) {
     interactions.push(new ol.interaction.KeyboardPan());
     interactions.push(new ol.interaction.KeyboardZoom({
@@ -91,7 +92,7 @@ ol.interaction.defaults = function(opt_options) {
     }));
   }
 
-  var mouseWheelZoom = options.mouseWheelZoom !== undefined ?
+  var mouseWheelZoom = ol.isDef(options.mouseWheelZoom) ?
       options.mouseWheelZoom : true;
   if (mouseWheelZoom) {
     interactions.push(new ol.interaction.MouseWheelZoom({
@@ -99,7 +100,7 @@ ol.interaction.defaults = function(opt_options) {
     }));
   }
 
-  var shiftDragZoom = options.shiftDragZoom !== undefined ?
+  var shiftDragZoom = ol.isDef(options.shiftDragZoom) ?
       options.shiftDragZoom : true;
   if (shiftDragZoom) {
     interactions.push(new ol.interaction.DragZoom());

--- a/src/ol/interaction/interactiondefaults.js
+++ b/src/ol/interaction/interactiondefaults.js
@@ -48,13 +48,13 @@ ol.interaction.defaults = function(opt_options) {
 
   var kinetic = new ol.Kinetic(-0.005, 0.05, 100);
 
-  var altShiftDragRotate = ol.isDef(options.altShiftDragRotate) ?
+  var altShiftDragRotate = options.altShiftDragRotate !== undefined ?
       options.altShiftDragRotate : true;
   if (altShiftDragRotate) {
     interactions.push(new ol.interaction.DragRotate());
   }
 
-  var doubleClickZoom = ol.isDef(options.doubleClickZoom) ?
+  var doubleClickZoom = options.doubleClickZoom !== undefined ?
       options.doubleClickZoom : true;
   if (doubleClickZoom) {
     interactions.push(new ol.interaction.DoubleClickZoom({
@@ -63,27 +63,27 @@ ol.interaction.defaults = function(opt_options) {
     }));
   }
 
-  var dragPan = ol.isDef(options.dragPan) ? options.dragPan : true;
+  var dragPan = options.dragPan !== undefined ? options.dragPan : true;
   if (dragPan) {
     interactions.push(new ol.interaction.DragPan({
       kinetic: kinetic
     }));
   }
 
-  var pinchRotate = ol.isDef(options.pinchRotate) ? options.pinchRotate :
+  var pinchRotate = options.pinchRotate !== undefined ? options.pinchRotate :
       true;
   if (pinchRotate) {
     interactions.push(new ol.interaction.PinchRotate());
   }
 
-  var pinchZoom = ol.isDef(options.pinchZoom) ? options.pinchZoom : true;
+  var pinchZoom = options.pinchZoom !== undefined ? options.pinchZoom : true;
   if (pinchZoom) {
     interactions.push(new ol.interaction.PinchZoom({
       duration: options.zoomDuration
     }));
   }
 
-  var keyboard = ol.isDef(options.keyboard) ? options.keyboard : true;
+  var keyboard = options.keyboard !== undefined ? options.keyboard : true;
   if (keyboard) {
     interactions.push(new ol.interaction.KeyboardPan());
     interactions.push(new ol.interaction.KeyboardZoom({
@@ -92,7 +92,7 @@ ol.interaction.defaults = function(opt_options) {
     }));
   }
 
-  var mouseWheelZoom = ol.isDef(options.mouseWheelZoom) ?
+  var mouseWheelZoom = options.mouseWheelZoom !== undefined ?
       options.mouseWheelZoom : true;
   if (mouseWheelZoom) {
     interactions.push(new ol.interaction.MouseWheelZoom({
@@ -100,7 +100,7 @@ ol.interaction.defaults = function(opt_options) {
     }));
   }
 
-  var shiftDragZoom = ol.isDef(options.shiftDragZoom) ?
+  var shiftDragZoom = options.shiftDragZoom !== undefined ?
       options.shiftDragZoom : true;
   if (shiftDragZoom) {
     interactions.push(new ol.interaction.DragZoom());

--- a/src/ol/interaction/keyboardpaninteraction.js
+++ b/src/ol/interaction/keyboardpaninteraction.js
@@ -4,6 +4,7 @@ goog.require('goog.asserts');
 goog.require('goog.events.KeyCodes');
 goog.require('goog.events.KeyHandler.EventType');
 goog.require('goog.functions');
+goog.require('ol');
 goog.require('ol.coordinate');
 goog.require('ol.events.ConditionType');
 goog.require('ol.events.condition');
@@ -34,13 +35,14 @@ ol.interaction.KeyboardPan = function(opt_options) {
     handleEvent: ol.interaction.KeyboardPan.handleEvent
   });
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = ol.isDef(opt_options) ? opt_options : {};
 
   /**
    * @private
    * @type {ol.events.ConditionType}
    */
-  this.condition_ = goog.isDef(options.condition) ? options.condition :
+  this.condition_ = ol.isDef(options.condition) ?
+      /** @type {ol.events.ConditionType} */ (options.condition) :
       goog.functions.and(ol.events.condition.noModifierKeys,
           ol.events.condition.targetNotEditable);
 
@@ -48,13 +50,15 @@ ol.interaction.KeyboardPan = function(opt_options) {
    * @private
    * @type {number}
    */
-  this.duration_ = goog.isDef(options.duration) ? options.duration : 100;
+  this.duration_ = ol.isDef(options.duration) ?
+      /** @type {number} */ (options.duration) : 100;
 
   /**
    * @private
    * @type {number}
    */
-  this.pixelDelta_ = goog.isDef(options.pixelDelta) ? options.pixelDelta : 128;
+  this.pixelDelta_ = ol.isDef(options.pixelDelta) ?
+      /** @type {number} */ (options.pixelDelta) : 128;
 
 };
 goog.inherits(ol.interaction.KeyboardPan, ol.interaction.Interaction);

--- a/src/ol/interaction/keyboardpaninteraction.js
+++ b/src/ol/interaction/keyboardpaninteraction.js
@@ -35,14 +35,14 @@ ol.interaction.KeyboardPan = function(opt_options) {
     handleEvent: ol.interaction.KeyboardPan.handleEvent
   });
 
-  var options = ol.isDef(opt_options) ? opt_options : {};
+  var options = opt_options || {};
 
   /**
    * @private
    * @type {ol.events.ConditionType}
    */
-  this.condition_ = ol.isDef(options.condition) ?
-      /** @type {ol.events.ConditionType} */ (options.condition) :
+  this.condition_ = options.condition !== undefined ?
+      options.condition :
       goog.functions.and(ol.events.condition.noModifierKeys,
           ol.events.condition.targetNotEditable);
 
@@ -50,15 +50,14 @@ ol.interaction.KeyboardPan = function(opt_options) {
    * @private
    * @type {number}
    */
-  this.duration_ = ol.isDef(options.duration) ?
-      /** @type {number} */ (options.duration) : 100;
+  this.duration_ = options.duration !== undefined ? options.duration : 100;
 
   /**
    * @private
    * @type {number}
    */
-  this.pixelDelta_ = ol.isDef(options.pixelDelta) ?
-      /** @type {number} */ (options.pixelDelta) : 128;
+  this.pixelDelta_ = options.pixelDelta !== undefined ?
+      options.pixelDelta : 128;
 
 };
 goog.inherits(ol.interaction.KeyboardPan, ol.interaction.Interaction);

--- a/src/ol/interaction/keyboardzoominteraction.js
+++ b/src/ol/interaction/keyboardzoominteraction.js
@@ -31,26 +31,26 @@ ol.interaction.KeyboardZoom = function(opt_options) {
     handleEvent: ol.interaction.KeyboardZoom.handleEvent
   });
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   /**
    * @private
    * @type {ol.events.ConditionType}
    */
-  this.condition_ = goog.isDef(options.condition) ? options.condition :
+  this.condition_ = options.condition ? options.condition :
           ol.events.condition.targetNotEditable;
 
   /**
    * @private
    * @type {number}
    */
-  this.delta_ = goog.isDef(options.delta) ? options.delta : 1;
+  this.delta_ = options.delta ? options.delta : 1;
 
   /**
    * @private
    * @type {number}
    */
-  this.duration_ = goog.isDef(options.duration) ? options.duration : 100;
+  this.duration_ = options.duration ? options.duration : 100;
 
 };
 goog.inherits(ol.interaction.KeyboardZoom, ol.interaction.Interaction);

--- a/src/ol/interaction/modifyinteraction.js
+++ b/src/ol/interaction/modifyinteraction.js
@@ -162,7 +162,8 @@ ol.interaction.Modify = function(options) {
    * @type {number}
    * @private
    */
-  this.pixelTolerance_ = options.pixelTolerance ? options.pixelTolerance : 10;
+  this.pixelTolerance_ = ol.isDef(options.pixelTolerance) ?
+      /** @type {number} */ (options.pixelTolerance) : 10;
 
   /**
    * @type {boolean}
@@ -192,7 +193,7 @@ ol.interaction.Modify = function(options) {
   this.overlay_ = new ol.layer.Vector({
     source: new ol.source.Vector({
       useSpatialIndex: false,
-      wrapX: options.wrapX ? options.wrapX : false
+      wrapX: !!options.wrapX
     }),
     style: options.style ? options.style :
         ol.interaction.Modify.getDefaultStyleFunction(),
@@ -238,7 +239,7 @@ goog.inherits(ol.interaction.Modify, ol.interaction.Pointer);
  */
 ol.interaction.Modify.prototype.addFeature_ = function(feature) {
   var geometry = feature.getGeometry();
-  if (this.SEGMENT_WRITERS_[geometry.getType()]) {
+  if (geometry.getType() in this.SEGMENT_WRITERS_) {
     this.SEGMENT_WRITERS_[geometry.getType()].call(this, feature, geometry);
   }
   var map = this.getMap();
@@ -822,10 +823,10 @@ ol.interaction.Modify.prototype.insertVertex_ = function(segmentData, vertex) {
 
   this.setGeometryCoordinates_(geometry, coordinates);
   var rTree = this.rBush_;
-  goog.asserts.assert(segment !== undefined, 'segment should be defined');
+  goog.asserts.assert(ol.isDef(segment), 'segment should be defined');
   rTree.remove(segmentData);
-  goog.asserts.assert(index !== undefined, 'index should be defined');
-  this.updateSegmentIndices_(geometry, index, depth, 1);
+  goog.asserts.assert(ol.isDef(index), 'index should be defined');
+  this.updateSegmentIndices_(geometry, /** @type {number} */ (index), depth, 1);
   var newSegmentData = /** @type {ol.interaction.SegmentDataType} */ ({
     segment: [segment[0], vertex],
     feature: feature,
@@ -975,7 +976,9 @@ ol.interaction.Modify.prototype.updateSegmentIndices_ = function(
   this.rBush_.forEachInExtent(geometry.getExtent(), function(segmentDataMatch) {
     if (segmentDataMatch.geometry === geometry &&
         (depth === undefined || segmentDataMatch.depth === undefined ||
-        goog.array.equals(segmentDataMatch.depth, depth)) &&
+        goog.array.equals(
+            /** @type {null|{length: number}} */ (segmentDataMatch.depth),
+            depth)) &&
         segmentDataMatch.index > index) {
       segmentDataMatch.index += delta;
     }

--- a/src/ol/interaction/modifyinteraction.js
+++ b/src/ol/interaction/modifyinteraction.js
@@ -116,7 +116,7 @@ ol.interaction.Modify = function(options) {
    * @type {ol.events.ConditionType}
    * @private
    */
-  this.deleteCondition_ = goog.isDef(options.deleteCondition) ?
+  this.deleteCondition_ = options.deleteCondition ?
       options.deleteCondition :
       /** @type {ol.events.ConditionType} */ (goog.functions.and(
           ol.events.condition.noModifierKeys,
@@ -161,8 +161,7 @@ ol.interaction.Modify = function(options) {
    * @type {number}
    * @private
    */
-  this.pixelTolerance_ = goog.isDef(options.pixelTolerance) ?
-      options.pixelTolerance : 10;
+  this.pixelTolerance_ = options.pixelTolerance ? options.pixelTolerance : 10;
 
   /**
    * @type {boolean}
@@ -192,9 +191,9 @@ ol.interaction.Modify = function(options) {
   this.overlay_ = new ol.layer.Vector({
     source: new ol.source.Vector({
       useSpatialIndex: false,
-      wrapX: goog.isDef(options.wrapX) ? options.wrapX : false
+      wrapX: options.wrapX ? options.wrapX : false
     }),
-    style: goog.isDef(options.style) ? options.style :
+    style: options.style ? options.style :
         ol.interaction.Modify.getDefaultStyleFunction(),
     updateWhileAnimating: true,
     updateWhileInteracting: true
@@ -238,7 +237,7 @@ goog.inherits(ol.interaction.Modify, ol.interaction.Pointer);
  */
 ol.interaction.Modify.prototype.addFeature_ = function(feature) {
   var geometry = feature.getGeometry();
-  if (goog.isDef(this.SEGMENT_WRITERS_[geometry.getType()])) {
+  if (this.SEGMENT_WRITERS_[geometry.getType()]) {
     this.SEGMENT_WRITERS_[geometry.getType()].call(this, feature, geometry);
   }
   var map = this.getMap();
@@ -822,9 +821,9 @@ ol.interaction.Modify.prototype.insertVertex_ = function(segmentData, vertex) {
 
   this.setGeometryCoordinates_(geometry, coordinates);
   var rTree = this.rBush_;
-  goog.asserts.assert(goog.isDef(segment), 'segment should be defined');
+  goog.asserts.assert(segment !== undefined, 'segment should be defined');
   rTree.remove(segmentData);
-  goog.asserts.assert(goog.isDef(index), 'index should be defined');
+  goog.asserts.assert(index !== undefined, 'index should be defined');
   this.updateSegmentIndices_(geometry, index, depth, 1);
   var newSegmentData = /** @type {ol.interaction.SegmentDataType} */ ({
     segment: [segment[0], vertex],
@@ -883,13 +882,13 @@ ol.interaction.Modify.prototype.removeVertex_ = function() {
       segmentsByFeature[uid] = [left, right, index];
     }
     newSegment = segmentsByFeature[uid];
-    if (goog.isDef(left)) {
+    if (left !== undefined) {
       newSegment[0] = left;
     }
-    if (goog.isDef(right)) {
+    if (right !== undefined) {
       newSegment[1] = right;
     }
-    if (goog.isDef(newSegment[0]) && goog.isDef(newSegment[1])) {
+    if (newSegment[0] !== undefined && newSegment[1] !== undefined) {
       component = coordinates;
       deleted = false;
       newIndex = index - 1;
@@ -974,7 +973,7 @@ ol.interaction.Modify.prototype.updateSegmentIndices_ = function(
     geometry, index, depth, delta) {
   this.rBush_.forEachInExtent(geometry.getExtent(), function(segmentDataMatch) {
     if (segmentDataMatch.geometry === geometry &&
-        (!goog.isDef(depth) || !goog.isDef(segmentDataMatch.depth) ||
+        (depth === undefined || segmentDataMatch.depth === undefined ||
         goog.array.equals(segmentDataMatch.depth, depth)) &&
         segmentDataMatch.index > index) {
       segmentDataMatch.index += delta;

--- a/src/ol/interaction/modifyinteraction.js
+++ b/src/ol/interaction/modifyinteraction.js
@@ -7,6 +7,7 @@ goog.require('goog.events');
 goog.require('goog.events.Event');
 goog.require('goog.events.EventType');
 goog.require('goog.functions');
+goog.require('ol');
 goog.require('ol.Collection');
 goog.require('ol.CollectionEventType');
 goog.require('ol.Feature');
@@ -882,13 +883,13 @@ ol.interaction.Modify.prototype.removeVertex_ = function() {
       segmentsByFeature[uid] = [left, right, index];
     }
     newSegment = segmentsByFeature[uid];
-    if (left !== undefined) {
+    if (ol.isDef(left)) {
       newSegment[0] = left;
     }
-    if (right !== undefined) {
+    if (ol.isDef(right)) {
       newSegment[1] = right;
     }
-    if (newSegment[0] !== undefined && newSegment[1] !== undefined) {
+    if (ol.isDef(newSegment[0]) && ol.isDef(newSegment[1])) {
       component = coordinates;
       deleted = false;
       newIndex = index - 1;

--- a/src/ol/interaction/modifyinteraction.js
+++ b/src/ol/interaction/modifyinteraction.js
@@ -162,8 +162,8 @@ ol.interaction.Modify = function(options) {
    * @type {number}
    * @private
    */
-  this.pixelTolerance_ = ol.isDef(options.pixelTolerance) ?
-      /** @type {number} */ (options.pixelTolerance) : 10;
+  this.pixelTolerance_ = options.pixelTolerance !== undefined ?
+      options.pixelTolerance : 10;
 
   /**
    * @type {boolean}
@@ -823,9 +823,9 @@ ol.interaction.Modify.prototype.insertVertex_ = function(segmentData, vertex) {
 
   this.setGeometryCoordinates_(geometry, coordinates);
   var rTree = this.rBush_;
-  goog.asserts.assert(ol.isDef(segment), 'segment should be defined');
+  goog.asserts.assert(segment !== undefined, 'segment should be defined');
   rTree.remove(segmentData);
-  goog.asserts.assert(ol.isDef(index), 'index should be defined');
+  goog.asserts.assert(index !== undefined, 'index should be defined');
   this.updateSegmentIndices_(geometry, /** @type {number} */ (index), depth, 1);
   var newSegmentData = /** @type {ol.interaction.SegmentDataType} */ ({
     segment: [segment[0], vertex],
@@ -884,13 +884,13 @@ ol.interaction.Modify.prototype.removeVertex_ = function() {
       segmentsByFeature[uid] = [left, right, index];
     }
     newSegment = segmentsByFeature[uid];
-    if (ol.isDef(left)) {
+    if (left !== undefined) {
       newSegment[0] = left;
     }
-    if (ol.isDef(right)) {
+    if (right !== undefined) {
       newSegment[1] = right;
     }
-    if (ol.isDef(newSegment[0]) && ol.isDef(newSegment[1])) {
+    if (newSegment[0] !== undefined && newSegment[1] !== undefined) {
       component = coordinates;
       deleted = false;
       newIndex = index - 1;

--- a/src/ol/interaction/mousewheelzoominteraction.js
+++ b/src/ol/interaction/mousewheelzoominteraction.js
@@ -25,7 +25,7 @@ ol.interaction.MouseWheelZoom = function(opt_options) {
     handleEvent: ol.interaction.MouseWheelZoom.handleEvent
   });
 
-  var options = ol.isDef(opt_options) ? opt_options : {};
+  var options = opt_options || {};
 
   /**
    * @private
@@ -37,15 +37,13 @@ ol.interaction.MouseWheelZoom = function(opt_options) {
    * @private
    * @type {number}
    */
-  this.duration_ = ol.isDef(options.duration) ?
-      /** @type {number} */ (options.duration) : 250;
+  this.duration_ = options.duration !== undefined ? options.duration : 250;
 
   /**
    * @private
    * @type {boolean}
    */
-  this.useAnchor_ = ol.isDef(options.useAnchor) ?
-      /** @type {boolean} */ (options.useAnchor) : true;
+  this.useAnchor_ = options.useAnchor !== undefined ? options.useAnchor : true;
 
   /**
    * @private
@@ -92,7 +90,7 @@ ol.interaction.MouseWheelZoom.handleEvent = function(mapBrowserEvent) {
 
     this.delta_ += mouseWheelEvent.deltaY;
 
-    if (!ol.isDef(this.startTime_)) {
+    if (this.startTime_ === undefined) {
       this.startTime_ = goog.now();
     }
 

--- a/src/ol/interaction/mousewheelzoominteraction.js
+++ b/src/ol/interaction/mousewheelzoominteraction.js
@@ -25,7 +25,7 @@ ol.interaction.MouseWheelZoom = function(opt_options) {
     handleEvent: ol.interaction.MouseWheelZoom.handleEvent
   });
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = ol.isDef(opt_options) ? opt_options : {};
 
   /**
    * @private
@@ -37,14 +37,15 @@ ol.interaction.MouseWheelZoom = function(opt_options) {
    * @private
    * @type {number}
    */
-  this.duration_ = goog.isDef(options.duration) ? options.duration : 250;
+  this.duration_ = ol.isDef(options.duration) ?
+      /** @type {number} */ (options.duration) : 250;
 
   /**
    * @private
    * @type {boolean}
    */
-  this.useAnchor_ = goog.isDef(options.useAnchor) ?
-      options.useAnchor : true;
+  this.useAnchor_ = ol.isDef(options.useAnchor) ?
+      /** @type {boolean} */ (options.useAnchor) : true;
 
   /**
    * @private
@@ -91,7 +92,7 @@ ol.interaction.MouseWheelZoom.handleEvent = function(mapBrowserEvent) {
 
     this.delta_ += mouseWheelEvent.deltaY;
 
-    if (!goog.isDef(this.startTime_)) {
+    if (!ol.isDef(this.startTime_)) {
       this.startTime_ = goog.now();
     }
 

--- a/src/ol/interaction/pinchrotateinteraction.js
+++ b/src/ol/interaction/pinchrotateinteraction.js
@@ -29,7 +29,7 @@ ol.interaction.PinchRotate = function(opt_options) {
     handleUpEvent: ol.interaction.PinchRotate.handleUpEvent_
   });
 
-  var options = ol.isDef(opt_options) ? opt_options : {};
+  var options = opt_options || {};
 
   /**
    * @private
@@ -59,15 +59,13 @@ ol.interaction.PinchRotate = function(opt_options) {
    * @private
    * @type {number}
    */
-  this.threshold_ = ol.isDef(options.threshold) ?
-      /** @type {number} */ (options.threshold) : 0.3;
+  this.threshold_ = options.threshold !== undefined ? options.threshold : 0.3;
 
   /**
    * @private
    * @type {number}
    */
-  this.duration_ = ol.isDef(options.duration) ?
-      /** @type {number} */ (options.duration) : 250;
+  this.duration_ = options.duration !== undefined ? options.duration : 250;
 
 };
 goog.inherits(ol.interaction.PinchRotate, ol.interaction.Pointer);
@@ -91,7 +89,7 @@ ol.interaction.PinchRotate.handleDragEvent_ = function(mapBrowserEvent) {
       touch1.clientY - touch0.clientY,
       touch1.clientX - touch0.clientX);
 
-  if (ol.isDef(this.lastAngle_)) {
+  if (this.lastAngle_ !== undefined) {
     var delta = angle - this.lastAngle_;
     this.rotationDelta_ += delta;
     if (!this.rotating_ &&

--- a/src/ol/interaction/pinchrotateinteraction.js
+++ b/src/ol/interaction/pinchrotateinteraction.js
@@ -3,6 +3,7 @@ goog.provide('ol.interaction.PinchRotate');
 goog.require('goog.asserts');
 goog.require('goog.functions');
 goog.require('goog.style');
+goog.require('ol');
 goog.require('ol.Coordinate');
 goog.require('ol.ViewHint');
 goog.require('ol.interaction.Interaction');
@@ -28,7 +29,7 @@ ol.interaction.PinchRotate = function(opt_options) {
     handleUpEvent: ol.interaction.PinchRotate.handleUpEvent_
   });
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = ol.isDef(opt_options) ? opt_options : {};
 
   /**
    * @private
@@ -58,13 +59,15 @@ ol.interaction.PinchRotate = function(opt_options) {
    * @private
    * @type {number}
    */
-  this.threshold_ = goog.isDef(options.threshold) ? options.threshold : 0.3;
+  this.threshold_ = ol.isDef(options.threshold) ?
+      /** @type {number} */ (options.threshold) : 0.3;
 
   /**
    * @private
    * @type {number}
    */
-  this.duration_ = goog.isDef(options.duration) ? options.duration : 250;
+  this.duration_ = ol.isDef(options.duration) ?
+      /** @type {number} */ (options.duration) : 250;
 
 };
 goog.inherits(ol.interaction.PinchRotate, ol.interaction.Pointer);
@@ -88,7 +91,7 @@ ol.interaction.PinchRotate.handleDragEvent_ = function(mapBrowserEvent) {
       touch1.clientY - touch0.clientY,
       touch1.clientX - touch0.clientX);
 
-  if (goog.isDef(this.lastAngle_)) {
+  if (ol.isDef(this.lastAngle_)) {
     var delta = angle - this.lastAngle_;
     this.rotationDelta_ += delta;
     if (!this.rotating_ &&

--- a/src/ol/interaction/pinchzoominteraction.js
+++ b/src/ol/interaction/pinchzoominteraction.js
@@ -41,8 +41,7 @@ ol.interaction.PinchZoom = function(opt_options) {
    * @private
    * @type {number}
    */
-  this.duration_ = ol.isDef(options.duration) ?
-      /** @type {number} */ (options.duration) : 400;
+  this.duration_ = options.duration !== undefined ? options.duration : 400;
 
   /**
    * @private
@@ -78,7 +77,7 @@ ol.interaction.PinchZoom.handleDragEvent_ = function(mapBrowserEvent) {
   // distance between touches
   var distance = Math.sqrt(dx * dx + dy * dy);
 
-  if (ol.isDef(this.lastDistance_)) {
+  if (this.lastDistance_ !== undefined) {
     scaleDelta = this.lastDistance_ / distance;
   }
   this.lastDistance_ = distance;

--- a/src/ol/interaction/pinchzoominteraction.js
+++ b/src/ol/interaction/pinchzoominteraction.js
@@ -3,6 +3,7 @@ goog.provide('ol.interaction.PinchZoom');
 goog.require('goog.asserts');
 goog.require('goog.functions');
 goog.require('goog.style');
+goog.require('ol');
 goog.require('ol.Coordinate');
 goog.require('ol.ViewHint');
 goog.require('ol.interaction.Interaction');
@@ -28,7 +29,7 @@ ol.interaction.PinchZoom = function(opt_options) {
     handleUpEvent: ol.interaction.PinchZoom.handleUpEvent_
   });
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   /**
    * @private
@@ -40,7 +41,8 @@ ol.interaction.PinchZoom = function(opt_options) {
    * @private
    * @type {number}
    */
-  this.duration_ = goog.isDef(options.duration) ? options.duration : 400;
+  this.duration_ = ol.isDef(options.duration) ?
+      /** @type {number} */ (options.duration) : 400;
 
   /**
    * @private
@@ -76,7 +78,7 @@ ol.interaction.PinchZoom.handleDragEvent_ = function(mapBrowserEvent) {
   // distance between touches
   var distance = Math.sqrt(dx * dx + dy * dy);
 
-  if (goog.isDef(this.lastDistance_)) {
+  if (ol.isDef(this.lastDistance_)) {
     scaleDelta = this.lastDistance_ / distance;
   }
   this.lastDistance_ = distance;

--- a/src/ol/interaction/pointerinteraction.js
+++ b/src/ol/interaction/pointerinteraction.js
@@ -26,9 +26,9 @@ goog.require('ol.interaction.Interaction');
  */
 ol.interaction.Pointer = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
-  var handleEvent = goog.isDef(options.handleEvent) ?
+  var handleEvent = options.handleEvent ?
       options.handleEvent : ol.interaction.Pointer.handleEvent;
 
   goog.base(this, {
@@ -39,28 +39,28 @@ ol.interaction.Pointer = function(opt_options) {
    * @type {function(ol.MapBrowserPointerEvent):boolean}
    * @private
    */
-  this.handleDownEvent_ = goog.isDef(options.handleDownEvent) ?
+  this.handleDownEvent_ = options.handleDownEvent ?
       options.handleDownEvent : ol.interaction.Pointer.handleDownEvent;
 
   /**
    * @type {function(ol.MapBrowserPointerEvent)}
    * @private
    */
-  this.handleDragEvent_ = goog.isDef(options.handleDragEvent) ?
+  this.handleDragEvent_ = options.handleDragEvent ?
       options.handleDragEvent : ol.interaction.Pointer.handleDragEvent;
 
   /**
    * @type {function(ol.MapBrowserPointerEvent)}
    * @private
    */
-  this.handleMoveEvent_ = goog.isDef(options.handleMoveEvent) ?
+  this.handleMoveEvent_ = options.handleMoveEvent ?
       options.handleMoveEvent : ol.interaction.Pointer.handleMoveEvent;
 
   /**
    * @type {function(ol.MapBrowserPointerEvent):boolean}
    * @private
    */
-  this.handleUpEvent_ = goog.isDef(options.handleUpEvent) ?
+  this.handleUpEvent_ = options.handleUpEvent ?
       options.handleUpEvent : ol.interaction.Pointer.handleUpEvent;
 
   /**

--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -105,51 +105,51 @@ ol.interaction.Select = function(opt_options) {
     handleEvent: ol.interaction.Select.handleEvent
   });
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   /**
    * @private
    * @type {ol.events.ConditionType}
    */
-  this.condition_ = goog.isDef(options.condition) ?
+  this.condition_ = options.condition ?
       options.condition : ol.events.condition.singleClick;
 
   /**
    * @private
    * @type {ol.events.ConditionType}
    */
-  this.addCondition_ = goog.isDef(options.addCondition) ?
+  this.addCondition_ = options.addCondition ?
       options.addCondition : ol.events.condition.never;
 
   /**
    * @private
    * @type {ol.events.ConditionType}
    */
-  this.removeCondition_ = goog.isDef(options.removeCondition) ?
+  this.removeCondition_ = options.removeCondition ?
       options.removeCondition : ol.events.condition.never;
 
   /**
    * @private
    * @type {ol.events.ConditionType}
    */
-  this.toggleCondition_ = goog.isDef(options.toggleCondition) ?
+  this.toggleCondition_ = options.toggleCondition ?
       options.toggleCondition : ol.events.condition.shiftKeyOnly;
 
   /**
    * @private
    * @type {boolean}
    */
-  this.multi_ = goog.isDef(options.multi) ? options.multi : false;
+  this.multi_ = options.multi ? options.multi : false;
 
   /**
    * @private
    * @type {ol.interaction.SelectFilterFunction}
    */
-  this.filter_ = goog.isDef(options.filter) ? options.filter :
+  this.filter_ = options.filter ? options.filter :
       goog.functions.TRUE;
 
   var layerFilter;
-  if (goog.isDef(options.layers)) {
+  if (options.layers) {
     if (goog.isFunction(options.layers)) {
       layerFilter = options.layers;
     } else {
@@ -183,7 +183,7 @@ ol.interaction.Select = function(opt_options) {
       features: options.features,
       wrapX: options.wrapX
     }),
-    style: goog.isDef(options.style) ? options.style :
+    style: options.style ? options.style :
         ol.interaction.Select.getDefaultStyleFunction(),
     updateWhileAnimating: true,
     updateWhileInteracting: true

--- a/src/ol/interaction/snapinteraction.js
+++ b/src/ol/interaction/snapinteraction.js
@@ -115,8 +115,8 @@ ol.interaction.Snap = function(opt_options) {
    * @type {number}
    * @private
    */
-  this.pixelTolerance_ = ol.isDef(options.pixelTolerance) ?
-      /** @type {number} */ (options.pixelTolerance) : 10;
+  this.pixelTolerance_ = options.pixelTolerance !== undefined ?
+      options.pixelTolerance : 10;
 
   /**
    * @type {function(ol.interaction.Snap.SegmentDataType, ol.interaction.Snap.SegmentDataType): number}
@@ -160,8 +160,7 @@ goog.inherits(ol.interaction.Snap, ol.interaction.Pointer);
  * @api
  */
 ol.interaction.Snap.prototype.addFeature = function(feature, opt_listen) {
-  var listen = ol.isDef(opt_listen) ?
-      /** @type {boolean} */ (opt_listen) : true;
+  var listen = opt_listen !== undefined ? opt_listen : true;
   var geometry = feature.getGeometry();
   var segmentWriter = this.SEGMENT_WRITERS_[geometry.getType()];
   if (segmentWriter) {
@@ -288,8 +287,7 @@ ol.interaction.Snap.prototype.handleGeometryModify_ = function(feature, evt) {
  * @api
  */
 ol.interaction.Snap.prototype.removeFeature = function(feature, opt_unlisten) {
-  var unlisten = ol.isDef(opt_unlisten) ?
-      /** @type {boolean} */ (opt_unlisten) : true;
+  var unlisten = opt_unlisten !== undefined ? opt_unlisten : true;
   var feature_uid = goog.getUid(feature);
   var extent = this.indexedFeaturesExtents_[feature_uid];
   if (extent) {

--- a/src/ol/interaction/snapinteraction.js
+++ b/src/ol/interaction/snapinteraction.js
@@ -6,6 +6,7 @@ goog.require('goog.asserts');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
 goog.require('goog.object');
+goog.require('ol');
 goog.require('ol.Collection');
 goog.require('ol.CollectionEvent');
 goog.require('ol.CollectionEventType');
@@ -54,19 +55,19 @@ ol.interaction.Snap = function(opt_options) {
     handleUpEvent: ol.interaction.Snap.handleUpEvent_
   });
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   /**
    * @type {ol.source.Vector}
    * @private
    */
-  this.source_ = goog.isDef(options.source) ? options.source : null;
+  this.source_ = options.source ? options.source : null;
 
   /**
    * @type {ol.Collection.<ol.Feature>}
    * @private
    */
-  this.features_ = goog.isDef(options.features) ? options.features : null;
+  this.features_ = options.features ? options.features : null;
 
   /**
    * @type {Array.<goog.events.Key>}
@@ -114,8 +115,8 @@ ol.interaction.Snap = function(opt_options) {
    * @type {number}
    * @private
    */
-  this.pixelTolerance_ = goog.isDef(options.pixelTolerance) ?
-      options.pixelTolerance : 10;
+  this.pixelTolerance_ = ol.isDef(options.pixelTolerance) ?
+      /** @type {number} */ (options.pixelTolerance) : 10;
 
   /**
    * @type {function(ol.interaction.Snap.SegmentDataType, ol.interaction.Snap.SegmentDataType): number}
@@ -159,10 +160,11 @@ goog.inherits(ol.interaction.Snap, ol.interaction.Pointer);
  * @api
  */
 ol.interaction.Snap.prototype.addFeature = function(feature, opt_listen) {
-  var listen = goog.isDef(opt_listen) ? opt_listen : true;
+  var listen = ol.isDef(opt_listen) ?
+      /** @type {boolean} */ (opt_listen) : true;
   var geometry = feature.getGeometry();
   var segmentWriter = this.SEGMENT_WRITERS_[geometry.getType()];
-  if (goog.isDef(segmentWriter)) {
+  if (segmentWriter) {
     var feature_uid = goog.getUid(feature);
     this.indexedFeaturesExtents_[feature_uid] = geometry.getExtent(
         ol.extent.createEmpty());
@@ -210,7 +212,7 @@ ol.interaction.Snap.prototype.getFeatures_ = function() {
   } else if (!goog.isNull(this.source_)) {
     features = this.source_.getFeatures();
   }
-  goog.asserts.assert(goog.isDef(features), 'features should be defined');
+  goog.asserts.assert(features !== undefined, 'features should be defined');
   return features;
 };
 
@@ -286,7 +288,8 @@ ol.interaction.Snap.prototype.handleGeometryModify_ = function(feature, evt) {
  * @api
  */
 ol.interaction.Snap.prototype.removeFeature = function(feature, opt_unlisten) {
-  var unlisten = goog.isDef(opt_unlisten) ? opt_unlisten : true;
+  var unlisten = ol.isDef(opt_unlisten) ?
+      /** @type {boolean} */ (opt_unlisten) : true;
   var feature_uid = goog.getUid(feature);
   var extent = this.indexedFeaturesExtents_[feature_uid];
   if (extent) {

--- a/src/ol/interaction/translateinteraction.js
+++ b/src/ol/interaction/translateinteraction.js
@@ -42,7 +42,7 @@ ol.interaction.Translate = function(options) {
    * @type {ol.Collection.<ol.Feature>}
    * @private
    */
-  this.features_ = goog.isDef(options.features) ? options.features : null;
+  this.features_ = options.features !== undefined ? options.features : null;
 
   /**
    * @type {ol.Feature}
@@ -147,7 +147,7 @@ ol.interaction.Translate.handleMoveEvent_ = function(event)
         'grabbing' : (isSelected ? 'grab' : 'pointer');
 
   } else {
-    elem.style.cursor = goog.isDef(this.previousCursor_) ?
+    elem.style.cursor = this.previousCursor_ !== undefined ?
         this.previousCursor_ : '';
     this.previousCursor_ = undefined;
   }

--- a/src/ol/layer/heatmaplayer.js
+++ b/src/ol/layer/heatmaplayer.js
@@ -4,6 +4,7 @@ goog.require('goog.asserts');
 goog.require('goog.events');
 goog.require('goog.math');
 goog.require('goog.object');
+goog.require('ol');
 goog.require('ol.Object');
 goog.require('ol.dom');
 goog.require('ol.layer.Vector');
@@ -37,7 +38,7 @@ ol.layer.HeatmapLayerProperty = {
  * @api
  */
 ol.layer.Heatmap = function(opt_options) {
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   var baseOptions = goog.object.clone(options);
 
@@ -58,7 +59,8 @@ ol.layer.Heatmap = function(opt_options) {
    * @private
    * @type {number}
    */
-  this.shadow_ = goog.isDef(options.shadow) ? options.shadow : 250;
+  this.shadow_ = ol.isDef(options.shadow) ?
+      /** @type {number} */ (options.shadow) : 250;
 
   /**
    * @private
@@ -76,12 +78,14 @@ ol.layer.Heatmap = function(opt_options) {
       ol.Object.getChangeEventType(ol.layer.HeatmapLayerProperty.GRADIENT),
       this.handleGradientChanged_, false, this);
 
-  this.setGradient(goog.isDef(options.gradient) ?
+  this.setGradient(options.gradient ?
       options.gradient : ol.layer.Heatmap.DEFAULT_GRADIENT);
 
-  this.setBlur(goog.isDef(options.blur) ? options.blur : 15);
+  this.setBlur(ol.isDef(options.blur) ?
+      /** @type {number} */ (options.blur) : 15);
 
-  this.setRadius(goog.isDef(options.radius) ? options.radius : 8);
+  this.setRadius(ol.isDef(options.radius) ?
+      /** @type {number} */ (options.radius) : 8);
 
   goog.events.listen(this, [
     ol.Object.getChangeEventType(ol.layer.HeatmapLayerProperty.BLUR),
@@ -90,7 +94,7 @@ ol.layer.Heatmap = function(opt_options) {
 
   this.handleStyleChanged_();
 
-  var weight = goog.isDef(options.weight) ? options.weight : 'weight';
+  var weight = options.weight ? options.weight : 'weight';
   var weightFunction;
   if (goog.isString(weight)) {
     weightFunction = function(feature) {
@@ -105,14 +109,15 @@ ol.layer.Heatmap = function(opt_options) {
   this.setStyle(goog.bind(function(feature, resolution) {
     goog.asserts.assert(!goog.isNull(this.styleCache_),
         'this.styleCache_ should not be null');
-    goog.asserts.assert(goog.isDef(this.circleImage_),
+    goog.asserts.assert(this.circleImage_ !== undefined,
         'this.circleImage_ should be defined');
     var weight = weightFunction(feature);
-    var opacity = goog.isDef(weight) ? goog.math.clamp(weight, 0, 1) : 1;
+    var opacity = ol.isDef(weight) ?
+        goog.math.clamp(/** @type {number} */ (weight), 0, 1) : 1;
     // cast to 8 bits
     var index = (255 * opacity) | 0;
     var style = this.styleCache_[index];
-    if (!goog.isDef(style)) {
+    if (!style) {
       style = [
         new ol.style.Style({
           image: new ol.style.Icon({
@@ -174,7 +179,7 @@ ol.layer.Heatmap.createGradient_ = function(colors) {
 ol.layer.Heatmap.prototype.createCircle_ = function() {
   var radius = this.getRadius();
   var blur = this.getBlur();
-  goog.asserts.assert(goog.isDef(radius) && goog.isDef(blur),
+  goog.asserts.assert(radius !== undefined && blur !== undefined,
       'radius and blur should be defined');
   var halfSize = radius + blur + 1;
   var size = 2 * halfSize;

--- a/src/ol/layer/heatmaplayer.js
+++ b/src/ol/layer/heatmaplayer.js
@@ -59,8 +59,7 @@ ol.layer.Heatmap = function(opt_options) {
    * @private
    * @type {number}
    */
-  this.shadow_ = ol.isDef(options.shadow) ?
-      /** @type {number} */ (options.shadow) : 250;
+  this.shadow_ = options.shadow !== undefined ? options.shadow : 250;
 
   /**
    * @private
@@ -81,10 +80,10 @@ ol.layer.Heatmap = function(opt_options) {
   this.setGradient(options.gradient ?
       options.gradient : ol.layer.Heatmap.DEFAULT_GRADIENT);
 
-  this.setBlur(ol.isDef(options.blur) ?
+  this.setBlur(options.blur !== undefined ?
       /** @type {number} */ (options.blur) : 15);
 
-  this.setRadius(ol.isDef(options.radius) ?
+  this.setRadius(options.radius !== undefined ?
       /** @type {number} */ (options.radius) : 8);
 
   goog.events.listen(this, [
@@ -112,8 +111,8 @@ ol.layer.Heatmap = function(opt_options) {
     goog.asserts.assert(this.circleImage_ !== undefined,
         'this.circleImage_ should be defined');
     var weight = weightFunction(feature);
-    var opacity = ol.isDef(weight) ?
-        goog.math.clamp(/** @type {number} */ (weight), 0, 1) : 1;
+    var opacity = weight !== undefined ?
+        goog.math.clamp(weight, 0, 1) : 1;
     // cast to 8 bits
     var index = (255 * opacity) | 0;
     var style = this.styleCache_[index];

--- a/src/ol/layer/imagelayer.js
+++ b/src/ol/layer/imagelayer.js
@@ -19,7 +19,7 @@ goog.require('ol.layer.Layer');
  * @api stable
  */
 ol.layer.Image = function(opt_options) {
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
   goog.base(this,  /** @type {olx.layer.LayerOptions} */ (options));
 };
 goog.inherits(ol.layer.Image, ol.layer.Layer);

--- a/src/ol/layer/layer.js
+++ b/src/ol/layer/layer.js
@@ -3,6 +3,7 @@ goog.provide('ol.layer.Layer');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
 goog.require('goog.object');
+goog.require('ol');
 goog.require('ol.Object');
 goog.require('ol.layer.Base');
 goog.require('ol.layer.LayerProperty');
@@ -52,7 +53,7 @@ ol.layer.Layer = function(options) {
    */
   this.sourceChangeKey_ = null;
 
-  if (goog.isDef(options.map)) {
+  if (options.map) {
     this.setMap(options.map);
   }
 
@@ -60,7 +61,7 @@ ol.layer.Layer = function(options) {
       ol.Object.getChangeEventType(ol.layer.LayerProperty.SOURCE),
       this.handleSourcePropertyChange_, false, this);
 
-  var source = goog.isDef(options.source) ? options.source : null;
+  var source = options.source ? options.source : null;
   this.setSource(source);
 };
 goog.inherits(ol.layer.Layer, ol.layer.Base);
@@ -84,7 +85,7 @@ ol.layer.Layer.visibleAtResolution = function(layerState, resolution) {
  * @inheritDoc
  */
 ol.layer.Layer.prototype.getLayersArray = function(opt_array) {
-  var array = goog.isDef(opt_array) ? opt_array : [];
+  var array = opt_array ? opt_array : [];
   array.push(this);
   return array;
 };
@@ -94,7 +95,7 @@ ol.layer.Layer.prototype.getLayersArray = function(opt_array) {
  * @inheritDoc
  */
 ol.layer.Layer.prototype.getLayerStatesArray = function(opt_states) {
-  var states = goog.isDef(opt_states) ? opt_states : [];
+  var states = opt_states ? opt_states : [];
   states.push(this.getLayerState());
   return states;
 };
@@ -108,7 +109,7 @@ ol.layer.Layer.prototype.getLayerStatesArray = function(opt_states) {
  */
 ol.layer.Layer.prototype.getSource = function() {
   var source = this.get(ol.layer.LayerProperty.SOURCE);
-  return goog.isDef(source) ?
+  return ol.isDef(source) ?
       /** @type {ol.source.Source} */ (source) : null;
 };
 

--- a/src/ol/layer/layer.js
+++ b/src/ol/layer/layer.js
@@ -109,8 +109,7 @@ ol.layer.Layer.prototype.getLayerStatesArray = function(opt_states) {
  */
 ol.layer.Layer.prototype.getSource = function() {
   var source = this.get(ol.layer.LayerProperty.SOURCE);
-  return ol.isDef(source) ?
-      /** @type {ol.source.Source} */ (source) : null;
+  return /** @type {ol.source.Source} */ (source) || null;
 };
 
 

--- a/src/ol/layer/layerbase.js
+++ b/src/ol/layer/layerbase.js
@@ -4,6 +4,7 @@ goog.provide('ol.layer.LayerState');
 
 goog.require('goog.math');
 goog.require('goog.object');
+goog.require('ol');
 goog.require('ol.Object');
 goog.require('ol.source.State');
 
@@ -67,23 +68,23 @@ ol.layer.Base = function(options) {
    */
   var properties = goog.object.clone(options);
   properties[ol.layer.LayerProperty.BRIGHTNESS] =
-      goog.isDef(options.brightness) ? options.brightness : 0;
+      ol.isDef(options.brightness) ? options.brightness : 0;
   properties[ol.layer.LayerProperty.CONTRAST] =
-      goog.isDef(options.contrast) ? options.contrast : 1;
+      ol.isDef(options.contrast) ? options.contrast : 1;
   properties[ol.layer.LayerProperty.HUE] =
-      goog.isDef(options.hue) ? options.hue : 0;
+      ol.isDef(options.hue) ? options.hue : 0;
   properties[ol.layer.LayerProperty.OPACITY] =
-      goog.isDef(options.opacity) ? options.opacity : 1;
+      ol.isDef(options.opacity) ? options.opacity : 1;
   properties[ol.layer.LayerProperty.SATURATION] =
-      goog.isDef(options.saturation) ? options.saturation : 1;
+      ol.isDef(options.saturation) ? options.saturation : 1;
   properties[ol.layer.LayerProperty.VISIBLE] =
-      goog.isDef(options.visible) ? options.visible : true;
+      ol.isDef(options.visible) ? options.visible : true;
   properties[ol.layer.LayerProperty.Z_INDEX] =
-      goog.isDef(options.zIndex) ? options.zIndex : 0;
+      ol.isDef(options.zIndex) ? options.zIndex : 0;
   properties[ol.layer.LayerProperty.MAX_RESOLUTION] =
-      goog.isDef(options.maxResolution) ? options.maxResolution : Infinity;
+      ol.isDef(options.maxResolution) ? options.maxResolution : Infinity;
   properties[ol.layer.LayerProperty.MIN_RESOLUTION] =
-      goog.isDef(options.minResolution) ? options.minResolution : 0;
+      ol.isDef(options.minResolution) ? options.minResolution : 0;
 
   this.setProperties(properties);
 };

--- a/src/ol/layer/layerbase.js
+++ b/src/ol/layer/layerbase.js
@@ -68,23 +68,23 @@ ol.layer.Base = function(options) {
    */
   var properties = goog.object.clone(options);
   properties[ol.layer.LayerProperty.BRIGHTNESS] =
-      ol.isDef(options.brightness) ? options.brightness : 0;
+      options.brightness !== undefined ? options.brightness : 0;
   properties[ol.layer.LayerProperty.CONTRAST] =
-      ol.isDef(options.contrast) ? options.contrast : 1;
+      options.contrast !== undefined ? options.contrast : 1;
   properties[ol.layer.LayerProperty.HUE] =
-      ol.isDef(options.hue) ? options.hue : 0;
+      options.hue !== undefined ? options.hue : 0;
   properties[ol.layer.LayerProperty.OPACITY] =
-      ol.isDef(options.opacity) ? options.opacity : 1;
+      options.opacity !== undefined ? options.opacity : 1;
   properties[ol.layer.LayerProperty.SATURATION] =
-      ol.isDef(options.saturation) ? options.saturation : 1;
+      options.saturation !== undefined ? options.saturation : 1;
   properties[ol.layer.LayerProperty.VISIBLE] =
-      ol.isDef(options.visible) ? options.visible : true;
+      options.visible !== undefined ? options.visible : true;
   properties[ol.layer.LayerProperty.Z_INDEX] =
-      ol.isDef(options.zIndex) ? options.zIndex : 0;
+      options.zIndex !== undefined ? options.zIndex : 0;
   properties[ol.layer.LayerProperty.MAX_RESOLUTION] =
-      ol.isDef(options.maxResolution) ? options.maxResolution : Infinity;
+      options.maxResolution !== undefined ? options.maxResolution : Infinity;
   properties[ol.layer.LayerProperty.MIN_RESOLUTION] =
-      ol.isDef(options.minResolution) ? options.minResolution : 0;
+      options.minResolution !== undefined ? options.minResolution : 0;
 
   this.setProperties(properties);
 };

--- a/src/ol/layer/layergroup.js
+++ b/src/ol/layer/layergroup.js
@@ -38,7 +38,7 @@ ol.layer.GroupProperty = {
  */
 ol.layer.Group = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options || {};
   var baseOptions = /** @type {olx.layer.GroupOptions} */
       (goog.object.clone(options));
   delete baseOptions.layers;

--- a/src/ol/layer/layergroup.js
+++ b/src/ol/layer/layergroup.js
@@ -191,7 +191,7 @@ ol.layer.Group.prototype.setLayers = function(layers) {
  * @inheritDoc
  */
 ol.layer.Group.prototype.getLayersArray = function(opt_array) {
-  var array = goog.isDef(opt_array) ? opt_array : [];
+  var array = opt_array !== undefined ? opt_array : [];
   this.getLayers().forEach(function(layer) {
     layer.getLayersArray(array);
   });
@@ -203,7 +203,7 @@ ol.layer.Group.prototype.getLayersArray = function(opt_array) {
  * @inheritDoc
  */
 ol.layer.Group.prototype.getLayerStatesArray = function(opt_states) {
-  var states = goog.isDef(opt_states) ? opt_states : [];
+  var states = opt_states !== undefined ? opt_states : [];
 
   var pos = states.length;
 

--- a/src/ol/layer/layergroup.js
+++ b/src/ol/layer/layergroup.js
@@ -226,8 +226,8 @@ ol.layer.Group.prototype.getLayerStatesArray = function(opt_states) {
         layerState.maxResolution, ownLayerState.maxResolution);
     layerState.minResolution = Math.max(
         layerState.minResolution, ownLayerState.minResolution);
-    if (goog.isDef(ownLayerState.extent)) {
-      if (goog.isDef(layerState.extent)) {
+    if (ownLayerState.extent !== undefined) {
+      if (layerState.extent !== undefined) {
         layerState.extent = ol.extent.getIntersection(
             layerState.extent, ownLayerState.extent);
       } else {

--- a/src/ol/layer/tilelayer.js
+++ b/src/ol/layer/tilelayer.js
@@ -38,10 +38,9 @@ ol.layer.Tile = function(opt_options) {
   delete baseOptions.useInterimTilesOnError;
   goog.base(this,  /** @type {olx.layer.LayerOptions} */ (baseOptions));
 
-  this.setPreload(ol.isDef(options.preload) ?
-      /** @type {number} */ (options.preload) : 0);
-  this.setUseInterimTilesOnError(ol.isDef(options.useInterimTilesOnError) ?
-      /** @type {boolean} */ (options.useInterimTilesOnError) : true);
+  this.setPreload(options.preload !== undefined ? options.preload : 0);
+  this.setUseInterimTilesOnError(options.useInterimTilesOnError !== undefined ?
+      options.useInterimTilesOnError : true);
 };
 goog.inherits(ol.layer.Tile, ol.layer.Layer);
 

--- a/src/ol/layer/tilelayer.js
+++ b/src/ol/layer/tilelayer.js
@@ -1,6 +1,7 @@
 goog.provide('ol.layer.Tile');
 
 goog.require('goog.object');
+goog.require('ol');
 goog.require('ol.layer.Layer');
 
 
@@ -29,7 +30,7 @@ ol.layer.TileProperty = {
  * @api stable
  */
 ol.layer.Tile = function(opt_options) {
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options ? opt_options : {};
 
   var baseOptions = goog.object.clone(options);
 
@@ -37,9 +38,10 @@ ol.layer.Tile = function(opt_options) {
   delete baseOptions.useInterimTilesOnError;
   goog.base(this,  /** @type {olx.layer.LayerOptions} */ (baseOptions));
 
-  this.setPreload(goog.isDef(options.preload) ? options.preload : 0);
-  this.setUseInterimTilesOnError(goog.isDef(options.useInterimTilesOnError) ?
-      options.useInterimTilesOnError : true);
+  this.setPreload(ol.isDef(options.preload) ?
+      /** @type {number} */ (options.preload) : 0);
+  this.setUseInterimTilesOnError(ol.isDef(options.useInterimTilesOnError) ?
+      /** @type {boolean} */ (options.useInterimTilesOnError) : true);
 };
 goog.inherits(ol.layer.Tile, ol.layer.Layer);
 

--- a/src/ol/layer/vectorlayer.js
+++ b/src/ol/layer/vectorlayer.js
@@ -51,8 +51,8 @@ ol.layer.Vector = function(opt_options) {
    * @type {number}
    * @private
    */
-  this.renderBuffer_ = ol.isDef(options.renderBuffer) ?
-      /** @type {number} */ (options.renderBuffer) : 100;
+  this.renderBuffer_ = options.renderBuffer !== undefined ?
+      options.renderBuffer : 100;
 
   /**
    * User provided style.
@@ -74,15 +74,15 @@ ol.layer.Vector = function(opt_options) {
    * @type {boolean}
    * @private
    */
-  this.updateWhileAnimating_ = ol.isDef(options.updateWhileAnimating) ?
-      /** @type {boolean} */ (options.updateWhileAnimating) : false;
+  this.updateWhileAnimating_ = options.updateWhileAnimating !== undefined ?
+      options.updateWhileAnimating : false;
 
   /**
    * @type {boolean}
    * @private
    */
-  this.updateWhileInteracting_ = ol.isDef(options.updateWhileInteracting) ?
-      /** @type {boolean} */ (options.updateWhileInteracting) : false;
+  this.updateWhileInteracting_ = options.updateWhileInteracting !== undefined ?
+      options.updateWhileInteracting : false;
 
 };
 goog.inherits(ol.layer.Vector, ol.layer.Layer);
@@ -180,11 +180,7 @@ ol.layer.Vector.prototype.setRenderOrder = function(renderOrder) {
  * @api stable
  */
 ol.layer.Vector.prototype.setStyle = function(style) {
-  this.style_ = ol.isDef(style) ?
-      /**
-       * @type {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|null}
-       */
-      (style) : ol.style.defaultStyleFunction;
+  this.style_ = style !== undefined ? style : ol.style.defaultStyleFunction;
   this.styleFunction_ = goog.isNull(style) ?
       undefined : ol.style.createStyleFunction(this.style_);
   this.changed();

--- a/src/ol/layer/vectorlayer.js
+++ b/src/ol/layer/vectorlayer.js
@@ -2,6 +2,7 @@ goog.provide('ol.layer.Vector');
 
 goog.require('goog.asserts');
 goog.require('goog.object');
+goog.require('ol');
 goog.require('ol.layer.Layer');
 goog.require('ol.style.Style');
 
@@ -30,11 +31,11 @@ ol.layer.VectorProperty = {
  */
 ol.layer.Vector = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ?
+  var options = opt_options ?
       opt_options : /** @type {olx.layer.VectorOptions} */ ({});
 
   goog.asserts.assert(
-      !goog.isDef(options.renderOrder) || goog.isNull(options.renderOrder) ||
+      options.renderOrder === undefined || goog.isNull(options.renderOrder) ||
       goog.isFunction(options.renderOrder),
       'renderOrder must be a comparator function');
 
@@ -50,8 +51,8 @@ ol.layer.Vector = function(opt_options) {
    * @type {number}
    * @private
    */
-  this.renderBuffer_ = goog.isDef(options.renderBuffer) ?
-      options.renderBuffer : 100;
+  this.renderBuffer_ = ol.isDef(options.renderBuffer) ?
+      /** @type {number} */ (options.renderBuffer) : 100;
 
   /**
    * User provided style.
@@ -73,15 +74,15 @@ ol.layer.Vector = function(opt_options) {
    * @type {boolean}
    * @private
    */
-  this.updateWhileAnimating_ = goog.isDef(options.updateWhileAnimating) ?
-      options.updateWhileAnimating : false;
+  this.updateWhileAnimating_ = ol.isDef(options.updateWhileAnimating) ?
+      /** @type {boolean} */ (options.updateWhileAnimating) : false;
 
   /**
    * @type {boolean}
    * @private
    */
-  this.updateWhileInteracting_ = goog.isDef(options.updateWhileInteracting) ?
-      options.updateWhileInteracting : false;
+  this.updateWhileInteracting_ = ol.isDef(options.updateWhileInteracting) ?
+      /** @type {boolean} */ (options.updateWhileInteracting) : false;
 
 };
 goog.inherits(ol.layer.Vector, ol.layer.Layer);
@@ -160,7 +161,7 @@ ol.layer.Vector.prototype.getUpdateWhileInteracting = function() {
  */
 ol.layer.Vector.prototype.setRenderOrder = function(renderOrder) {
   goog.asserts.assert(
-      !goog.isDef(renderOrder) || goog.isNull(renderOrder) ||
+      renderOrder === undefined || goog.isNull(renderOrder) ||
       goog.isFunction(renderOrder),
       'renderOrder must be a comparator function');
   this.set(ol.layer.VectorProperty.RENDER_ORDER, renderOrder);
@@ -174,12 +175,16 @@ ol.layer.Vector.prototype.setRenderOrder = function(renderOrder) {
  * it is `null` the layer has no style (a `null` style), so only features
  * that have their own styles will be rendered in the layer. See
  * {@link ol.style} for information on the default style.
- * @param {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined}
+ * @param {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|null|undefined}
  *     style Layer style.
  * @api stable
  */
 ol.layer.Vector.prototype.setStyle = function(style) {
-  this.style_ = goog.isDef(style) ? style : ol.style.defaultStyleFunction;
+  this.style_ = ol.isDef(style) ?
+      /**
+       * @type {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|null}
+       */
+      (style) : ol.style.defaultStyleFunction;
   this.styleFunction_ = goog.isNull(style) ?
       undefined : ol.style.createStyleFunction(this.style_);
   this.changed();

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -181,22 +181,23 @@ ol.Map = function(options) {
    * @type {boolean}
    * @private
    */
-  this.loadTilesWhileAnimating_ = goog.isDef(options.loadTilesWhileAnimating) ?
-      options.loadTilesWhileAnimating : false;
+  this.loadTilesWhileAnimating_ =
+      options.loadTilesWhileAnimating !== undefined ?
+          options.loadTilesWhileAnimating : false;
 
   /**
    * @type {boolean}
    * @private
    */
   this.loadTilesWhileInteracting_ =
-      goog.isDef(options.loadTilesWhileInteracting) ?
+      options.loadTilesWhileInteracting !== undefined ?
           options.loadTilesWhileInteracting : false;
 
   /**
    * @private
    * @type {number}
    */
-  this.pixelRatio_ = goog.isDef(options.pixelRatio) ?
+  this.pixelRatio_ = options.pixelRatio !== undefined ?
       options.pixelRatio : ol.has.DEVICE_PIXEL_RATIO;
 
   /**
@@ -1486,7 +1487,7 @@ ol.Map.createOptionsInternal = function(options) {
 
   values[ol.MapProperty.TARGET] = options.target;
 
-  values[ol.MapProperty.VIEW] = goog.isDef(options.view) ?
+  values[ol.MapProperty.VIEW] = options.view !== undefined ?
       options.view : new ol.View();
 
   /**

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -1201,10 +1201,7 @@ ol.Map.prototype.render = function() {
 ol.Map.prototype.removeControl = function(control) {
   var controls = this.getControls();
   goog.asserts.assert(controls !== undefined, 'controls should be defined');
-  if (goog.isDef(controls.remove(control))) {
-    return control;
-  }
-  return undefined;
+  return controls.remove(control);
 };
 
 
@@ -1216,14 +1213,10 @@ ol.Map.prototype.removeControl = function(control) {
  * @api stable
  */
 ol.Map.prototype.removeInteraction = function(interaction) {
-  var removed;
   var interactions = this.getInteractions();
   goog.asserts.assert(interactions !== undefined,
       'interactions should be defined');
-  if (goog.isDef(interactions.remove(interaction))) {
-    removed = interaction;
-  }
-  return removed;
+  return interactions.remove(interaction);
 };
 
 
@@ -1250,10 +1243,7 @@ ol.Map.prototype.removeLayer = function(layer) {
 ol.Map.prototype.removeOverlay = function(overlay) {
   var overlays = this.getOverlays();
   goog.asserts.assert(overlays !== undefined, 'overlays should be defined');
-  if (goog.isDef(overlays.remove(overlay))) {
-    return overlay;
-  }
-  return undefined;
+  return overlays.remove(overlay);
 };
 
 

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -496,7 +496,7 @@ goog.inherits(ol.Map, ol.Object);
  */
 ol.Map.prototype.addControl = function(control) {
   var controls = this.getControls();
-  goog.asserts.assert(goog.isDef(controls), 'controls should be defined');
+  goog.asserts.assert(controls !== undefined, 'controls should be defined');
   controls.push(control);
 };
 
@@ -508,7 +508,7 @@ ol.Map.prototype.addControl = function(control) {
  */
 ol.Map.prototype.addInteraction = function(interaction) {
   var interactions = this.getInteractions();
-  goog.asserts.assert(goog.isDef(interactions),
+  goog.asserts.assert(interactions !== undefined,
       'interactions should be defined');
   interactions.push(interaction);
 };
@@ -534,7 +534,7 @@ ol.Map.prototype.addLayer = function(layer) {
  */
 ol.Map.prototype.addOverlay = function(overlay) {
   var overlays = this.getOverlays();
-  goog.asserts.assert(goog.isDef(overlays), 'overlays should be defined');
+  goog.asserts.assert(overlays !== undefined, 'overlays should be defined');
   overlays.push(overlay);
 };
 
@@ -600,10 +600,10 @@ ol.Map.prototype.forEachFeatureAtPixel =
     return;
   }
   var coordinate = this.getCoordinateFromPixel(pixel);
-  var thisArg = goog.isDef(opt_this) ? opt_this : null;
-  var layerFilter = goog.isDef(opt_layerFilter) ?
+  var thisArg = opt_this !== undefined ? opt_this : null;
+  var layerFilter = opt_layerFilter !== undefined ?
       opt_layerFilter : goog.functions.TRUE;
-  var thisArg2 = goog.isDef(opt_this2) ? opt_this2 : null;
+  var thisArg2 = opt_this2 !== undefined ? opt_this2 : null;
   return this.renderer_.forEachFeatureAtCoordinate(
       coordinate, this.frameState_, callback, thisArg,
       layerFilter, thisArg2);
@@ -637,10 +637,10 @@ ol.Map.prototype.forEachLayerAtPixel =
   if (goog.isNull(this.frameState_)) {
     return;
   }
-  var thisArg = goog.isDef(opt_this) ? opt_this : null;
-  var layerFilter = goog.isDef(opt_layerFilter) ?
+  var thisArg = opt_this !== undefined ? opt_this : null;
+  var layerFilter = opt_layerFilter !== undefined ?
       opt_layerFilter : goog.functions.TRUE;
-  var thisArg2 = goog.isDef(opt_this2) ? opt_this2 : null;
+  var thisArg2 = opt_this2 !== undefined ? opt_this2 : null;
   return this.renderer_.forEachLayerAtPixel(
       pixel, this.frameState_, callback, thisArg,
       layerFilter, thisArg2);
@@ -668,9 +668,9 @@ ol.Map.prototype.hasFeatureAtPixel =
     return false;
   }
   var coordinate = this.getCoordinateFromPixel(pixel);
-  var layerFilter = goog.isDef(opt_layerFilter) ?
+  var layerFilter = opt_layerFilter !== undefined ?
       opt_layerFilter : goog.functions.TRUE;
-  var thisArg = goog.isDef(opt_this) ? opt_this : null;
+  var thisArg = opt_this !== undefined ? opt_this : null;
   return this.renderer_.hasFeatureAtCoordinate(
       coordinate, this.frameState_, layerFilter, thisArg);
 };
@@ -723,7 +723,7 @@ ol.Map.prototype.getTarget = function() {
  */
 ol.Map.prototype.getTargetElement = function() {
   var target = this.getTarget();
-  return goog.isDef(target) ? goog.dom.getElement(target) : null;
+  return target !== undefined ? goog.dom.getElement(target) : null;
 };
 
 
@@ -941,7 +941,7 @@ ol.Map.prototype.handleMapBrowserEvent = function(mapBrowserEvent) {
   this.focus_ = mapBrowserEvent.coordinate;
   mapBrowserEvent.frameState = this.frameState_;
   var interactions = this.getInteractions();
-  goog.asserts.assert(goog.isDef(interactions),
+  goog.asserts.assert(interactions !== undefined,
       'interactions should be defined');
   var interactionsArray = interactions.getArray();
   var i;
@@ -1199,7 +1199,7 @@ ol.Map.prototype.render = function() {
  */
 ol.Map.prototype.removeControl = function(control) {
   var controls = this.getControls();
-  goog.asserts.assert(goog.isDef(controls), 'controls should be defined');
+  goog.asserts.assert(controls !== undefined, 'controls should be defined');
   if (goog.isDef(controls.remove(control))) {
     return control;
   }
@@ -1217,7 +1217,7 @@ ol.Map.prototype.removeControl = function(control) {
 ol.Map.prototype.removeInteraction = function(interaction) {
   var removed;
   var interactions = this.getInteractions();
-  goog.asserts.assert(goog.isDef(interactions),
+  goog.asserts.assert(interactions !== undefined,
       'interactions should be defined');
   if (goog.isDef(interactions.remove(interaction))) {
     removed = interaction;
@@ -1248,7 +1248,7 @@ ol.Map.prototype.removeLayer = function(layer) {
  */
 ol.Map.prototype.removeOverlay = function(overlay) {
   var overlays = this.getOverlays();
-  goog.asserts.assert(goog.isDef(overlays), 'overlays should be defined');
+  goog.asserts.assert(overlays !== undefined, 'overlays should be defined');
   if (goog.isDef(overlays.remove(overlay))) {
     return overlay;
   }
@@ -1268,7 +1268,7 @@ ol.Map.prototype.renderFrame_ = function(time) {
   var view = this.getView();
   /** @type {?olx.FrameState} */
   var frameState = null;
-  if (goog.isDef(size) && ol.size.hasArea(size) &&
+  if (size !== undefined && ol.size.hasArea(size) &&
       !goog.isNull(view) && view.isDef()) {
     var viewHints = view.getHints();
     var layerStatesArray = this.getLayerGroup().getLayerStatesArray();

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -1466,7 +1466,7 @@ ol.Map.createOptionsInternal = function(options) {
   var values = {};
 
   var logos = {};
-  if (!goog.isDef(options.logo) ||
+  if (options.logo === undefined ||
       (goog.isBoolean(options.logo) && options.logo)) {
     logos[ol.OL3_LOGO_URL] = ol.OL3_URL;
   } else {

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -1452,7 +1452,7 @@ ol.Map.createOptionsInternal = function(options) {
    * @type {Element|Document}
    */
   var keyboardEventTarget = null;
-  if (goog.isDef(options.keyboardEventTarget)) {
+  if (options.keyboardEventTarget !== undefined) {
     // cannot use goog.dom.getElement because its argument cannot be
     // of type Document
     keyboardEventTarget = goog.isString(options.keyboardEventTarget) ?
@@ -1498,7 +1498,7 @@ ol.Map.createOptionsInternal = function(options) {
    * @type {Array.<ol.RendererType>}
    */
   var rendererTypes;
-  if (goog.isDef(options.renderer)) {
+  if (options.renderer !== undefined) {
     if (goog.isArray(options.renderer)) {
       rendererTypes = options.renderer;
     } else if (goog.isString(options.renderer)) {
@@ -1533,7 +1533,7 @@ ol.Map.createOptionsInternal = function(options) {
   }
 
   var controls;
-  if (goog.isDef(options.controls)) {
+  if (options.controls !== undefined) {
     if (goog.isArray(options.controls)) {
       controls = new ol.Collection(options.controls.slice());
     } else {
@@ -1546,7 +1546,7 @@ ol.Map.createOptionsInternal = function(options) {
   }
 
   var interactions;
-  if (goog.isDef(options.interactions)) {
+  if (options.interactions !== undefined) {
     if (goog.isArray(options.interactions)) {
       interactions = new ol.Collection(options.interactions.slice());
     } else {
@@ -1559,7 +1559,7 @@ ol.Map.createOptionsInternal = function(options) {
   }
 
   var overlays;
-  if (goog.isDef(options.overlays)) {
+  if (options.overlays !== undefined) {
     if (goog.isArray(options.overlays)) {
       overlays = new ol.Collection(options.overlays.slice());
     } else {

--- a/src/ol/mapbrowserevent.js
+++ b/src/ol/mapbrowserevent.js
@@ -73,7 +73,7 @@ ol.MapBrowserEvent = function(type, map, browserEvent, opt_dragging,
    * @type {boolean}
    * @api stable
    */
-  this.dragging = goog.isDef(opt_dragging) ? opt_dragging : false;
+  this.dragging = opt_dragging !== undefined ? opt_dragging : false;
 
 };
 goog.inherits(ol.MapBrowserEvent, ol.MapEvent);

--- a/src/ol/mapevent.js
+++ b/src/ol/mapevent.js
@@ -55,7 +55,7 @@ ol.MapEvent = function(type, map, opt_frameState) {
    * @type {?olx.FrameState}
    * @api
    */
-  this.frameState = goog.isDef(opt_frameState) ? opt_frameState : null;
+  this.frameState = opt_frameState !== undefined ? opt_frameState : null;
 
 };
 goog.inherits(ol.MapEvent, goog.events.Event);

--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -116,7 +116,7 @@ ol.Object = function(opt_values) {
    */
   this.values_ = {};
 
-  if (goog.isDef(opt_values)) {
+  if (opt_values !== undefined) {
     this.setProperties(opt_values);
   }
 };

--- a/src/ol/ol.js
+++ b/src/ol/ol.js
@@ -240,13 +240,3 @@ ol.WEBGL_EXTENSIONS; // value is set in `ol.has`
 ol.inherits =
     goog.inherits;
 // note that the newline above is necessary to satisfy the linter
-
-
-/**
- * Determine if a value is defined.
- * @param {?} value The value to test.
- * @return {boolean} The value is defined.
- */
-ol.isDef = function(value) {
-  return value !== undefined;
-};

--- a/src/ol/ol.js
+++ b/src/ol/ol.js
@@ -240,3 +240,13 @@ ol.WEBGL_EXTENSIONS; // value is set in `ol.has`
 ol.inherits =
     goog.inherits;
 // note that the newline above is necessary to satisfy the linter
+
+
+/**
+ * Determine if a value is defined.
+ * @param {?} value The value to test.
+ * @return {boolean} The value is defined.
+ */
+ol.isDef = function(value) {
+  return value !== undefined;
+};

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -78,14 +78,14 @@ ol.Overlay = function(options) {
    * @private
    * @type {boolean}
    */
-  this.insertFirst_ = goog.isDef(options.insertFirst) ?
+  this.insertFirst_ = options.insertFirst !== undefined ?
       options.insertFirst : true;
 
   /**
    * @private
    * @type {boolean}
    */
-  this.stopEvent_ = goog.isDef(options.stopEvent) ? options.stopEvent : true;
+  this.stopEvent_ = options.stopEvent !== undefined ? options.stopEvent : true;
 
   /**
    * @private
@@ -100,20 +100,20 @@ ol.Overlay = function(options) {
    * @protected
    * @type {boolean}
    */
-  this.autoPan = goog.isDef(options.autoPan) ? options.autoPan : false;
+  this.autoPan = options.autoPan !== undefined ? options.autoPan : false;
 
   /**
    * @private
    * @type {olx.animation.PanOptions}
    */
-  this.autoPanAnimation_ = goog.isDef(options.autoPanAnimation) ?
+  this.autoPanAnimation_ = options.autoPanAnimation !== undefined ?
       options.autoPanAnimation : /** @type {olx.animation.PanOptions} */ ({});
 
   /**
    * @private
    * @type {number}
    */
-  this.autoPanMargin_ = goog.isDef(options.autoPanMargin) ?
+  this.autoPanMargin_ = options.autoPanMargin !== undefined ?
       options.autoPanMargin : 20;
 
   /**
@@ -162,9 +162,9 @@ ol.Overlay = function(options) {
     this.setElement(options.element);
   }
 
-  this.setOffset(goog.isDef(options.offset) ? options.offset : [0, 0]);
+  this.setOffset(options.offset !== undefined ? options.offset : [0, 0]);
 
-  this.setPositioning(goog.isDef(options.positioning) ?
+  this.setPositioning(options.positioning !== undefined ?
       /** @type {ol.OverlayPositioning} */ (options.positioning) :
       ol.OverlayPositioning.TOP_LEFT);
 

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -366,7 +366,7 @@ ol.Overlay.prototype.panIntoView_ = function() {
   goog.asserts.assert(this.autoPan, 'this.autoPan should be true');
   var map = this.getMap();
 
-  if (!goog.isDef(map) || goog.isNull(map.getTargetElement())) {
+  if (map === undefined || goog.isNull(map.getTargetElement())) {
     return;
   }
 
@@ -474,7 +474,7 @@ ol.Overlay.prototype.setVisible = function(visible) {
 ol.Overlay.prototype.updatePixelPosition = function() {
   var map = this.getMap();
   var position = this.getPosition();
-  if (!goog.isDef(map) || !map.isRendered() || !goog.isDef(position)) {
+  if (map === undefined || !map.isRendered() || position === undefined) {
     this.setVisible(false);
     return;
   }

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -403,7 +403,7 @@ ol.Overlay.prototype.panIntoView_ = function() {
 
     if (delta[0] !== 0 || delta[1] !== 0) {
       var center = map.getView().getCenter();
-      goog.asserts.assert(goog.isDef(center), 'center should be defined');
+      goog.asserts.assert(center !== undefined, 'center should be defined');
       var centerPx = map.getPixelFromCoordinate(center);
       var newCenterPx = [
         centerPx[0] + delta[0],
@@ -430,7 +430,7 @@ ol.Overlay.prototype.panIntoView_ = function() {
 ol.Overlay.prototype.getRect_ = function(element, size) {
   goog.asserts.assert(goog.isDefAndNotNull(element),
       'element should be defined');
-  goog.asserts.assert(goog.isDef(size), 'size should be defined');
+  goog.asserts.assert(size !== undefined, 'size should be defined');
 
   var offset = goog.style.getPageOffset(element);
   return [
@@ -492,13 +492,13 @@ ol.Overlay.prototype.updatePixelPosition = function() {
  */
 ol.Overlay.prototype.updateRenderedPosition = function(pixel, mapSize) {
   goog.asserts.assert(!goog.isNull(pixel), 'pixel should not be null');
-  goog.asserts.assert(goog.isDef(mapSize), 'mapSize should be defined');
+  goog.asserts.assert(mapSize !== undefined, 'mapSize should be defined');
   var style = this.element_.style;
   var offset = this.getOffset();
   goog.asserts.assert(goog.isArray(offset), 'offset should be an array');
 
   var positioning = this.getPositioning();
-  goog.asserts.assert(goog.isDef(positioning),
+  goog.asserts.assert(positioning !== undefined,
       'positioning should be defined');
 
   var offsetX = offset[0];

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -158,7 +158,7 @@ ol.Overlay = function(options) {
       this, ol.Object.getChangeEventType(ol.OverlayProperty.POSITIONING),
       this.handlePositioningChanged, false, this);
 
-  if (goog.isDef(options.element)) {
+  if (options.element !== undefined) {
     this.setElement(options.element);
   }
 
@@ -168,7 +168,7 @@ ol.Overlay = function(options) {
       /** @type {ol.OverlayPositioning} */ (options.positioning) :
       ol.OverlayPositioning.TOP_LEFT);
 
-  if (goog.isDef(options.position)) {
+  if (options.position !== undefined) {
     this.setPosition(options.position);
   }
 

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -297,7 +297,7 @@ ol.Overlay.prototype.handleOffsetChanged = function() {
  */
 ol.Overlay.prototype.handlePositionChanged = function() {
   this.updatePixelPosition();
-  if (goog.isDef(this.get(ol.OverlayProperty.POSITION)) && this.autoPan) {
+  if (this.get(ol.OverlayProperty.POSITION) !== undefined && this.autoPan) {
     this.panIntoView_();
   }
 };

--- a/src/ol/pointer/pointerevent.js
+++ b/src/ol/pointer/pointerevent.js
@@ -59,7 +59,7 @@ ol.pointer.PointerEvent = function(type, browserEvent, opt_eventDict) {
    */
   this.browserEvent = browserEvent;
 
-  var eventDict = goog.isDef(opt_eventDict) ? opt_eventDict : {};
+  var eventDict = opt_eventDict ? opt_eventDict : {};
 
   /**
    * @type {number}

--- a/src/ol/pointer/touchsource.js
+++ b/src/ol/pointer/touchsource.js
@@ -32,6 +32,7 @@ goog.provide('ol.pointer.TouchSource');
 
 goog.require('goog.array');
 goog.require('goog.object');
+goog.require('ol');
 goog.require('ol.pointer.EventSource');
 goog.require('ol.pointer.MouseSource');
 
@@ -168,7 +169,7 @@ ol.pointer.TouchSource.prototype.resetClickCountHandler_ = function() {
  * @private
  */
 ol.pointer.TouchSource.prototype.cancelResetClickCount_ = function() {
-  if (goog.isDef(this.resetId_)) {
+  if (ol.isDef(this.resetId_)) {
     goog.global.clearTimeout(this.resetId_);
   }
 };

--- a/src/ol/pointer/touchsource.js
+++ b/src/ol/pointer/touchsource.js
@@ -169,7 +169,7 @@ ol.pointer.TouchSource.prototype.resetClickCountHandler_ = function() {
  * @private
  */
 ol.pointer.TouchSource.prototype.cancelResetClickCount_ = function() {
-  if (ol.isDef(this.resetId_)) {
+  if (this.resetId_ !== undefined) {
     goog.global.clearTimeout(this.resetId_);
   }
 };

--- a/src/ol/proj/epsg3857projection.js
+++ b/src/ol/proj/epsg3857projection.js
@@ -110,7 +110,7 @@ ol.proj.EPSG3857.fromEPSG4326 = function(input, opt_output, opt_dimension) {
   var length = input.length,
       dimension = opt_dimension > 1 ? opt_dimension : 2,
       output = opt_output;
-  if (!goog.isDef(output)) {
+  if (output === undefined) {
     if (dimension > 2) {
       // preserve values beyond second dimension
       output = input.slice();
@@ -141,7 +141,7 @@ ol.proj.EPSG3857.toEPSG4326 = function(input, opt_output, opt_dimension) {
   var length = input.length,
       dimension = opt_dimension > 1 ? opt_dimension : 2,
       output = opt_output;
-  if (!goog.isDef(output)) {
+  if (output === undefined) {
     if (dimension > 2) {
       // preserve values beyond second dimension
       output = input.slice();

--- a/src/ol/proj/proj.js
+++ b/src/ol/proj/proj.js
@@ -99,27 +99,27 @@ ol.proj.Projection = function(options) {
    * @private
    * @type {ol.Extent}
    */
-  this.extent_ = goog.isDef(options.extent) ? options.extent : null;
+  this.extent_ = options.extent !== undefined ? options.extent : null;
 
   /**
    * @private
    * @type {ol.Extent}
    */
-  this.worldExtent_ = goog.isDef(options.worldExtent) ?
+  this.worldExtent_ = options.worldExtent !== undefined ?
       options.worldExtent : null;
 
   /**
    * @private
    * @type {string}
    */
-  this.axisOrientation_ = goog.isDef(options.axisOrientation) ?
+  this.axisOrientation_ = options.axisOrientation !== undefined ?
       options.axisOrientation : 'enu';
 
   /**
    * @private
    * @type {boolean}
    */
-  this.global_ = goog.isDef(options.global) ? options.global : false;
+  this.global_ = options.global !== undefined ? options.global : false;
 
 
   /**
@@ -132,7 +132,7 @@ ol.proj.Projection = function(options) {
   * @private
   * @type {function(number, ol.Coordinate):number}
   */
-  this.getPointResolutionFunc_ = goog.isDef(options.getPointResolution) ?
+  this.getPointResolutionFunc_ = options.getPointResolution !== undefined ?
       options.getPointResolution : this.getPointResolution_;
 
   /**
@@ -149,7 +149,7 @@ ol.proj.Projection = function(options) {
       !goog.isDef(projections[code])) {
     var def = proj4.defs(code);
     if (def !== undefined) {
-      if (goog.isDef(def.axis) && options.axisOrientation === undefined) {
+      if (def.axis !== undefined && options.axisOrientation === undefined) {
         this.axisOrientation_ = def.axis;
       }
       if (options.units === undefined) {

--- a/src/ol/proj/proj.js
+++ b/src/ol/proj/proj.js
@@ -155,7 +155,7 @@ ol.proj.Projection = function(options) {
       if (!goog.isDef(options.units)) {
         var units = def.units;
         if (!goog.isDef(units)) {
-          if (goog.isDef(def.to_meter)) {
+          if (def.to_meter !== undefined) {
             units = def.to_meter.toString();
             ol.proj.METERS_PER_UNIT[units] = def.to_meter;
           }

--- a/src/ol/proj/proj.js
+++ b/src/ol/proj/proj.js
@@ -149,7 +149,7 @@ ol.proj.Projection = function(options) {
       !goog.isDef(projections[code])) {
     var def = proj4.defs(code);
     if (def !== undefined) {
-      if (goog.isDef(def.axis) && !goog.isDef(options.axisOrientation)) {
+      if (goog.isDef(def.axis) && options.axisOrientation === undefined) {
         this.axisOrientation_ = def.axis;
       }
       if (options.units === undefined) {

--- a/src/ol/proj/proj.js
+++ b/src/ol/proj/proj.js
@@ -148,7 +148,7 @@ ol.proj.Projection = function(options) {
   if (ol.ENABLE_PROJ4JS && typeof proj4 == 'function' &&
       !goog.isDef(projections[code])) {
     var def = proj4.defs(code);
-    if (goog.isDef(def)) {
+    if (def !== undefined) {
       if (goog.isDef(def.axis) && !goog.isDef(options.axisOrientation)) {
         this.axisOrientation_ = def.axis;
       }
@@ -165,7 +165,7 @@ ol.proj.Projection = function(options) {
       var currentCode, currentDef, currentProj, proj4Transform;
       for (currentCode in projections) {
         currentDef = proj4.defs(currentCode);
-        if (goog.isDef(currentDef)) {
+        if (currentDef !== undefined) {
           currentProj = ol.proj.get(currentCode);
           if (currentDef === def) {
             ol.proj.addEquivalentProjections([currentProj, this]);
@@ -361,7 +361,7 @@ ol.proj.Projection.prototype.getPointResolution_ = function(resolution, point) {
         vertices.slice(4, 6), vertices.slice(6, 8));
     var pointResolution = (width + height) / 2;
     var metersPerUnit = this.getMetersPerUnit();
-    if (goog.isDef(metersPerUnit)) {
+    if (metersPerUnit !== undefined) {
       pointResolution /= metersPerUnit;
     }
     return pointResolution;
@@ -761,7 +761,7 @@ ol.proj.identityTransform = function(input, opt_output, opt_dimension) {
  */
 ol.proj.cloneTransform = function(input, opt_output, opt_dimension) {
   var output;
-  if (goog.isDef(opt_output)) {
+  if (opt_output !== undefined) {
     for (var i = 0, ii = input.length; i < ii; ++i) {
       opt_output[i] = input[i];
     }

--- a/src/ol/proj/proj.js
+++ b/src/ol/proj/proj.js
@@ -152,7 +152,7 @@ ol.proj.Projection = function(options) {
       if (goog.isDef(def.axis) && !goog.isDef(options.axisOrientation)) {
         this.axisOrientation_ = def.axis;
       }
-      if (!goog.isDef(options.units)) {
+      if (options.units === undefined) {
         var units = def.units;
         if (units === undefined) {
           if (def.to_meter !== undefined) {

--- a/src/ol/proj/proj.js
+++ b/src/ol/proj/proj.js
@@ -154,7 +154,7 @@ ol.proj.Projection = function(options) {
       }
       if (!goog.isDef(options.units)) {
         var units = def.units;
-        if (!goog.isDef(units)) {
+        if (units === undefined) {
           if (def.to_meter !== undefined) {
             units = def.to_meter.toString();
             ol.proj.METERS_PER_UNIT[units] = def.to_meter;
@@ -725,7 +725,7 @@ ol.proj.getTransformFromProjections =
       goog.object.containsKey(transforms[sourceCode], destinationCode)) {
     transform = transforms[sourceCode][destinationCode];
   }
-  if (!goog.isDef(transform)) {
+  if (transform === undefined) {
     goog.asserts.assert(goog.isDef(transform), 'transform should be defined');
     transform = ol.proj.identityTransform;
   }

--- a/src/ol/proj/proj.js
+++ b/src/ol/proj/proj.js
@@ -652,7 +652,7 @@ ol.proj.get = function(projectionLike) {
   } else if (goog.isString(projectionLike)) {
     var code = projectionLike;
     projection = ol.proj.projections_[code];
-    if (ol.ENABLE_PROJ4JS && !goog.isDef(projection) &&
+    if (ol.ENABLE_PROJ4JS && projection === undefined &&
         typeof proj4 == 'function' && goog.isDef(proj4.defs(code))) {
       projection = new ol.proj.Projection({code: code});
       ol.proj.addProjection(projection);

--- a/src/ol/proj/proj.js
+++ b/src/ol/proj/proj.js
@@ -653,7 +653,7 @@ ol.proj.get = function(projectionLike) {
     var code = projectionLike;
     projection = ol.proj.projections_[code];
     if (ol.ENABLE_PROJ4JS && projection === undefined &&
-        typeof proj4 == 'function' && goog.isDef(proj4.defs(code))) {
+        typeof proj4 == 'function' && proj4.defs(code) !== undefined) {
       projection = new ol.proj.Projection({code: code});
       ol.proj.addProjection(projection);
     }

--- a/src/ol/proj/proj.js
+++ b/src/ol/proj/proj.js
@@ -146,7 +146,7 @@ ol.proj.Projection = function(options) {
   goog.asserts.assert(code !== undefined,
       'Option "code" is required for constructing instance');
   if (ol.ENABLE_PROJ4JS && typeof proj4 == 'function' &&
-      !goog.isDef(projections[code])) {
+      projections[code] === undefined) {
     var def = proj4.defs(code);
     if (def !== undefined) {
       if (def.axis !== undefined && options.axisOrientation === undefined) {

--- a/src/ol/proj/proj.js
+++ b/src/ol/proj/proj.js
@@ -143,7 +143,7 @@ ol.proj.Projection = function(options) {
 
   var projections = ol.proj.projections_;
   var code = options.code;
-  goog.asserts.assert(goog.isDef(code),
+  goog.asserts.assert(code !== undefined,
       'Option "code" is required for constructing instance');
   if (ol.ENABLE_PROJ4JS && typeof proj4 == 'function' &&
       !goog.isDef(projections[code])) {
@@ -563,8 +563,8 @@ ol.proj.createTransformFromCoordinateTransform = function(transform) {
        */
       function(input, opt_output, opt_dimension) {
         var length = input.length;
-        var dimension = goog.isDef(opt_dimension) ? opt_dimension : 2;
-        var output = goog.isDef(opt_output) ? opt_output : new Array(length);
+        var dimension = opt_dimension !== undefined ? opt_dimension : 2;
+        var output = opt_output !== undefined ? opt_output : new Array(length);
         var point, i, j;
         for (i = 0; i < length; i += dimension) {
           point = transform([input[i], input[i + 1]]);
@@ -617,7 +617,7 @@ ol.proj.removeTransform = function(source, destination) {
  */
 ol.proj.fromLonLat = function(coordinate, opt_projection) {
   return ol.proj.transform(coordinate, 'EPSG:4326',
-      goog.isDef(opt_projection) ? opt_projection : 'EPSG:3857');
+      opt_projection !== undefined ? opt_projection : 'EPSG:3857');
 };
 
 
@@ -632,7 +632,7 @@ ol.proj.fromLonLat = function(coordinate, opt_projection) {
  */
 ol.proj.toLonLat = function(coordinate, opt_projection) {
   return ol.proj.transform(coordinate,
-      goog.isDef(opt_projection) ? opt_projection : 'EPSG:3857', 'EPSG:4326');
+      opt_projection !== undefined ? opt_projection : 'EPSG:3857', 'EPSG:4326');
 };
 
 
@@ -726,7 +726,7 @@ ol.proj.getTransformFromProjections =
     transform = transforms[sourceCode][destinationCode];
   }
   if (transform === undefined) {
-    goog.asserts.assert(goog.isDef(transform), 'transform should be defined');
+    goog.asserts.assert(transform !== undefined, 'transform should be defined');
     transform = ol.proj.identityTransform;
   }
   return transform;
@@ -740,7 +740,7 @@ ol.proj.getTransformFromProjections =
  * @return {Array.<number>} Input coordinate array (same array as input).
  */
 ol.proj.identityTransform = function(input, opt_output, opt_dimension) {
-  if (goog.isDef(opt_output) && input !== opt_output) {
+  if (opt_output !== undefined && input !== opt_output) {
     // TODO: consider making this a warning instead
     goog.asserts.fail('This should not be used internally.');
     for (var i = 0, ii = input.length; i < ii; ++i) {

--- a/src/ol/render/canvas/canvasimmediate.js
+++ b/src/ol/render/canvas/canvasimmediate.js
@@ -494,7 +494,7 @@ ol.render.canvas.Immediate.prototype.drawFeature = function(feature, style) {
     render.setTextStyle(style.getText());
     var renderGeometry =
         ol.render.canvas.Immediate.GEOMETRY_RENDERERS_[geometry.getType()];
-    goog.asserts.assert(goog.isDef(renderGeometry),
+    goog.asserts.assert(renderGeometry !== undefined,
         'renderGeometry should be defined');
     renderGeometry.call(render, geometry, null);
   });
@@ -517,7 +517,7 @@ ol.render.canvas.Immediate.prototype.drawGeometryCollectionGeometry =
     var geometry = geometries[i];
     var geometryRenderer =
         ol.render.canvas.Immediate.GEOMETRY_RENDERERS_[geometry.getType()];
-    goog.asserts.assert(goog.isDef(geometryRenderer),
+    goog.asserts.assert(geometryRenderer !== undefined,
         'geometryRenderer should be defined');
     geometryRenderer.call(this, geometry, feature);
   }
@@ -872,15 +872,15 @@ ol.render.canvas.Immediate.prototype.setFillStrokeStyle =
     var strokeStyleWidth = strokeStyle.getWidth();
     var strokeStyleMiterLimit = strokeStyle.getMiterLimit();
     this.strokeState_ = {
-      lineCap: goog.isDef(strokeStyleLineCap) ?
+      lineCap: strokeStyleLineCap !== undefined ?
           strokeStyleLineCap : ol.render.canvas.defaultLineCap,
       lineDash: goog.isDefAndNotNull(strokeStyleLineDash) ?
           strokeStyleLineDash : ol.render.canvas.defaultLineDash,
-      lineJoin: goog.isDef(strokeStyleLineJoin) ?
+      lineJoin: strokeStyleLineJoin !== undefined ?
           strokeStyleLineJoin : ol.render.canvas.defaultLineJoin,
-      lineWidth: this.pixelRatio_ * (goog.isDef(strokeStyleWidth) ?
+      lineWidth: this.pixelRatio_ * (strokeStyleWidth !== undefined ?
           strokeStyleWidth : ol.render.canvas.defaultLineWidth),
-      miterLimit: goog.isDef(strokeStyleMiterLimit) ?
+      miterLimit: strokeStyleMiterLimit !== undefined ?
           strokeStyleMiterLimit : ol.render.canvas.defaultMiterLimit,
       strokeStyle: ol.color.asString(!goog.isNull(strokeStyleColor) ?
           strokeStyleColor : ol.render.canvas.defaultStrokeStyle)
@@ -961,15 +961,15 @@ ol.render.canvas.Immediate.prototype.setTextStyle = function(textStyle) {
       var textStrokeStyleWidth = textStrokeStyle.getWidth();
       var textStrokeStyleMiterLimit = textStrokeStyle.getMiterLimit();
       this.textStrokeState_ = {
-        lineCap: goog.isDef(textStrokeStyleLineCap) ?
+        lineCap: textStrokeStyleLineCap !== undefined ?
             textStrokeStyleLineCap : ol.render.canvas.defaultLineCap,
         lineDash: goog.isDefAndNotNull(textStrokeStyleLineDash) ?
             textStrokeStyleLineDash : ol.render.canvas.defaultLineDash,
-        lineJoin: goog.isDef(textStrokeStyleLineJoin) ?
+        lineJoin: textStrokeStyleLineJoin !== undefined ?
             textStrokeStyleLineJoin : ol.render.canvas.defaultLineJoin,
-        lineWidth: goog.isDef(textStrokeStyleWidth) ?
+        lineWidth: textStrokeStyleWidth !== undefined ?
             textStrokeStyleWidth : ol.render.canvas.defaultLineWidth,
-        miterLimit: goog.isDef(textStrokeStyleMiterLimit) ?
+        miterLimit: textStrokeStyleMiterLimit !== undefined ?
             textStrokeStyleMiterLimit : ol.render.canvas.defaultMiterLimit,
         strokeStyle: ol.color.asString(!goog.isNull(textStrokeStyleColor) ?
             textStrokeStyleColor : ol.render.canvas.defaultStrokeStyle)
@@ -984,20 +984,20 @@ ol.render.canvas.Immediate.prototype.setTextStyle = function(textStyle) {
     var textTextAlign = textStyle.getTextAlign();
     var textTextBaseline = textStyle.getTextBaseline();
     this.textState_ = {
-      font: goog.isDef(textFont) ?
+      font: textFont !== undefined ?
           textFont : ol.render.canvas.defaultFont,
-      textAlign: goog.isDef(textTextAlign) ?
+      textAlign: textTextAlign !== undefined ?
           textTextAlign : ol.render.canvas.defaultTextAlign,
-      textBaseline: goog.isDef(textTextBaseline) ?
+      textBaseline: textTextBaseline !== undefined ?
           textTextBaseline : ol.render.canvas.defaultTextBaseline
     };
-    this.text_ = goog.isDef(textText) ? textText : '';
+    this.text_ = textText !== undefined ? textText : '';
     this.textOffsetX_ =
-        goog.isDef(textOffsetX) ? (this.pixelRatio_ * textOffsetX) : 0;
+        textOffsetX !== undefined ? (this.pixelRatio_ * textOffsetX) : 0;
     this.textOffsetY_ =
-        goog.isDef(textOffsetY) ? (this.pixelRatio_ * textOffsetY) : 0;
-    this.textRotation_ = goog.isDef(textRotation) ? textRotation : 0;
-    this.textScale_ = this.pixelRatio_ * (goog.isDef(textScale) ?
+        textOffsetY !== undefined ? (this.pixelRatio_ * textOffsetY) : 0;
+    this.textRotation_ = textRotation !== undefined ? textRotation : 0;
+    this.textScale_ = this.pixelRatio_ * (textScale !== undefined ?
         textScale : 1);
   }
 };

--- a/src/ol/render/canvas/canvasimmediate.js
+++ b/src/ol/render/canvas/canvasimmediate.js
@@ -485,7 +485,7 @@ ol.render.canvas.Immediate.prototype.drawFeature = function(feature, style) {
     return;
   }
   var zIndex = style.getZIndex();
-  if (!goog.isDef(zIndex)) {
+  if (zIndex === undefined) {
     zIndex = 0;
   }
   this.drawAsync(zIndex, function(render) {

--- a/src/ol/render/canvas/canvasimmediate.js
+++ b/src/ol/render/canvas/canvasimmediate.js
@@ -417,7 +417,7 @@ ol.render.canvas.Immediate.prototype.drawRings_ =
 ol.render.canvas.Immediate.prototype.drawAsync = function(zIndex, callback) {
   var zIndexKey = zIndex.toString();
   var callbacks = this.callbacksByZIndex_[zIndexKey];
-  if (goog.isDef(callbacks)) {
+  if (callbacks !== undefined) {
     callbacks.push(callback);
   } else {
     this.callbacksByZIndex_[zIndexKey] = [callback];

--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -257,11 +257,12 @@ ol.render.canvas.Replay.prototype.replay_ = function(
       case ol.render.canvas.Instruction.BEGIN_GEOMETRY:
         feature = /** @type {ol.Feature} */ (instruction[1]);
         var featureUid = goog.getUid(feature).toString();
-        if (goog.isDef(skippedFeaturesHash[featureUid]) ||
+        if (skippedFeaturesHash[featureUid] !== undefined ||
             !goog.isDefAndNotNull(feature.getGeometry())) {
           i = /** @type {number} */ (instruction[2]);
         } else if (opt_hitExtent !== undefined && !ol.extent.intersects(
-            opt_hitExtent, feature.getGeometry().getExtent())) {
+            /** @type {Array<number>} */ (opt_hitExtent),
+            feature.getGeometry().getExtent())) {
           i = /** @type {number} */ (instruction[2]);
         } else {
           ++i;
@@ -451,7 +452,8 @@ ol.render.canvas.Replay.prototype.replay_ = function(
             '6th instruction should be a number');
         goog.asserts.assert(!goog.isNull(instruction[6]),
             '7th instruction should not be null');
-        var usePixelRatio = goog.isDef(instruction[7]) ? instruction[7] : true;
+        var usePixelRatio = instruction[7] !== undefined ?
+            instruction[7] : true;
         var lineWidth = /** @type {number} */ (instruction[2]);
         context.strokeStyle = /** @type {string} */ (instruction[1]);
         context.lineWidth = usePixelRatio ? lineWidth * pixelRatio : lineWidth;

--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -260,7 +260,7 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         if (goog.isDef(skippedFeaturesHash[featureUid]) ||
             !goog.isDefAndNotNull(feature.getGeometry())) {
           i = /** @type {number} */ (instruction[2]);
-        } else if (goog.isDef(opt_hitExtent) && !ol.extent.intersects(
+        } else if (opt_hitExtent !== undefined && !ol.extent.intersects(
             opt_hitExtent, feature.getGeometry().getExtent())) {
           i = /** @type {number} */ (instruction[2]);
         } else {
@@ -966,13 +966,13 @@ ol.render.canvas.LineStringReplay.prototype.setStrokeStyle_ = function() {
   var lineJoin = state.lineJoin;
   var lineWidth = state.lineWidth;
   var miterLimit = state.miterLimit;
-  goog.asserts.assert(goog.isDef(strokeStyle),
+  goog.asserts.assert(strokeStyle !== undefined,
       'strokeStyle should be defined');
-  goog.asserts.assert(goog.isDef(lineCap), 'lineCap should be defined');
+  goog.asserts.assert(lineCap !== undefined, 'lineCap should be defined');
   goog.asserts.assert(!goog.isNull(lineDash), 'lineDash should not be null');
-  goog.asserts.assert(goog.isDef(lineJoin), 'lineJoin should be defined');
-  goog.asserts.assert(goog.isDef(lineWidth), 'lineWidth should be defined');
-  goog.asserts.assert(goog.isDef(miterLimit), 'miterLimit should be defined');
+  goog.asserts.assert(lineJoin !== undefined, 'lineJoin should be defined');
+  goog.asserts.assert(lineWidth !== undefined, 'lineWidth should be defined');
+  goog.asserts.assert(miterLimit !== undefined, 'miterLimit should be defined');
   if (state.currentStrokeStyle != strokeStyle ||
       state.currentLineCap != lineCap ||
       !goog.array.equals(state.currentLineDash, lineDash) ||
@@ -1087,19 +1087,19 @@ ol.render.canvas.LineStringReplay.prototype.setFillStrokeStyle =
   this.state_.strokeStyle = ol.color.asString(!goog.isNull(strokeStyleColor) ?
       strokeStyleColor : ol.render.canvas.defaultStrokeStyle);
   var strokeStyleLineCap = strokeStyle.getLineCap();
-  this.state_.lineCap = goog.isDef(strokeStyleLineCap) ?
+  this.state_.lineCap = strokeStyleLineCap !== undefined ?
       strokeStyleLineCap : ol.render.canvas.defaultLineCap;
   var strokeStyleLineDash = strokeStyle.getLineDash();
   this.state_.lineDash = !goog.isNull(strokeStyleLineDash) ?
       strokeStyleLineDash : ol.render.canvas.defaultLineDash;
   var strokeStyleLineJoin = strokeStyle.getLineJoin();
-  this.state_.lineJoin = goog.isDef(strokeStyleLineJoin) ?
+  this.state_.lineJoin = strokeStyleLineJoin !== undefined ?
       strokeStyleLineJoin : ol.render.canvas.defaultLineJoin;
   var strokeStyleWidth = strokeStyle.getWidth();
-  this.state_.lineWidth = goog.isDef(strokeStyleWidth) ?
+  this.state_.lineWidth = strokeStyleWidth !== undefined ?
       strokeStyleWidth : ol.render.canvas.defaultLineWidth;
   var strokeStyleMiterLimit = strokeStyle.getMiterLimit();
-  this.state_.miterLimit = goog.isDef(strokeStyleMiterLimit) ?
+  this.state_.miterLimit = strokeStyleMiterLimit !== undefined ?
       strokeStyleMiterLimit : ol.render.canvas.defaultMiterLimit;
 
   if (this.state_.lineWidth > this.maxLineWidth) {
@@ -1398,19 +1398,19 @@ ol.render.canvas.PolygonReplay.prototype.setFillStrokeStyle =
     state.strokeStyle = ol.color.asString(!goog.isNull(strokeStyleColor) ?
         strokeStyleColor : ol.render.canvas.defaultStrokeStyle);
     var strokeStyleLineCap = strokeStyle.getLineCap();
-    state.lineCap = goog.isDef(strokeStyleLineCap) ?
+    state.lineCap = strokeStyleLineCap !== undefined ?
         strokeStyleLineCap : ol.render.canvas.defaultLineCap;
     var strokeStyleLineDash = strokeStyle.getLineDash();
     state.lineDash = !goog.isNull(strokeStyleLineDash) ?
         strokeStyleLineDash.slice() : ol.render.canvas.defaultLineDash;
     var strokeStyleLineJoin = strokeStyle.getLineJoin();
-    state.lineJoin = goog.isDef(strokeStyleLineJoin) ?
+    state.lineJoin = strokeStyleLineJoin !== undefined ?
         strokeStyleLineJoin : ol.render.canvas.defaultLineJoin;
     var strokeStyleWidth = strokeStyle.getWidth();
-    state.lineWidth = goog.isDef(strokeStyleWidth) ?
+    state.lineWidth = strokeStyleWidth !== undefined ?
         strokeStyleWidth : ol.render.canvas.defaultLineWidth;
     var strokeStyleMiterLimit = strokeStyle.getMiterLimit();
-    state.miterLimit = goog.isDef(strokeStyleMiterLimit) ?
+    state.miterLimit = strokeStyleMiterLimit !== undefined ?
         strokeStyleMiterLimit : ol.render.canvas.defaultMiterLimit;
 
     if (state.lineWidth > this.maxLineWidth) {
@@ -1441,17 +1441,18 @@ ol.render.canvas.PolygonReplay.prototype.setFillStrokeStyles_ = function() {
   var lineJoin = state.lineJoin;
   var lineWidth = state.lineWidth;
   var miterLimit = state.miterLimit;
-  if (goog.isDef(fillStyle) && state.currentFillStyle != fillStyle) {
+  if (fillStyle !== undefined && state.currentFillStyle != fillStyle) {
     this.instructions.push(
         [ol.render.canvas.Instruction.SET_FILL_STYLE, fillStyle]);
     state.currentFillStyle = state.fillStyle;
   }
   if (strokeStyle !== undefined) {
-    goog.asserts.assert(goog.isDef(lineCap), 'lineCap should be defined');
+    goog.asserts.assert(lineCap !== undefined, 'lineCap should be defined');
     goog.asserts.assert(!goog.isNull(lineDash), 'lineDash should not be null');
-    goog.asserts.assert(goog.isDef(lineJoin), 'lineJoin should be defined');
-    goog.asserts.assert(goog.isDef(lineWidth), 'lineWidth should be defined');
-    goog.asserts.assert(goog.isDef(miterLimit), 'miterLimit should be defined');
+    goog.asserts.assert(lineJoin !== undefined, 'lineJoin should be defined');
+    goog.asserts.assert(lineWidth !== undefined, 'lineWidth should be defined');
+    goog.asserts.assert(miterLimit !== undefined,
+        'miterLimit should be defined');
     if (state.currentStrokeStyle != strokeStyle ||
         state.currentLineCap != lineCap ||
         state.currentLineDash != lineDash ||
@@ -1722,15 +1723,15 @@ ol.render.canvas.TextReplay.prototype.setTextStyle = function(textStyle) {
       var textStrokeStyleLineJoin = textStrokeStyle.getLineJoin();
       var textStrokeStyleWidth = textStrokeStyle.getWidth();
       var textStrokeStyleMiterLimit = textStrokeStyle.getMiterLimit();
-      var lineCap = goog.isDef(textStrokeStyleLineCap) ?
+      var lineCap = textStrokeStyleLineCap !== undefined ?
           textStrokeStyleLineCap : ol.render.canvas.defaultLineCap;
       var lineDash = goog.isDefAndNotNull(textStrokeStyleLineDash) ?
           textStrokeStyleLineDash.slice() : ol.render.canvas.defaultLineDash;
-      var lineJoin = goog.isDef(textStrokeStyleLineJoin) ?
+      var lineJoin = textStrokeStyleLineJoin !== undefined ?
           textStrokeStyleLineJoin : ol.render.canvas.defaultLineJoin;
-      var lineWidth = goog.isDef(textStrokeStyleWidth) ?
+      var lineWidth = textStrokeStyleWidth !== undefined ?
           textStrokeStyleWidth : ol.render.canvas.defaultLineWidth;
-      var miterLimit = goog.isDef(textStrokeStyleMiterLimit) ?
+      var miterLimit = textStrokeStyleMiterLimit !== undefined ?
           textStrokeStyleMiterLimit : ol.render.canvas.defaultMiterLimit;
       var strokeStyle = ol.color.asString(!goog.isNull(textStrokeStyleColor) ?
           textStrokeStyleColor : ol.render.canvas.defaultStrokeStyle);
@@ -1761,11 +1762,11 @@ ol.render.canvas.TextReplay.prototype.setTextStyle = function(textStyle) {
     var textText = textStyle.getText();
     var textTextAlign = textStyle.getTextAlign();
     var textTextBaseline = textStyle.getTextBaseline();
-    var font = goog.isDef(textFont) ?
+    var font = textFont !== undefined ?
         textFont : ol.render.canvas.defaultFont;
-    var textAlign = goog.isDef(textTextAlign) ?
+    var textAlign = textTextAlign !== undefined ?
         textTextAlign : ol.render.canvas.defaultTextAlign;
-    var textBaseline = goog.isDef(textTextBaseline) ?
+    var textBaseline = textTextBaseline !== undefined ?
         textTextBaseline : ol.render.canvas.defaultTextBaseline;
     if (goog.isNull(this.textState_)) {
       this.textState_ = {
@@ -1779,11 +1780,11 @@ ol.render.canvas.TextReplay.prototype.setTextStyle = function(textStyle) {
       textState.textAlign = textAlign;
       textState.textBaseline = textBaseline;
     }
-    this.text_ = goog.isDef(textText) ? textText : '';
-    this.textOffsetX_ = goog.isDef(textOffsetX) ? textOffsetX : 0;
-    this.textOffsetY_ = goog.isDef(textOffsetY) ? textOffsetY : 0;
-    this.textRotation_ = goog.isDef(textRotation) ? textRotation : 0;
-    this.textScale_ = goog.isDef(textScale) ? textScale : 1;
+    this.text_ = textText !== undefined ? textText : '';
+    this.textOffsetX_ = textOffsetX !== undefined ? textOffsetX : 0;
+    this.textOffsetY_ = textOffsetY !== undefined ? textOffsetY : 0;
+    this.textRotation_ = textRotation !== undefined ? textRotation : 0;
+    this.textScale_ = textScale !== undefined ? textScale : 1;
   }
 };
 
@@ -1917,7 +1918,7 @@ ol.render.canvas.ReplayGroup.prototype.forEachFeatureAtCoordinate = function(
  */
 ol.render.canvas.ReplayGroup.prototype.getReplay =
     function(zIndex, replayType) {
-  var zIndexKey = goog.isDef(zIndex) ? zIndex.toString() : '0';
+  var zIndexKey = zIndex !== undefined ? zIndex.toString() : '0';
   var replays = this.replaysByZIndex_[zIndexKey];
   if (replays === undefined) {
     replays = {};
@@ -1926,7 +1927,7 @@ ol.render.canvas.ReplayGroup.prototype.getReplay =
   var replay = replays[replayType];
   if (replay === undefined) {
     var Constructor = ol.render.canvas.BATCH_CONSTRUCTORS_[replayType];
-    goog.asserts.assert(goog.isDef(Constructor),
+    goog.asserts.assert(Constructor !== undefined,
         replayType +
         ' constructor missing from ol.render.canvas.BATCH_CONSTRUCTORS_');
     replay = new Constructor(this.tolerance_, this.maxExtent_,

--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -716,25 +716,25 @@ ol.render.canvas.ImageReplay.prototype.drawPointGeometry =
   if (goog.isNull(this.image_)) {
     return;
   }
-  goog.asserts.assert(goog.isDef(this.anchorX_),
+  goog.asserts.assert(this.anchorX_ !== undefined,
       'this.anchorX_ should be defined');
-  goog.asserts.assert(goog.isDef(this.anchorY_),
+  goog.asserts.assert(this.anchorY_ !== undefined,
       'this.anchorY_ should be defined');
-  goog.asserts.assert(goog.isDef(this.height_),
+  goog.asserts.assert(this.height_ !== undefined,
       'this.height_ should be defined');
-  goog.asserts.assert(goog.isDef(this.opacity_),
+  goog.asserts.assert(this.opacity_ !== undefined,
       'this.opacity_ should be defined');
-  goog.asserts.assert(goog.isDef(this.originX_),
+  goog.asserts.assert(this.originX_ !== undefined,
       'this.originX_ should be defined');
-  goog.asserts.assert(goog.isDef(this.originY_),
+  goog.asserts.assert(this.originY_ !== undefined,
       'this.originY_ should be defined');
-  goog.asserts.assert(goog.isDef(this.rotateWithView_),
+  goog.asserts.assert(this.rotateWithView_ !== undefined,
       'this.rotateWithView_ should be defined');
-  goog.asserts.assert(goog.isDef(this.rotation_),
+  goog.asserts.assert(this.rotation_ !== undefined,
       'this.rotation_ should be defined');
-  goog.asserts.assert(goog.isDef(this.scale_),
+  goog.asserts.assert(this.scale_ !== undefined,
       'this.scale_ should be defined');
-  goog.asserts.assert(goog.isDef(this.width_),
+  goog.asserts.assert(this.width_ !== undefined,
       'this.width_ should be defined');
   this.beginGeometry(pointGeometry, feature);
   var flatCoordinates = pointGeometry.getFlatCoordinates();
@@ -769,25 +769,25 @@ ol.render.canvas.ImageReplay.prototype.drawMultiPointGeometry =
   if (goog.isNull(this.image_)) {
     return;
   }
-  goog.asserts.assert(goog.isDef(this.anchorX_),
+  goog.asserts.assert(this.anchorX_ !== undefined,
       'this.anchorX_ should be defined');
-  goog.asserts.assert(goog.isDef(this.anchorY_),
+  goog.asserts.assert(this.anchorY_ !== undefined,
       'this.anchorY_ should be defined');
-  goog.asserts.assert(goog.isDef(this.height_),
+  goog.asserts.assert(this.height_ !== undefined,
       'this.height_ should be defined');
-  goog.asserts.assert(goog.isDef(this.opacity_),
+  goog.asserts.assert(this.opacity_ !== undefined,
       'this.opacity_ should be defined');
-  goog.asserts.assert(goog.isDef(this.originX_),
+  goog.asserts.assert(this.originX_ !== undefined,
       'this.originX_ should be defined');
-  goog.asserts.assert(goog.isDef(this.originY_),
+  goog.asserts.assert(this.originY_ !== undefined,
       'this.originY_ should be defined');
-  goog.asserts.assert(goog.isDef(this.rotateWithView_),
+  goog.asserts.assert(this.rotateWithView_ !== undefined,
       'this.rotateWithView_ should be defined');
-  goog.asserts.assert(goog.isDef(this.rotation_),
+  goog.asserts.assert(this.rotation_ !== undefined,
       'this.rotation_ should be defined');
-  goog.asserts.assert(goog.isDef(this.scale_),
+  goog.asserts.assert(this.scale_ !== undefined,
       'this.scale_ should be defined');
-  goog.asserts.assert(goog.isDef(this.width_),
+  goog.asserts.assert(this.width_ !== undefined,
       'this.width_ should be defined');
   this.beginGeometry(multiPointGeometry, feature);
   var flatCoordinates = multiPointGeometry.getFlatCoordinates();
@@ -1198,7 +1198,7 @@ ol.render.canvas.PolygonReplay.prototype.drawFlatCoordinatess_ =
     this.instructions.push(fillInstruction);
   }
   if (state.strokeStyle !== undefined) {
-    goog.asserts.assert(goog.isDef(state.lineWidth),
+    goog.asserts.assert(state.lineWidth !== undefined,
         'state.lineWidth should be defined');
     var strokeInstruction = [ol.render.canvas.Instruction.STROKE];
     this.instructions.push(strokeInstruction);
@@ -1221,7 +1221,7 @@ ol.render.canvas.PolygonReplay.prototype.drawCircleGeometry =
     return;
   }
   if (strokeStyle !== undefined) {
-    goog.asserts.assert(goog.isDef(state.lineWidth),
+    goog.asserts.assert(state.lineWidth !== undefined,
         'state.lineWidth should be defined');
   }
   this.setFillStrokeStyles_();
@@ -1251,7 +1251,7 @@ ol.render.canvas.PolygonReplay.prototype.drawCircleGeometry =
     this.instructions.push(fillInstruction);
   }
   if (state.strokeStyle !== undefined) {
-    goog.asserts.assert(goog.isDef(state.lineWidth),
+    goog.asserts.assert(state.lineWidth !== undefined,
         'state.lineWidth should be defined');
     var strokeInstruction = [ol.render.canvas.Instruction.STROKE];
     this.instructions.push(strokeInstruction);
@@ -1274,7 +1274,7 @@ ol.render.canvas.PolygonReplay.prototype.drawPolygonGeometry =
     return;
   }
   if (strokeStyle !== undefined) {
-    goog.asserts.assert(goog.isDef(state.lineWidth),
+    goog.asserts.assert(state.lineWidth !== undefined,
         'state.lineWidth should be defined');
   }
   this.setFillStrokeStyles_();
@@ -1310,7 +1310,7 @@ ol.render.canvas.PolygonReplay.prototype.drawMultiPolygonGeometry =
     return;
   }
   if (strokeStyle !== undefined) {
-    goog.asserts.assert(goog.isDef(state.lineWidth),
+    goog.asserts.assert(state.lineWidth !== undefined,
         'state.lineWidth should be defined');
   }
   this.setFillStrokeStyles_();

--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -406,7 +406,7 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         ++i;
         break;
       case ol.render.canvas.Instruction.END_GEOMETRY:
-        if (goog.isDef(featureCallback)) {
+        if (featureCallback !== undefined) {
           feature = /** @type {ol.Feature} */ (instruction[1]);
           var result = featureCallback(feature);
           if (result) {
@@ -1220,7 +1220,7 @@ ol.render.canvas.PolygonReplay.prototype.drawCircleGeometry =
   if (!goog.isDef(fillStyle) && !goog.isDef(strokeStyle)) {
     return;
   }
-  if (goog.isDef(strokeStyle)) {
+  if (strokeStyle !== undefined) {
     goog.asserts.assert(goog.isDef(state.lineWidth),
         'state.lineWidth should be defined');
   }
@@ -1273,7 +1273,7 @@ ol.render.canvas.PolygonReplay.prototype.drawPolygonGeometry =
   if (!goog.isDef(fillStyle) && !goog.isDef(strokeStyle)) {
     return;
   }
-  if (goog.isDef(strokeStyle)) {
+  if (strokeStyle !== undefined) {
     goog.asserts.assert(goog.isDef(state.lineWidth),
         'state.lineWidth should be defined');
   }
@@ -1309,7 +1309,7 @@ ol.render.canvas.PolygonReplay.prototype.drawMultiPolygonGeometry =
   if (!goog.isDef(fillStyle) && !goog.isDef(strokeStyle)) {
     return;
   }
-  if (goog.isDef(strokeStyle)) {
+  if (strokeStyle !== undefined) {
     goog.asserts.assert(goog.isDef(state.lineWidth),
         'state.lineWidth should be defined');
   }
@@ -1446,7 +1446,7 @@ ol.render.canvas.PolygonReplay.prototype.setFillStrokeStyles_ = function() {
         [ol.render.canvas.Instruction.SET_FILL_STYLE, fillStyle]);
     state.currentFillStyle = state.fillStyle;
   }
-  if (goog.isDef(strokeStyle)) {
+  if (strokeStyle !== undefined) {
     goog.asserts.assert(goog.isDef(lineCap), 'lineCap should be defined');
     goog.asserts.assert(!goog.isNull(lineDash), 'lineDash should not be null');
     goog.asserts.assert(goog.isDef(lineJoin), 'lineJoin should be defined');
@@ -1984,7 +1984,7 @@ ol.render.canvas.ReplayGroup.prototype.replay = function(
     replays = this.replaysByZIndex_[zs[i].toString()];
     for (j = 0, jj = ol.render.REPLAY_ORDER.length; j < jj; ++j) {
       replay = replays[ol.render.REPLAY_ORDER[j]];
-      if (goog.isDef(replay)) {
+      if (replay !== undefined) {
         replay.replay(context, pixelRatio, transform, viewRotation,
             skippedFeaturesHash);
       }
@@ -2020,7 +2020,7 @@ ol.render.canvas.ReplayGroup.prototype.replayHitDetection_ = function(
     replays = this.replaysByZIndex_[zs[i].toString()];
     for (j = ol.render.REPLAY_ORDER.length - 1; j >= 0; --j) {
       replay = replays[ol.render.REPLAY_ORDER[j]];
-      if (goog.isDef(replay)) {
+      if (replay !== undefined) {
         result = replay.replayHitDetection(context, transform, viewRotation,
             skippedFeaturesHash, featureCallback, opt_hitExtent);
         if (result) {

--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -1194,10 +1194,10 @@ ol.render.canvas.PolygonReplay.prototype.drawFlatCoordinatess_ =
   // FIXME or all polygons together?
   var fillInstruction = [ol.render.canvas.Instruction.FILL];
   this.hitDetectionInstructions.push(fillInstruction);
-  if (goog.isDef(state.fillStyle)) {
+  if (state.fillStyle !== undefined) {
     this.instructions.push(fillInstruction);
   }
-  if (goog.isDef(state.strokeStyle)) {
+  if (state.strokeStyle !== undefined) {
     goog.asserts.assert(goog.isDef(state.lineWidth),
         'state.lineWidth should be defined');
     var strokeInstruction = [ol.render.canvas.Instruction.STROKE];
@@ -1230,7 +1230,7 @@ ol.render.canvas.PolygonReplay.prototype.drawCircleGeometry =
   this.hitDetectionInstructions.push(
       [ol.render.canvas.Instruction.SET_FILL_STYLE,
        ol.color.asString(ol.render.canvas.defaultFillStyle)]);
-  if (goog.isDef(state.strokeStyle)) {
+  if (state.strokeStyle !== undefined) {
     this.hitDetectionInstructions.push(
         [ol.render.canvas.Instruction.SET_STROKE_STYLE,
          state.strokeStyle, state.lineWidth, state.lineCap, state.lineJoin,
@@ -1247,10 +1247,10 @@ ol.render.canvas.PolygonReplay.prototype.drawCircleGeometry =
   this.hitDetectionInstructions.push(beginPathInstruction, circleInstruction);
   var fillInstruction = [ol.render.canvas.Instruction.FILL];
   this.hitDetectionInstructions.push(fillInstruction);
-  if (goog.isDef(state.fillStyle)) {
+  if (state.fillStyle !== undefined) {
     this.instructions.push(fillInstruction);
   }
-  if (goog.isDef(state.strokeStyle)) {
+  if (state.strokeStyle !== undefined) {
     goog.asserts.assert(goog.isDef(state.lineWidth),
         'state.lineWidth should be defined');
     var strokeInstruction = [ol.render.canvas.Instruction.STROKE];
@@ -1283,7 +1283,7 @@ ol.render.canvas.PolygonReplay.prototype.drawPolygonGeometry =
   this.hitDetectionInstructions.push(
       [ol.render.canvas.Instruction.SET_FILL_STYLE,
        ol.color.asString(ol.render.canvas.defaultFillStyle)]);
-  if (goog.isDef(state.strokeStyle)) {
+  if (state.strokeStyle !== undefined) {
     this.hitDetectionInstructions.push(
         [ol.render.canvas.Instruction.SET_STROKE_STYLE,
          state.strokeStyle, state.lineWidth, state.lineCap, state.lineJoin,
@@ -1319,7 +1319,7 @@ ol.render.canvas.PolygonReplay.prototype.drawMultiPolygonGeometry =
   this.hitDetectionInstructions.push(
       [ol.render.canvas.Instruction.SET_FILL_STYLE,
        ol.color.asString(ol.render.canvas.defaultFillStyle)]);
-  if (goog.isDef(state.strokeStyle)) {
+  if (state.strokeStyle !== undefined) {
     this.hitDetectionInstructions.push(
         [ol.render.canvas.Instruction.SET_STROKE_STYLE,
          state.strokeStyle, state.lineWidth, state.lineCap, state.lineJoin,
@@ -1887,7 +1887,7 @@ ol.render.canvas.ReplayGroup.prototype.forEachFeatureAtCoordinate = function(
    * @type {ol.Extent}
    */
   var hitExtent;
-  if (goog.isDef(this.renderBuffer_)) {
+  if (this.renderBuffer_ !== undefined) {
     hitExtent = ol.extent.createEmpty();
     ol.extent.extendCoordinate(hitExtent, coordinate);
     ol.extent.buffer(hitExtent, resolution * this.renderBuffer_, hitExtent);

--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -1007,7 +1007,7 @@ ol.render.canvas.LineStringReplay.prototype.drawLineStringGeometry =
   goog.asserts.assert(!goog.isNull(state), 'state should not be null');
   var strokeStyle = state.strokeStyle;
   var lineWidth = state.lineWidth;
-  if (!goog.isDef(strokeStyle) || !goog.isDef(lineWidth)) {
+  if (strokeStyle === undefined || lineWidth === undefined) {
     return;
   }
   this.setStrokeStyle_();
@@ -1035,7 +1035,7 @@ ol.render.canvas.LineStringReplay.prototype.drawMultiLineStringGeometry =
   goog.asserts.assert(!goog.isNull(state), 'state should not be null');
   var strokeStyle = state.strokeStyle;
   var lineWidth = state.lineWidth;
-  if (!goog.isDef(strokeStyle) || !goog.isDef(lineWidth)) {
+  if (strokeStyle === undefined || lineWidth === undefined) {
     return;
   }
   this.setStrokeStyle_();
@@ -1217,7 +1217,7 @@ ol.render.canvas.PolygonReplay.prototype.drawCircleGeometry =
   goog.asserts.assert(!goog.isNull(state), 'state should not be null');
   var fillStyle = state.fillStyle;
   var strokeStyle = state.strokeStyle;
-  if (!goog.isDef(fillStyle) && !goog.isDef(strokeStyle)) {
+  if (fillStyle === undefined && strokeStyle === undefined) {
     return;
   }
   if (strokeStyle !== undefined) {
@@ -1270,7 +1270,7 @@ ol.render.canvas.PolygonReplay.prototype.drawPolygonGeometry =
   goog.asserts.assert(!goog.isNull(state), 'state should not be null');
   var fillStyle = state.fillStyle;
   var strokeStyle = state.strokeStyle;
-  if (!goog.isDef(fillStyle) && !goog.isDef(strokeStyle)) {
+  if (fillStyle === undefined && strokeStyle === undefined) {
     return;
   }
   if (strokeStyle !== undefined) {
@@ -1306,7 +1306,7 @@ ol.render.canvas.PolygonReplay.prototype.drawMultiPolygonGeometry =
   goog.asserts.assert(!goog.isNull(state), 'state should not be null');
   var fillStyle = state.fillStyle;
   var strokeStyle = state.strokeStyle;
-  if (!goog.isDef(fillStyle) && !goog.isDef(strokeStyle)) {
+  if (fillStyle === undefined && strokeStyle === undefined) {
     return;
   }
   if (strokeStyle !== undefined) {

--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -1919,12 +1919,12 @@ ol.render.canvas.ReplayGroup.prototype.getReplay =
     function(zIndex, replayType) {
   var zIndexKey = goog.isDef(zIndex) ? zIndex.toString() : '0';
   var replays = this.replaysByZIndex_[zIndexKey];
-  if (!goog.isDef(replays)) {
+  if (replays === undefined) {
     replays = {};
     this.replaysByZIndex_[zIndexKey] = replays;
   }
   var replay = replays[replayType];
-  if (!goog.isDef(replay)) {
+  if (replay === undefined) {
     var Constructor = ol.render.canvas.BATCH_CONSTRUCTORS_[replayType];
     goog.asserts.assert(goog.isDef(Constructor),
         replayType +

--- a/src/ol/render/vector.js
+++ b/src/ol/render/vector.js
@@ -127,7 +127,7 @@ ol.renderer.vector.renderFeature_ = function(
   var simplifiedGeometry = geometry.getSimplifiedGeometry(squaredTolerance);
   var geometryRenderer =
       ol.renderer.vector.GEOMETRY_RENDERERS_[simplifiedGeometry.getType()];
-  goog.asserts.assert(goog.isDef(geometryRenderer),
+  goog.asserts.assert(geometryRenderer !== undefined,
       'geometryRenderer should be defined');
   geometryRenderer(replayGroup, simplifiedGeometry, style, feature);
 };
@@ -149,7 +149,7 @@ ol.renderer.vector.renderGeometryCollectionGeometry_ =
   for (i = 0, ii = geometries.length; i < ii; ++i) {
     var geometryRenderer =
         ol.renderer.vector.GEOMETRY_RENDERERS_[geometries[i].getType()];
-    goog.asserts.assert(goog.isDef(geometryRenderer),
+    goog.asserts.assert(geometryRenderer !== undefined,
         'geometryRenderer should be defined');
     geometryRenderer(replayGroup, geometries[i], style, feature);
   }

--- a/src/ol/render/webgl/webglimmediate.js
+++ b/src/ol/render/webgl/webglimmediate.js
@@ -131,7 +131,7 @@ ol.render.webgl.Immediate.prototype.drawFeature = function(feature, style) {
     return;
   }
   var zIndex = style.getZIndex();
-  if (!goog.isDef(zIndex)) {
+  if (zIndex === undefined) {
     zIndex = 0;
   }
   this.drawAsync(zIndex, function(render) {

--- a/src/ol/render/webgl/webglimmediate.js
+++ b/src/ol/render/webgl/webglimmediate.js
@@ -103,7 +103,7 @@ ol.render.webgl.Immediate.prototype.flush = function() {
 ol.render.webgl.Immediate.prototype.drawAsync = function(zIndex, callback) {
   var zIndexKey = zIndex.toString();
   var callbacks = this.callbacksByZIndex_[zIndexKey];
-  if (goog.isDef(callbacks)) {
+  if (callbacks !== undefined) {
     callbacks.push(callback);
   } else {
     this.callbacksByZIndex_[zIndexKey] = [callback];

--- a/src/ol/render/webgl/webglreplay.js
+++ b/src/ol/render/webgl/webglreplay.js
@@ -280,19 +280,20 @@ ol.render.webgl.ImageReplay.prototype.drawAsync = goog.abstractMethod;
  */
 ol.render.webgl.ImageReplay.prototype.drawCoordinates_ =
     function(flatCoordinates, offset, end, stride) {
-  goog.asserts.assert(goog.isDef(this.anchorX_), 'anchorX is defined');
-  goog.asserts.assert(goog.isDef(this.anchorY_), 'anchorY is defined');
-  goog.asserts.assert(goog.isDef(this.height_), 'height is defined');
-  goog.asserts.assert(goog.isDef(this.imageHeight_), 'imageHeight is defined');
-  goog.asserts.assert(goog.isDef(this.imageWidth_), 'imageWidth is defined');
-  goog.asserts.assert(goog.isDef(this.opacity_), 'opacity is defined');
-  goog.asserts.assert(goog.isDef(this.originX_), 'originX is defined');
-  goog.asserts.assert(goog.isDef(this.originY_), 'originY is defined');
-  goog.asserts.assert(goog.isDef(this.rotateWithView_),
+  goog.asserts.assert(this.anchorX_ !== undefined, 'anchorX is defined');
+  goog.asserts.assert(this.anchorY_ !== undefined, 'anchorY is defined');
+  goog.asserts.assert(this.height_ !== undefined, 'height is defined');
+  goog.asserts.assert(this.imageHeight_ !== undefined,
+      'imageHeight is defined');
+  goog.asserts.assert(this.imageWidth_ !== undefined, 'imageWidth is defined');
+  goog.asserts.assert(this.opacity_ !== undefined, 'opacity is defined');
+  goog.asserts.assert(this.originX_ !== undefined, 'originX is defined');
+  goog.asserts.assert(this.originY_ !== undefined, 'originY is defined');
+  goog.asserts.assert(this.rotateWithView_ !== undefined,
       'rotateWithView is defined');
-  goog.asserts.assert(goog.isDef(this.rotation_), 'rotation is defined');
-  goog.asserts.assert(goog.isDef(this.scale_), 'scale is defined');
-  goog.asserts.assert(goog.isDef(this.width_), 'width is defined');
+  goog.asserts.assert(this.rotation_ !== undefined, 'rotation is defined');
+  goog.asserts.assert(this.scale_ !== undefined, 'scale is defined');
+  goog.asserts.assert(this.width_ !== undefined, 'width is defined');
   var anchorX = this.anchorX_;
   var anchorY = this.anchorY_;
   var height = this.height_;

--- a/src/ol/render/webgl/webglreplay.js
+++ b/src/ol/render/webgl/webglreplay.js
@@ -914,13 +914,13 @@ ol.render.webgl.ImageReplay.prototype.setImageStyle = function(imageStyle) {
       'imageStyle hitDetectionImage is not null');
   goog.asserts.assert(!goog.isNull(hitDetectionImageSize),
       'imageStyle hitDetectionImageSize is not null');
-  goog.asserts.assert(goog.isDef(opacity), 'imageStyle opacity is defined');
+  goog.asserts.assert(opacity !== undefined, 'imageStyle opacity is defined');
   goog.asserts.assert(!goog.isNull(origin), 'imageStyle origin is not null');
-  goog.asserts.assert(goog.isDef(rotateWithView),
+  goog.asserts.assert(rotateWithView !== undefined,
       'imageStyle rotateWithView is defined');
-  goog.asserts.assert(goog.isDef(rotation), 'imageStyle rotation is defined');
+  goog.asserts.assert(rotation !== undefined, 'imageStyle rotation is defined');
   goog.asserts.assert(!goog.isNull(size), 'imageStyle size is not null');
-  goog.asserts.assert(goog.isDef(scale), 'imageStyle scale is defined');
+  goog.asserts.assert(scale !== undefined, 'imageStyle scale is defined');
 
   var currentImage;
   if (this.images_.length === 0) {
@@ -1039,7 +1039,7 @@ ol.render.webgl.ReplayGroup.prototype.getReplay =
   var replay = this.replays_[replayType];
   if (replay === undefined) {
     var constructor = ol.render.webgl.BATCH_CONSTRUCTORS_[replayType];
-    goog.asserts.assert(goog.isDef(constructor),
+    goog.asserts.assert(constructor !== undefined,
         replayType +
         ' constructor missing from ol.render.webgl.BATCH_CONSTRUCTORS_');
     replay = new constructor(this.tolerance_, this.maxExtent_);
@@ -1231,7 +1231,7 @@ ol.render.webgl.ReplayGroup.prototype.hasFeatureAtCoordinate = function(
         return imageData[3] > 0;
       }, false);
 
-  return goog.isDef(hasFeature);
+  return hasFeature !== undefined;
 };
 
 

--- a/src/ol/render/webgl/webglreplay.js
+++ b/src/ol/render/webgl/webglreplay.js
@@ -733,7 +733,7 @@ ol.render.webgl.ImageReplay.prototype.drawReplaySkipping_ =
       var feature = this.startIndicesFeature_[featureIndex];
 
       var featureUid = goog.getUid(feature).toString();
-      if (goog.isDef(skippedFeaturesHash[featureUid])) {
+      if (skippedFeaturesHash[featureUid] !== undefined) {
         // feature should be skipped
         if (start !== end) {
           // draw the features so far
@@ -865,10 +865,11 @@ ol.render.webgl.ImageReplay.prototype.drawHitDetectionReplayOneByOne_ =
       feature = this.startIndicesFeature_[featureIndex];
       featureUid = goog.getUid(feature).toString();
 
-      if (!goog.isDef(skippedFeaturesHash[featureUid]) &&
+      if (skippedFeaturesHash[featureUid] === undefined &&
           goog.isDefAndNotNull(feature.getGeometry()) &&
           (opt_hitExtent === undefined || ol.extent.intersects(
-              opt_hitExtent, feature.getGeometry().getExtent()))) {
+              /** @type {Array<number>} */ (opt_hitExtent),
+              feature.getGeometry().getExtent()))) {
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
         this.drawElements_(gl, start, end, elementType, elementSize);
 

--- a/src/ol/render/webgl/webglreplay.js
+++ b/src/ol/render/webgl/webglreplay.js
@@ -1078,7 +1078,7 @@ ol.render.webgl.ReplayGroup.prototype.replay = function(context,
   var i, ii, replay, result;
   for (i = 0, ii = ol.render.REPLAY_ORDER.length; i < ii; ++i) {
     replay = this.replays_[ol.render.REPLAY_ORDER[i]];
-    if (goog.isDef(replay)) {
+    if (replay !== undefined) {
       replay.replay(context,
           center, resolution, rotation, size, pixelRatio,
           opacity, brightness, contrast, hue, saturation, skippedFeaturesHash,
@@ -1117,7 +1117,7 @@ ol.render.webgl.ReplayGroup.prototype.replayHitDetection_ = function(context,
   var i, replay, result;
   for (i = ol.render.REPLAY_ORDER.length - 1; i >= 0; --i) {
     replay = this.replays_[ol.render.REPLAY_ORDER[i]];
-    if (goog.isDef(replay)) {
+    if (replay !== undefined) {
       result = replay.replay(context,
           center, resolution, rotation, size, pixelRatio,
           opacity, brightness, contrast, hue, saturation,

--- a/src/ol/render/webgl/webglreplay.js
+++ b/src/ol/render/webgl/webglreplay.js
@@ -634,7 +634,7 @@ ol.render.webgl.ImageReplay.prototype.replay = function(context,
 
   // draw!
   var result;
-  if (!goog.isDef(featureCallback)) {
+  if (featureCallback === undefined) {
     this.drawReplay_(gl, context, skippedFeaturesHash,
         this.textures_, this.groupIndices_);
   } else {
@@ -1037,7 +1037,7 @@ ol.render.webgl.ReplayGroup.prototype.finish = function(context) {
 ol.render.webgl.ReplayGroup.prototype.getReplay =
     function(zIndex, replayType) {
   var replay = this.replays_[replayType];
-  if (!goog.isDef(replay)) {
+  if (replay === undefined) {
     var constructor = ol.render.webgl.BATCH_CONSTRUCTORS_[replayType];
     goog.asserts.assert(goog.isDef(constructor),
         replayType +

--- a/src/ol/render/webgl/webglreplay.js
+++ b/src/ol/render/webgl/webglreplay.js
@@ -866,7 +866,7 @@ ol.render.webgl.ImageReplay.prototype.drawHitDetectionReplayOneByOne_ =
 
       if (!goog.isDef(skippedFeaturesHash[featureUid]) &&
           goog.isDefAndNotNull(feature.getGeometry()) &&
-          (!goog.isDef(opt_hitExtent) || ol.extent.intersects(
+          (opt_hitExtent === undefined || ol.extent.intersects(
               opt_hitExtent, feature.getGeometry().getExtent()))) {
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
         this.drawElements_(gl, start, end, elementType, elementSize);

--- a/src/ol/render/webgl/webglreplay.js
+++ b/src/ol/render/webgl/webglreplay.js
@@ -1163,7 +1163,7 @@ ol.render.webgl.ReplayGroup.prototype.forEachFeatureAtCoordinate = function(
    * @type {ol.Extent}
    */
   var hitExtent;
-  if (goog.isDef(this.renderBuffer_)) {
+  if (this.renderBuffer_ !== undefined) {
     // build an extent around the coordinate, so that only features that
     // intersect this extent are checked
     hitExtent = ol.extent.buffer(

--- a/src/ol/renderer/canvas/canvasimagelayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasimagelayerrenderer.js
@@ -163,7 +163,7 @@ ol.renderer.canvas.ImageLayer.prototype.prepareFrame =
   var hints = frameState.viewHints;
 
   var renderedExtent = frameState.extent;
-  if (goog.isDef(layerState.extent)) {
+  if (layerState.extent !== undefined) {
     renderedExtent = ol.extent.getIntersection(
         renderedExtent, layerState.extent);
   }

--- a/src/ol/renderer/canvas/canvaslayerrenderer.js
+++ b/src/ol/renderer/canvas/canvaslayerrenderer.js
@@ -48,9 +48,9 @@ ol.renderer.canvas.Layer.prototype.composeFrame =
 
     // clipped rendering if layer extent is set
     var extent = layerState.extent;
-    var clipped = goog.isDef(extent);
+    var clipped = extent !== undefined;
     if (clipped) {
-      goog.asserts.assert(goog.isDef(extent),
+      goog.asserts.assert(extent !== undefined,
           'layerState extent is defined');
       var pixelRatio = frameState.pixelRatio;
       var topLeft = ol.extent.getTopLeft(extent);
@@ -126,7 +126,7 @@ ol.renderer.canvas.Layer.prototype.dispatchComposeEvent_ =
     function(type, context, frameState, opt_transform) {
   var layer = this.getLayer();
   if (layer.hasListener(type)) {
-    var transform = goog.isDef(opt_transform) ?
+    var transform = opt_transform !== undefined ?
         opt_transform : this.getTransform(frameState, 0);
     var render = new ol.render.canvas.Immediate(
         context, frameState.pixelRatio, frameState.extent, transform,

--- a/src/ol/renderer/canvas/canvastilelayerrenderer.js
+++ b/src/ol/renderer/canvas/canvastilelayerrenderer.js
@@ -217,7 +217,7 @@ ol.renderer.canvas.TileLayer.prototype.prepareFrame =
     extent = frameState.extent;
   }
 
-  if (goog.isDef(layerState.extent)) {
+  if (layerState.extent !== undefined) {
     extent = ol.extent.getIntersection(extent, layerState.extent);
   }
   if (ol.extent.isEmpty(extent)) {

--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -172,7 +172,7 @@ ol.renderer.canvas.VectorLayer.prototype.forEachFeatureAtCoordinate =
          * @return {?} Callback result.
          */
         function(feature) {
-          goog.asserts.assert(goog.isDef(feature), 'received a feature');
+          goog.asserts.assert(feature !== undefined, 'received a feature');
           var key = goog.getUid(feature).toString();
           if (!(key in features)) {
             features[key] = true;

--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -228,7 +228,7 @@ ol.renderer.canvas.VectorLayer.prototype.prepareFrame =
   var vectorLayerRenderBuffer = vectorLayer.getRenderBuffer();
   var vectorLayerRenderOrder = vectorLayer.getRenderOrder();
 
-  if (!goog.isDef(vectorLayerRenderOrder)) {
+  if (vectorLayerRenderOrder === undefined) {
     vectorLayerRenderOrder = ol.renderer.vector.defaultOrder;
   }
 

--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -275,10 +275,14 @@ ol.renderer.canvas.VectorLayer.prototype.prepareFrame =
        */
       function(feature) {
     var styles;
-    if (goog.isDef(feature.getStyleFunction())) {
-      styles = feature.getStyleFunction().call(feature, resolution);
-    } else if (goog.isDef(vectorLayer.getStyleFunction())) {
-      styles = vectorLayer.getStyleFunction()(feature, resolution);
+    var styleFunction = feature.getStyleFunction();
+    if (styleFunction) {
+      styles = styleFunction.call(feature, resolution);
+    } else {
+      styleFunction = vectorLayer.getStyleFunction();
+      if (styleFunction) {
+        styles = styleFunction(feature, resolution);
+      }
     }
     if (goog.isDefAndNotNull(styles)) {
       var dirty = this.renderFeature(

--- a/src/ol/renderer/dom/domimagelayerrenderer.js
+++ b/src/ol/renderer/dom/domimagelayerrenderer.js
@@ -94,7 +94,7 @@ ol.renderer.dom.ImageLayer.prototype.prepareFrame =
   var hints = frameState.viewHints;
 
   var renderedExtent = frameState.extent;
-  if (goog.isDef(layerState.extent)) {
+  if (layerState.extent !== undefined) {
     renderedExtent = ol.extent.getIntersection(
         renderedExtent, layerState.extent);
   }

--- a/src/ol/renderer/dom/domtilelayerrenderer.js
+++ b/src/ol/renderer/dom/domtilelayerrenderer.js
@@ -119,7 +119,7 @@ ol.renderer.dom.TileLayer.prototype.prepareFrame =
     extent = frameState.extent;
   }
 
-  if (goog.isDef(layerState.extent)) {
+  if (layerState.extent !== undefined) {
     extent = ol.extent.getIntersection(extent, layerState.extent);
   }
 

--- a/src/ol/renderer/dom/domvectorlayerrenderer.js
+++ b/src/ol/renderer/dom/domvectorlayerrenderer.js
@@ -283,10 +283,14 @@ ol.renderer.dom.VectorLayer.prototype.prepareFrame =
        */
       function(feature) {
     var styles;
-    if (goog.isDef(feature.getStyleFunction())) {
-      styles = feature.getStyleFunction().call(feature, resolution);
-    } else if (goog.isDef(vectorLayer.getStyleFunction())) {
-      styles = vectorLayer.getStyleFunction()(feature, resolution);
+    var styleFunction = feature.getStyleFunction();
+    if (styleFunction) {
+      styles = styleFunction.call(feature, resolution);
+    } else {
+      styleFunction = vectorLayer.getStyleFunction();
+      if (styleFunction) {
+        styles = styleFunction(feature, resolution);
+      }
     }
     if (goog.isDefAndNotNull(styles)) {
       var dirty = this.renderFeature(

--- a/src/ol/renderer/dom/domvectorlayerrenderer.js
+++ b/src/ol/renderer/dom/domvectorlayerrenderer.js
@@ -250,7 +250,7 @@ ol.renderer.dom.VectorLayer.prototype.prepareFrame =
   var vectorLayerRenderBuffer = vectorLayer.getRenderBuffer();
   var vectorLayerRenderOrder = vectorLayer.getRenderOrder();
 
-  if (!goog.isDef(vectorLayerRenderOrder)) {
+  if (vectorLayerRenderOrder === undefined) {
     vectorLayerRenderOrder = ol.renderer.vector.defaultOrder;
   }
 

--- a/src/ol/renderer/dom/domvectorlayerrenderer.js
+++ b/src/ol/renderer/dom/domvectorlayerrenderer.js
@@ -194,7 +194,7 @@ ol.renderer.dom.VectorLayer.prototype.forEachFeatureAtCoordinate =
          * @return {?} Callback result.
          */
         function(feature) {
-          goog.asserts.assert(goog.isDef(feature), 'received a feature');
+          goog.asserts.assert(feature !== undefined, 'received a feature');
           var key = goog.getUid(feature).toString();
           if (!(key in features)) {
             features[key] = true;

--- a/src/ol/renderer/layerrenderer.js
+++ b/src/ol/renderer/layerrenderer.js
@@ -221,7 +221,7 @@ ol.renderer.Layer.prototype.updateAttributions =
  */
 ol.renderer.Layer.prototype.updateLogos = function(frameState, source) {
   var logo = source.getLogo();
-  if (goog.isDef(logo)) {
+  if (logo !== undefined) {
     if (goog.isString(logo)) {
       frameState.logos[logo] = '';
     } else if (goog.isObject(logo)) {
@@ -319,7 +319,7 @@ ol.renderer.Layer.prototype.manageTilePyramid = function(
                 tileGrid.getTileCoordCenter(tile.tileCoord), tileResolution]);
             }
           }
-          if (goog.isDef(opt_tileCallback)) {
+          if (opt_tileCallback !== undefined) {
             opt_tileCallback.call(opt_this, tile);
           }
         } else {

--- a/src/ol/renderer/maprenderer.js
+++ b/src/ol/renderer/maprenderer.js
@@ -9,6 +9,7 @@ goog.require('goog.events.EventType');
 goog.require('goog.functions');
 goog.require('goog.object');
 goog.require('goog.vec.Mat4');
+goog.require('ol');
 goog.require('ol.extent');
 goog.require('ol.layer.Layer');
 goog.require('ol.renderer.Layer');
@@ -139,7 +140,7 @@ ol.renderer.Map.prototype.forEachFeatureAtCoordinate =
    * @return {?} Callback result.
    */
   function forEachFeatureAtCoordinate(feature) {
-    goog.asserts.assert(goog.isDef(feature), 'received a feature');
+    goog.asserts.assert(feature !== undefined, 'received a feature');
     var key = goog.getUid(feature).toString();
     if (!(key in features)) {
       features[key] = true;
@@ -241,7 +242,7 @@ ol.renderer.Map.prototype.hasFeatureAtCoordinate =
   var hasFeature = this.forEachFeatureAtCoordinate(
       coordinate, frameState, goog.functions.TRUE, this, layerFilter, thisArg);
 
-  return goog.isDef(hasFeature);
+  return ol.isDef(hasFeature);
 };
 
 

--- a/src/ol/renderer/maprenderer.js
+++ b/src/ol/renderer/maprenderer.js
@@ -140,7 +140,7 @@ ol.renderer.Map.prototype.forEachFeatureAtCoordinate =
    * @return {?} Callback result.
    */
   function forEachFeatureAtCoordinate(feature) {
-    goog.asserts.assert(feature !== undefined, 'received a feature');
+    goog.asserts.assert(ol.isDef(feature), 'received a feature');
     var key = goog.getUid(feature).toString();
     if (!(key in features)) {
       features[key] = true;

--- a/src/ol/renderer/maprenderer.js
+++ b/src/ol/renderer/maprenderer.js
@@ -140,7 +140,7 @@ ol.renderer.Map.prototype.forEachFeatureAtCoordinate =
    * @return {?} Callback result.
    */
   function forEachFeatureAtCoordinate(feature) {
-    goog.asserts.assert(ol.isDef(feature), 'received a feature');
+    goog.asserts.assert(feature !== undefined, 'received a feature');
     var key = goog.getUid(feature).toString();
     if (!(key in features)) {
       features[key] = true;
@@ -242,7 +242,7 @@ ol.renderer.Map.prototype.hasFeatureAtCoordinate =
   var hasFeature = this.forEachFeatureAtCoordinate(
       coordinate, frameState, goog.functions.TRUE, this, layerFilter, thisArg);
 
-  return ol.isDef(hasFeature);
+  return hasFeature !== undefined;
 };
 
 

--- a/src/ol/renderer/webgl/webglimagelayerrenderer.js
+++ b/src/ol/renderer/webgl/webglimagelayerrenderer.js
@@ -225,7 +225,7 @@ ol.renderer.webgl.ImageLayer.prototype.hasFeatureAtCoordinate =
     function(coordinate, frameState) {
   var hasFeature = this.forEachFeatureAtCoordinate(
       coordinate, frameState, goog.functions.TRUE, this);
-  return goog.isDef(hasFeature);
+  return hasFeature !== undefined;
 };
 
 

--- a/src/ol/renderer/webgl/webglimagelayerrenderer.js
+++ b/src/ol/renderer/webgl/webglimagelayerrenderer.js
@@ -118,7 +118,7 @@ ol.renderer.webgl.ImageLayer.prototype.prepareFrame =
   var hints = frameState.viewHints;
 
   var renderedExtent = frameState.extent;
-  if (goog.isDef(layerState.extent)) {
+  if (layerState.extent !== undefined) {
     renderedExtent = ol.extent.getIntersection(
         renderedExtent, layerState.extent);
   }

--- a/src/ol/renderer/webgl/webgllayerrenderer.js
+++ b/src/ol/renderer/webgl/webgllayerrenderer.js
@@ -110,7 +110,7 @@ ol.renderer.webgl.Layer.prototype.bindFramebuffer =
 
   var gl = this.mapRenderer.getGL();
 
-  if (!goog.isDef(this.framebufferDimension) ||
+  if (this.framebufferDimension === undefined ||
       this.framebufferDimension != framebufferDimension) {
 
     frameState.postRenderFunctions.push(

--- a/src/ol/renderer/webgl/webgltilelayerrenderer.js
+++ b/src/ol/renderer/webgl/webgltilelayerrenderer.js
@@ -251,7 +251,7 @@ ol.renderer.webgl.TileLayer.prototype.prepareFrame =
       for (y = tileRange.minY; y <= tileRange.maxY; ++y) {
 
         tile = tileSource.getTile(z, x, y, pixelRatio, projection);
-        if (goog.isDef(layerState.extent)) {
+        if (layerState.extent !== undefined) {
           // ignore tiles outside layer extent
           tileExtent = tileGrid.getTileCoordExtent(tile.tileCoord, tmpExtent);
           if (!ol.extent.intersects(tileExtent, layerState.extent)) {

--- a/src/ol/renderer/webgl/webglvectorlayerrenderer.js
+++ b/src/ol/renderer/webgl/webglvectorlayerrenderer.js
@@ -223,7 +223,7 @@ ol.renderer.webgl.VectorLayer.prototype.prepareFrame =
   var vectorLayerRenderBuffer = vectorLayer.getRenderBuffer();
   var vectorLayerRenderOrder = vectorLayer.getRenderOrder();
 
-  if (!goog.isDef(vectorLayerRenderOrder)) {
+  if (vectorLayerRenderOrder === undefined) {
     vectorLayerRenderOrder = ol.renderer.vector.defaultOrder;
   }
 

--- a/src/ol/renderer/webgl/webglvectorlayerrenderer.js
+++ b/src/ol/renderer/webgl/webglvectorlayerrenderer.js
@@ -129,7 +129,7 @@ ol.renderer.webgl.VectorLayer.prototype.forEachFeatureAtCoordinate =
          * @return {?} Callback result.
          */
         function(feature) {
-          goog.asserts.assert(goog.isDef(feature), 'received a feature');
+          goog.asserts.assert(feature !== undefined, 'received a feature');
           var key = goog.getUid(feature).toString();
           if (!(key in features)) {
             features[key] = true;

--- a/src/ol/renderer/webgl/webglvectorlayerrenderer.js
+++ b/src/ol/renderer/webgl/webglvectorlayerrenderer.js
@@ -256,10 +256,14 @@ ol.renderer.webgl.VectorLayer.prototype.prepareFrame =
        */
       function(feature) {
     var styles;
-    if (goog.isDef(feature.getStyleFunction())) {
-      styles = feature.getStyleFunction().call(feature, resolution);
-    } else if (goog.isDef(vectorLayer.getStyleFunction())) {
-      styles = vectorLayer.getStyleFunction()(feature, resolution);
+    var styleFunction = feature.getStyleFunction();
+    if (styleFunction) {
+      styles = styleFunction.call(feature, resolution);
+    } else {
+      styleFunction = vectorLayer.getStyleFunction();
+      if (styleFunction) {
+        styles = styleFunction(feature, resolution);
+      }
     }
     if (goog.isDefAndNotNull(styles)) {
       var dirty = this.renderFeature(

--- a/src/ol/resolutionconstraint.js
+++ b/src/ol/resolutionconstraint.js
@@ -25,7 +25,7 @@ ol.ResolutionConstraint.createSnapToResolutions =
        * @return {number|undefined} Resolution.
        */
       function(resolution, delta, direction) {
-        if (goog.isDef(resolution)) {
+        if (resolution !== undefined) {
           var z =
               ol.array.linearFindNearest(resolutions, resolution, direction);
           z = goog.math.clamp(z + delta, 0, resolutions.length - 1);
@@ -53,7 +53,7 @@ ol.ResolutionConstraint.createSnapToPower =
        * @return {number|undefined} Resolution.
        */
       function(resolution, delta, direction) {
-        if (goog.isDef(resolution)) {
+        if (resolution !== undefined) {
           var offset;
           if (direction > 0) {
             offset = 0;
@@ -65,7 +65,7 @@ ol.ResolutionConstraint.createSnapToPower =
           var oldLevel = Math.floor(
               Math.log(maxResolution / resolution) / Math.log(power) + offset);
           var newLevel = Math.max(oldLevel + delta, 0);
-          if (goog.isDef(opt_maxLevel)) {
+          if (opt_maxLevel !== undefined) {
             newLevel = Math.min(newLevel, opt_maxLevel);
           }
           return maxResolution / Math.pow(power, newLevel);

--- a/src/ol/rotationconstraint.js
+++ b/src/ol/rotationconstraint.js
@@ -16,7 +16,7 @@ ol.RotationConstraintType;
  * @return {number|undefined} Rotation.
  */
 ol.RotationConstraint.disable = function(rotation, delta) {
-  if (goog.isDef(rotation)) {
+  if (rotation !== undefined) {
     return 0;
   } else {
     return undefined;
@@ -30,7 +30,7 @@ ol.RotationConstraint.disable = function(rotation, delta) {
  * @return {number|undefined} Rotation.
  */
 ol.RotationConstraint.none = function(rotation, delta) {
-  if (goog.isDef(rotation)) {
+  if (rotation !== undefined) {
     return rotation + delta;
   } else {
     return undefined;
@@ -51,7 +51,7 @@ ol.RotationConstraint.createSnapToN = function(n) {
        * @return {number|undefined} Rotation.
        */
       function(rotation, delta) {
-        if (goog.isDef(rotation)) {
+        if (rotation !== undefined) {
           rotation = Math.floor((rotation + delta) / theta + 0.5) * theta;
           return rotation;
         } else {
@@ -74,7 +74,7 @@ ol.RotationConstraint.createSnapToZero = function(opt_tolerance) {
        * @return {number|undefined} Rotation.
        */
       function(rotation, delta) {
-        if (goog.isDef(rotation)) {
+        if (rotation !== undefined) {
           if (Math.abs(rotation + delta) <= tolerance) {
             return 0;
           } else {

--- a/src/ol/size.js
+++ b/src/ol/size.js
@@ -21,7 +21,7 @@ ol.Size;
  * @return {ol.Size}
  */
 ol.size.buffer = function(size, buffer, opt_size) {
-  if (!goog.isDef(opt_size)) {
+  if (opt_size === undefined) {
     opt_size = [0, 0];
   }
   opt_size[0] = size[0] + 2 * buffer;
@@ -59,7 +59,7 @@ ol.size.hasArea = function(size) {
  * @return {ol.Size}
  */
 ol.size.scale = function(size, ratio, opt_size) {
-  if (!goog.isDef(opt_size)) {
+  if (opt_size === undefined) {
     opt_size = [0, 0];
   }
   opt_size[0] = (size[0] * ratio + 0.5) | 0;
@@ -82,7 +82,7 @@ ol.size.toSize = function(size, opt_size) {
     return size;
   } else {
     goog.asserts.assert(goog.isNumber(size));
-    if (!goog.isDef(opt_size)) {
+    if (opt_size === undefined) {
       opt_size = [size, size];
     } else {
       opt_size[0] = size;

--- a/src/ol/source/bingmapssource.js
+++ b/src/ol/source/bingmapssource.js
@@ -32,20 +32,20 @@ ol.source.BingMaps = function(options) {
     projection: ol.proj.get('EPSG:3857'),
     state: ol.source.State.LOADING,
     tileLoadFunction: options.tileLoadFunction,
-    wrapX: goog.isDef(options.wrapX) ? options.wrapX : true
+    wrapX: options.wrapX !== undefined ? options.wrapX : true
   });
 
   /**
    * @private
    * @type {string}
    */
-  this.culture_ = goog.isDef(options.culture) ? options.culture : 'en-us';
+  this.culture_ = options.culture !== undefined ? options.culture : 'en-us';
 
   /**
    * @private
    * @type {number}
    */
-  this.maxZoom_ = goog.isDef(options.maxZoom) ? options.maxZoom : -1;
+  this.maxZoom_ = options.maxZoom !== undefined ? options.maxZoom : -1;
 
   var uri = new goog.Uri(
       'https://dev.virtualearth.net/REST/v1/Imagery/Metadata/' +

--- a/src/ol/source/clustersource.js
+++ b/src/ol/source/clustersource.js
@@ -103,7 +103,7 @@ ol.source.Cluster.prototype.onSourceChange_ = function() {
  * @private
  */
 ol.source.Cluster.prototype.cluster_ = function() {
-  if (!goog.isDef(this.resolution_)) {
+  if (this.resolution_ === undefined) {
     return;
   }
   this.features_.length = 0;

--- a/src/ol/source/clustersource.js
+++ b/src/ol/source/clustersource.js
@@ -42,7 +42,7 @@ ol.source.Cluster = function(options) {
    * @type {number}
    * @private
    */
-  this.distance_ = goog.isDef(options.distance) ? options.distance : 20;
+  this.distance_ = options.distance !== undefined ? options.distance : 20;
 
   /**
    * @type {Array.<ol.Feature>}

--- a/src/ol/source/imagecanvassource.js
+++ b/src/ol/source/imagecanvassource.js
@@ -23,7 +23,7 @@ ol.source.ImageCanvas = function(options) {
     logo: options.logo,
     projection: options.projection,
     resolutions: options.resolutions,
-    state: goog.isDef(options.state) ?
+    state: options.state !== undefined ?
         /** @type {ol.source.State} */ (options.state) : undefined
   });
 
@@ -49,7 +49,7 @@ ol.source.ImageCanvas = function(options) {
    * @private
    * @type {number}
    */
-  this.ratio_ = goog.isDef(options.ratio) ?
+  this.ratio_ = options.ratio !== undefined ?
       options.ratio : 1.5;
 
 };

--- a/src/ol/source/imagemapguidesource.js
+++ b/src/ol/source/imagemapguidesource.js
@@ -149,7 +149,7 @@ ol.source.ImageMapGuide.prototype.getImage =
   var size = [width * pixelRatio, height * pixelRatio];
 
   var imageUrl = this.imageUrlFunction_(extent, size, projection);
-  if (goog.isDef(imageUrl)) {
+  if (imageUrl !== undefined) {
     image = new ol.Image(extent, resolution, pixelRatio,
         this.getAttributions(), imageUrl, this.crossOrigin_,
         this.imageLoadFunction_);

--- a/src/ol/source/imagemapguidesource.js
+++ b/src/ol/source/imagemapguidesource.js
@@ -34,20 +34,20 @@ ol.source.ImageMapGuide = function(options) {
    * @type {?string}
    */
   this.crossOrigin_ =
-      goog.isDef(options.crossOrigin) ? options.crossOrigin : null;
+      options.crossOrigin !== undefined ? options.crossOrigin : null;
 
   /**
    * @private
    * @type {number}
    */
-  this.displayDpi_ = goog.isDef(options.displayDpi) ?
+  this.displayDpi_ = options.displayDpi !== undefined ?
       options.displayDpi : 96;
 
   /**
    * @private
    * @type {Object}
    */
-  this.params_ = goog.isDef(options.params) ? options.params : {};
+  this.params_ = options.params !== undefined ? options.params : {};
 
   var imageUrlFunction;
   if (options.url !== undefined) {
@@ -67,33 +67,33 @@ ol.source.ImageMapGuide = function(options) {
    * @private
    * @type {ol.ImageLoadFunctionType}
    */
-  this.imageLoadFunction_ = goog.isDef(options.imageLoadFunction) ?
+  this.imageLoadFunction_ = options.imageLoadFunction !== undefined ?
       options.imageLoadFunction : ol.source.Image.defaultImageLoadFunction;
 
   /**
    * @private
    * @type {boolean}
    */
-  this.hidpi_ = goog.isDef(options.hidpi) ? options.hidpi : true;
+  this.hidpi_ = options.hidpi !== undefined ? options.hidpi : true;
 
   /**
    * @private
    * @type {number}
    */
-  this.metersPerUnit_ = goog.isDef(options.metersPerUnit) ?
+  this.metersPerUnit_ = options.metersPerUnit !== undefined ?
       options.metersPerUnit : 1;
 
   /**
    * @private
    * @type {number}
    */
-  this.ratio_ = goog.isDef(options.ratio) ? options.ratio : 1;
+  this.ratio_ = options.ratio !== undefined ? options.ratio : 1;
 
   /**
    * @private
    * @type {boolean}
    */
-  this.useOverlay_ = goog.isDef(options.useOverlay) ?
+  this.useOverlay_ = options.useOverlay !== undefined ?
       options.useOverlay : false;
 
   /**

--- a/src/ol/source/imagemapguidesource.js
+++ b/src/ol/source/imagemapguidesource.js
@@ -50,7 +50,7 @@ ol.source.ImageMapGuide = function(options) {
   this.params_ = goog.isDef(options.params) ? options.params : {};
 
   var imageUrlFunction;
-  if (goog.isDef(options.url)) {
+  if (options.url !== undefined) {
     imageUrlFunction = ol.ImageUrlFunction.createFromParamsFunction(
         options.url, this.params_, goog.bind(this.getUrl, this));
   } else {

--- a/src/ol/source/imagesource.js
+++ b/src/ol/source/imagesource.js
@@ -48,7 +48,7 @@ ol.source.Image = function(options) {
    * @private
    * @type {Array.<number>}
    */
-  this.resolutions_ = goog.isDef(options.resolutions) ?
+  this.resolutions_ = options.resolutions !== undefined ?
       options.resolutions : null;
   goog.asserts.assert(goog.isNull(this.resolutions_) ||
       goog.array.isSorted(this.resolutions_,

--- a/src/ol/source/imagestaticsource.js
+++ b/src/ol/source/imagestaticsource.js
@@ -21,7 +21,7 @@ goog.require('ol.source.Image');
  */
 ol.source.ImageStatic = function(options) {
 
-  var attributions = goog.isDef(options.attributions) ?
+  var attributions = options.attributions !== undefined ?
       options.attributions : null;
 
   var imageExtent = options.imageExtent;
@@ -32,11 +32,11 @@ ol.source.ImageStatic = function(options) {
     resolutions = [resolution];
   }
 
-  var crossOrigin = goog.isDef(options.crossOrigin) ?
+  var crossOrigin = options.crossOrigin !== undefined ?
       options.crossOrigin : null;
 
   var /** @type {ol.ImageLoadFunctionType} */ imageLoadFunction =
-      goog.isDef(options.imageLoadFunction) ?
+      options.imageLoadFunction !== undefined ?
       options.imageLoadFunction : ol.source.Image.defaultImageLoadFunction;
 
   goog.base(this, {

--- a/src/ol/source/imagestaticsource.js
+++ b/src/ol/source/imagestaticsource.js
@@ -27,7 +27,7 @@ ol.source.ImageStatic = function(options) {
   var imageExtent = options.imageExtent;
 
   var resolution, resolutions;
-  if (goog.isDef(options.imageSize)) {
+  if (options.imageSize !== undefined) {
     resolution = ol.extent.getHeight(imageExtent) / options.imageSize[1];
     resolutions = [resolution];
   }

--- a/src/ol/source/imagevectorsource.js
+++ b/src/ol/source/imagevectorsource.js
@@ -166,7 +166,7 @@ ol.source.ImageVector.prototype.forEachFeatureAtCoordinate = function(
          * @return {?} Callback result.
          */
         function(feature) {
-          goog.asserts.assert(goog.isDef(feature), 'passed a feature');
+          goog.asserts.assert(feature !== undefined, 'passed a feature');
           var key = goog.getUid(feature).toString();
           if (!(key in features)) {
             features[key] = true;
@@ -290,7 +290,7 @@ ol.source.ImageVector.prototype.renderFeature_ =
  * @api stable
  */
 ol.source.ImageVector.prototype.setStyle = function(style) {
-  this.style_ = goog.isDef(style) ? style : ol.style.defaultStyleFunction;
+  this.style_ = style !== undefined ? style : ol.style.defaultStyleFunction;
   this.styleFunction_ = goog.isNull(style) ?
       undefined : ol.style.createStyleFunction(this.style_);
   this.changed();

--- a/src/ol/source/imagevectorsource.js
+++ b/src/ol/source/imagevectorsource.js
@@ -261,7 +261,7 @@ ol.source.ImageVector.prototype.renderFeature_ =
   var styles;
   if (goog.isDef(feature.getStyleFunction())) {
     styles = feature.getStyleFunction().call(feature, resolution);
-  } else if (goog.isDef(this.styleFunction_)) {
+  } else if (this.styleFunction_ !== undefined) {
     styles = this.styleFunction_(feature, resolution);
   }
   if (!goog.isDefAndNotNull(styles)) {

--- a/src/ol/source/imagevectorsource.js
+++ b/src/ol/source/imagevectorsource.js
@@ -259,9 +259,10 @@ ol.source.ImageVector.prototype.handleSourceChange_ = function() {
 ol.source.ImageVector.prototype.renderFeature_ =
     function(feature, resolution, pixelRatio, replayGroup) {
   var styles;
-  if (goog.isDef(feature.getStyleFunction())) {
-    styles = feature.getStyleFunction().call(feature, resolution);
-  } else if (this.styleFunction_ !== undefined) {
+  var styleFunction = feature.getStyleFunction();
+  if (styleFunction) {
+    styles = styleFunction.call(feature, resolution);
+  } else if (this.styleFunction_) {
     styles = this.styleFunction_(feature, resolution);
   }
   if (!goog.isDefAndNotNull(styles)) {

--- a/src/ol/source/imagewmssource.js
+++ b/src/ol/source/imagewmssource.js
@@ -194,7 +194,7 @@ ol.source.ImageWMS.prototype.getImage =
 
   resolution = this.findNearestResolution(resolution);
 
-  if (pixelRatio != 1 && (!this.hidpi_ || !goog.isDef(this.serverType_))) {
+  if (pixelRatio != 1 && (!this.hidpi_ || this.serverType_ === undefined)) {
     pixelRatio = 1;
   }
 

--- a/src/ol/source/imagewmssource.js
+++ b/src/ol/source/imagewmssource.js
@@ -45,7 +45,7 @@ ol.source.ImageWMS = function(opt_options) {
    * @type {?string}
    */
   this.crossOrigin_ =
-      goog.isDef(options.crossOrigin) ? options.crossOrigin : null;
+      options.crossOrigin !== undefined ? options.crossOrigin : null;
 
   /**
    * @private
@@ -57,7 +57,7 @@ ol.source.ImageWMS = function(opt_options) {
    * @private
    * @type {ol.ImageLoadFunctionType}
    */
-  this.imageLoadFunction_ = goog.isDef(options.imageLoadFunction) ?
+  this.imageLoadFunction_ = options.imageLoadFunction !== undefined ?
       options.imageLoadFunction : ol.source.Image.defaultImageLoadFunction;
 
   /**
@@ -84,7 +84,7 @@ ol.source.ImageWMS = function(opt_options) {
    * @private
    * @type {boolean}
    */
-  this.hidpi_ = goog.isDef(options.hidpi) ? options.hidpi : true;
+  this.hidpi_ = options.hidpi !== undefined ? options.hidpi : true;
 
   /**
    * @private
@@ -108,7 +108,7 @@ ol.source.ImageWMS = function(opt_options) {
    * @private
    * @type {number}
    */
-  this.ratio_ = goog.isDef(options.ratio) ? options.ratio : 1.5;
+  this.ratio_ = options.ratio !== undefined ? options.ratio : 1.5;
 
 };
 goog.inherits(ol.source.ImageWMS, ol.source.Image);
@@ -281,7 +281,7 @@ ol.source.ImageWMS.prototype.getImageLoadFunction = function() {
 ol.source.ImageWMS.prototype.getRequestUrl_ =
     function(extent, size, pixelRatio, projection, params) {
 
-  goog.asserts.assert(goog.isDef(this.url_), 'url is defined');
+  goog.asserts.assert(this.url_ !== undefined, 'url is defined');
 
   params[this.v13_ ? 'CRS' : 'SRS'] = projection.getCode();
 

--- a/src/ol/source/imagewmssource.js
+++ b/src/ol/source/imagewmssource.js
@@ -31,7 +31,7 @@ goog.require('ol.source.wms.ServerType');
  */
 ol.source.ImageWMS = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options || {};
 
   goog.base(this, {
     attributions: options.attributions,

--- a/src/ol/source/imagewmssource.js
+++ b/src/ol/source/imagewmssource.js
@@ -142,7 +142,7 @@ ol.source.ImageWMS.prototype.getGetFeatureInfoUrl =
   goog.asserts.assert(!('VERSION' in params),
       'key VERSION is not allowed in params');
 
-  if (!goog.isDef(this.url_)) {
+  if (this.url_ === undefined) {
     return undefined;
   }
 
@@ -188,7 +188,7 @@ ol.source.ImageWMS.prototype.getParams = function() {
 ol.source.ImageWMS.prototype.getImage =
     function(extent, resolution, pixelRatio, projection) {
 
-  if (!goog.isDef(this.url_)) {
+  if (this.url_ === undefined) {
     return null;
   }
 

--- a/src/ol/source/imagewmssource.js
+++ b/src/ol/source/imagewmssource.js
@@ -295,7 +295,7 @@ ol.source.ImageWMS.prototype.getRequestUrl_ =
     switch (this.serverType_) {
       case ol.source.wms.ServerType.GEOSERVER:
         var dpi = (90 * pixelRatio + 0.5) | 0;
-        if (goog.isDef(params['FORMAT_OPTIONS'])) {
+        if ('FORMAT_OPTIONS' in params) {
           params['FORMAT_OPTIONS'] += ';dpi:' + dpi;
         } else {
           params['FORMAT_OPTIONS'] = 'dpi:' + dpi;

--- a/src/ol/source/mapquestsource.js
+++ b/src/ol/source/mapquestsource.js
@@ -18,7 +18,7 @@ goog.require('ol.source.XYZ');
  */
 ol.source.MapQuest = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options || {};
   goog.asserts.assert(options.layer in ol.source.MapQuestConfig,
       'known layer configured');
 

--- a/src/ol/source/mapquestsource.js
+++ b/src/ol/source/mapquestsource.js
@@ -31,7 +31,7 @@ ol.source.MapQuest = function(opt_options) {
    */
   this.layer_ = options.layer;
 
-  var url = goog.isDef(options.url) ? options.url :
+  var url = options.url !== undefined ? options.url :
       'https://otile{1-4}-s.mqcdn.com/tiles/1.0.0/' +
       this.layer_ + '/{z}/{x}/{y}.jpg';
 

--- a/src/ol/source/osmsource.js
+++ b/src/ol/source/osmsource.js
@@ -16,7 +16,7 @@ goog.require('ol.source.XYZ');
  */
 ol.source.OSM = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options || {};
 
   var attributions;
   if (goog.isDef(options.attributions)) {

--- a/src/ol/source/osmsource.js
+++ b/src/ol/source/osmsource.js
@@ -19,7 +19,7 @@ ol.source.OSM = function(opt_options) {
   var options = opt_options || {};
 
   var attributions;
-  if (goog.isDef(options.attributions)) {
+  if (options.attributions !== undefined) {
     attributions = options.attributions;
   } else {
     attributions = [ol.source.OSM.ATTRIBUTION];

--- a/src/ol/source/osmsource.js
+++ b/src/ol/source/osmsource.js
@@ -25,17 +25,17 @@ ol.source.OSM = function(opt_options) {
     attributions = [ol.source.OSM.ATTRIBUTION];
   }
 
-  var crossOrigin = goog.isDef(options.crossOrigin) ?
+  var crossOrigin = options.crossOrigin !== undefined ?
       options.crossOrigin : 'anonymous';
 
-  var url = goog.isDef(options.url) ?
+  var url = options.url !== undefined ?
       options.url : 'https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png';
 
   goog.base(this, {
     attributions: attributions,
     crossOrigin: crossOrigin,
     opaque: true,
-    maxZoom: goog.isDef(options.maxZoom) ? options.maxZoom : 19,
+    maxZoom: options.maxZoom !== undefined ? options.maxZoom : 19,
     tileLoadFunction: options.tileLoadFunction,
     url: url,
     wrapX: options.wrapX

--- a/src/ol/source/rastersource.js
+++ b/src/ol/source/rastersource.js
@@ -48,14 +48,14 @@ ol.source.Raster = function(options) {
    * @private
    * @type {ol.raster.OperationType}
    */
-  this.operationType_ = goog.isDef(options.operationType) ?
+  this.operationType_ = options.operationType !== undefined ?
       options.operationType : ol.raster.OperationType.PIXEL;
 
   /**
    * @private
    * @type {number}
    */
-  this.threads_ = goog.isDef(options.threads) ? options.threads : 1;
+  this.threads_ = options.threads !== undefined ? options.threads : 1;
 
   /**
    * @private

--- a/src/ol/source/rastersource.js
+++ b/src/ol/source/rastersource.js
@@ -133,7 +133,7 @@ ol.source.Raster = function(options) {
 
   goog.base(this, {});
 
-  if (goog.isDef(options.operation)) {
+  if (options.operation !== undefined) {
     this.setOperation(options.operation, options.lib);
   }
 

--- a/src/ol/source/source.js
+++ b/src/ol/source/source.js
@@ -57,7 +57,7 @@ ol.source.Source = function(options) {
    * @private
    * @type {Array.<ol.Attribution>}
    */
-  this.attributions_ = goog.isDef(options.attributions) ?
+  this.attributions_ = options.attributions !== undefined ?
       options.attributions : null;
 
   /**
@@ -70,14 +70,14 @@ ol.source.Source = function(options) {
    * @private
    * @type {ol.source.State}
    */
-  this.state_ = goog.isDef(options.state) ?
+  this.state_ = options.state !== undefined ?
       options.state : ol.source.State.READY;
 
   /**
    * @private
    * @type {boolean}
    */
-  this.wrapX_ = goog.isDef(options.wrapX) ? options.wrapX : false;
+  this.wrapX_ = options.wrapX !== undefined ? options.wrapX : false;
 
 };
 goog.inherits(ol.source.Source, ol.Object);

--- a/src/ol/source/stamensource.js
+++ b/src/ol/source/stamensource.js
@@ -98,7 +98,7 @@ ol.source.Stamen = function(options) {
       'known layer configured');
   var layerConfig = ol.source.StamenLayerConfig[options.layer];
 
-  var url = goog.isDef(options.url) ? options.url :
+  var url = options.url !== undefined ? options.url :
       'https://stamen-tiles-{a-d}.a.ssl.fastly.net/' + options.layer +
       '/{z}/{x}/{y}.' + layerConfig.extension;
 

--- a/src/ol/source/tilearcgisrestsource.js
+++ b/src/ol/source/tilearcgisrestsource.js
@@ -34,7 +34,7 @@ ol.source.TileArcGISRest = function(opt_options) {
 
   var options = opt_options || {};
 
-  var params = goog.isDef(options.params) ? options.params : {};
+  var params = options.params !== undefined ? options.params : {};
 
   goog.base(this, {
     attributions: options.attributions,
@@ -44,11 +44,11 @@ ol.source.TileArcGISRest = function(opt_options) {
     tileGrid: options.tileGrid,
     tileLoadFunction: options.tileLoadFunction,
     tileUrlFunction: goog.bind(this.tileUrlFunction_, this),
-    wrapX: goog.isDef(options.wrapX) ? options.wrapX : true
+    wrapX: options.wrapX !== undefined ? options.wrapX : true
   });
 
   var urls = options.urls;
-  if (urls === undefined && goog.isDef(options.url)) {
+  if (urls === undefined && options.url !== undefined) {
     urls = ol.TileUrlFunction.expandUrl(options.url);
   }
 

--- a/src/ol/source/tilearcgisrestsource.js
+++ b/src/ol/source/tilearcgisrestsource.js
@@ -32,7 +32,7 @@ goog.require('ol.tilecoord');
  */
 ol.source.TileArcGISRest = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options || {};
 
   var params = goog.isDef(options.params) ? options.params : {};
 

--- a/src/ol/source/tilearcgisrestsource.js
+++ b/src/ol/source/tilearcgisrestsource.js
@@ -48,7 +48,7 @@ ol.source.TileArcGISRest = function(opt_options) {
   });
 
   var urls = options.urls;
-  if (!goog.isDef(urls) && goog.isDef(options.url)) {
+  if (urls === undefined && goog.isDef(options.url)) {
     urls = ol.TileUrlFunction.expandUrl(options.url);
   }
 

--- a/src/ol/source/tilearcgisrestsource.js
+++ b/src/ol/source/tilearcgisrestsource.js
@@ -173,7 +173,7 @@ ol.source.TileArcGISRest.prototype.getUrls = function() {
  * @api stable
  */
 ol.source.TileArcGISRest.prototype.setUrl = function(url) {
-  var urls = goog.isDef(url) ? ol.TileUrlFunction.expandUrl(url) : null;
+  var urls = url !== undefined ? ol.TileUrlFunction.expandUrl(url) : null;
   this.setUrls(urls);
 };
 

--- a/src/ol/source/tiledebugsource.js
+++ b/src/ol/source/tiledebugsource.js
@@ -48,7 +48,7 @@ goog.inherits(ol.DebugTile_, ol.Tile);
  * @inheritDoc
  */
 ol.DebugTile_.prototype.getImage = function(opt_context) {
-  var key = goog.isDef(opt_context) ? goog.getUid(opt_context) : -1;
+  var key = opt_context !== undefined ? goog.getUid(opt_context) : -1;
   if (key in this.canvasByContext_) {
     return this.canvasByContext_[key];
   } else {

--- a/src/ol/source/tiledebugsource.js
+++ b/src/ol/source/tiledebugsource.js
@@ -92,7 +92,7 @@ ol.source.TileDebug = function(options) {
     opaque: false,
     projection: options.projection,
     tileGrid: options.tileGrid,
-    wrapX: goog.isDef(options.wrapX) ? options.wrapX : true
+    wrapX: options.wrapX !== undefined ? options.wrapX : true
   });
 
 };

--- a/src/ol/source/tileimagesource.js
+++ b/src/ol/source/tileimagesource.js
@@ -32,7 +32,7 @@ ol.source.TileImage = function(options) {
     logo: options.logo,
     opaque: options.opaque,
     projection: options.projection,
-    state: goog.isDef(options.state) ?
+    state: options.state !== undefined ?
         /** @type {ol.source.State} */ (options.state) : undefined,
     tileGrid: options.tileGrid,
     tilePixelRatio: options.tilePixelRatio,
@@ -43,7 +43,7 @@ ol.source.TileImage = function(options) {
    * @protected
    * @type {ol.TileUrlFunctionType}
    */
-  this.tileUrlFunction = goog.isDef(options.tileUrlFunction) ?
+  this.tileUrlFunction = options.tileUrlFunction !== undefined ?
       options.tileUrlFunction :
       ol.TileUrlFunction.nullTileUrlFunction;
 
@@ -52,13 +52,13 @@ ol.source.TileImage = function(options) {
    * @type {?string}
    */
   this.crossOrigin =
-      goog.isDef(options.crossOrigin) ? options.crossOrigin : null;
+      options.crossOrigin !== undefined ? options.crossOrigin : null;
 
   /**
    * @protected
    * @type {ol.TileLoadFunctionType}
    */
-  this.tileLoadFunction = goog.isDef(options.tileLoadFunction) ?
+  this.tileLoadFunction = options.tileLoadFunction !== undefined ?
       options.tileLoadFunction : ol.source.TileImage.defaultTileLoadFunction;
 
   /**
@@ -66,7 +66,7 @@ ol.source.TileImage = function(options) {
    * @type {function(new: ol.ImageTile, ol.TileCoord, ol.TileState, string,
    *        ?string, ol.TileLoadFunctionType)}
    */
-  this.tileClass = goog.isDef(options.tileClass) ?
+  this.tileClass = options.tileClass !== undefined ?
       options.tileClass : ol.ImageTile;
 
 };

--- a/src/ol/source/tileimagesource.js
+++ b/src/ol/source/tileimagesource.js
@@ -99,8 +99,8 @@ ol.source.TileImage.prototype.getTile =
         this.tileUrlFunction(urlTileCoord, pixelRatio, projection);
     var tile = new this.tileClass(
         tileCoord,
-        goog.isDef(tileUrl) ? ol.TileState.IDLE : ol.TileState.EMPTY,
-        goog.isDef(tileUrl) ? tileUrl : '',
+        tileUrl !== undefined ? ol.TileState.IDLE : ol.TileState.EMPTY,
+        tileUrl !== undefined ? tileUrl : '',
         this.crossOrigin,
         this.tileLoadFunction);
     goog.events.listen(tile, goog.events.EventType.CHANGE,

--- a/src/ol/source/tilejsonsource.js
+++ b/src/ol/source/tilejsonsource.js
@@ -57,13 +57,13 @@ ol.source.TileJSON.prototype.handleTileJSONResponse = function(tileJSON) {
 
   var sourceProjection = this.getProjection();
   var extent;
-  if (goog.isDef(tileJSON.bounds)) {
+  if (tileJSON.bounds !== undefined) {
     var transform = ol.proj.getTransformFromProjections(
         epsg4326Projection, sourceProjection);
     extent = ol.extent.applyTransform(tileJSON.bounds, transform);
   }
 
-  if (goog.isDef(tileJSON.scheme)) {
+  if (tileJSON.scheme !== undefined) {
     goog.asserts.assert(tileJSON.scheme == 'xyz', 'tileJSON-scheme is "xyz"');
   }
   var minZoom = tileJSON.minzoom || 0;

--- a/src/ol/source/tilejsonsource.js
+++ b/src/ol/source/tilejsonsource.js
@@ -79,7 +79,7 @@ ol.source.TileJSON.prototype.handleTileJSONResponse = function(tileJSON) {
 
   if (goog.isDef(tileJSON.attribution) &&
       goog.isNull(this.getAttributions())) {
-    var attributionExtent = goog.isDef(extent) ?
+    var attributionExtent = extent !== undefined ?
         extent : epsg4326Projection.getExtent();
     /** @type {Object.<string, Array.<ol.TileRange>>} */
     var tileRanges = {};

--- a/src/ol/source/tilejsonsource.js
+++ b/src/ol/source/tilejsonsource.js
@@ -36,7 +36,7 @@ ol.source.TileJSON = function(options) {
     projection: ol.proj.get('EPSG:3857'),
     state: ol.source.State.LOADING,
     tileLoadFunction: options.tileLoadFunction,
-    wrapX: goog.isDef(options.wrapX) ? options.wrapX : true
+    wrapX: options.wrapX !== undefined ? options.wrapX : true
   });
 
   var request = new goog.net.Jsonp(options.url);
@@ -77,7 +77,7 @@ ol.source.TileJSON.prototype.handleTileJSONResponse = function(tileJSON) {
 
   this.tileUrlFunction = ol.TileUrlFunction.createFromTemplates(tileJSON.tiles);
 
-  if (goog.isDef(tileJSON.attribution) &&
+  if (tileJSON.attribution !== undefined &&
       goog.isNull(this.getAttributions())) {
     var attributionExtent = extent !== undefined ?
         extent : epsg4326Projection.getExtent();

--- a/src/ol/source/tilesource.js
+++ b/src/ol/source/tilesource.js
@@ -56,20 +56,20 @@ ol.source.Tile = function(options) {
    * @private
    * @type {boolean}
    */
-  this.opaque_ = goog.isDef(options.opaque) ? options.opaque : false;
+  this.opaque_ = options.opaque !== undefined ? options.opaque : false;
 
   /**
    * @private
    * @type {number}
    */
-  this.tilePixelRatio_ = goog.isDef(options.tilePixelRatio) ?
+  this.tilePixelRatio_ = options.tilePixelRatio !== undefined ?
       options.tilePixelRatio : 1;
 
   /**
    * @protected
    * @type {ol.tilegrid.TileGrid}
    */
-  this.tileGrid = goog.isDef(options.tileGrid) ? options.tileGrid : null;
+  this.tileGrid = options.tileGrid !== undefined ? options.tileGrid : null;
 
   /**
    * @protected

--- a/src/ol/source/tilesource.js
+++ b/src/ol/source/tilesource.js
@@ -227,7 +227,7 @@ ol.source.Tile.prototype.getTilePixelSize =
  */
 ol.source.Tile.prototype.getTileCoordForTileUrlFunction =
     function(tileCoord, opt_projection) {
-  var projection = goog.isDef(opt_projection) ?
+  var projection = opt_projection !== undefined ?
       opt_projection : this.getProjection();
   var tileGrid = this.getTileGridForProjection(projection);
   goog.asserts.assert(!goog.isNull(tileGrid), 'tile grid needed');

--- a/src/ol/source/tileutfgridsource.js
+++ b/src/ol/source/tileutfgridsource.js
@@ -35,7 +35,7 @@ ol.source.TileUTFGrid = function(options) {
    * @private
    * @type {boolean}
    */
-  this.preemptive_ = goog.isDef(options.preemptive) ?
+  this.preemptive_ = options.preemptive !== undefined ?
       options.preemptive : true;
 
   /**

--- a/src/ol/source/tileutfgridsource.js
+++ b/src/ol/source/tileutfgridsource.js
@@ -139,7 +139,7 @@ ol.source.TileUTFGrid.prototype.handleTileJSONResponse = function(tileJSON) {
   this.tileUrlFunction_ = ol.TileUrlFunction.createFromTemplates(grids);
 
   if (tileJSON.attribution !== undefined) {
-    var attributionExtent = goog.isDef(extent) ?
+    var attributionExtent = extent !== undefined ?
         extent : epsg4326Projection.getExtent();
     /** @type {Object.<string, Array.<ol.TileRange>>} */
     var tileRanges = {};
@@ -178,8 +178,8 @@ ol.source.TileUTFGrid.prototype.getTile =
     var tileUrl = this.tileUrlFunction_(urlTileCoord, pixelRatio, projection);
     var tile = new ol.source.TileUTFGridTile_(
         tileCoord,
-        goog.isDef(tileUrl) ? ol.TileState.IDLE : ol.TileState.EMPTY,
-        goog.isDef(tileUrl) ? tileUrl : '',
+        tileUrl !== undefined ? ol.TileState.IDLE : ol.TileState.EMPTY,
+        tileUrl !== undefined ? tileUrl : '',
         this.tileGrid.getTileCoordExtent(tileCoord),
         this.preemptive_);
     this.tileCache.set(tileCoordKey, tile);

--- a/src/ol/source/tileutfgridsource.js
+++ b/src/ol/source/tileutfgridsource.js
@@ -110,13 +110,13 @@ ol.source.TileUTFGrid.prototype.handleTileJSONResponse = function(tileJSON) {
 
   var sourceProjection = this.getProjection();
   var extent;
-  if (goog.isDef(tileJSON.bounds)) {
+  if (tileJSON.bounds !== undefined) {
     var transform = ol.proj.getTransformFromProjections(
         epsg4326Projection, sourceProjection);
     extent = ol.extent.applyTransform(tileJSON.bounds, transform);
   }
 
-  if (goog.isDef(tileJSON.scheme)) {
+  if (tileJSON.scheme !== undefined) {
     goog.asserts.assert(tileJSON.scheme == 'xyz', 'tileJSON-scheme is "xyz"');
   }
   var minZoom = tileJSON.minzoom || 0;
@@ -138,7 +138,7 @@ ol.source.TileUTFGrid.prototype.handleTileJSONResponse = function(tileJSON) {
 
   this.tileUrlFunction_ = ol.TileUrlFunction.createFromTemplates(grids);
 
-  if (goog.isDef(tileJSON.attribution)) {
+  if (tileJSON.attribution !== undefined) {
     var attributionExtent = goog.isDef(extent) ?
         extent : epsg4326Projection.getExtent();
     /** @type {Object.<string, Array.<ol.TileRange>>} */

--- a/src/ol/source/tilevectorsource.js
+++ b/src/ol/source/tilevectorsource.js
@@ -67,11 +67,11 @@ ol.source.TileVector = function(options) {
    */
   this.tiles_ = {};
 
-  if (goog.isDef(options.tileUrlFunction)) {
+  if (options.tileUrlFunction !== undefined) {
     this.setTileUrlFunction(options.tileUrlFunction);
-  } else if (goog.isDef(options.urls)) {
+  } else if (options.urls !== undefined) {
     this.setUrls(options.urls);
-  } else if (goog.isDef(options.url)) {
+  } else if (options.url !== undefined) {
     this.setUrl(options.url);
   }
 

--- a/src/ol/source/tilevectorsource.js
+++ b/src/ol/source/tilevectorsource.js
@@ -36,7 +36,7 @@ ol.source.TileVector = function(options) {
    * @private
    * @type {ol.format.Feature|undefined}
    */
-  this.format_ = goog.isDef(options.format) ? options.format : null;
+  this.format_ = options.format !== undefined ? options.format : null;
 
   /**
    * @private
@@ -54,7 +54,7 @@ ol.source.TileVector = function(options) {
    * @private
    * @type {?ol.TileVectorLoadFunctionType}
    */
-  this.tileLoadFunction_ = goog.isDef(options.tileLoadFunction) ?
+  this.tileLoadFunction_ = options.tileLoadFunction !== undefined ?
       options.tileLoadFunction : null;
 
   goog.asserts.assert(!goog.isNull(this.format_) ||

--- a/src/ol/source/tilevectorsource.js
+++ b/src/ol/source/tilevectorsource.js
@@ -129,7 +129,7 @@ ol.source.TileVector.prototype.forEachFeatureAtCoordinateAndResolution =
 
   var tileKey = this.getTileKeyZXY_(tileCoord[0], tileCoord[1], tileCoord[2]);
   var features = tiles[tileKey];
-  if (goog.isDef(features)) {
+  if (features !== undefined) {
     var i, ii;
     for (i = 0, ii = features.length; i < ii; ++i) {
       var feature = features[i];
@@ -168,7 +168,7 @@ ol.source.TileVector.prototype.forEachFeatureInExtentAtResolution =
     for (y = tileRange.minY; y <= tileRange.maxY; ++y) {
       var tileKey = this.getTileKeyZXY_(z, x, y);
       var features = tiles[tileKey];
-      if (goog.isDef(features)) {
+      if (features !== undefined) {
         var i, ii;
         for (i = 0, ii = features.length; i < ii; ++i) {
           var result = f.call(opt_this, features[i]);
@@ -305,7 +305,7 @@ ol.source.TileVector.prototype.loadFeatures =
             tileCoord, projection);
         var url = goog.isNull(urlTileCoord) ? undefined :
             tileUrlFunction(urlTileCoord, 1, projection);
-        if (goog.isDef(url)) {
+        if (url !== undefined) {
           tiles[tileKey] = [];
           var tileSuccess = goog.partial(success, tileKey);
           if (!goog.isNull(this.tileLoadFunction_)) {

--- a/src/ol/source/tilewmssource.js
+++ b/src/ol/source/tilewmssource.js
@@ -52,7 +52,7 @@ ol.source.TileWMS = function(opt_options) {
   });
 
   var urls = options.urls;
-  if (!goog.isDef(urls) && goog.isDef(options.url)) {
+  if (urls === undefined && goog.isDef(options.url)) {
     urls = ol.TileUrlFunction.expandUrl(options.url);
   }
 

--- a/src/ol/source/tilewmssource.js
+++ b/src/ol/source/tilewmssource.js
@@ -240,7 +240,7 @@ ol.source.TileWMS.prototype.getRequestUrl_ =
     switch (this.serverType_) {
       case ol.source.wms.ServerType.GEOSERVER:
         var dpi = (90 * pixelRatio + 0.5) | 0;
-        if (goog.isDef(params['FORMAT_OPTIONS'])) {
+        if ('FORMAT_OPTIONS' in params) {
           params['FORMAT_OPTIONS'] += ';dpi:' + dpi;
         } else {
           params['FORMAT_OPTIONS'] = 'dpi:' + dpi;

--- a/src/ol/source/tilewmssource.js
+++ b/src/ol/source/tilewmssource.js
@@ -337,7 +337,7 @@ ol.source.TileWMS.prototype.resetCoordKeyPrefix_ = function() {
  * @api stable
  */
 ol.source.TileWMS.prototype.setUrl = function(url) {
-  var urls = goog.isDef(url) ? ol.TileUrlFunction.expandUrl(url) : null;
+  var urls = url !== undefined ? ol.TileUrlFunction.expandUrl(url) : null;
   this.setUrls(urls);
 };
 

--- a/src/ol/source/tilewmssource.js
+++ b/src/ol/source/tilewmssource.js
@@ -292,7 +292,7 @@ ol.source.TileWMS.prototype.getRequestUrl_ =
 ol.source.TileWMS.prototype.getTilePixelSize =
     function(z, pixelRatio, projection) {
   var tileSize = goog.base(this, 'getTilePixelSize', z, pixelRatio, projection);
-  if (pixelRatio == 1 || !this.hidpi_ || !goog.isDef(this.serverType_)) {
+  if (pixelRatio == 1 || !this.hidpi_ || this.serverType_ === undefined) {
     return tileSize;
   } else {
     return ol.size.scale(tileSize, pixelRatio, this.tmpSize);
@@ -373,7 +373,7 @@ ol.source.TileWMS.prototype.tileUrlFunction_ =
     return undefined;
   }
 
-  if (pixelRatio != 1 && (!this.hidpi_ || !goog.isDef(this.serverType_))) {
+  if (pixelRatio != 1 && (!this.hidpi_ || this.serverType_ === undefined)) {
     pixelRatio = 1;
   }
 

--- a/src/ol/source/tilewmssource.js
+++ b/src/ol/source/tilewmssource.js
@@ -33,7 +33,7 @@ goog.require('ol.tilecoord');
  */
 ol.source.TileWMS = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options || {};
 
   var params = goog.isDef(options.params) ? options.params : {};
 

--- a/src/ol/source/tilewmssource.js
+++ b/src/ol/source/tilewmssource.js
@@ -35,7 +35,7 @@ ol.source.TileWMS = function(opt_options) {
 
   var options = opt_options || {};
 
-  var params = goog.isDef(options.params) ? options.params : {};
+  var params = options.params !== undefined ? options.params : {};
 
   var transparent = goog.object.get(params, 'TRANSPARENT', true);
 
@@ -48,11 +48,11 @@ ol.source.TileWMS = function(opt_options) {
     tileGrid: options.tileGrid,
     tileLoadFunction: options.tileLoadFunction,
     tileUrlFunction: goog.bind(this.tileUrlFunction_, this),
-    wrapX: goog.isDef(options.wrapX) ? options.wrapX : true
+    wrapX: options.wrapX !== undefined ? options.wrapX : true
   });
 
   var urls = options.urls;
-  if (urls === undefined && goog.isDef(options.url)) {
+  if (urls === undefined && options.url !== undefined) {
     urls = ol.TileUrlFunction.expandUrl(options.url);
   }
 
@@ -66,7 +66,7 @@ ol.source.TileWMS = function(opt_options) {
    * @private
    * @type {number}
    */
-  this.gutter_ = goog.isDef(options.gutter) ? options.gutter : 0;
+  this.gutter_ = options.gutter !== undefined ? options.gutter : 0;
 
   /**
    * @private
@@ -91,7 +91,7 @@ ol.source.TileWMS = function(opt_options) {
    * @private
    * @type {boolean}
    */
-  this.hidpi_ = goog.isDef(options.hidpi) ? options.hidpi : true;
+  this.hidpi_ = options.hidpi !== undefined ? options.hidpi : true;
 
   /**
    * @private

--- a/src/ol/source/vectorsource.js
+++ b/src/ol/source/vectorsource.js
@@ -75,7 +75,7 @@ ol.source.VectorEventType = {
  */
 ol.source.Vector = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options || {};
 
   goog.base(this, {
     attributions: options.attributions,

--- a/src/ol/source/vectorsource.js
+++ b/src/ol/source/vectorsource.js
@@ -572,7 +572,7 @@ ol.source.Vector.prototype.getFeatures = function() {
           features, goog.object.getValues(this.nullGeometryFeatures_));
     }
   }
-  goog.asserts.assert(goog.isDef(features),
+  goog.asserts.assert(features !== undefined,
       'Neither featuresRtree_ nor featuresCollection_ are available');
   return features;
 };
@@ -692,7 +692,7 @@ ol.source.Vector.prototype.getExtent = function() {
  */
 ol.source.Vector.prototype.getFeatureById = function(id) {
   var feature = this.idIndex_[id.toString()];
-  return goog.isDef(feature) ? feature : null;
+  return feature !== undefined ? feature : null;
 };
 
 

--- a/src/ol/source/vectorsource.js
+++ b/src/ol/source/vectorsource.js
@@ -164,10 +164,10 @@ ol.source.Vector = function(opt_options) {
   if (!useSpatialIndex && !goog.isDef(collection)) {
     collection = new ol.Collection(features);
   }
-  if (goog.isDef(features)) {
+  if (features !== undefined) {
     this.addFeaturesInternal(features);
   }
-  if (goog.isDef(collection)) {
+  if (collection !== undefined) {
     this.bindFeaturesCollection_(collection);
   }
 
@@ -246,7 +246,7 @@ ol.source.Vector.prototype.setupChangeEvents_ = function(featureKey, feature) {
 ol.source.Vector.prototype.addToIndex_ = function(featureKey, feature) {
   var valid = true;
   var id = feature.getId();
-  if (goog.isDef(id)) {
+  if (id !== undefined) {
     if (!(id.toString() in this.idIndex_)) {
       this.idIndex_[id.toString()] = feature;
     } else {
@@ -726,7 +726,7 @@ ol.source.Vector.prototype.handleFeatureChange_ = function(event) {
   }
   var id = feature.getId();
   var removed;
-  if (goog.isDef(id)) {
+  if (id !== undefined) {
     var sid = id.toString();
     if (featureKey in this.undefIdIndex_) {
       delete this.undefIdIndex_[featureKey];
@@ -827,7 +827,7 @@ ol.source.Vector.prototype.removeFeatureInternal = function(feature) {
       goog.events.unlistenByKey);
   delete this.featureChangeKeys_[featureKey];
   var id = feature.getId();
-  if (goog.isDef(id)) {
+  if (id !== undefined) {
     delete this.idIndex_[id.toString()];
   } else {
     delete this.undefIdIndex_[featureKey];

--- a/src/ol/source/vectorsource.js
+++ b/src/ol/source/vectorsource.js
@@ -91,9 +91,9 @@ ol.source.Vector = function(opt_options) {
    */
   this.loader_ = goog.nullFunction;
 
-  if (goog.isDef(options.loader)) {
+  if (options.loader !== undefined) {
     this.loader_ = options.loader;
-  } else if (goog.isDef(options.url)) {
+  } else if (options.url !== undefined) {
     goog.asserts.assert(goog.isDef(options.format),
         'format must be set when url is set');
     // create a XHR feature loader for "url" and "format"

--- a/src/ol/source/vectorsource.js
+++ b/src/ol/source/vectorsource.js
@@ -82,7 +82,7 @@ ol.source.Vector = function(opt_options) {
     logo: options.logo,
     projection: undefined,
     state: ol.source.State.READY,
-    wrapX: goog.isDef(options.wrapX) ? options.wrapX : true
+    wrapX: options.wrapX !== undefined ? options.wrapX : true
   });
 
   /**
@@ -94,7 +94,7 @@ ol.source.Vector = function(opt_options) {
   if (options.loader !== undefined) {
     this.loader_ = options.loader;
   } else if (options.url !== undefined) {
-    goog.asserts.assert(goog.isDef(options.format),
+    goog.asserts.assert(options.format !== undefined,
         'format must be set when url is set');
     // create a XHR feature loader for "url" and "format"
     this.loader_ = ol.featureloader.xhr(options.url, options.format);
@@ -104,11 +104,11 @@ ol.source.Vector = function(opt_options) {
    * @private
    * @type {ol.LoadingStrategy}
    */
-  this.strategy_ = goog.isDef(options.strategy) ? options.strategy :
+  this.strategy_ = options.strategy !== undefined ? options.strategy :
       ol.loadingstrategy.all;
 
   var useSpatialIndex =
-      goog.isDef(options.useSpatialIndex) ? options.useSpatialIndex : true;
+      options.useSpatialIndex !== undefined ? options.useSpatialIndex : true;
 
   /**
    * @private

--- a/src/ol/source/vectorsource.js
+++ b/src/ol/source/vectorsource.js
@@ -161,7 +161,7 @@ ol.source.Vector = function(opt_options) {
   } else if (goog.isArray(options.features)) {
     features = options.features;
   }
-  if (!useSpatialIndex && !goog.isDef(collection)) {
+  if (!useSpatialIndex && collection === undefined) {
     collection = new ol.Collection(features);
   }
   if (features !== undefined) {

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -404,7 +404,7 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
     goog.array.forEach(l['Dimension'], function(elt, index, array) {
       var key = elt['Identifier'];
       var value = elt['default'];
-      if (goog.isDef(value)) {
+      if (value !== undefined) {
         goog.asserts.assert(goog.array.contains(elt['values'], value),
             'default value contained in values');
       } else {
@@ -432,7 +432,7 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
 
   var wgs84BoundingBox = l['WGS84BoundingBox'];
   var extent, wrapX;
-  if (goog.isDef(wgs84BoundingBox)) {
+  if (wgs84BoundingBox !== undefined) {
     var wgs84ProjectionExtent = ol.proj.get('EPSG:4326').getExtent();
     wrapX = (wgs84BoundingBox[0] == wgs84ProjectionExtent[0] &&
         wgs84BoundingBox[2] == wgs84ProjectionExtent[2]);

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -83,7 +83,7 @@ ol.source.WMTS = function(options) {
   this.style_ = options.style;
 
   var urls = options.urls;
-  if (!goog.isDef(urls) && goog.isDef(options.url)) {
+  if (urls === undefined && goog.isDef(options.url)) {
     urls = ol.TileUrlFunction.expandUrl(options.url);
   }
 

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -355,7 +355,7 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
   var tileMatrixSets = wmtsCap['Contents']['TileMatrixSet'];
   var idx, matrixSet;
   if (l['TileMatrixSetLink'].length > 1) {
-    if (goog.isDef(config['projection'])) {
+    if ('projection' in config) {
       idx = goog.array.findIndex(l['TileMatrixSetLink'],
           function(elt, index, array) {
             var tileMatrixSet = goog.array.find(tileMatrixSets, function(el) {
@@ -384,11 +384,11 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
       'TileMatrixSet must not be null');
 
   var format = /** @type {string} */ (l['Format'][0]);
-  if (goog.isDef(config['format'])) {
+  if ('format' in config) {
     format = config['format'];
   }
   idx = goog.array.findIndex(l['Style'], function(elt, index, array) {
-    if (goog.isDef(config['style'])) {
+    if ('style' in config) {
       return elt['Title'] == config['style'];
     } else {
       return elt['isDefault'];
@@ -400,7 +400,7 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
   var style = /** @type {string} */ (l['Style'][idx]['Identifier']);
 
   var dimensions = {};
-  if (goog.isDef(l['Dimension'])) {
+  if ('Dimension' in l) {
     goog.array.forEach(l['Dimension'], function(elt, index, array) {
       var key = elt['Identifier'];
       var value = elt['default'];
@@ -423,7 +423,7 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
       'found matrixSet in Contents/TileMatrixSet');
 
   var projection;
-  if (goog.isDef(config['projection'])) {
+  if ('projection' in config) {
     projection = ol.proj.get(config['projection']);
   } else {
     projection = ol.proj.get(matrixSetObj['SupportedCRS'].replace(

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -43,19 +43,19 @@ ol.source.WMTS = function(options) {
    * @private
    * @type {string}
    */
-  this.version_ = goog.isDef(options.version) ? options.version : '1.0.0';
+  this.version_ = options.version !== undefined ? options.version : '1.0.0';
 
   /**
    * @private
    * @type {string}
    */
-  this.format_ = goog.isDef(options.format) ? options.format : 'image/jpeg';
+  this.format_ = options.format !== undefined ? options.format : 'image/jpeg';
 
   /**
    * @private
    * @type {Object}
    */
-  this.dimensions_ = goog.isDef(options.dimensions) ? options.dimensions : {};
+  this.dimensions_ = options.dimensions !== undefined ? options.dimensions : {};
 
   /**
    * @private
@@ -83,7 +83,7 @@ ol.source.WMTS = function(options) {
   this.style_ = options.style;
 
   var urls = options.urls;
-  if (urls === undefined && goog.isDef(options.url)) {
+  if (urls === undefined && options.url !== undefined) {
     urls = ol.TileUrlFunction.expandUrl(options.url);
   }
 
@@ -100,7 +100,7 @@ ol.source.WMTS = function(options) {
    * @private
    * @type {ol.source.WMTSRequestEncoding}
    */
-  this.requestEncoding_ = goog.isDef(options.requestEncoding) ?
+  this.requestEncoding_ = options.requestEncoding !== undefined ?
       /** @type {ol.source.WMTSRequestEncoding} */ (options.requestEncoding) :
       ol.source.WMTSRequestEncoding.KVP;
 
@@ -190,7 +190,7 @@ ol.source.WMTS = function(options) {
     tileLoadFunction: options.tileLoadFunction,
     tilePixelRatio: options.tilePixelRatio,
     tileUrlFunction: tileUrlFunction,
-    wrapX: goog.isDef(options.wrapX) ? options.wrapX : false
+    wrapX: options.wrapX !== undefined ? options.wrapX : false
   });
 
 };

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -410,7 +410,7 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
       } else {
         value = elt['values'][0];
       }
-      goog.asserts.assert(goog.isDef(value), 'value could be found');
+      goog.asserts.assert(value !== undefined, 'value could be found');
       dimensions[key] = value;
     });
   }
@@ -454,7 +454,7 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
   /** @type {!Array.<string>} */
   var urls = [];
   var requestEncoding = config['requestEncoding'];
-  requestEncoding = goog.isDef(requestEncoding) ? requestEncoding : '';
+  requestEncoding = requestEncoding !== undefined ? requestEncoding : '';
 
   goog.asserts.assert(
       goog.array.contains(['REST', 'RESTful', 'KVP', ''], requestEncoding),

--- a/src/ol/source/xyzsource.js
+++ b/src/ol/source/xyzsource.js
@@ -28,10 +28,10 @@ goog.require('ol.source.TileImage');
  * @api stable
  */
 ol.source.XYZ = function(options) {
-  var projection = goog.isDef(options.projection) ?
+  var projection = options.projection !== undefined ?
       options.projection : 'EPSG:3857';
 
-  var tileGrid = goog.isDef(options.tileGrid) ? options.tileGrid :
+  var tileGrid = options.tileGrid !== undefined ? options.tileGrid :
       ol.tilegrid.createXYZ({
         extent: ol.tilegrid.extentFromProjection(projection),
         maxZoom: options.maxZoom,
@@ -53,7 +53,7 @@ ol.source.XYZ = function(options) {
     tileLoadFunction: options.tileLoadFunction,
     tilePixelRatio: options.tilePixelRatio,
     tileUrlFunction: ol.TileUrlFunction.nullTileUrlFunction,
-    wrapX: goog.isDef(options.wrapX) ? options.wrapX : true
+    wrapX: options.wrapX !== undefined ? options.wrapX : true
   });
 
   if (options.tileUrlFunction !== undefined) {

--- a/src/ol/source/xyzsource.js
+++ b/src/ol/source/xyzsource.js
@@ -56,11 +56,11 @@ ol.source.XYZ = function(options) {
     wrapX: goog.isDef(options.wrapX) ? options.wrapX : true
   });
 
-  if (goog.isDef(options.tileUrlFunction)) {
+  if (options.tileUrlFunction !== undefined) {
     this.setTileUrlFunction(options.tileUrlFunction);
-  } else if (goog.isDef(options.urls)) {
+  } else if (options.urls !== undefined) {
     this.setUrls(options.urls);
-  } else if (goog.isDef(options.url)) {
+  } else if (options.url !== undefined) {
     this.setUrl(options.url);
   }
 

--- a/src/ol/source/zoomifysource.js
+++ b/src/ol/source/zoomifysource.js
@@ -36,7 +36,7 @@ ol.source.Zoomify = function(opt_options) {
   var options = opt_options || {};
 
   var size = options.size;
-  var tierSizeCalculation = goog.isDef(options.tierSizeCalculation) ?
+  var tierSizeCalculation = options.tierSizeCalculation !== undefined ?
       options.tierSizeCalculation :
       ol.source.ZoomifyTierSizeCalculation.DEFAULT;
 

--- a/src/ol/source/zoomifysource.js
+++ b/src/ol/source/zoomifysource.js
@@ -165,7 +165,8 @@ goog.inherits(ol.source.ZoomifyTile_, ol.ImageTile);
  */
 ol.source.ZoomifyTile_.prototype.getImage = function(opt_context) {
   var tileSize = ol.DEFAULT_TILE_SIZE;
-  var key = goog.isDef(opt_context) ? goog.getUid(opt_context).toString() : '';
+  var key = opt_context !== undefined ?
+      goog.getUid(opt_context).toString() : '';
   if (key in this.zoomifyImageByContext_) {
     return this.zoomifyImageByContext_[key];
   } else {

--- a/src/ol/source/zoomifysource.js
+++ b/src/ol/source/zoomifysource.js
@@ -33,7 +33,7 @@ ol.source.ZoomifyTierSizeCalculation = {
  */
 ol.source.Zoomify = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options || {};
 
   var size = options.size;
   var tierSizeCalculation = goog.isDef(options.tierSizeCalculation) ?

--- a/src/ol/structs/lrucache.js
+++ b/src/ol/structs/lrucache.js
@@ -130,7 +130,7 @@ ol.structs.LRUCache.prototype.forEach = function(f, opt_this) {
  */
 ol.structs.LRUCache.prototype.get = function(key) {
   var entry = this.entries_[key];
-  goog.asserts.assert(goog.isDef(entry), 'an entry exists for key %s', key);
+  goog.asserts.assert(entry !== undefined, 'an entry exists for key %s', key);
   if (entry === this.newest_) {
     return entry.value_;
   } else if (entry === this.oldest_) {

--- a/src/ol/style/atlasmanager.js
+++ b/src/ol/style/atlasmanager.js
@@ -47,7 +47,7 @@ ol.style.AtlasManager = function(opt_options) {
    * @private
    * @type {number}
    */
-  this.currentSize_ = goog.isDef(options.initialSize) ?
+  this.currentSize_ = options.initialSize !== undefined ?
       options.initialSize : ol.INITIAL_ATLAS_SIZE;
 
   /**
@@ -55,9 +55,9 @@ ol.style.AtlasManager = function(opt_options) {
    * @private
    * @type {number}
    */
-  this.maxSize_ = goog.isDef(options.maxSize) ?
+  this.maxSize_ = options.maxSize !== undefined ?
       options.maxSize : ol.MAX_ATLAS_SIZE != -1 ?
-          ol.MAX_ATLAS_SIZE : goog.isDef(ol.WEBGL_MAX_TEXTURE_SIZE) ?
+          ol.MAX_ATLAS_SIZE : ol.WEBGL_MAX_TEXTURE_SIZE !== undefined ?
               ol.WEBGL_MAX_TEXTURE_SIZE : 2048;
 
   /**
@@ -65,7 +65,7 @@ ol.style.AtlasManager = function(opt_options) {
    * @private
    * @type {number}
    */
-  this.space_ = goog.isDef(options.space) ? options.space : 1;
+  this.space_ = options.space !== undefined ? options.space : 1;
 
   /**
    * @private

--- a/src/ol/style/atlasmanager.js
+++ b/src/ol/style/atlasmanager.js
@@ -191,7 +191,7 @@ ol.style.AtlasManager.prototype.add =
   // even if no hit-detection entry is requested, we insert a fake entry into
   // the hit-detection atlas, to make sure that the offset is the same for
   // the original image and the hit-detection image.
-  var renderHitCallback = goog.isDef(opt_renderHitCallback) ?
+  var renderHitCallback = opt_renderHitCallback !== undefined ?
       opt_renderHitCallback : goog.functions.NULL;
 
   /** @type {?ol.style.AtlasInfo} */

--- a/src/ol/style/atlasmanager.js
+++ b/src/ol/style/atlasmanager.js
@@ -40,7 +40,7 @@ ol.style.AtlasManagerInfo;
  */
 ol.style.AtlasManager = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options || {};
 
   /**
    * The size in pixels of the latest atlas image.

--- a/src/ol/style/circlestyle.js
+++ b/src/ol/style/circlestyle.js
@@ -249,7 +249,7 @@ ol.style.Circle.prototype.render_ = function(atlasManager) {
   if (!goog.isNull(this.stroke_)) {
     strokeStyle = ol.color.asString(this.stroke_.getColor());
     strokeWidth = this.stroke_.getWidth();
-    if (!goog.isDef(strokeWidth)) {
+    if (strokeWidth === undefined) {
       strokeWidth = ol.render.canvas.defaultLineWidth;
     }
     lineDash = this.stroke_.getLineDash();
@@ -269,7 +269,7 @@ ol.style.Circle.prototype.render_ = function(atlasManager) {
     lineDash: lineDash
   };
 
-  if (!goog.isDef(atlasManager)) {
+  if (atlasManager === undefined) {
     // no atlas manager is used, create a new canvas
     this.canvas_ = /** @type {HTMLCanvasElement} */
         (goog.dom.createElement(goog.dom.TagName.CANVAS));

--- a/src/ol/style/circlestyle.js
+++ b/src/ol/style/circlestyle.js
@@ -50,13 +50,13 @@ ol.style.Circle = function(opt_options) {
    * @private
    * @type {ol.style.Fill}
    */
-  this.fill_ = goog.isDef(options.fill) ? options.fill : null;
+  this.fill_ = options.fill !== undefined ? options.fill : null;
 
   /**
    * @private
    * @type {ol.style.Stroke}
    */
-  this.stroke_ = goog.isDef(options.stroke) ? options.stroke : null;
+  this.stroke_ = options.stroke !== undefined ? options.stroke : null;
 
   /**
    * @private
@@ -99,7 +99,7 @@ ol.style.Circle = function(opt_options) {
   /**
    * @type {boolean}
    */
-  var snapToPixel = goog.isDef(options.snapToPixel) ?
+  var snapToPixel = options.snapToPixel !== undefined ?
       options.snapToPixel : true;
 
   goog.base(this, {
@@ -435,7 +435,7 @@ ol.style.Circle.prototype.getChecksum = function() {
 
   if (recalculate) {
     var checksum = 'c' + strokeChecksum + fillChecksum +
-        (goog.isDef(this.radius_) ? this.radius_.toString() : '-');
+        (this.radius_ !== undefined ? this.radius_.toString() : '-');
     this.checksums_ = [checksum, strokeChecksum, fillChecksum, this.radius_];
   }
 

--- a/src/ol/style/circlestyle.js
+++ b/src/ol/style/circlestyle.js
@@ -26,7 +26,7 @@ goog.require('ol.style.Stroke');
  */
 ol.style.Circle = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options || {};
 
   /**
    * @private

--- a/src/ol/style/fillstyle.js
+++ b/src/ol/style/fillstyle.js
@@ -58,7 +58,7 @@ ol.style.Fill.prototype.setColor = function(color) {
  * @inheritDoc
  */
 ol.style.Fill.prototype.getChecksum = function() {
-  if (!goog.isDef(this.checksum_)) {
+  if (this.checksum_ === undefined) {
     this.checksum_ = 'f' + (!goog.isNull(this.color_) ?
         ol.color.asString(this.color_) : '-');
   }

--- a/src/ol/style/fillstyle.js
+++ b/src/ol/style/fillstyle.js
@@ -22,7 +22,7 @@ ol.style.Fill = function(opt_options) {
    * @private
    * @type {ol.Color|string}
    */
-  this.color_ = goog.isDef(options.color) ? options.color : null;
+  this.color_ = options.color !== undefined ? options.color : null;
 
   /**
    * @private

--- a/src/ol/style/fillstyle.js
+++ b/src/ol/style/fillstyle.js
@@ -16,7 +16,7 @@ goog.require('ol.structs.IHasChecksum');
  */
 ol.style.Fill = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options || {};
 
   /**
    * @private

--- a/src/ol/style/iconstyle.js
+++ b/src/ol/style/iconstyle.js
@@ -55,7 +55,7 @@ ol.style.Icon = function(opt_options) {
    * @private
    * @type {Array.<number>}
    */
-  this.anchor_ = goog.isDef(options.anchor) ? options.anchor : [0.5, 0.5];
+  this.anchor_ = options.anchor !== undefined ? options.anchor : [0.5, 0.5];
 
   /**
    * @private
@@ -67,38 +67,38 @@ ol.style.Icon = function(opt_options) {
    * @private
    * @type {ol.style.IconOrigin}
    */
-  this.anchorOrigin_ = goog.isDef(options.anchorOrigin) ?
+  this.anchorOrigin_ = options.anchorOrigin !== undefined ?
       options.anchorOrigin : ol.style.IconOrigin.TOP_LEFT;
 
   /**
    * @private
    * @type {ol.style.IconAnchorUnits}
    */
-  this.anchorXUnits_ = goog.isDef(options.anchorXUnits) ?
+  this.anchorXUnits_ = options.anchorXUnits !== undefined ?
       options.anchorXUnits : ol.style.IconAnchorUnits.FRACTION;
 
   /**
    * @private
    * @type {ol.style.IconAnchorUnits}
    */
-  this.anchorYUnits_ = goog.isDef(options.anchorYUnits) ?
+  this.anchorYUnits_ = options.anchorYUnits !== undefined ?
       options.anchorYUnits : ol.style.IconAnchorUnits.FRACTION;
 
   /**
    * @type {?string}
    */
   var crossOrigin =
-      goog.isDef(options.crossOrigin) ? options.crossOrigin : null;
+      options.crossOrigin !== undefined ? options.crossOrigin : null;
 
   /**
    * @type {Image}
    */
-  var image = goog.isDef(options.img) ? options.img : null;
+  var image = options.img !== undefined ? options.img : null;
 
   /**
    * @type {ol.Size}
    */
-  var imgSize = goog.isDef(options.imgSize) ? options.imgSize : null;
+  var imgSize = options.imgSize !== undefined ? options.imgSize : null;
 
   /**
    * @type {string|undefined}
@@ -123,7 +123,7 @@ ol.style.Icon = function(opt_options) {
   /**
    * @type {ol.style.ImageState}
    */
-  var imageState = goog.isDef(options.src) ?
+  var imageState = options.src !== undefined ?
       ol.style.ImageState.IDLE : ol.style.ImageState.LOADED;
 
   /**
@@ -137,13 +137,13 @@ ol.style.Icon = function(opt_options) {
    * @private
    * @type {Array.<number>}
    */
-  this.offset_ = goog.isDef(options.offset) ? options.offset : [0, 0];
+  this.offset_ = options.offset !== undefined ? options.offset : [0, 0];
 
   /**
    * @private
    * @type {ol.style.IconOrigin}
    */
-  this.offsetOrigin_ = goog.isDef(options.offsetOrigin) ?
+  this.offsetOrigin_ = options.offsetOrigin !== undefined ?
       options.offsetOrigin : ol.style.IconOrigin.TOP_LEFT;
 
   /**
@@ -156,33 +156,33 @@ ol.style.Icon = function(opt_options) {
    * @private
    * @type {ol.Size}
    */
-  this.size_ = goog.isDef(options.size) ? options.size : null;
+  this.size_ = options.size !== undefined ? options.size : null;
 
   /**
    * @type {number}
    */
-  var opacity = goog.isDef(options.opacity) ? options.opacity : 1;
+  var opacity = options.opacity !== undefined ? options.opacity : 1;
 
   /**
    * @type {boolean}
    */
-  var rotateWithView = goog.isDef(options.rotateWithView) ?
+  var rotateWithView = options.rotateWithView !== undefined ?
       options.rotateWithView : false;
 
   /**
    * @type {number}
    */
-  var rotation = goog.isDef(options.rotation) ? options.rotation : 0;
+  var rotation = options.rotation !== undefined ? options.rotation : 0;
 
   /**
    * @type {number}
    */
-  var scale = goog.isDef(options.scale) ? options.scale : 1;
+  var scale = options.scale !== undefined ? options.scale : 1;
 
   /**
    * @type {boolean}
    */
-  var snapToPixel = goog.isDef(options.snapToPixel) ?
+  var snapToPixel = options.snapToPixel !== undefined ?
       options.snapToPixel : true;
 
   goog.base(this, {
@@ -553,7 +553,7 @@ ol.style.IconImage_.prototype.getSrc = function() {
  */
 ol.style.IconImage_.prototype.load = function() {
   if (this.imageState_ == ol.style.ImageState.IDLE) {
-    goog.asserts.assert(goog.isDef(this.src_),
+    goog.asserts.assert(this.src_ !== undefined,
         'this.src_ must not be undefined');
     goog.asserts.assert(goog.isNull(this.imageListenerKeys_),
         'no listener keys existing');

--- a/src/ol/style/iconstyle.js
+++ b/src/ol/style/iconstyle.js
@@ -49,7 +49,7 @@ ol.style.IconOrigin = {
  */
 ol.style.Icon = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options || {};
 
   /**
    * @private

--- a/src/ol/style/iconstyle.js
+++ b/src/ol/style/iconstyle.js
@@ -108,13 +108,13 @@ ol.style.Icon = function(opt_options) {
   goog.asserts.assert(!(goog.isDef(src) && !goog.isNull(image)),
       'image and src can not provided at the same time');
   goog.asserts.assert(
-      !goog.isDef(src) || (goog.isDef(src) && goog.isNull(imgSize)),
+      src === undefined || (goog.isDef(src) && goog.isNull(imgSize)),
       'imgSize should not be set when src is provided');
   goog.asserts.assert(
       goog.isNull(image) || (!goog.isNull(image) && !goog.isNull(imgSize)),
       'imgSize must be set when image is provided');
 
-  if ((!goog.isDef(src) || src.length === 0) && !goog.isNull(image)) {
+  if ((src === undefined || src.length === 0) && !goog.isNull(image)) {
     src = image.src;
   }
   goog.asserts.assert(goog.isDef(src) && src.length > 0,

--- a/src/ol/style/iconstyle.js
+++ b/src/ol/style/iconstyle.js
@@ -105,10 +105,10 @@ ol.style.Icon = function(opt_options) {
    */
   var src = options.src;
 
-  goog.asserts.assert(!(goog.isDef(src) && !goog.isNull(image)),
+  goog.asserts.assert(!(src !== undefined && !goog.isNull(image)),
       'image and src can not provided at the same time');
   goog.asserts.assert(
-      src === undefined || (goog.isDef(src) && goog.isNull(imgSize)),
+      src === undefined || (src !== undefined && goog.isNull(imgSize)),
       'imgSize should not be set when src is provided');
   goog.asserts.assert(
       goog.isNull(image) || (!goog.isNull(image) && !goog.isNull(imgSize)),
@@ -117,7 +117,7 @@ ol.style.Icon = function(opt_options) {
   if ((src === undefined || src.length === 0) && !goog.isNull(image)) {
     src = image.src;
   }
-  goog.asserts.assert(goog.isDef(src) && src.length > 0,
+  goog.asserts.assert(src !== undefined && src.length > 0,
       'must provide a defined and non-empty src or image');
 
   /**
@@ -620,7 +620,7 @@ goog.addSingletonGetter(ol.style.IconImageCache);
  * @return {string} Cache key.
  */
 ol.style.IconImageCache.getKey = function(src, crossOrigin) {
-  goog.asserts.assert(goog.isDef(crossOrigin),
+  goog.asserts.assert(crossOrigin !== undefined,
       'argument crossOrigin must be defined');
   return crossOrigin + ':' + src;
 };

--- a/src/ol/style/regularshapestyle.js
+++ b/src/ol/style/regularshapestyle.js
@@ -315,7 +315,7 @@ ol.style.RegularShape.prototype.render_ = function(atlasManager) {
   if (!goog.isNull(this.stroke_)) {
     strokeStyle = ol.color.asString(this.stroke_.getColor());
     strokeWidth = this.stroke_.getWidth();
-    if (!goog.isDef(strokeWidth)) {
+    if (strokeWidth === undefined) {
       strokeWidth = ol.render.canvas.defaultLineWidth;
     }
     lineDash = this.stroke_.getLineDash();
@@ -323,15 +323,15 @@ ol.style.RegularShape.prototype.render_ = function(atlasManager) {
       lineDash = null;
     }
     lineJoin = this.stroke_.getLineJoin();
-    if (!goog.isDef(lineJoin)) {
+    if (lineJoin === undefined) {
       lineJoin = ol.render.canvas.defaultLineJoin;
     }
     lineCap = this.stroke_.getLineCap();
-    if (!goog.isDef(lineCap)) {
+    if (lineCap === undefined) {
       lineCap = ol.render.canvas.defaultLineCap;
     }
     miterLimit = this.stroke_.getMiterLimit();
-    if (!goog.isDef(miterLimit)) {
+    if (miterLimit === undefined) {
       miterLimit = ol.render.canvas.defaultMiterLimit;
     }
   }
@@ -349,7 +349,7 @@ ol.style.RegularShape.prototype.render_ = function(atlasManager) {
     miterLimit: miterLimit
   };
 
-  if (!goog.isDef(atlasManager)) {
+  if (atlasManager === undefined) {
     // no atlas manager is used, create a new canvas
     this.canvas_ = /** @type {HTMLCanvasElement} */
         (goog.dom.createElement(goog.dom.TagName.CANVAS));

--- a/src/ol/style/regularshapestyle.js
+++ b/src/ol/style/regularshapestyle.js
@@ -30,7 +30,7 @@ goog.require('ol.style.Stroke');
 ol.style.RegularShape = function(options) {
 
   goog.asserts.assert(
-      goog.isDef(options.radius) || goog.isDef(options.radius1),
+      options.radius !== undefined || options.radius1 !== undefined,
       'must provide either "radius" or "radius1"');
 
   /**
@@ -55,7 +55,7 @@ ol.style.RegularShape = function(options) {
    * @private
    * @type {ol.style.Fill}
    */
-  this.fill_ = goog.isDef(options.fill) ? options.fill : null;
+  this.fill_ = options.fill !== undefined ? options.fill : null;
 
   /**
    * @private
@@ -73,7 +73,7 @@ ol.style.RegularShape = function(options) {
    * @private
    * @type {number}
    */
-  this.radius_ = /** @type {number} */ (goog.isDef(options.radius) ?
+  this.radius_ = /** @type {number} */ (options.radius !== undefined ?
       options.radius : options.radius1);
 
   /**
@@ -81,19 +81,19 @@ ol.style.RegularShape = function(options) {
    * @type {number}
    */
   this.radius2_ =
-      goog.isDef(options.radius2) ? options.radius2 : this.radius_;
+      options.radius2 !== undefined ? options.radius2 : this.radius_;
 
   /**
    * @private
    * @type {number}
    */
-  this.angle_ = goog.isDef(options.angle) ? options.angle : 0;
+  this.angle_ = options.angle !== undefined ? options.angle : 0;
 
   /**
    * @private
    * @type {ol.style.Stroke}
    */
-  this.stroke_ = goog.isDef(options.stroke) ? options.stroke : null;
+  this.stroke_ = options.stroke !== undefined ? options.stroke : null;
 
   /**
    * @private
@@ -124,13 +124,13 @@ ol.style.RegularShape = function(options) {
   /**
    * @type {boolean}
    */
-  var snapToPixel = goog.isDef(options.snapToPixel) ?
+  var snapToPixel = options.snapToPixel !== undefined ?
       options.snapToPixel : true;
 
   goog.base(this, {
     opacity: 1,
     rotateWithView: false,
-    rotation: goog.isDef(options.rotation) ? options.rotation : 0,
+    rotation: options.rotation !== undefined ? options.rotation : 0,
     scale: 1,
     snapToPixel: snapToPixel
   });
@@ -536,10 +536,10 @@ ol.style.RegularShape.prototype.getChecksum = function() {
 
   if (recalculate) {
     var checksum = 'r' + strokeChecksum + fillChecksum +
-        (goog.isDef(this.radius_) ? this.radius_.toString() : '-') +
-        (goog.isDef(this.radius2_) ? this.radius2_.toString() : '-') +
-        (goog.isDef(this.angle_) ? this.angle_.toString() : '-') +
-        (goog.isDef(this.points_) ? this.points_.toString() : '-');
+        (this.radius_ !== undefined ? this.radius_.toString() : '-') +
+        (this.radius2_ !== undefined ? this.radius2_.toString() : '-') +
+        (this.angle_ !== undefined ? this.angle_.toString() : '-') +
+        (this.points_ !== undefined ? this.points_.toString() : '-');
     this.checksums_ = [checksum, strokeChecksum, fillChecksum,
       this.radius_, this.radius2_, this.angle_, this.points_];
   }

--- a/src/ol/style/strokestyle.js
+++ b/src/ol/style/strokestyle.js
@@ -27,7 +27,7 @@ ol.style.Stroke = function(opt_options) {
    * @private
    * @type {ol.Color|string}
    */
-  this.color_ = goog.isDef(options.color) ? options.color : null;
+  this.color_ = options.color !== undefined ? options.color : null;
 
   /**
    * @private
@@ -39,7 +39,7 @@ ol.style.Stroke = function(opt_options) {
    * @private
    * @type {Array.<number>}
    */
-  this.lineDash_ = goog.isDef(options.lineDash) ? options.lineDash : null;
+  this.lineDash_ = options.lineDash !== undefined ? options.lineDash : null;
 
   /**
    * @private
@@ -207,15 +207,15 @@ ol.style.Stroke.prototype.getChecksum = function() {
     var raw = 's' +
         (!goog.isNull(this.color_) ?
             ol.color.asString(this.color_) : '-') + ',' +
-        (goog.isDef(this.lineCap_) ?
+        (this.lineCap_ !== undefined ?
             this.lineCap_.toString() : '-') + ',' +
         (!goog.isNull(this.lineDash_) ?
             this.lineDash_.toString() : '-') + ',' +
-        (goog.isDef(this.lineJoin_) ?
+        (this.lineJoin_ !== undefined ?
             this.lineJoin_ : '-') + ',' +
-        (goog.isDef(this.miterLimit_) ?
+        (this.miterLimit_ !== undefined ?
             this.miterLimit_.toString() : '-') + ',' +
-        (goog.isDef(this.width_) ?
+        (this.width_ !== undefined ?
             this.width_.toString() : '-');
 
     var md5 = new goog.crypt.Md5();

--- a/src/ol/style/strokestyle.js
+++ b/src/ol/style/strokestyle.js
@@ -203,7 +203,7 @@ ol.style.Stroke.prototype.setWidth = function(width) {
  * @inheritDoc
  */
 ol.style.Stroke.prototype.getChecksum = function() {
-  if (!goog.isDef(this.checksum_)) {
+  if (this.checksum_ === undefined) {
     var raw = 's' +
         (!goog.isNull(this.color_) ?
             ol.color.asString(this.color_) : '-') + ',' +

--- a/src/ol/style/strokestyle.js
+++ b/src/ol/style/strokestyle.js
@@ -21,7 +21,7 @@ goog.require('ol.structs.IHasChecksum');
  */
 ol.style.Stroke = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options || {};
 
   /**
    * @private

--- a/src/ol/style/style.js
+++ b/src/ol/style/style.js
@@ -48,25 +48,25 @@ ol.style.Style = function(opt_options) {
    * @private
    * @type {ol.style.Fill}
    */
-  this.fill_ = goog.isDef(options.fill) ? options.fill : null;
+  this.fill_ = options.fill !== undefined ? options.fill : null;
 
   /**
    * @private
    * @type {ol.style.Image}
    */
-  this.image_ = goog.isDef(options.image) ? options.image : null;
+  this.image_ = options.image !== undefined ? options.image : null;
 
   /**
    * @private
    * @type {ol.style.Stroke}
    */
-  this.stroke_ = goog.isDef(options.stroke) ? options.stroke : null;
+  this.stroke_ = options.stroke !== undefined ? options.stroke : null;
 
   /**
    * @private
    * @type {ol.style.Text}
    */
-  this.text_ = goog.isDef(options.text) ? options.text : null;
+  this.text_ = options.text !== undefined ? options.text : null;
 
   /**
    * @private

--- a/src/ol/style/style.js
+++ b/src/ol/style/style.js
@@ -26,7 +26,7 @@ goog.require('ol.style.Stroke');
  */
 ol.style.Style = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options || {};
 
   /**
    * @private

--- a/src/ol/style/style.js
+++ b/src/ol/style/style.js
@@ -172,7 +172,7 @@ ol.style.Style.prototype.setGeometry = function(geometry) {
     };
   } else if (goog.isNull(geometry)) {
     this.geometryFunction_ = ol.style.defaultGeometryFunction;
-  } else if (goog.isDef(geometry)) {
+  } else if (geometry !== undefined) {
     goog.asserts.assertInstanceof(geometry, ol.geom.Geometry,
         'geometry must be an ol.geom.Geometry instance');
     this.geometryFunction_ = function() {

--- a/src/ol/style/style.js
+++ b/src/ol/style/style.js
@@ -40,7 +40,7 @@ ol.style.Style = function(opt_options) {
    */
   this.geometryFunction_ = ol.style.defaultGeometryFunction;
 
-  if (goog.isDef(options.geometry)) {
+  if (options.geometry !== undefined) {
     this.setGeometry(options.geometry);
   }
 

--- a/src/ol/style/textstyle.js
+++ b/src/ol/style/textstyle.js
@@ -57,26 +57,26 @@ ol.style.Text = function(opt_options) {
    * @private
    * @type {ol.style.Fill}
    */
-  this.fill_ = goog.isDef(options.fill) ? options.fill :
+  this.fill_ = options.fill !== undefined ? options.fill :
       new ol.style.Fill({color: ol.style.Text.DEFAULT_FILL_COLOR_});
 
   /**
    * @private
    * @type {ol.style.Stroke}
    */
-  this.stroke_ = goog.isDef(options.stroke) ? options.stroke : null;
+  this.stroke_ = options.stroke !== undefined ? options.stroke : null;
 
   /**
    * @private
    * @type {number}
    */
-  this.offsetX_ = goog.isDef(options.offsetX) ? options.offsetX : 0;
+  this.offsetX_ = options.offsetX !== undefined ? options.offsetX : 0;
 
   /**
    * @private
    * @type {number}
    */
-  this.offsetY_ = goog.isDef(options.offsetY) ? options.offsetY : 0;
+  this.offsetY_ = options.offsetY !== undefined ? options.offsetY : 0;
 };
 
 

--- a/src/ol/style/textstyle.js
+++ b/src/ol/style/textstyle.js
@@ -15,7 +15,7 @@ goog.require('ol.style.Fill');
  */
 ol.style.Text = function(opt_options) {
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options || {};
 
   /**
    * @private

--- a/src/ol/tilecache.js
+++ b/src/ol/tilecache.js
@@ -21,7 +21,7 @@ ol.TileCache = function(opt_highWaterMark) {
    * @private
    * @type {number}
    */
-  this.highWaterMark_ = goog.isDef(opt_highWaterMark) ?
+  this.highWaterMark_ = opt_highWaterMark !== undefined ?
       opt_highWaterMark : ol.DEFAULT_TILE_CACHE_HIGH_WATER_MARK;
 
 };

--- a/src/ol/tilecoord.js
+++ b/src/ol/tilecoord.js
@@ -50,7 +50,7 @@ ol.tilecoord.createFromString = function(str) {
  * @return {ol.TileCoord} Tile coordinate.
  */
 ol.tilecoord.createOrUpdate = function(z, x, y, opt_tileCoord) {
-  if (goog.isDef(opt_tileCoord)) {
+  if (opt_tileCoord !== undefined) {
     opt_tileCoord[0] = z;
     opt_tileCoord[1] = x;
     opt_tileCoord[2] = y;

--- a/src/ol/tilegrid/tilegrid.js
+++ b/src/ol/tilegrid/tilegrid.js
@@ -64,7 +64,7 @@ ol.tilegrid.TileGrid = function(options) {
    * @type {Array.<ol.Coordinate>}
    */
   this.origins_ = null;
-  if (goog.isDef(options.origins)) {
+  if (options.origins !== undefined) {
     this.origins_ = options.origins;
     goog.asserts.assert(this.origins_.length == this.resolutions_.length,
         'number of origins and resolutions must be equal');
@@ -87,7 +87,7 @@ ol.tilegrid.TileGrid = function(options) {
    * @type {Array.<number|ol.Size>}
    */
   this.tileSizes_ = null;
-  if (goog.isDef(options.tileSizes)) {
+  if (options.tileSizes !== undefined) {
     this.tileSizes_ = options.tileSizes;
     goog.asserts.assert(this.tileSizes_.length == this.resolutions_.length,
         'number of tileSizes and resolutions must be equal');
@@ -118,7 +118,7 @@ ol.tilegrid.TileGrid = function(options) {
    */
   this.fullTileRanges_ = null;
 
-  if (goog.isDef(options.sizes)) {
+  if (options.sizes !== undefined) {
     goog.asserts.assert(options.sizes.length == this.resolutions_.length,
         'number of sizes and resolutions must be equal');
     this.fullTileRanges_ = goog.array.map(options.sizes, function(size, z) {

--- a/src/ol/tilegrid/tilegrid.js
+++ b/src/ol/tilegrid/tilegrid.js
@@ -36,7 +36,7 @@ ol.tilegrid.TileGrid = function(options) {
    * @protected
    * @type {number}
    */
-  this.minZoom = goog.isDef(options.minZoom) ? options.minZoom : 0;
+  this.minZoom = options.minZoom !== undefined ? options.minZoom : 0;
 
   /**
    * @private
@@ -57,7 +57,7 @@ ol.tilegrid.TileGrid = function(options) {
    * @private
    * @type {ol.Coordinate}
    */
-  this.origin_ = goog.isDef(options.origin) ? options.origin : null;
+  this.origin_ = options.origin !== undefined ? options.origin : null;
 
   /**
    * @private
@@ -97,7 +97,7 @@ ol.tilegrid.TileGrid = function(options) {
    * @private
    * @type {number|ol.Size}
    */
-  this.tileSize_ = goog.isDef(options.tileSize) ?
+  this.tileSize_ = options.tileSize !== undefined ?
       options.tileSize :
       goog.isNull(this.tileSizes_) ? ol.DEFAULT_TILE_SIZE : null;
   goog.asserts.assert(

--- a/src/ol/tilegrid/tilegrid.js
+++ b/src/ol/tilegrid/tilegrid.js
@@ -72,7 +72,7 @@ ol.tilegrid.TileGrid = function(options) {
 
   var extent = options.extent;
 
-  if (goog.isDef(extent) &&
+  if (extent !== undefined &&
       goog.isNull(this.origin_) && goog.isNull(this.origins_)) {
     this.origin_ = ol.extent.getTopLeft(extent);
   }
@@ -109,7 +109,7 @@ ol.tilegrid.TileGrid = function(options) {
    * @private
    * @type {ol.Extent}
    */
-  this.extent_ = goog.isDef(extent) ? extent : null;
+  this.extent_ = extent !== undefined ? extent : null;
 
 
   /**
@@ -127,7 +127,7 @@ ol.tilegrid.TileGrid = function(options) {
       var tileRange = new ol.TileRange(
           Math.min(0, size[0]), Math.max(size[0] - 1, -1),
           Math.min(0, size[1]), Math.max(size[1] - 1, -1));
-      if (this.minZoom <= z && z <= this.maxZoom && goog.isDef(extent)) {
+      if (this.minZoom <= z && z <= this.maxZoom && extent !== undefined) {
         goog.asserts.assert(tileRange.containsTileRange(
             this.getTileRangeForExtentAndZ(extent, z)),
             'extent tile range must not exceed tilegrid width and height');
@@ -527,7 +527,7 @@ ol.tilegrid.getForProjection = function(projection) {
  */
 ol.tilegrid.createForExtent =
     function(extent, opt_maxZoom, opt_tileSize, opt_corner) {
-  var corner = goog.isDef(opt_corner) ?
+  var corner = opt_corner !== undefined ?
       opt_corner : ol.extent.Corner.TOP_LEFT;
 
   var resolutions = ol.tilegrid.resolutionsFromExtent(
@@ -550,7 +550,7 @@ ol.tilegrid.createForExtent =
  */
 ol.tilegrid.createXYZ = function(opt_options) {
   var options = /** @type {olx.tilegrid.TileGridOptions} */ ({});
-  goog.object.extend(options, goog.isDef(opt_options) ?
+  goog.object.extend(options, opt_options !== undefined ?
       opt_options : /** @type {olx.tilegrid.XYZOptions} */ ({}));
   if (options.extent === undefined) {
     options.extent = ol.proj.get('EPSG:3857').getExtent();
@@ -574,13 +574,13 @@ ol.tilegrid.createXYZ = function(opt_options) {
  */
 ol.tilegrid.resolutionsFromExtent =
     function(extent, opt_maxZoom, opt_tileSize) {
-  var maxZoom = goog.isDef(opt_maxZoom) ?
+  var maxZoom = opt_maxZoom !== undefined ?
       opt_maxZoom : ol.DEFAULT_MAX_ZOOM;
 
   var height = ol.extent.getHeight(extent);
   var width = ol.extent.getWidth(extent);
 
-  var tileSize = ol.size.toSize(goog.isDef(opt_tileSize) ?
+  var tileSize = ol.size.toSize(opt_tileSize !== undefined ?
       opt_tileSize : ol.DEFAULT_TILE_SIZE);
   var maxResolution = Math.max(
       width / tileSize[0], height / tileSize[1]);

--- a/src/ol/tilegrid/tilegrid.js
+++ b/src/ol/tilegrid/tilegrid.js
@@ -552,7 +552,7 @@ ol.tilegrid.createXYZ = function(opt_options) {
   var options = /** @type {olx.tilegrid.TileGridOptions} */ ({});
   goog.object.extend(options, goog.isDef(opt_options) ?
       opt_options : /** @type {olx.tilegrid.XYZOptions} */ ({}));
-  if (!goog.isDef(options.extent)) {
+  if (options.extent === undefined) {
     options.extent = ol.proj.get('EPSG:3857').getExtent();
   }
   options.resolutions = ol.tilegrid.resolutionsFromExtent(

--- a/src/ol/tilerange.js
+++ b/src/ol/tilerange.js
@@ -79,7 +79,7 @@ ol.TileRange.boundingTileRange = function(var_args) {
  * @return {ol.TileRange} Tile range.
  */
 ol.TileRange.createOrUpdate = function(minX, maxX, minY, maxY, tileRange) {
-  if (goog.isDef(tileRange)) {
+  if (tileRange !== undefined) {
     tileRange.minX = minX;
     tileRange.maxX = maxX;
     tileRange.minY = minY;

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -703,7 +703,7 @@ ol.View.createResolutionConstraint_ = function(options) {
 
     // user provided minResolution takes precedence
     minResolution = options.minResolution;
-    if (!goog.isDef(minResolution)) {
+    if (minResolution === undefined) {
       if (options.maxZoom !== undefined) {
         if (options.maxResolution !== undefined) {
           minResolution = maxResolution / Math.pow(zoomFactor, maxZoom);

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -175,7 +175,7 @@ goog.inherits(ol.View, ol.Object);
 ol.View.prototype.calculateCenterRotate = function(rotation, anchor) {
   var center;
   var currentCenter = this.getCenter();
-  if (goog.isDef(currentCenter)) {
+  if (currentCenter !== undefined) {
     center = [currentCenter[0] - anchor[0], currentCenter[1] - anchor[1]];
     ol.coordinate.rotate(center, rotation - this.getRotation());
     ol.coordinate.add(center, anchor);
@@ -421,7 +421,7 @@ ol.View.prototype.getZoom = function() {
   var offset;
   var resolution = this.getResolution();
 
-  if (goog.isDef(resolution)) {
+  if (resolution !== undefined) {
     var res, z = 0;
     do {
       res = this.constrainResolution(this.maxResolution_, z);
@@ -564,7 +564,7 @@ ol.View.prototype.isDef = function() {
  * @api stable
  */
 ol.View.prototype.rotate = function(rotation, opt_anchor) {
-  if (goog.isDef(opt_anchor)) {
+  if (opt_anchor !== undefined) {
     var center = this.calculateCenterRotate(rotation, opt_anchor);
     this.setCenter(center);
   }
@@ -695,7 +695,7 @@ ol.View.createResolutionConstraint_ = function(options) {
 
     // user provided maxResolution takes precedence
     maxResolution = options.maxResolution;
-    if (goog.isDef(maxResolution)) {
+    if (maxResolution !== undefined) {
       minZoom = 0;
     } else {
       maxResolution = defaultMaxResolution / Math.pow(zoomFactor, minZoom);

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -738,7 +738,7 @@ ol.View.createRotationConstraint_ = function(options) {
       options.enableRotation : true;
   if (enableRotation) {
     var constrainRotation = options.constrainRotation;
-    if (!goog.isDef(constrainRotation) || constrainRotation === true) {
+    if (constrainRotation === undefined || constrainRotation === true) {
       return ol.RotationConstraint.createSnapToZero();
     } else if (constrainRotation === false) {
       return ol.RotationConstraint.none;

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -112,7 +112,7 @@ ol.View = function(opt_options) {
    * @type {Object.<string, *>}
    */
   var properties = {};
-  properties[ol.ViewProperty.CENTER] = goog.isDef(options.center) ?
+  properties[ol.ViewProperty.CENTER] = options.center !== undefined ?
       options.center : null;
 
   /**
@@ -161,7 +161,7 @@ ol.View = function(opt_options) {
         this.maxResolution_, options.zoom - this.minZoom_);
   }
   properties[ol.ViewProperty.ROTATION] =
-      goog.isDef(options.rotation) ? options.rotation : 0;
+      options.rotation !== undefined ? options.rotation : 0;
   this.setProperties(properties);
 };
 goog.inherits(ol.View, ol.Object);
@@ -458,10 +458,10 @@ ol.View.prototype.fit = function(geometry, size, opt_options) {
 
   var options = opt_options || {};
 
-  var padding = goog.isDef(options.padding) ? options.padding : [0, 0, 0, 0];
-  var constrainResolution = goog.isDef(options.constrainResolution) ?
+  var padding = options.padding !== undefined ? options.padding : [0, 0, 0, 0];
+  var constrainResolution = options.constrainResolution !== undefined ?
       options.constrainResolution : true;
-  var nearest = goog.isDef(options.nearest) ? options.nearest : false;
+  var nearest = options.nearest !== undefined ? options.nearest : false;
   var minResolution;
   if (options.minResolution !== undefined) {
     minResolution = options.minResolution;
@@ -662,13 +662,13 @@ ol.View.createResolutionConstraint_ = function(options) {
   var defaultMaxZoom = 28;
   var defaultZoomFactor = 2;
 
-  var minZoom = goog.isDef(options.minZoom) ?
+  var minZoom = options.minZoom !== undefined ?
       options.minZoom : ol.DEFAULT_MIN_ZOOM;
 
-  var maxZoom = goog.isDef(options.maxZoom) ?
+  var maxZoom = options.maxZoom !== undefined ?
       options.maxZoom : defaultMaxZoom;
 
-  var zoomFactor = goog.isDef(options.zoomFactor) ?
+  var zoomFactor = options.zoomFactor !== undefined ?
       options.zoomFactor : defaultZoomFactor;
 
   if (options.resolutions !== undefined) {
@@ -734,7 +734,7 @@ ol.View.createResolutionConstraint_ = function(options) {
  * @return {ol.RotationConstraintType} Rotation constraint.
  */
 ol.View.createRotationConstraint_ = function(options) {
-  var enableRotation = goog.isDef(options.enableRotation) ?
+  var enableRotation = options.enableRotation !== undefined ?
       options.enableRotation : true;
   if (enableRotation) {
     var constrainRotation = options.constrainRotation;

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -193,7 +193,7 @@ ol.View.prototype.calculateCenterZoom = function(resolution, anchor) {
   var center;
   var currentCenter = this.getCenter();
   var currentResolution = this.getResolution();
-  if (goog.isDef(currentCenter) && goog.isDef(currentResolution)) {
+  if (currentCenter !== undefined && currentResolution !== undefined) {
     var x = anchor[0] -
         resolution * (anchor[0] - currentCenter[0]) / currentResolution;
     var y = anchor[1] -
@@ -278,10 +278,10 @@ ol.View.prototype.calculateExtent = function(size) {
   goog.asserts.assert(goog.isDefAndNotNull(center),
       'The view center is not defined');
   var resolution = this.getResolution();
-  goog.asserts.assert(goog.isDef(resolution),
+  goog.asserts.assert(resolution !== undefined,
       'The view resolution is not defined');
   var rotation = this.getRotation();
-  goog.asserts.assert(goog.isDef(rotation),
+  goog.asserts.assert(rotation !== undefined,
       'The view rotation is not defined');
 
   return ol.extent.getForViewAndSize(center, resolution, rotation, size);
@@ -404,7 +404,7 @@ ol.View.prototype.getState = function() {
       Math.round(center[0] / resolution) * resolution,
       Math.round(center[1] / resolution) * resolution
     ],
-    projection: goog.isDef(projection) ? projection : null,
+    projection: projection !== undefined ? projection : null,
     resolution: resolution,
     rotation: rotation
   });
@@ -433,7 +433,7 @@ ol.View.prototype.getZoom = function() {
     } while (res > this.minResolution_);
   }
 
-  return goog.isDef(offset) ? this.minZoom_ + offset : offset;
+  return offset !== undefined ? this.minZoom_ + offset : offset;
 };
 
 
@@ -475,7 +475,7 @@ ol.View.prototype.fit = function(geometry, size, opt_options) {
 
   // calculate rotated extent
   var rotation = this.getRotation();
-  goog.asserts.assert(goog.isDef(rotation), 'rotation was not defined');
+  goog.asserts.assert(rotation !== undefined, 'rotation was not defined');
   var cosAngle = Math.cos(-rotation);
   var sinAngle = Math.sin(-rotation);
   var minRotX = +Infinity;

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -100,7 +100,7 @@ ol.ViewHint = {
  */
 ol.View = function(opt_options) {
   goog.base(this);
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options || {};
 
   /**
    * @private
@@ -456,7 +456,7 @@ ol.View.prototype.fit = function(geometry, size, opt_options) {
     geometry = ol.geom.Polygon.fromExtent(geometry);
   }
 
-  var options = goog.isDef(opt_options) ? opt_options : {};
+  var options = opt_options || {};
 
   var padding = goog.isDef(options.padding) ? options.padding : [0, 0, 0, 0];
   var constrainResolution = goog.isDef(options.constrainResolution) ?

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -553,7 +553,7 @@ ol.View.prototype.centerOn = function(coordinate, size, position) {
  */
 ol.View.prototype.isDef = function() {
   return goog.isDefAndNotNull(this.getCenter()) &&
-      goog.isDef(this.getResolution());
+      this.getResolution() !== undefined;
 };
 
 

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -154,9 +154,9 @@ ol.View = function(opt_options) {
   this.constraints_ = new ol.Constraints(
       centerConstraint, resolutionConstraint, rotationConstraint);
 
-  if (goog.isDef(options.resolution)) {
+  if (options.resolution !== undefined) {
     properties[ol.ViewProperty.RESOLUTION] = options.resolution;
-  } else if (goog.isDef(options.zoom)) {
+  } else if (options.zoom !== undefined) {
     properties[ol.ViewProperty.RESOLUTION] = this.constrainResolution(
         this.maxResolution_, options.zoom - this.minZoom_);
   }
@@ -463,9 +463,9 @@ ol.View.prototype.fit = function(geometry, size, opt_options) {
       options.constrainResolution : true;
   var nearest = goog.isDef(options.nearest) ? options.nearest : false;
   var minResolution;
-  if (goog.isDef(options.minResolution)) {
+  if (options.minResolution !== undefined) {
     minResolution = options.minResolution;
-  } else if (goog.isDef(options.maxZoom)) {
+  } else if (options.maxZoom !== undefined) {
     minResolution = this.constrainResolution(
         this.maxResolution_, options.maxZoom - this.minZoom_, 0);
   } else {
@@ -638,7 +638,7 @@ ol.View.prototype.setZoom = function(zoom) {
  * @return {ol.CenterConstraintType}
  */
 ol.View.createCenterConstraint_ = function(options) {
-  if (goog.isDef(options.extent)) {
+  if (options.extent !== undefined) {
     return ol.CenterConstraint.createExtent(options.extent);
   } else {
     return ol.CenterConstraint.none;
@@ -671,7 +671,7 @@ ol.View.createResolutionConstraint_ = function(options) {
   var zoomFactor = goog.isDef(options.zoomFactor) ?
       options.zoomFactor : defaultZoomFactor;
 
-  if (goog.isDef(options.resolutions)) {
+  if (options.resolutions !== undefined) {
     var resolutions = options.resolutions;
     maxResolution = resolutions[0];
     minResolution = resolutions[resolutions.length - 1];
@@ -704,8 +704,8 @@ ol.View.createResolutionConstraint_ = function(options) {
     // user provided minResolution takes precedence
     minResolution = options.minResolution;
     if (!goog.isDef(minResolution)) {
-      if (goog.isDef(options.maxZoom)) {
-        if (goog.isDef(options.maxResolution)) {
+      if (options.maxZoom !== undefined) {
+        if (options.maxResolution !== undefined) {
           minResolution = maxResolution / Math.pow(zoomFactor, maxZoom);
         } else {
           minResolution = defaultMaxResolution / Math.pow(zoomFactor, maxZoom);

--- a/src/ol/webgl/buffer.js
+++ b/src/ol/webgl/buffer.js
@@ -27,13 +27,13 @@ ol.webgl.Buffer = function(opt_arr, opt_usage) {
    * @private
    * @type {Array.<number>}
    */
-  this.arr_ = goog.isDef(opt_arr) ? opt_arr : [];
+  this.arr_ = opt_arr !== undefined ? opt_arr : [];
 
   /**
    * @private
    * @type {number}
    */
-  this.usage_ = goog.isDef(opt_usage) ?
+  this.usage_ = opt_usage !== undefined ?
       opt_usage : ol.webgl.BufferUsage.STATIC_DRAW;
 
 };

--- a/src/ol/webgl/context.js
+++ b/src/ol/webgl/context.js
@@ -367,11 +367,11 @@ ol.webgl.Context.createTexture_ = function(gl, opt_wrapS, opt_wrapT) {
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
 
-  if (goog.isDef(opt_wrapS)) {
+  if (opt_wrapS !== undefined) {
     gl.texParameteri(
         goog.webgl.TEXTURE_2D, goog.webgl.TEXTURE_WRAP_S, opt_wrapS);
   }
-  if (goog.isDef(opt_wrapT)) {
+  if (opt_wrapT !== undefined) {
     gl.texParameteri(
         goog.webgl.TEXTURE_2D, goog.webgl.TEXTURE_WRAP_T, opt_wrapT);
   }

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -391,7 +391,7 @@ ol.xml.makeArrayPusher = function(valueReader, opt_this) {
        * @param {Array.<*>} objectStack Object stack.
        */
       function(node, objectStack) {
-        var value = valueReader.call(goog.isDef(opt_this) ? opt_this : this,
+        var value = valueReader.call(opt_this !== undefined ? opt_this : this,
             node, objectStack);
         if (value !== undefined) {
           var array = objectStack[objectStack.length - 1];
@@ -418,7 +418,7 @@ ol.xml.makeReplacer = function(valueReader, opt_this) {
        * @param {Array.<*>} objectStack Object stack.
        */
       function(node, objectStack) {
-        var value = valueReader.call(goog.isDef(opt_this) ? opt_this : this,
+        var value = valueReader.call(opt_this !== undefined ? opt_this : this,
             node, objectStack);
         if (value !== undefined) {
           objectStack[objectStack.length - 1] = value;
@@ -438,7 +438,7 @@ ol.xml.makeReplacer = function(valueReader, opt_this) {
  */
 ol.xml.makeObjectPropertyPusher =
     function(valueReader, opt_property, opt_this) {
-  goog.asserts.assert(goog.isDef(valueReader),
+  goog.asserts.assert(valueReader !== undefined,
       'undefined valueReader, expected function(this: T, Node, Array.<*>)');
   return (
       /**
@@ -446,12 +446,12 @@ ol.xml.makeObjectPropertyPusher =
        * @param {Array.<*>} objectStack Object stack.
        */
       function(node, objectStack) {
-        var value = valueReader.call(goog.isDef(opt_this) ? opt_this : this,
+        var value = valueReader.call(opt_this !== undefined ? opt_this : this,
             node, objectStack);
         if (value !== undefined) {
           var object = /** @type {Object} */
               (objectStack[objectStack.length - 1]);
-          var property = goog.isDef(opt_property) ?
+          var property = opt_property !== undefined ?
               opt_property : node.localName;
           goog.asserts.assert(goog.isObject(object),
               'entity from stack was not an object');
@@ -472,7 +472,7 @@ ol.xml.makeObjectPropertyPusher =
  */
 ol.xml.makeObjectPropertySetter =
     function(valueReader, opt_property, opt_this) {
-  goog.asserts.assert(goog.isDef(valueReader),
+  goog.asserts.assert(valueReader !== undefined,
       'undefined valueReader, expected function(this: T, Node, Array.<*>)');
   return (
       /**
@@ -480,12 +480,12 @@ ol.xml.makeObjectPropertySetter =
        * @param {Array.<*>} objectStack Object stack.
        */
       function(node, objectStack) {
-        var value = valueReader.call(goog.isDef(opt_this) ? opt_this : this,
+        var value = valueReader.call(opt_this !== undefined ? opt_this : this,
             node, objectStack);
         if (value !== undefined) {
           var object = /** @type {Object} */
               (objectStack[objectStack.length - 1]);
-          var property = goog.isDef(opt_property) ?
+          var property = opt_property !== undefined ?
               opt_property : node.localName;
           goog.asserts.assert(goog.isObject(object),
               'entity from stack was not an object');
@@ -507,7 +507,7 @@ ol.xml.makeObjectPropertySetter =
  */
 ol.xml.makeChildAppender = function(nodeWriter, opt_this) {
   return function(node, value, objectStack) {
-    nodeWriter.call(goog.isDef(opt_this) ? opt_this : this,
+    nodeWriter.call(opt_this !== undefined ? opt_this : this,
         node, value, objectStack);
     var parent = objectStack[objectStack.length - 1];
     goog.asserts.assert(goog.isObject(parent),
@@ -584,7 +584,7 @@ ol.xml.makeSimpleNodeFactory = function(opt_nodeName, opt_namespaceURI) {
         if (opt_namespaceURI === undefined) {
           namespaceURI = node.namespaceURI;
         }
-        goog.asserts.assert(goog.isDef(nodeName), 'nodeName was undefined');
+        goog.asserts.assert(nodeName !== undefined, 'nodeName was undefined');
         return ol.xml.createElementNS(namespaceURI, nodeName);
       }
   );
@@ -637,7 +637,7 @@ ol.xml.makeStructureNS = function(namespaceURIs, structure, opt_structureNS) {
   /**
    * @type {Object.<string, *>}
    */
-  var structureNS = goog.isDef(opt_structureNS) ? opt_structureNS : {};
+  var structureNS = opt_structureNS !== undefined ? opt_structureNS : {};
   var i, ii;
   for (i = 0, ii = namespaceURIs.length; i < ii; ++i) {
     structureNS[namespaceURIs[i]] = structure;
@@ -711,13 +711,13 @@ ol.xml.pushParseAndPop = function(
  */
 ol.xml.serialize = function(
     serializersNS, nodeFactory, values, objectStack, opt_keys, opt_this) {
-  var length = (goog.isDef(opt_keys) ? opt_keys : values).length;
+  var length = (opt_keys !== undefined ? opt_keys : values).length;
   var value, node;
   for (var i = 0; i < length; ++i) {
     value = values[i];
     if (value !== undefined) {
       node = nodeFactory.call(opt_this, value, objectStack,
-          goog.isDef(opt_keys) ? opt_keys[i] : undefined);
+          opt_keys !== undefined ? opt_keys[i] : undefined);
       if (node !== undefined) {
         serializersNS[node.namespaceURI][node.localName]
             .call(opt_this, node, value, objectStack);

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -194,7 +194,7 @@ ol.xml.isNode_ = function(value) {
  * @return {boolean} Is node.
  */
 ol.xml.isNodeIE_ = function(value) {
-  return goog.isObject(value) && goog.isDef(value.nodeType);
+  return goog.isObject(value) && value.nodeType !== undefined;
 };
 
 

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -537,7 +537,7 @@ ol.xml.makeChildAppender = function(nodeWriter, opt_this) {
 ol.xml.makeArraySerializer = function(nodeWriter, opt_this) {
   var serializersNS, nodeFactory;
   return function(node, value, objectStack) {
-    if (!goog.isDef(serializersNS)) {
+    if (serializersNS === undefined) {
       serializersNS = {};
       var serializers = {};
       serializers[node.localName] = nodeWriter;
@@ -577,11 +577,11 @@ ol.xml.makeSimpleNodeFactory = function(opt_nodeName, opt_namespaceURI) {
         goog.asserts.assert(ol.xml.isNode(node) || ol.xml.isDocument(node),
             'expected node %s to be a Node or a Document', node);
         var nodeName = fixedNodeName;
-        if (!goog.isDef(nodeName)) {
+        if (nodeName === undefined) {
           nodeName = opt_nodeName;
         }
         var namespaceURI = opt_namespaceURI;
-        if (!goog.isDef(opt_namespaceURI)) {
+        if (opt_namespaceURI === undefined) {
           namespaceURI = node.namespaceURI;
         }
         goog.asserts.assert(goog.isDef(nodeName), 'nodeName was undefined');

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -132,7 +132,7 @@ ol.xml.getLocalName_ = function(node) {
  */
 ol.xml.getLocalNameIE_ = function(node) {
   var localName = node.localName;
-  if (goog.isDef(localName)) {
+  if (localName !== undefined) {
     return localName;
   }
   var baseName = node.baseName;
@@ -227,7 +227,7 @@ ol.xml.getAttributeNS_ = function(node, namespaceURI, name) {
 ol.xml.getAttributeNSActiveX_ = function(node, namespaceURI, name) {
   var attributeValue = '';
   var attributeNode = ol.xml.getAttributeNodeNS(node, namespaceURI, name);
-  if (goog.isDef(attributeNode)) {
+  if (attributeNode !== undefined) {
     attributeValue = attributeNode.nodeValue;
   }
   return attributeValue;
@@ -363,7 +363,7 @@ ol.xml.makeArrayExtender = function(valueReader, opt_this) {
        */
       function(node, objectStack) {
         var value = valueReader.call(opt_this, node, objectStack);
-        if (goog.isDef(value)) {
+        if (value !== undefined) {
           goog.asserts.assert(goog.isArray(value),
               'valueReader function is expected to return an array of values');
           var array = /** @type {Array.<*>} */
@@ -393,7 +393,7 @@ ol.xml.makeArrayPusher = function(valueReader, opt_this) {
       function(node, objectStack) {
         var value = valueReader.call(goog.isDef(opt_this) ? opt_this : this,
             node, objectStack);
-        if (goog.isDef(value)) {
+        if (value !== undefined) {
           var array = objectStack[objectStack.length - 1];
           goog.asserts.assert(goog.isArray(array),
               'objectStack is supposed to be an array of arrays');
@@ -420,7 +420,7 @@ ol.xml.makeReplacer = function(valueReader, opt_this) {
       function(node, objectStack) {
         var value = valueReader.call(goog.isDef(opt_this) ? opt_this : this,
             node, objectStack);
-        if (goog.isDef(value)) {
+        if (value !== undefined) {
           objectStack[objectStack.length - 1] = value;
         }
       });
@@ -448,7 +448,7 @@ ol.xml.makeObjectPropertyPusher =
       function(node, objectStack) {
         var value = valueReader.call(goog.isDef(opt_this) ? opt_this : this,
             node, objectStack);
-        if (goog.isDef(value)) {
+        if (value !== undefined) {
           var object = /** @type {Object} */
               (objectStack[objectStack.length - 1]);
           var property = goog.isDef(opt_property) ?
@@ -482,7 +482,7 @@ ol.xml.makeObjectPropertySetter =
       function(node, objectStack) {
         var value = valueReader.call(goog.isDef(opt_this) ? opt_this : this,
             node, objectStack);
-        if (goog.isDef(value)) {
+        if (value !== undefined) {
           var object = /** @type {Object} */
               (objectStack[objectStack.length - 1]);
           var property = goog.isDef(opt_property) ?
@@ -658,9 +658,9 @@ ol.xml.parseNode = function(parsersNS, node, objectStack, opt_this) {
   var n;
   for (n = node.firstElementChild; !goog.isNull(n); n = n.nextElementSibling) {
     var parsers = parsersNS[n.namespaceURI];
-    if (goog.isDef(parsers)) {
+    if (parsers !== undefined) {
       var parser = parsers[n.localName];
-      if (goog.isDef(parser)) {
+      if (parser !== undefined) {
         parser.call(opt_this, n, objectStack);
       }
     }
@@ -715,10 +715,10 @@ ol.xml.serialize = function(
   var value, node;
   for (var i = 0; i < length; ++i) {
     value = values[i];
-    if (goog.isDef(value)) {
+    if (value !== undefined) {
       node = nodeFactory.call(opt_this, value, objectStack,
           goog.isDef(opt_keys) ? opt_keys[i] : undefined);
-      if (goog.isDef(node)) {
+      if (node !== undefined) {
         serializersNS[node.namespaceURI][node.localName]
             .call(opt_this, node, value, objectStack);
       }

--- a/test/spec/ol/extent.test.js
+++ b/test/spec/ol/extent.test.js
@@ -837,7 +837,7 @@ describe('ol.extent', function() {
     it('takes arbitrary function', function() {
       var transformFn = function(input, output, opt_dimension) {
         var dimension = goog.isDef(opt_dimension) ? opt_dimension : 2;
-        if (!goog.isDef(output)) {
+        if (output === undefined) {
           output = new Array(input.length);
         }
         var n = input.length;

--- a/test/spec/ol/extent.test.js
+++ b/test/spec/ol/extent.test.js
@@ -836,7 +836,7 @@ describe('ol.extent', function() {
 
     it('takes arbitrary function', function() {
       var transformFn = function(input, output, opt_dimension) {
-        var dimension = goog.isDef(opt_dimension) ? opt_dimension : 2;
+        var dimension = opt_dimension !== undefined ? opt_dimension : 2;
         if (output === undefined) {
           output = new Array(input.length);
         }

--- a/test/spec/ol/interaction/drawinteraction.test.js
+++ b/test/spec/ol/interaction/drawinteraction.test.js
@@ -48,7 +48,7 @@ describe('ol.interaction.Draw', function() {
     var viewport = map.getViewport();
     // calculated in case body has top < 0 (test runner with small window)
     var position = goog.style.getClientPosition(viewport);
-    var shiftKey = goog.isDef(opt_shiftKey) ? opt_shiftKey : false;
+    var shiftKey = opt_shiftKey !== undefined ? opt_shiftKey : false;
     var event = new ol.MapBrowserPointerEvent(type, map,
         new ol.pointer.PointerEvent(type,
             new goog.events.BrowserEvent({

--- a/test/spec/ol/interaction/modifyinteraction.test.js
+++ b/test/spec/ol/interaction/modifyinteraction.test.js
@@ -64,7 +64,7 @@ describe('ol.interaction.Modify', function() {
     var viewport = map.getViewport();
     // calculated in case body has top < 0 (test runner with small window)
     var position = goog.style.getClientPosition(viewport);
-    var shiftKey = goog.isDef(opt_shiftKey) ? opt_shiftKey : false;
+    var shiftKey = opt_shiftKey !== undefined ? opt_shiftKey : false;
     var event = new ol.MapBrowserPointerEvent(type, map,
         new ol.pointer.PointerEvent(type,
             new goog.events.BrowserEvent({

--- a/test/spec/ol/interaction/selectinteraction.test.js
+++ b/test/spec/ol/interaction/selectinteraction.test.js
@@ -79,7 +79,7 @@ describe('ol.interaction.Select', function() {
     var viewport = map.getViewport();
     // calculated in case body has top < 0 (test runner with small window)
     var position = goog.style.getClientPosition(viewport);
-    var shiftKey = goog.isDef(opt_shiftKey) ? opt_shiftKey : false;
+    var shiftKey = opt_shiftKey !== undefined ? opt_shiftKey : false;
     var event = new ol.MapBrowserPointerEvent(type, map,
         new ol.pointer.PointerEvent(type,
             new goog.events.BrowserEvent({

--- a/test/spec/ol/interaction/translateinteraction.test.js
+++ b/test/spec/ol/interaction/translateinteraction.test.js
@@ -54,7 +54,7 @@ describe('ol.interaction.Translate', function() {
     var viewport = map.getViewport();
     // calculated in case body has top < 0 (test runner with small window)
     var position = goog.style.getClientPosition(viewport);
-    var shiftKey = goog.isDef(opt_shiftKey) ? opt_shiftKey : false;
+    var shiftKey = opt_shiftKey !== undefined ? opt_shiftKey : false;
     var event = new ol.MapBrowserPointerEvent(type, map,
         new ol.pointer.PointerEvent(type,
         new goog.events.BrowserEvent({

--- a/test/spec/ol/pointer/touchsource.test.js
+++ b/test/spec/ol/pointer/touchsource.test.js
@@ -118,7 +118,7 @@ describe('ol.pointer.TouchSource', function() {
   });
 
   function simulateTouchEvent(type, changedTouches, touches) {
-    touches = goog.isDef(touches) ? touches : changedTouches;
+    touches = touches !== undefined ? touches : changedTouches;
 
     var event = new goog.events.BrowserEvent({
       type: type,

--- a/test_rendering/spec/ol/layer/tile.test.js
+++ b/test_rendering/spec/ol/layer/tile.test.js
@@ -11,7 +11,7 @@ describe('ol.rendering.layer.Tile', function() {
       target: target,
       renderer: renderer,
       view: new ol.View({
-        center: goog.isDef(opt_center) ? opt_center : ol.proj.transform(
+        center: opt_center !== undefined ? opt_center : ol.proj.transform(
             [-122.416667, 37.783333], 'EPSG:4326', 'EPSG:3857'),
         zoom: 5
       })


### PR DESCRIPTION
As part of a larger effort to remove our dependency on the Closure Library (see #4128), this branch removes our use of `goog.isDef()`.

I pushed this branch to the main OpenLayers repo so more people can contribute.  I'll happily cherry pick commits from other forks as well.
