### PR TITLE
Remove use of goog.array.isEmpty

### DIFF
--- a/src/ol/control/control.js
+++ b/src/ol/control/control.js
@@ -108,7 +108,7 @@ ol.control.Control.prototype.setMap = function(map) {
   if (!goog.isNull(this.map_)) {
     goog.dom.removeNode(this.element);
   }
-  if (!goog.array.isEmpty(this.listenerKeys)) {
+  if (this.listenerKeys.length > 0) {
     goog.array.forEach(this.listenerKeys, goog.events.unlistenByKey);
     this.listenerKeys.length = 0;
   }

--- a/src/ol/format/wktformat.js
+++ b/src/ol/format/wktformat.js
@@ -1,6 +1,5 @@
 goog.provide('ol.format.WKT');
 
-goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('ol.Feature');
 goog.require('ol.format.Feature');
@@ -59,7 +58,7 @@ ol.format.WKT.EMPTY = 'EMPTY';
  */
 ol.format.WKT.encodePointGeometry_ = function(geom) {
   var coordinates = geom.getCoordinates();
-  if (goog.array.isEmpty(coordinates)) {
+  if (coordinates.length === 0) {
     return '';
   }
   return coordinates[0] + ' ' + coordinates[1];

--- a/src/ol/geom/geometrycollection.js
+++ b/src/ol/geom/geometrycollection.js
@@ -1,6 +1,5 @@
 goog.provide('ol.geom.GeometryCollection');
 
-goog.require('goog.array');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
 goog.require('goog.object');
@@ -231,7 +230,7 @@ ol.geom.GeometryCollection.prototype.intersectsExtent = function(extent) {
  * @return {boolean} Is empty.
  */
 ol.geom.GeometryCollection.prototype.isEmpty = function() {
-  return goog.array.isEmpty(this.geometries_);
+  return this.geometries_.length === 0;
 };
 
 

--- a/src/ol/source/tilearcgisrestsource.js
+++ b/src/ol/source/tilearcgisrestsource.js
@@ -1,6 +1,5 @@
 goog.provide('ol.source.TileArcGISRest');
 
-goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.math');
 goog.require('goog.object');
@@ -101,7 +100,7 @@ ol.source.TileArcGISRest.prototype.getRequestUrl_ =
         pixelRatio, projection, params) {
 
   var urls = this.urls_;
-  if (goog.array.isEmpty(urls)) {
+  if (urls.length === 0) {
     return undefined;
   }
 

--- a/src/ol/source/tilewmssource.js
+++ b/src/ol/source/tilewmssource.js
@@ -4,7 +4,6 @@
 
 goog.provide('ol.source.TileWMS');
 
-goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.math');
 goog.require('goog.object');
@@ -222,7 +221,7 @@ ol.source.TileWMS.prototype.getRequestUrl_ =
         pixelRatio, projection, params) {
 
   var urls = this.urls_;
-  if (goog.array.isEmpty(urls)) {
+  if (urls.length === 0) {
     return undefined;
   }
 


### PR DESCRIPTION
A small step to remove our dependency on the Closure Library (see #4128)