### PR TITLE
Fix for inline SVG icons in IE11 (messed up the old branch)

### DIFF
--- a/src/ol/style/iconstyle.js
+++ b/src/ol/style/iconstyle.js
@@ -426,7 +426,7 @@ ol.style.IconImage_ = function(image, src, size, crossOrigin, imageState) {
    * @type {boolean}
    */
   this.tainting_ = false;
-
+  if (this.imageState_ == ol.style.ImageState.LOADED)this.determineTainting_();
 };
 goog.inherits(ol.style.IconImage_, goog.events.EventTarget);
 
@@ -456,8 +456,8 @@ ol.style.IconImage_.get = function(image, src, size, crossOrigin, imageState) {
  */
 ol.style.IconImage_.prototype.determineTainting_ = function() {
   var context = ol.dom.createCanvasContext2D(1, 1);
-  context.drawImage(this.image_, 0, 0);
   try {
+    context.drawImage(this.image_, 0, 0);
     context.getImageData(0, 0, 1, 1);
   } catch (e) {
     this.tainting_ = true;


### PR DESCRIPTION
Sorry for my several pulls, but I had never rebased a branch and messed everything up... :-S At least now I know how to do it.

However, everything should work now, and you should be able to merge the pull without any problems. 

This pulls solve the problem that already loaded images never calls determineTainting_() and because of this might taint the canvas. Inline SVG images can in this case be considered as already loaded images. With the current code there is no problem to draw inline SVG icons to the map, but if you try to add interactions to them, like making it possible to move points, you will get a security error in IE11. By changing the lines in my pull everything will work as it should. 