### PR TITLE
Do not ignore layer filter for unmanaged layers

### DIFF
--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -148,31 +148,6 @@ ol.interaction.Select = function(opt_options) {
   this.filter_ = goog.isDef(options.filter) ? options.filter :
       goog.functions.TRUE;
 
-  var layerFilter;
-  if (goog.isDef(options.layers)) {
-    if (goog.isFunction(options.layers)) {
-      layerFilter = options.layers;
-    } else {
-      var layers = options.layers;
-      layerFilter =
-          /**
-           * @param {ol.layer.Layer} layer Layer.
-           * @return {boolean} Include.
-           */
-          function(layer) {
-        return goog.array.contains(layers, layer);
-      };
-    }
-  } else {
-    layerFilter = goog.functions.TRUE;
-  }
-
-  /**
-   * @private
-   * @type {function(ol.layer.Layer): boolean}
-   */
-  this.layerFilter_ = layerFilter;
-
   /**
    * @private
    * @type {ol.layer.Vector}
@@ -188,6 +163,41 @@ ol.interaction.Select = function(opt_options) {
     updateWhileAnimating: true,
     updateWhileInteracting: true
   });
+
+  var layerFilter;
+  if (goog.isDef(options.layers)) {
+    var userLayerFilter;
+    if (goog.isFunction(options.layers)) {
+      userLayerFilter = options.layers;
+    } else {
+      var layers = options.layers;
+      userLayerFilter = (
+          /**
+           * @param {ol.layer.Layer} layer Layer.
+           * @return {boolean} Include.
+           */
+          function(layer) {
+            return goog.array.contains(layers, layer);
+          });
+    }
+    var featureOverlay = this.featureOverlay_;
+    layerFilter = goog.functions.or(userLayerFilter, (
+        /**
+         * @param {ol.layer.Layer} layer Layer.
+         * @return {boolean} Include.
+         */
+        function(layer) {
+          return layer === featureOverlay;
+        }));
+  } else {
+    layerFilter = goog.functions.TRUE;
+  }
+
+  /**
+   * @private
+   * @type {function(ol.layer.Layer): boolean}
+   */
+  this.layerFilter_ = layerFilter;
 
   var features = this.featureOverlay_.getSource().getFeaturesCollection();
   goog.events.listen(features, ol.CollectionEventType.ADD,

--- a/src/ol/layer/layer.js
+++ b/src/ol/layer/layer.js
@@ -149,8 +149,7 @@ ol.layer.Layer.prototype.handleSourcePropertyChange_ = function() {
 
 /**
  * Sets the layer to be rendered on a map. The map will not manage this layer in
- * its layers collection, layer filters in {@link ol.Map#forEachLayerAtPixel}
- * will not filter the layer, and it will be rendered on top. This is useful for
+ * its layers collection, and it will be rendered on top. This is useful for
  * temporary layers. To remove an unmanaged layer from the map, use
  * `#setMap(null)`.
  *

--- a/src/ol/renderer/maprenderer.js
+++ b/src/ol/renderer/maprenderer.js
@@ -166,9 +166,8 @@ ol.renderer.Map.prototype.forEachFeatureAtCoordinate =
   for (i = numLayers - 1; i >= 0; --i) {
     var layerState = layerStates[i];
     var layer = layerState.layer;
-    if (!layerState.managed ||
-        (ol.layer.Layer.visibleAtResolution(layerState, viewResolution) &&
-        layerFilter.call(thisArg2, layer))) {
+    if (ol.layer.Layer.visibleAtResolution(layerState, viewResolution) &&
+        layerFilter.call(thisArg2, layer)) {
       var layerRenderer = this.getLayerRenderer(layer);
       if (!goog.isNull(layer.getSource())) {
         result = layerRenderer.forEachFeatureAtCoordinate(

--- a/test/spec/ol/renderer/canvas/canvasmaprenderer.test.js
+++ b/test/spec/ol/renderer/canvas/canvasmaprenderer.test.js
@@ -46,16 +46,7 @@ describe('ol.renderer.canvas.Map', function() {
       document.body.removeChild(target);
     });
 
-    it('always includes unmanaged layers', function() {
-      layer.setMap(map);
-      map.renderSync();
-      var cb = sinon.spy();
-      map.forEachFeatureAtPixel(map.getPixelFromCoordinate([0, 0]), cb, null,
-          function() { return false; });
-      expect(cb).to.be.called();
-    });
-
-    it('filters managed layers', function() {
+    it('filters layers', function() {
       map.addLayer(layer);
       map.renderSync();
       var cb = sinon.spy();


### PR DESCRIPTION
PR #3883 made `forEachFeatureAtPixel` ignore unmanaged layers. This commit reverts that change, and modifies the Select interaction to make sure that the unmanaged layer it uses internally is not filtered out when the user provides a layer filter.

So this PR fixes #3878 in a different way, and it addresses the limitation reported in #2940, where unmanaged layers cannot be filtered out.

@ahocevar, @probins, do you anticipate problems with that approach?