### PR TITLE
Only animate when resolution is about to be changed

### DIFF
--- a/src/ol/interaction/interaction.js
+++ b/src/ol/interaction/interaction.js
@@ -222,6 +222,7 @@ ol.interaction.Interaction.zoomWithoutConstraints =
     var currentResolution = view.getResolution();
     var currentCenter = view.getCenter();
     if (currentResolution !== undefined && currentCenter &&
+        resolution !== currentResolution &&
         opt_duration && opt_duration > 0) {
       map.beforeRender(ol.animation.zoom({
         resolution: /** @type {number} */ (currentResolution),


### PR DESCRIPTION
Fixes #4115.

The reason for the observed behaviour is because for rendering, the center is snapped to pixels ((`view.getState().center`)). During the animation when fully zoomed in or out, floating point calculations cause the pixel snapped center to differ by one pixel at different steps in the animation.