### PR TITLE
 Tile Preload Example Documentation Description Error #4147 Fix

### DIFF
--- a/examples/preload.html
+++ b/examples/preload.html
@@ -3,7 +3,7 @@ template: example.html
 title: Preload example
 shortdesc: Example of tile preloading.
 docs: >
-  <p>The map on the left preloads low resolution tiles.  The map on the right does not use any preloading.  Try zooming out and panning to see the difference.</p>
+  <p>The map on the top preloads low resolution tiles.  The map on the bottom does not use any preloading.  Try zooming out and panning to see the difference.</p>
 tags: "preload, bing"
 ---
 <div class="row-fluid">


### PR DESCRIPTION
 Modified the preload.html example to reflect the correct position of the maps displayed in the example when viewed with a web browser.  This is related to #4147