### PR TITLE
Fix for inline SVG icons in IE11

### DIFF
--- a/src/ol/style/iconstyle.js
+++ b/src/ol/style/iconstyle.js
@@ -426,7 +426,7 @@ ol.style.IconImage_ = function(image, src, size, crossOrigin, imageState) {
    * @type {boolean}
    */
   this.tainting_ = false;
-  if(this.imageState_ == ol.style.ImageState.LOADED)this.determineTainting_();
+  if (this.imageState_ == ol.style.ImageState.LOADED)this.determineTainting_();
 };
 goog.inherits(ol.style.IconImage_, goog.events.EventTarget);
 

--- a/src/ol/style/iconstyle.js
+++ b/src/ol/style/iconstyle.js
@@ -426,7 +426,7 @@ ol.style.IconImage_ = function(image, src, size, crossOrigin, imageState) {
    * @type {boolean}
    */
   this.tainting_ = false;
-
+  if(this.imageState_ == ol.style.ImageState.LOADED)this.determineTainting_();
 };
 goog.inherits(ol.style.IconImage_, goog.events.EventTarget);
 
@@ -456,8 +456,8 @@ ol.style.IconImage_.get = function(image, src, size, crossOrigin, imageState) {
  */
 ol.style.IconImage_.prototype.determineTainting_ = function() {
   var context = ol.dom.createCanvasContext2D(1, 1);
-  context.drawImage(this.image_, 0, 0);
   try {
+    context.drawImage(this.image_, 0, 0);
     context.getImageData(0, 0, 1, 1);
   } catch (e) {
     this.tainting_ = true;


### PR DESCRIPTION
This will resolves #4090 the problem with inline SVG icons in IE11. (The image size must however be set to two integer values and can't handle fractional values, but that is in a compleatly other place in the code.)

Since inline SVG never is loaded determineTainting_() was never called for them, and there is what I have found no way to set that an image is tainting the canvas when you define your image. This code simply makes a tainting check for all images that are loaded when initialized so they get the right tainting value. 

The other part of my fix is to move a line of code into the try statement since it otherwise will cause an error in IE11.