### PR TITLE
Add a "features" option to ol.interaction.Select

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -2779,6 +2779,7 @@ olx.interaction.PointerOptions.prototype.handleUpEvent;
  *     removeCondition: (ol.events.ConditionType|undefined),
  *     toggleCondition: (ol.events.ConditionType|undefined),
  *     multi: (boolean|undefined),
+ *     features: (ol.Collection.<ol.Feature>|undefined),
  *     filter: (ol.interaction.SelectFilterFunction|undefined),
  *     wrapX: (boolean|undefined)}}
  * @api
@@ -2867,6 +2868,17 @@ olx.interaction.SelectOptions.prototype.toggleCondition;
  * @api
  */
 olx.interaction.SelectOptions.prototype.multi;
+
+
+/**
+ * Collection where the interaction will place selected features. Optional. If
+ * not set the interaction will create a collection. In any case the collection
+ * used by the interaction is returnd by
+ * {@link ol.interaction.Select#getFeatures}.
+ * @type {ol.Collection.<ol.Feature>}
+ * @api
+ */
+olx.interaction.SelectOptions.prototype.features;
 
 
 /**

--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -180,6 +180,7 @@ ol.interaction.Select = function(opt_options) {
   this.featureOverlay_ = new ol.layer.Vector({
     source: new ol.source.Vector({
       useSpatialIndex: false,
+      features: options.features,
       wrapX: options.wrapX
     }),
     style: goog.isDef(options.style) ? options.style :

--- a/test/spec/ol/interaction/selectinteraction.test.js
+++ b/test/spec/ol/interaction/selectinteraction.test.js
@@ -98,6 +98,16 @@ describe('ol.interaction.Select', function() {
       expect(select).to.be.a(ol.interaction.Interaction);
     });
 
+    describe('user-provided collection', function() {
+
+      it('uses the user-provided collection', function() {
+        var features = new ol.Collection();
+        var select = new ol.interaction.Select({features: features});
+        expect(select.getFeatures()).to.be(features);
+      });
+
+    });
+
   });
 
   describe('selecting a polygon', function() {
@@ -269,6 +279,7 @@ goog.require('goog.dispose');
 goog.require('goog.events');
 goog.require('goog.events.BrowserEvent');
 goog.require('goog.style');
+goog.require('ol.Collection');
 goog.require('ol.Feature');
 goog.require('ol.Map');
 goog.require('ol.MapBrowserEvent.EventType');


### PR DESCRIPTION
This PR adds a `features` option to `ol.interaction.Select`. This option makes it possible to configure a `Select` interaction with a user-created collection.

```js
var featureCollection = new ol.Collection();
var selectInteraction = new ol.interaction.Select({
  features: featureCollection
});
```

We need this in our applications to be able to create independent components where the central point is the collection.

Please review.