### PR TITLE
Remove bogus assertion

### DIFF
--- a/src/ol/interaction/modifyinteraction.js
+++ b/src/ol/interaction/modifyinteraction.js
@@ -973,9 +973,8 @@ ol.interaction.Modify.prototype.setGeometryCoordinates_ =
 ol.interaction.Modify.prototype.updateSegmentIndices_ = function(
     geometry, index, depth, delta) {
   this.rBush_.forEachInExtent(geometry.getExtent(), function(segmentDataMatch) {
-    goog.asserts.assert(goog.isDef(segmentDataMatch.depth));
     if (segmentDataMatch.geometry === geometry &&
-        (!goog.isDef(depth) ||
+        (!goog.isDef(depth) || !goog.isDef(segmentDataMatch.depth) ||
         goog.array.equals(segmentDataMatch.depth, depth)) &&
         segmentDataMatch.index > index) {
       segmentDataMatch.index += delta;


### PR DESCRIPTION
This commit removes an incorrect assertion from the modify interaction, which currently triggers when adding vertices to a line string.

The bug can be reproduced in http://jsfiddle.net/5m3897xu/1/. Click on the line string to edit it. Add a vertex on one of the two segments. This should trigger the assertion. The same example works as expected when ol.js is used instead of ol-debug.js.

Please review.