### PR TITLE
#4171: Prefer current layout as default on Multipolygon.setPolygons()

### DIFF
--- a/src/ol/geom/multipolygon.js
+++ b/src/ol/geom/multipolygon.js
@@ -409,10 +409,13 @@ ol.geom.MultiPolygon.prototype.setFlatCoordinates =
  * @param {Array.<ol.geom.Polygon>} polygons Polygons.
  */
 ol.geom.MultiPolygon.prototype.setPolygons = function(polygons) {
-  var layout = ol.geom.GeometryLayout.XY;
+  var layout = this.getLayout();
   var flatCoordinates = [];
   var endss = [];
   var i, ii, ends;
+  if(!goog.isDefAndNotNull(layout)){
+    layout = ol.geom.GeometryLayout.XY;
+  }
   for (i = 0, ii = polygons.length; i < ii; ++i) {
     var polygon = polygons[i];
     if (i === 0) {

--- a/src/ol/geom/multipolygon.js
+++ b/src/ol/geom/multipolygon.js
@@ -413,9 +413,6 @@ ol.geom.MultiPolygon.prototype.setPolygons = function(polygons) {
   var flatCoordinates = [];
   var endss = [];
   var i, ii, ends;
-  if(!goog.isDefAndNotNull(layout)){
-    layout = ol.geom.GeometryLayout.XY;
-  }
   for (i = 0, ii = polygons.length; i < ii; ++i) {
     var polygon = polygons[i];
     if (i === 0) {


### PR DESCRIPTION
PR to prefer a Multipolygons current layout over XY as new layout to be used when no Polygons (=empty array) is provided for Multipolygon.setPolygons(...).
Fixes Issue #4171.