### PR TITLE
API method for simplifying geometries

### DIFF
--- a/src/ol/geom/geometry.js
+++ b/src/ol/geom/geometry.js
@@ -170,9 +170,11 @@ ol.geom.Geometry.prototype.getExtent = function(opt_extent) {
 
 
 /**
- * Create a simplified version of this geometry using the {@link
+ * Create a simplified version of this geometry.  For linestrings, this uses
+ * the the {@link
  * http://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm
- * Douglas Peucker} algorithm.
+ * Douglas Peucker} algorithm.  For polygons, a quantization-based
+ * simplification is used to preserve topology.
  * @function
  * @param {number} tolerance The tolerance distance for simplification.
  * @return {ol.geom.Geometry} A new, simplified version of the original

--- a/src/ol/geom/geometry.js
+++ b/src/ol/geom/geometry.js
@@ -172,7 +172,7 @@ ol.geom.Geometry.prototype.getExtent = function(opt_extent) {
 /**
  * Create a simplified version of this geometry.  For linestrings, this uses
  * the the {@link
- * http://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm
+ * https://en.wikipedia.org/wiki/Ramer-Douglas-Peucker_algorithm
  * Douglas Peucker} algorithm.  For polygons, a quantization-based
  * simplification is used to preserve topology.
  * @function
@@ -189,7 +189,7 @@ ol.geom.Geometry.prototype.simplify = function(tolerance) {
 /**
  * Create a simplified version of this geometry using the Douglas Peucker
  * algorithm.
- * @see http://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm
+ * @see https://en.wikipedia.org/wiki/Ramer-Douglas-Peucker_algorithm
  * @function
  * @param {number} squaredTolerance Squared tolerance.
  * @return {ol.geom.Geometry} Simplified geometry.

--- a/src/ol/geom/geometry.js
+++ b/src/ol/geom/geometry.js
@@ -179,6 +179,7 @@ ol.geom.Geometry.prototype.getExtent = function(opt_extent) {
  * @param {number} tolerance The tolerance distance for simplification.
  * @return {ol.geom.Geometry} A new, simplified version of the original
  *     geometry.
+ * @api
  */
 ol.geom.Geometry.prototype.simplify = function(tolerance) {
   return this.getSimplifiedGeometry(tolerance * tolerance);

--- a/src/ol/geom/geometry.js
+++ b/src/ol/geom/geometry.js
@@ -170,6 +170,20 @@ ol.geom.Geometry.prototype.getExtent = function(opt_extent) {
 
 
 /**
+ * Create a simplified version of this geometry using the {@link
+ * http://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm
+ * Douglas Peucker} algorithm.
+ * @function
+ * @param {number} tolerance The tolerance distance for simplification.
+ * @return {ol.geom.Geometry} A new, simplified version of the original
+ *     geometry.
+ */
+ol.geom.Geometry.prototype.simplify = function(tolerance) {
+  return this.getSimplifiedGeometry(tolerance * tolerance);
+};
+
+
+/**
  * Create a simplified version of this geometry using the Douglas Peucker
  * algorithm.
  * @see http://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm

--- a/src/ol/geom/simplegeometry.js
+++ b/src/ol/geom/simplegeometry.js
@@ -144,6 +144,7 @@ ol.geom.SimpleGeometry.prototype.getLayout = function() {
 
 /**
  * @inheritDoc
+ * @api
  */
 ol.geom.SimpleGeometry.prototype.getSimplifiedGeometry =
     function(squaredTolerance) {

--- a/src/ol/geom/simplegeometry.js
+++ b/src/ol/geom/simplegeometry.js
@@ -144,7 +144,6 @@ ol.geom.SimpleGeometry.prototype.getLayout = function() {
 
 /**
  * @inheritDoc
- * @api
  */
 ol.geom.SimpleGeometry.prototype.getSimplifiedGeometry =
     function(squaredTolerance) {

--- a/test/spec/ol/geom/linestring.test.js
+++ b/test/spec/ol/geom/linestring.test.js
@@ -263,6 +263,29 @@ describe('ol.geom.LineString', function() {
 
     });
 
+    describe('#simplify', function() {
+
+      it('returns a simplified geometry', function() {
+        var simplified = lineString.simplify(1);
+        expect(simplified).to.be.an(ol.geom.LineString);
+        expect(simplified.getCoordinates()).to.eql(
+            [[0, 0], [3, 3], [5, 1], [7, 5]]);
+      });
+
+      it('does not modify the original', function() {
+        lineString.simplify(1);
+        expect(lineString.getCoordinates()).to.eql(
+            [[0, 0], [1.5, 1], [3, 3], [5, 1], [6, 3.5], [7, 5]]);
+      });
+
+      it('delegates to the internal method', function() {
+        var simplified = lineString.simplify(2);
+        var internal = lineString.getSimplifiedGeometry(4);
+        expect(simplified.getCoordinates()).to.eql(internal.getCoordinates());
+      });
+
+    });
+
     describe('#getSimplifiedGeometry', function() {
 
       it('returns the expectedResult', function() {


### PR DESCRIPTION
This exposes a method for users to generate simplified geometries.  Internally, we continue to use the verbose/awkward `geometry.getSimplifiedGeometry(squaredTolerance)`.  Users get the more convenient `geometry.simplify(tolerance)` method.

Fixes #4058.
