### PR TITLE
Remove use of goog.object.remove

### DIFF
--- a/src/ol/format/esrijsonformat.js
+++ b/src/ol/format/esrijsonformat.js
@@ -656,7 +656,7 @@ ol.format.EsriJSON.prototype.writeFeatureObject = function(
         ol.format.EsriJSON.writeGeometry_(geometry, opt_options);
   }
   var properties = feature.getProperties();
-  goog.object.remove(properties, feature.getGeometryName());
+  delete properties[feature.getGeometryName()];
   if (!goog.object.isEmpty(properties)) {
     object['attributes'] = properties;
   } else {

--- a/src/ol/format/geojsonformat.js
+++ b/src/ol/format/geojsonformat.js
@@ -545,7 +545,7 @@ ol.format.GeoJSON.prototype.writeFeatureObject = function(
     object['geometry'] = null;
   }
   var properties = feature.getProperties();
-  goog.object.remove(properties, feature.getGeometryName());
+  delete properties[feature.getGeometryName()];
   if (!goog.object.isEmpty(properties)) {
     object['properties'] = properties;
   } else {

--- a/src/ol/format/gpxformat.js
+++ b/src/ol/format/gpxformat.js
@@ -74,14 +74,14 @@ ol.format.GPX.appendCoordinate_ = function(flatCoordinates, node, values) {
   if (goog.object.containsKey(values, 'ele')) {
     flatCoordinates.push(
         /** @type {number} */ (values['ele']));
-    goog.object.remove(values, 'ele');
+    delete values['ele'];
   } else {
     flatCoordinates.push(0);
   }
   if (goog.object.containsKey(values, 'time')) {
     flatCoordinates.push(
         /** @type {number} */ (values['time']));
-    goog.object.remove(values, 'time');
+    delete values['time'];
   } else {
     flatCoordinates.push(0);
   }
@@ -200,7 +200,7 @@ ol.format.GPX.readRte_ = function(node, objectStack) {
   }
   var flatCoordinates = /** @type {Array.<number>} */
       (values['flatCoordinates']);
-  goog.object.remove(values, 'flatCoordinates');
+  delete values['flatCoordinates'];
   var geometry = new ol.geom.LineString(null);
   geometry.setFlatCoordinates(ol.geom.GeometryLayout.XYZM, flatCoordinates);
   ol.format.Feature.transformWithOptions(geometry, false, options);
@@ -230,9 +230,9 @@ ol.format.GPX.readTrk_ = function(node, objectStack) {
   }
   var flatCoordinates = /** @type {Array.<number>} */
       (values['flatCoordinates']);
-  goog.object.remove(values, 'flatCoordinates');
+  delete values['flatCoordinates'];
   var ends = /** @type {Array.<number>} */ (values['ends']);
-  goog.object.remove(values, 'ends');
+  delete values['ends'];
   var geometry = new ol.geom.MultiLineString(null);
   geometry.setFlatCoordinates(
       ol.geom.GeometryLayout.XYZM, flatCoordinates, ends);

--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -1686,7 +1686,7 @@ ol.format.KML.prototype.readPlacemark_ = function(node, objectStack) {
     ol.format.Feature.transformWithOptions(geometry, false, options);
   }
   feature.setGeometry(geometry);
-  goog.object.remove(object, 'geometry');
+  delete object['geometry'];
 
   if (this.extractStyles_) {
     var style = object['Style'];
@@ -1695,7 +1695,7 @@ ol.format.KML.prototype.readPlacemark_ = function(node, objectStack) {
         style, styleUrl, this.defaultStyle_, this.sharedStyles_);
     feature.setStyle(styleFunction);
   }
-  goog.object.remove(object, 'Style');
+  delete object['Style'];
   // we do not remove the styleUrl property from the object, so it
   // gets stored on feature when setProperties is called
 

--- a/src/ol/pointer/mousesource.js
+++ b/src/ol/pointer/mousesource.js
@@ -248,6 +248,5 @@ ol.pointer.MouseSource.prototype.cancel = function(inEvent) {
  * Remove the mouse from the list of active pointers.
  */
 ol.pointer.MouseSource.prototype.cleanupMouse = function() {
-  goog.object.remove(this.pointerMap,
-      ol.pointer.MouseSource.POINTER_ID.toString());
+  delete this.pointerMap[ol.pointer.MouseSource.POINTER_ID.toString()];
 };

--- a/src/ol/pointer/mssource.js
+++ b/src/ol/pointer/mssource.js
@@ -30,7 +30,6 @@
 
 goog.provide('ol.pointer.MsSource');
 
-goog.require('goog.object');
 goog.require('ol.pointer.EventSource');
 
 
@@ -98,7 +97,7 @@ ol.pointer.MsSource.prototype.prepareEvent_ = function(inEvent) {
  * @param {number} pointerId
  */
 ol.pointer.MsSource.prototype.cleanup = function(pointerId) {
-  goog.object.remove(this.pointerMap, pointerId);
+  delete this.pointerMap[pointerId.toString()];
 };
 
 
@@ -108,7 +107,7 @@ ol.pointer.MsSource.prototype.cleanup = function(pointerId) {
  * @param {goog.events.BrowserEvent} inEvent
  */
 ol.pointer.MsSource.prototype.msPointerDown = function(inEvent) {
-  this.pointerMap[inEvent.getBrowserEvent().pointerId] = inEvent;
+  this.pointerMap[inEvent.getBrowserEvent().pointerId.toString()] = inEvent;
   var e = this.prepareEvent_(inEvent);
   this.dispatcher.down(e, inEvent);
 };

--- a/src/ol/pointer/touchsource.js
+++ b/src/ol/pointer/touchsource.js
@@ -425,7 +425,7 @@ ol.pointer.TouchSource.prototype.cancelOut_ =
  * @param {Object} inPointer
  */
 ol.pointer.TouchSource.prototype.cleanUpPointer_ = function(inPointer) {
-  goog.object.remove(this.pointerMap, inPointer.pointerId);
+  delete this.pointerMap[inPointer.pointerId];
   this.removePrimaryPointer_(inPointer);
 };
 

--- a/src/ol/structs/rbush.js
+++ b/src/ol/structs/rbush.js
@@ -118,7 +118,7 @@ ol.structs.RBush.prototype.remove = function(value) {
   // get the object in which the value was wrapped when adding to the
   // internal rbush. then use that object to do the removal.
   var item = this.items_[uid];
-  goog.object.remove(this.items_, uid);
+  delete this.items_[uid];
   return this.rbush_.remove(item) !== null;
 };
 


### PR DESCRIPTION
If the return value is not used, `goog.object.remove(obj, key)` should be simplified to `delete obj[key]`