### PR TITLE
Remove use of goog.math.clamp()

### DIFF
--- a/src/ol/centerconstraint.js
+++ b/src/ol/centerconstraint.js
@@ -1,7 +1,7 @@
 goog.provide('ol.CenterConstraint');
 goog.provide('ol.CenterConstraintType');
 
-goog.require('goog.math');
+goog.require('ol.math');
 
 
 /**
@@ -23,8 +23,8 @@ ol.CenterConstraint.createExtent = function(extent) {
       function(center) {
         if (center) {
           return [
-            goog.math.clamp(center[0], extent[0], extent[2]),
-            goog.math.clamp(center[1], extent[1], extent[3])
+            ol.math.clamp(center[0], extent[0], extent[2]),
+            ol.math.clamp(center[1], extent[1], extent[3])
           ];
         } else {
           return undefined;

--- a/src/ol/color/color.js
+++ b/src/ol/color/color.js
@@ -9,9 +9,9 @@ goog.provide('ol.color');
 goog.require('goog.asserts');
 goog.require('goog.color');
 goog.require('goog.color.names');
-goog.require('goog.math');
 goog.require('goog.vec.Mat4');
 goog.require('ol');
+goog.require('ol.math');
 
 
 /**
@@ -271,11 +271,11 @@ ol.color.isValid = function(color) {
  * @return {ol.Color} Clamped color.
  */
 ol.color.normalize = function(color, opt_color) {
-  var result = opt_color ? opt_color : [];
-  result[0] = goog.math.clamp((color[0] + 0.5) | 0, 0, 255);
-  result[1] = goog.math.clamp((color[1] + 0.5) | 0, 0, 255);
-  result[2] = goog.math.clamp((color[2] + 0.5) | 0, 0, 255);
-  result[3] = goog.math.clamp(color[3], 0, 1);
+  var result = opt_color || [];
+  result[0] = ol.math.clamp((color[0] + 0.5) | 0, 0, 255);
+  result[1] = ol.math.clamp((color[1] + 0.5) | 0, 0, 255);
+  result[2] = ol.math.clamp((color[2] + 0.5) | 0, 0, 255);
+  result[3] = ol.math.clamp(color[3], 0, 1);
   return result;
 };
 

--- a/src/ol/control/zoomslidercontrol.js
+++ b/src/ol/control/zoomslidercontrol.js
@@ -11,7 +11,6 @@ goog.require('goog.events.EventType');
 goog.require('goog.fx.DragEvent');
 goog.require('goog.fx.Dragger');
 goog.require('goog.fx.Dragger.EventType');
-goog.require('goog.math');
 goog.require('goog.math.Rect');
 goog.require('goog.style');
 goog.require('ol.Size');
@@ -20,6 +19,7 @@ goog.require('ol.animation');
 goog.require('ol.control.Control');
 goog.require('ol.css');
 goog.require('ol.easing');
+goog.require('ol.math');
 
 
 
@@ -301,7 +301,7 @@ ol.control.ZoomSlider.prototype.getRelativePosition_ = function(x, y) {
   } else {
     amount = (y - draggerLimits.top) / draggerLimits.height;
   }
-  return goog.math.clamp(amount, 0, 1);
+  return ol.math.clamp(amount, 0, 1);
 };
 
 

--- a/src/ol/graticule.js
+++ b/src/ol/graticule.js
@@ -1,11 +1,11 @@
 goog.provide('ol.Graticule');
 
 goog.require('goog.asserts');
-goog.require('goog.math');
 goog.require('ol.extent');
 goog.require('ol.geom.GeometryLayout');
 goog.require('ol.geom.LineString');
 goog.require('ol.geom.flat.geodesic');
+goog.require('ol.math');
 goog.require('ol.proj');
 goog.require('ol.render.EventType');
 goog.require('ol.style.Stroke');
@@ -238,7 +238,7 @@ ol.Graticule.prototype.createGraticule_ =
   // Create meridians
 
   centerLon = Math.floor(centerLon / interval) * interval;
-  lon = goog.math.clamp(centerLon, this.minLon_, this.maxLon_);
+  lon = ol.math.clamp(centerLon, this.minLon_, this.maxLon_);
 
   idx = this.addMeridian_(lon, minLat, maxLat, squaredTolerance, extent, 0);
 
@@ -248,7 +248,7 @@ ol.Graticule.prototype.createGraticule_ =
     idx = this.addMeridian_(lon, minLat, maxLat, squaredTolerance, extent, idx);
   }
 
