### PR TITLE
Set context.fillStyle to a string

### DIFF
--- a/examples/feature-animation.js
+++ b/examples/feature-animation.js
@@ -72,8 +72,7 @@ function flash(feature) {
       snapToPixel: false,
       stroke: new ol.style.Stroke({
         color: 'rgba(255, 0, 0, ' + opacity + ')',
-        width: 1,
-        opacity: opacity
+        width: 1
       })
     });
 

--- a/src/ol/style/circlestyle.js
+++ b/src/ol/style/circlestyle.js
@@ -405,7 +405,7 @@ ol.style.Circle.prototype.drawHitDetectionCanvas_ =
       renderOptions.size / 2, renderOptions.size / 2,
       this.radius_, 0, 2 * Math.PI, true);
 
-  context.fillStyle = ol.render.canvas.defaultFillStyle;
+  context.fillStyle = ol.color.asString(ol.render.canvas.defaultFillStyle);
   context.fill();
   if (!goog.isNull(this.stroke_)) {
     context.strokeStyle = renderOptions.strokeStyle;


### PR DESCRIPTION
The value we set `context.fillStyle` to should always be a string. This commit fixes a bug in circlestyle.js where `context.fillStyle` was set to an array of numbers instead of a string.

Fixes #4074. Thanks @wlerner for his help on tracking down this bug!