### PR TITLE
Use version 20150920 of Closure Compiler

### DIFF
--- a/closure-util.json
+++ b/closure-util.json
@@ -1,3 +1,3 @@
 {
-  "library_url": "https://github.com/google/closure-library/archive/a5f9b8a.zip"
+  "library_url": "https://github.com/google/closure-library/archive/5b25e65.zip"
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "async": "0.9.0",
     "browserify": "9.0.3",
-    "closure-util": "1.7.0",
+    "closure-util": "1.8.0",
     "fs-extra": "0.12.0",
     "glob": "5.0.3",
     "graceful-fs": "3.0.2",

--- a/src/ol/ol.js
+++ b/src/ol/ol.js
@@ -232,8 +232,8 @@ ol.WEBGL_EXTENSIONS; // value is set in `ol.has`
  *       // Other code here.
  *     };
  *
- * @param {Function} childCtor Child constructor.
- * @param {Function} parentCtor Parent constructor.
+ * @param {!Function} childCtor Child constructor.
+ * @param {!Function} parentCtor Parent constructor.
  * @function
  * @api
  */

--- a/tasks/test-rendering.js
+++ b/tasks/test-rendering.js
@@ -39,26 +39,14 @@ serve.createServer(function(err, server) {
       url + '/test_rendering/index.html'
     ];
 
+    // The current version of slimerjs is 0.9.6, but this version does not work
+    // for us because of https://github.com/laurentj/slimerjs/issues/333. This
+    // issue is now fixed in master and slimerjs-edge (nightly builds) works for
+    // us. But we should use slimerjs instead of slimerjs-edge when a new
+    // release is published.
     var child = spawn(slimerjs.path, args, {stdio: 'inherit'});
     child.on('exit', function(code) {
-      // FIXME SlimerJS has a problem with returning the correct return
-      // code when using a custom profile, see
-      // https://github.com/laurentj/slimerjs/issues/333
-      // as a work-around we are currently reading the return code from
-      // a file created in the profile directory.
-      // if this issue is fixed we should use the npm package 'slimerjs'
-      // instead of the nightly build 'slimerjs-edge'.
-      var exitstatus = path.join(profile, 'exitstatus');
-      fs.readFile(exitstatus, {encoding: 'utf-8'}, function(err, data) {
-        if (err) {
-          process.stderr.write(
-              'Error getting the exit status of SlimerJS' + '\n');
-          process.stderr.write(err.stack + '\n');
-          process.exit(1);
-        } else {
-          process.exit(data);
-        }
-      });
+      process.exit(code);
     });
   });
 


### PR DESCRIPTION
This PR updates OpenLayers to use the latest version of Closure Compiler (20150920). This requires using a recent version of Closure Library as well. It also requires a minor change to the `ol.inherits`'s signature.