-  lon = goog.math.clamp(centerLon, this.minLon_, this.maxLon_);
+  lon = ol.math.clamp(centerLon, this.minLon_, this.maxLon_);
 
   cnt = 0;
   while (lon != this.maxLon_ && cnt++ < maxLines) {
@@ -261,7 +261,7 @@ ol.Graticule.prototype.createGraticule_ =
   // Create parallels
 
   centerLat = Math.floor(centerLat / interval) * interval;
-  lat = goog.math.clamp(centerLat, this.minLat_, this.maxLat_);
+  lat = ol.math.clamp(centerLat, this.minLat_, this.maxLat_);
 
   idx = this.addParallel_(lat, minLon, maxLon, squaredTolerance, extent, 0);
 
@@ -271,7 +271,7 @@ ol.Graticule.prototype.createGraticule_ =
     idx = this.addParallel_(lat, minLon, maxLon, squaredTolerance, extent, idx);
   }
 
-  lat = goog.math.clamp(centerLat, this.minLat_, this.maxLat_);
+  lat = ol.math.clamp(centerLat, this.minLat_, this.maxLat_);
 
   cnt = 0;
   while (lat != this.maxLat_ && cnt++ < maxLines) {

--- a/src/ol/interaction/mousewheelzoominteraction.js
+++ b/src/ol/interaction/mousewheelzoominteraction.js
@@ -3,10 +3,10 @@ goog.provide('ol.interaction.MouseWheelZoom');
 goog.require('goog.asserts');
 goog.require('goog.events.MouseWheelEvent');
 goog.require('goog.events.MouseWheelHandler.EventType');
-goog.require('goog.math');
 goog.require('ol');
 goog.require('ol.Coordinate');
 goog.require('ol.interaction.Interaction');
+goog.require('ol.math');
 
 
 
@@ -114,7 +114,7 @@ ol.interaction.MouseWheelZoom.handleEvent = function(mapBrowserEvent) {
  */
 ol.interaction.MouseWheelZoom.prototype.doZoom_ = function(map) {
   var maxDelta = ol.MOUSEWHEELZOOM_MAXDELTA;
-  var delta = goog.math.clamp(this.delta_, -maxDelta, maxDelta);
+  var delta = ol.math.clamp(this.delta_, -maxDelta, maxDelta);
 
   var view = map.getView();
   goog.asserts.assert(!goog.isNull(view), 'view should not be null');

--- a/src/ol/layer/heatmaplayer.js
+++ b/src/ol/layer/heatmaplayer.js
@@ -2,12 +2,12 @@ goog.provide('ol.layer.Heatmap');
 
 goog.require('goog.asserts');
 goog.require('goog.events');
-goog.require('goog.math');
 goog.require('goog.object');
 goog.require('ol');
 goog.require('ol.Object');
 goog.require('ol.dom');
 goog.require('ol.layer.Vector');
+goog.require('ol.math');
 goog.require('ol.render.EventType');
 goog.require('ol.style.Icon');
 goog.require('ol.style.Style');
@@ -111,8 +111,7 @@ ol.layer.Heatmap = function(opt_options) {
     goog.asserts.assert(this.circleImage_ !== undefined,
         'this.circleImage_ should be defined');
     var weight = weightFunction(feature);
-    var opacity = weight !== undefined ?
-        goog.math.clamp(weight, 0, 1) : 1;
+    var opacity = weight !== undefined ? ol.math.clamp(weight, 0, 1) : 1;
     // cast to 8 bits
     var index = (255 * opacity) | 0;
     var style = this.styleCache_[index];

--- a/src/ol/layer/layerbase.js
+++ b/src/ol/layer/layerbase.js
@@ -2,10 +2,10 @@ goog.provide('ol.layer.Base');
 goog.provide('ol.layer.LayerProperty');
 goog.provide('ol.layer.LayerState');
 
-goog.require('goog.math');
 goog.require('goog.object');
 goog.require('ol');
 goog.require('ol.Object');
+goog.require('ol.math');
 goog.require('ol.source.State');
 
 
@@ -141,10 +141,10 @@ ol.layer.Base.prototype.getLayerState = function() {
   var minResolution = this.getMinResolution();
   return {
     layer: /** @type {ol.layer.Layer} */ (this),
-    brightness: goog.math.clamp(brightness, -1, 1),
+    brightness: ol.math.clamp(brightness, -1, 1),
     contrast: Math.max(contrast, 0),
     hue: hue,
-    opacity: goog.math.clamp(opacity, 0, 1),
+    opacity: ol.math.clamp(opacity, 0, 1),
     saturation: Math.max(saturation, 0),
     sourceState: sourceState,
     visible: visible,

--- a/src/ol/layer/layergroup.js
+++ b/src/ol/layer/layergroup.js
@@ -4,7 +4,6 @@ goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
-goog.require('goog.math');
 goog.require('goog.object');
 goog.require('ol.Collection');
 goog.require('ol.CollectionEvent');
@@ -13,6 +12,7 @@ goog.require('ol.Object');
 goog.require('ol.ObjectEventType');
 goog.require('ol.extent');
 goog.require('ol.layer.Base');
+goog.require('ol.math');
 goog.require('ol.source.State');
 
 
@@ -215,7 +215,7 @@ ol.layer.Group.prototype.getLayerStatesArray = function(opt_states) {
   var i, ii, layerState;
   for (i = pos, ii = states.length; i < ii; i++) {
     layerState = states[i];
-    layerState.brightness = goog.math.clamp(
+    layerState.brightness = ol.math.clamp(
         layerState.brightness + ownLayerState.brightness, -1, 1);
     layerState.contrast *= ownLayerState.contrast;
     layerState.hue += ownLayerState.hue;

--- a/src/ol/math.js
+++ b/src/ol/math.js
@@ -4,6 +4,19 @@ goog.require('goog.asserts');
 
 
 /**
+ * Takes a number and clamps it to within the provided bounds.
+ * @param {number} value The input number.
+ * @param {number} min The minimum value to return.
+ * @param {number} max The maximum value to return.
+ * @return {number} The input number if it is within bounds, or the nearest
+ *     number within the bounds.
+ */
+ol.math.clamp = function(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+};
+
+
+/**
  * @param {number} x X.
  * @return {number} Hyperbolic cosine of x.
  */

--- a/src/ol/resolutionconstraint.js
+++ b/src/ol/resolutionconstraint.js
@@ -1,8 +1,8 @@
 goog.provide('ol.ResolutionConstraint');
 goog.provide('ol.ResolutionConstraintType');
 
-goog.require('goog.math');
 goog.require('ol.array');
+goog.require('ol.math');
 
 
 /**
@@ -28,7 +28,7 @@ ol.ResolutionConstraint.createSnapToResolutions =
         if (resolution !== undefined) {
           var z =
               ol.array.linearFindNearest(resolutions, resolution, direction);
-          z = goog.math.clamp(z + delta, 0, resolutions.length - 1);
+          z = ol.math.clamp(z + delta, 0, resolutions.length - 1);
           return resolutions[z];
         } else {
           return undefined;

--- a/src/ol/tilegrid/tilegrid.js
+++ b/src/ol/tilegrid/tilegrid.js
@@ -2,7 +2,6 @@ goog.provide('ol.tilegrid.TileGrid');
 
 goog.require('goog.array');
 goog.require('goog.asserts');
-goog.require('goog.math');
 goog.require('goog.object');
 goog.require('ol');
 goog.require('ol.Coordinate');
@@ -11,6 +10,7 @@ goog.require('ol.TileRange');
 goog.require('ol.array');
 goog.require('ol.extent');
 goog.require('ol.extent.Corner');
+goog.require('ol.math');
 goog.require('ol.proj');
 goog.require('ol.proj.METERS_PER_UNIT');
 goog.require('ol.proj.Projection');
@@ -483,7 +483,7 @@ ol.tilegrid.TileGrid.prototype.getFullTileRange = function(z) {
  */
 ol.tilegrid.TileGrid.prototype.getZForResolution = function(resolution) {
   var z = ol.array.linearFindNearest(this.resolutions_, resolution, 0);
-  return goog.math.clamp(z, this.minZoom, this.maxZoom);
+  return ol.math.clamp(z, this.minZoom, this.maxZoom);
 };
 
 

--- a/test/spec/ol/math.test.js
+++ b/test/spec/ol/math.test.js
@@ -1,6 +1,31 @@
 goog.provide('ol.test.math');
 
 
+describe('ol.math.clamp', function() {
+
+  it('returns the correct value at -Infinity', function() {
+    expect(ol.math.clamp(-Infinity, 10, 20)).to.eql(10);
+  });
+
+  it('returns the correct value at min', function() {
+    expect(ol.math.clamp(10, 10, 20)).to.eql(10);
+  });
+
+  it('returns the correct value at mid point', function() {
+    expect(ol.math.clamp(15, 10, 20)).to.eql(15);
+  });
+
+  it('returns the correct value at max', function() {
+    expect(ol.math.clamp(20, 10, 20)).to.eql(20);
+  });
+
+  it('returns the correct value at Infinity', function() {
+    expect(ol.math.clamp(Infinity, 10, 20)).to.eql(20);
+  });
+
+});
+
+
 describe('ol.math.cosh', function() {
 
   it('returns the correct value at -Infinity', function() {


### PR DESCRIPTION
This replaces `goog.math.clamp()` with `ol.math.clamp()`.

See #4128 for context.