### PR TITLE
Remove use of goog.isDefAndNotNull()

### DIFF
--- a/src/ol/control/fullscreencontrol.js
+++ b/src/ol/control/fullscreencontrol.js
@@ -114,11 +114,9 @@ ol.control.FullScreen.prototype.handleFullScreen_ = function() {
     goog.dom.fullscreen.exitFullScreen();
   } else {
     var target = map.getTarget();
-    goog.asserts.assert(goog.isDefAndNotNull(target),
-        'target should be defined');
+    goog.asserts.assert(target, 'target should be defined');
     var element = goog.dom.getElement(target);
-    goog.asserts.assert(goog.isDefAndNotNull(element),
-        'element should be defined');
+    goog.asserts.assert(element, 'element should be defined');
     if (this.keys_) {
       goog.dom.fullscreen.requestFullScreenWithKeys(element);
     } else {

--- a/src/ol/control/overviewmapcontrol.js
+++ b/src/ol/control/overviewmapcontrol.js
@@ -395,7 +395,7 @@ ol.control.OverviewMap.prototype.updateBox_ = function() {
   overlay.setPosition(rotateBottomLeft);
 
   // set box size calculated from map extent size and overview map resolution
-  if (goog.isDefAndNotNull(box)) {
+  if (box) {
     var boxWidth = Math.abs((bottomLeft[0] - topRight[0]) / ovresolution);
     var boxHeight = Math.abs((topRight[1] - bottomLeft[1]) / ovresolution);
     goog.style.setBorderBoxSize(box, new goog.math.Size(

--- a/src/ol/control/zoomslidercontrol.js
+++ b/src/ol/control/zoomslidercontrol.js
@@ -182,7 +182,7 @@ ol.control.ZoomSlider.render = function(mapEvent) {
   if (goog.isNull(mapEvent.frameState)) {
     return;
   }
-  goog.asserts.assert(goog.isDefAndNotNull(mapEvent.frameState.viewState),
+  goog.asserts.assert(mapEvent.frameState.viewState,
       'viewState should be defined');
   if (!this.sliderInitialized_) {
     this.initSlider_();

--- a/src/ol/deviceorientation.js
+++ b/src/ol/deviceorientation.js
@@ -114,24 +114,23 @@ ol.DeviceOrientation.prototype.disposeInternal = function() {
 ol.DeviceOrientation.prototype.orientationChange_ = function(browserEvent) {
   var event = /** @type {DeviceOrientationEvent} */
       (browserEvent.getBrowserEvent());
-  if (goog.isDefAndNotNull(event.alpha)) {
+  if (event.alpha !== null) {
     var alpha = goog.math.toRadians(event.alpha);
     this.set(ol.DeviceOrientationProperty.ALPHA, alpha);
     // event.absolute is undefined in iOS.
     if (goog.isBoolean(event.absolute) && event.absolute) {
       this.set(ol.DeviceOrientationProperty.HEADING, alpha);
-    } else if (goog.isDefAndNotNull(event.webkitCompassHeading) &&
-               goog.isDefAndNotNull(event.webkitCompassAccuracy) &&
+    } else if (goog.isNumber(event.webkitCompassHeading) &&
                event.webkitCompassAccuracy != -1) {
       var heading = goog.math.toRadians(event.webkitCompassHeading);
       this.set(ol.DeviceOrientationProperty.HEADING, heading);
     }
   }
-  if (goog.isDefAndNotNull(event.beta)) {
+  if (event.beta !== null) {
     this.set(ol.DeviceOrientationProperty.BETA,
         goog.math.toRadians(event.beta));
   }
-  if (goog.isDefAndNotNull(event.gamma)) {
+  if (event.gamma !== null) {
     this.set(ol.DeviceOrientationProperty.GAMMA,
         goog.math.toRadians(event.gamma));
   }

--- a/src/ol/feature.js
+++ b/src/ol/feature.js
@@ -124,7 +124,7 @@ ol.Feature.prototype.clone = function() {
   var clone = new ol.Feature(this.getProperties());
   clone.setGeometryName(this.getGeometryName());
   var geometry = this.getGeometry();
-  if (goog.isDefAndNotNull(geometry)) {
+  if (geometry) {
     clone.setGeometry(geometry.clone());
   }
   var style = this.getStyle();
@@ -215,7 +215,7 @@ ol.Feature.prototype.handleGeometryChanged_ = function() {
     this.geometryChangeKey_ = null;
   }
   var geometry = this.getGeometry();
-  if (goog.isDefAndNotNull(geometry)) {
+  if (geometry) {
     this.geometryChangeKey_ = goog.events.listen(geometry,
         goog.events.EventType.CHANGE, this.handleGeometryChange_, false, this);
   }

--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -90,7 +90,7 @@ ol.featureloader.loadFeaturesXhr = function(url, format, success) {
                 } else {
                   goog.asserts.fail('unexpected format type');
                 }
-                if (goog.isDefAndNotNull(source)) {
+                if (source) {
                   var features = format.readFeatures(source,
                       {featureProjection: projection});
                   success.call(this, features);

--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -84,7 +84,7 @@ ol.featureloader.loadFeaturesXhr = function(url, format, success) {
                   if (!goog.userAgent.IE) {
                     source = xhrIo.getResponseXml();
                   }
-                  if (!goog.isDefAndNotNull(source)) {
+                  if (!source) {
                     source = ol.xml.parse(xhrIo.getResponseText());
                   }
                 } else {

--- a/src/ol/format/esrijsonformat.js
+++ b/src/ol/format/esrijsonformat.js
@@ -60,15 +60,15 @@ ol.format.EsriJSON.readGeometry_ = function(object, opt_options) {
   var type;
   if (goog.isNumber(object.x) && goog.isNumber(object.y)) {
     type = ol.geom.GeometryType.POINT;
-  } else if (goog.isDefAndNotNull(object.points)) {
+  } else if (object.points) {
     type = ol.geom.GeometryType.MULTI_POINT;
-  } else if (goog.isDefAndNotNull(object.paths)) {
+  } else if (object.paths) {
     if (object.paths.length === 1) {
       type = ol.geom.GeometryType.LINE_STRING;
     } else {
       type = ol.geom.GeometryType.MULTI_LINE_STRING;
     }
-  } else if (goog.isDefAndNotNull(object.rings)) {
+  } else if (object.rings) {
     var layout = ol.format.EsriJSON.getGeometryLayout_(object);
     var rings = ol.format.EsriJSON.convertRings_(object.rings, layout);
     object = /** @type {EsriJSONGeometry} */(goog.object.clone(object));
@@ -149,13 +149,13 @@ ol.format.EsriJSON.readPointGeometry_ = function(object) {
   goog.asserts.assert(goog.isNumber(object.x), 'object.x should be number');
   goog.asserts.assert(goog.isNumber(object.y), 'object.y should be number');
   var point;
-  if (goog.isDefAndNotNull(object.m) && goog.isDefAndNotNull(object.z)) {
+  if (object.m !== undefined && object.z !== undefined) {
     point = new ol.geom.Point([object.x, object.y, object.z, object.m],
         ol.geom.GeometryLayout.XYZM);
-  } else if (goog.isDefAndNotNull(object.z)) {
+  } else if (object.z !== undefined) {
     point = new ol.geom.Point([object.x, object.y, object.z],
         ol.geom.GeometryLayout.XYZ);
-  } else if (goog.isDefAndNotNull(object.m)) {
+  } else if (object.m !== undefined) {
     point = new ol.geom.Point([object.x, object.y, object.m],
         ol.geom.GeometryLayout.XYM);
   } else {
@@ -219,8 +219,7 @@ ol.format.EsriJSON.getGeometryLayout_ = function(object) {
  * @return {ol.geom.Geometry} MultiPoint.
  */
 ol.format.EsriJSON.readMultiPointGeometry_ = function(object) {
-  goog.asserts.assert(goog.isDefAndNotNull(object.points),
-      'object.points should be defined');
+  goog.asserts.assert(object.points, 'object.points should be defined');
   var layout = ol.format.EsriJSON.getGeometryLayout_(object);
   return new ol.geom.MultiPoint(object.points, layout);
 };
@@ -232,7 +231,7 @@ ol.format.EsriJSON.readMultiPointGeometry_ = function(object) {
  * @return {ol.geom.Geometry} MultiPolygon.
  */
 ol.format.EsriJSON.readMultiPolygonGeometry_ = function(object) {
-  goog.asserts.assert(goog.isDefAndNotNull(object.rings));
+  goog.asserts.assert(object.rings);
   goog.asserts.assert(object.rings.length > 1,
       'object.rings should have length larger than 1');
   var layout = ol.format.EsriJSON.getGeometryLayout_(object);
@@ -248,7 +247,7 @@ ol.format.EsriJSON.readMultiPolygonGeometry_ = function(object) {
  * @return {ol.geom.Geometry} Polygon.
  */
 ol.format.EsriJSON.readPolygonGeometry_ = function(object) {
-  goog.asserts.assert(goog.isDefAndNotNull(object.rings));
+  goog.asserts.assert(object.rings);
   var layout = ol.format.EsriJSON.getGeometryLayout_(object);
   return new ol.geom.Polygon(object.rings, layout);
 };
@@ -483,10 +482,9 @@ ol.format.EsriJSON.prototype.readFeatures;
 ol.format.EsriJSON.prototype.readFeatureFromObject = function(
     object, opt_options) {
   var esriJSONFeature = /** @type {EsriJSONFeature} */ (object);
-  goog.asserts.assert(goog.isDefAndNotNull(esriJSONFeature.geometry) ||
-      goog.isDefAndNotNull(esriJSONFeature.compressedGeometry) ||
-      goog.isDefAndNotNull(esriJSONFeature.attributes),
-      'geometry, compressedGeometry or attributes should be defined');
+  goog.asserts.assert(esriJSONFeature.geometry ||
+      esriJSONFeature.attributes,
+      'geometry or attributes should be defined');
   var geometry = ol.format.EsriJSON.readGeometry_(esriJSONFeature.geometry,
       opt_options);
   var feature = new ol.Feature();
@@ -516,7 +514,7 @@ ol.format.EsriJSON.prototype.readFeaturesFromObject = function(
     object, opt_options) {
   var esriJSONObject = /** @type {EsriJSONObject} */ (object);
   var options = opt_options ? opt_options : {};
-  if (goog.isDefAndNotNull(esriJSONObject.features)) {
+  if (esriJSONObject.features) {
     var esriJSONFeatureCollection = /** @type {EsriJSONFeatureCollection} */
         (object);
     /** @type {Array.<ol.Feature>} */
@@ -573,8 +571,7 @@ ol.format.EsriJSON.prototype.readProjection;
  */
 ol.format.EsriJSON.prototype.readProjectionFromObject = function(object) {
   var esriJSONObject = /** @type {EsriJSONObject} */ (object);
-  if (goog.isDefAndNotNull(esriJSONObject.spatialReference) &&
-      goog.isDefAndNotNull(esriJSONObject.spatialReference.wkid)) {
+  if (esriJSONObject.spatialReference && esriJSONObject.spatialReference.wkid) {
     var crs = esriJSONObject.spatialReference.wkid;
     return ol.proj.get('EPSG:' + crs);
   } else {

--- a/src/ol/format/esrijsonformat.js
+++ b/src/ol/format/esrijsonformat.js
@@ -650,7 +650,7 @@ ol.format.EsriJSON.prototype.writeFeatureObject = function(
   opt_options = this.adaptOptions(opt_options);
   var object = {};
   var geometry = feature.getGeometry();
-  if (goog.isDefAndNotNull(geometry)) {
+  if (geometry) {
     object['geometry'] =
         ol.format.EsriJSON.writeGeometry_(geometry, opt_options);
   }

--- a/src/ol/format/featureformat.js
+++ b/src/ol/format/featureformat.js
@@ -67,7 +67,7 @@ ol.format.Feature.prototype.adaptOptions = function(options) {
   if (options) {
     updatedOptions = {
       featureProjection: options.featureProjection,
-      dataProjection: goog.isDefAndNotNull(options.dataProjection) ?
+      dataProjection: options.dataProjection ?
           options.dataProjection : this.defaultDataProjection,
       rightHanded: options.rightHanded
     };

--- a/src/ol/format/geojsonformat.js
+++ b/src/ol/format/geojsonformat.js
@@ -484,7 +484,7 @@ ol.format.GeoJSON.prototype.readProjection;
 ol.format.GeoJSON.prototype.readProjectionFromObject = function(object) {
   var geoJSONObject = /** @type {GeoJSONObject} */ (object);
   var crs = geoJSONObject.crs;
-  if (goog.isDefAndNotNull(crs)) {
+  if (crs) {
     if (crs.type == 'name') {
       return ol.proj.get(crs.properties.name);
     } else if (crs.type == 'EPSG') {
@@ -530,11 +530,11 @@ ol.format.GeoJSON.prototype.writeFeatureObject = function(
     'type': 'Feature'
   };
   var id = feature.getId();
-  if (goog.isDefAndNotNull(id)) {
+  if (id) {
     object['id'] = id;
   }
   var geometry = feature.getGeometry();
-  if (goog.isDefAndNotNull(geometry)) {
+  if (geometry) {
     object['geometry'] =
         ol.format.GeoJSON.writeGeometry_(geometry, opt_options);
   } else {

--- a/src/ol/format/geojsonformat.js
+++ b/src/ol/format/geojsonformat.js
@@ -38,7 +38,7 @@ ol.format.GeoJSON = function(opt_options) {
    * @inheritDoc
    */
   this.defaultDataProjection = ol.proj.get(
-      goog.isDefAndNotNull(options.defaultDataProjection) ?
+      options.defaultDataProjection ?
           options.defaultDataProjection : 'EPSG:4326');
 
 

--- a/src/ol/format/gml/gml3format.js
+++ b/src/ol/format/gml/gml3format.js
@@ -643,7 +643,7 @@ ol.format.GML3.prototype.writePos_ = function(node, value, objectStack) {
   goog.asserts.assert(goog.isObject(context), 'context should be an Object');
   var srsName = context['srsName'];
   var axisOrientation = 'enu';
-  if (goog.isDefAndNotNull(srsName)) {
+  if (srsName) {
     axisOrientation = ol.proj.get(srsName).getAxisOrientation();
   }
   var point = value.getCoordinates();
@@ -666,7 +666,7 @@ ol.format.GML3.prototype.writePos_ = function(node, value, objectStack) {
  */
 ol.format.GML3.prototype.getCoords_ = function(point, opt_srsName) {
   var axisOrientation = 'enu';
-  if (goog.isDefAndNotNull(opt_srsName)) {
+  if (opt_srsName) {
     axisOrientation = ol.proj.get(opt_srsName).getAxisOrientation();
   }
   return ((axisOrientation.substr(0, 2) === 'en') ?
@@ -708,7 +708,7 @@ ol.format.GML3.prototype.writePoint_ = function(node, geometry, objectStack) {
   var context = objectStack[objectStack.length - 1];
   goog.asserts.assert(goog.isObject(context), 'context should be an Object');
   var srsName = context['srsName'];
-  if (goog.isDefAndNotNull(srsName)) {
+  if (srsName) {
     node.setAttribute('srsName', srsName);
   }
   var pos = ol.xml.createElementNS(node.namespaceURI, 'pos');
@@ -763,7 +763,7 @@ ol.format.GML3.prototype.writeLinearRing_ =
   var context = objectStack[objectStack.length - 1];
   goog.asserts.assert(goog.isObject(context), 'context should be an Object');
   var srsName = context['srsName'];
-  if (goog.isDefAndNotNull(srsName)) {
+  if (srsName) {
     node.setAttribute('srsName', srsName);
   }
   var posList = ol.xml.createElementNS(node.namespaceURI, 'posList');
@@ -864,7 +864,7 @@ ol.format.GML3.prototype.writeMultiSurfaceOrPolygon_ =
   goog.asserts.assert(goog.isObject(context), 'context should be an Object');
   var srsName = context['srsName'];
   var surface = context['surface'];
-  if (goog.isDefAndNotNull(srsName)) {
+  if (srsName) {
     node.setAttribute('srsName', srsName);
   }
   var polygons = geometry.getPolygons();
@@ -886,7 +886,7 @@ ol.format.GML3.prototype.writeMultiPoint_ = function(node, geometry,
   var context = objectStack[objectStack.length - 1];
   goog.asserts.assert(goog.isObject(context), 'context should be an Object');
   var srsName = context['srsName'];
-  if (goog.isDefAndNotNull(srsName)) {
+  if (srsName) {
     node.setAttribute('srsName', srsName);
   }
   var points = geometry.getPoints();
@@ -909,7 +909,7 @@ ol.format.GML3.prototype.writeMultiCurveOrLineString_ =
   goog.asserts.assert(goog.isObject(context), 'context should be an Object');
   var srsName = context['srsName'];
   var curve = context['curve'];
-  if (goog.isDefAndNotNull(srsName)) {
+  if (srsName) {
     node.setAttribute('srsName', srsName);
   }
   var lines = geometry.getLineStrings();

--- a/src/ol/format/gml/gml3format.js
+++ b/src/ol/format/gml/gml3format.js
@@ -804,7 +804,7 @@ ol.format.GML3.prototype.writeSurfaceOrPolygon_ =
   var context = objectStack[objectStack.length - 1];
   goog.asserts.assert(goog.isObject(context), 'context should be an Object');
   var srsName = context['srsName'];
-  if (node.nodeName !== 'PolygonPatch' && goog.isDefAndNotNull(srsName)) {
+  if (node.nodeName !== 'PolygonPatch' && srsName) {
     node.setAttribute('srsName', srsName);
   }
   if (node.nodeName === 'Polygon' || node.nodeName === 'PolygonPatch') {
@@ -834,8 +834,7 @@ ol.format.GML3.prototype.writeCurveOrLineString_ =
   var context = objectStack[objectStack.length - 1];
   goog.asserts.assert(goog.isObject(context), 'context should be an Object');
   var srsName = context['srsName'];
-  if (node.nodeName !== 'LineStringSegment' &&
-      goog.isDefAndNotNull(srsName)) {
+  if (node.nodeName !== 'LineStringSegment' && srsName) {
     node.setAttribute('srsName', srsName);
   }
   if (node.nodeName === 'LineString' ||

--- a/src/ol/format/gml/gmlbaseformat.js
+++ b/src/ol/format/gml/gmlbaseformat.js
@@ -116,7 +116,7 @@ ol.format.GMLBase.prototype.readFeaturesInternal = function(node, objectStack) {
     var featureType = context['featureType'];
     var featureNS = context['featureNS'];
     var i, ii, prefix = 'p', defaultPrefix = 'p0';
-    if (!featureType && goog.isDefAndNotNull(node.childNodes)) {
+    if (!featureType && node.childNodes) {
       featureType = [], featureNS = {};
       for (i = 0, ii = node.childNodes.length; i < ii; ++i) {
         var child = node.childNodes[i];

--- a/src/ol/format/gml/gmlbaseformat.js
+++ b/src/ol/format/gml/gmlbaseformat.js
@@ -180,7 +180,7 @@ ol.format.GMLBase.prototype.readGeometryElement = function(node, objectStack) {
   context['srsName'] = node.firstElementChild.getAttribute('srsName');
   var geometry = ol.xml.pushParseAndPop(/** @type {ol.geom.Geometry} */(null),
       this.GEOMETRY_PARSERS_, node, objectStack, this);
-  if (goog.isDefAndNotNull(geometry)) {
+  if (geometry) {
     return /** @type {ol.geom.Geometry} */ (
         ol.format.Feature.transformWithOptions(geometry, false, context));
   } else {
@@ -243,7 +243,7 @@ ol.format.GMLBase.prototype.readPoint = function(node, objectStack) {
   goog.asserts.assert(node.localName == 'Point', 'localName should be Point');
   var flatCoordinates =
       this.readFlatCoordinatesFromNode_(node, objectStack);
-  if (goog.isDefAndNotNull(flatCoordinates)) {
+  if (flatCoordinates) {
     var point = new ol.geom.Point(null);
     goog.asserts.assert(flatCoordinates.length == 3,
         'flatCoordinates should have a length of 3');
@@ -382,7 +382,7 @@ ol.format.GMLBase.prototype.readLineString = function(node, objectStack) {
       'localName should be LineString');
   var flatCoordinates =
       this.readFlatCoordinatesFromNode_(node, objectStack);
-  if (goog.isDefAndNotNull(flatCoordinates)) {
+  if (flatCoordinates) {
     var lineString = new ol.geom.LineString(null);
     lineString.setFlatCoordinates(ol.geom.GeometryLayout.XYZ, flatCoordinates);
     return lineString;
@@ -406,7 +406,7 @@ ol.format.GMLBase.prototype.readFlatLinearRing_ = function(node, objectStack) {
   var ring = ol.xml.pushParseAndPop(/** @type {Array.<number>} */(null),
       this.GEOMETRY_FLAT_COORDINATES_PARSERS_, node,
       objectStack, this);
-  if (goog.isDefAndNotNull(ring)) {
+  if (ring) {
     return ring;
   } else {
     return undefined;

--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -950,7 +950,7 @@ ol.format.KML.readPoint_ = function(node, objectStack) {
       objectStack);
   var flatCoordinates =
       ol.format.KML.readFlatCoordinatesFromNode_(node, objectStack);
-  if (goog.isDefAndNotNull(flatCoordinates)) {
+  if (flatCoordinates) {
     var point = new ol.geom.Point(null);
     goog.asserts.assert(flatCoordinates.length == 3,
         'flatCoordinates should have a length of 3');
@@ -1684,7 +1684,7 @@ ol.format.KML.prototype.readPlacemark_ = function(node, objectStack) {
   var options = /** @type {olx.format.ReadOptions} */ (objectStack[0]);
 
   var geometry = object['geometry'];
-  if (goog.isDefAndNotNull(geometry)) {
+  if (geometry) {
     ol.format.Feature.transformWithOptions(geometry, false, options);
   }
   feature.setGeometry(geometry);
@@ -2295,7 +2295,7 @@ ol.format.KML.writePlacemark_ = function(node, feature, objectStack) {
   // serialize geometry
   var options = /** @type {olx.format.WriteOptions} */ (objectStack[0]);
   var geometry = feature.getGeometry();
-  if (goog.isDefAndNotNull(geometry)) {
+  if (geometry) {
     geometry =
         ol.format.Feature.transformWithOptions(geometry, true, options);
   }
@@ -2751,7 +2751,7 @@ ol.format.KML.DOCUMENT_NODE_FACTORY_ = function(value, objectStack,
  */
 ol.format.KML.GEOMETRY_NODE_FACTORY_ = function(value, objectStack,
     opt_nodeName) {
-  if (goog.isDefAndNotNull(value)) {
+  if (value) {
     goog.asserts.assertInstanceof(value, ol.geom.Geometry,
         'value should be an ol.geom.Geometry');
     var parentNode = objectStack[objectStack.length - 1].node;

--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -394,7 +394,7 @@ ol.format.KML.readFlatCoordinates_ = function(node) {
  */
 ol.format.KML.readStyleUrl_ = function(node) {
   var s = goog.string.trim(ol.xml.getAllTextContent(node, false));
-  if (goog.isDefAndNotNull(node.baseURI)) {
+  if (node.baseURI) {
     return goog.Uri.resolve(node.baseURI, s).toString();
   } else {
     return s;
@@ -410,7 +410,7 @@ ol.format.KML.readStyleUrl_ = function(node) {
  */
 ol.format.KML.readURI_ = function(node) {
   var s = ol.xml.getAllTextContent(node, false);
-  if (goog.isDefAndNotNull(node.baseURI)) {
+  if (node.baseURI) {
     return goog.Uri.resolve(node.baseURI, goog.string.trim(s)).toString();
   } else {
     return goog.string.trim(s);
@@ -980,8 +980,7 @@ ol.format.KML.readPolygon_ = function(node, objectStack) {
   var flatLinearRings = ol.xml.pushParseAndPop(
       /** @type {Array.<Array.<number>>} */ ([null]),
       ol.format.KML.FLAT_LINEAR_RINGS_PARSERS_, node, objectStack);
-  if (goog.isDefAndNotNull(flatLinearRings) &&
-      !goog.isNull(flatLinearRings[0])) {
+  if (flatLinearRings && !goog.isNull(flatLinearRings[0])) {
     var polygon = new ol.geom.Polygon(null);
     var flatCoordinates = flatLinearRings[0];
     var ends = [flatCoordinates.length];
@@ -1721,7 +1720,7 @@ ol.format.KML.prototype.readSharedStyle_ = function(node, objectStack) {
     var style = ol.format.KML.readStyle_(node, objectStack);
     if (style) {
       var styleUri;
-      if (goog.isDefAndNotNull(node.baseURI)) {
+      if (node.baseURI) {
         styleUri = goog.Uri.resolve(node.baseURI, '#' + id).toString();
       } else {
         styleUri = '#' + id;
@@ -1751,7 +1750,7 @@ ol.format.KML.prototype.readSharedStyleMap_ = function(node, objectStack) {
     return;
   }
   var styleUri;
-  if (goog.isDefAndNotNull(node.baseURI)) {
+  if (node.baseURI) {
     styleUri = goog.Uri.resolve(node.baseURI, '#' + id).toString();
   } else {
     styleUri = '#' + id;
@@ -2267,7 +2266,7 @@ ol.format.KML.writePlacemark_ = function(node, feature, objectStack) {
   var /** @type {ol.xml.NodeStackItem} */ context = {node: node};
 
   // set id
-  if (goog.isDefAndNotNull(feature.getId())) {
+  if (feature.getId()) {
     node.setAttribute('id', feature.getId());
   }
 

--- a/src/ol/format/polylineformat.js
+++ b/src/ol/format/polylineformat.js
@@ -356,7 +356,7 @@ ol.format.Polyline.prototype.readProjection;
  */
 ol.format.Polyline.prototype.writeFeatureText = function(feature, opt_options) {
   var geometry = feature.getGeometry();
-  if (goog.isDefAndNotNull(geometry)) {
+  if (geometry) {
     return this.writeGeometryText(geometry, opt_options);
   } else {
     goog.asserts.fail('geometry needs to be defined');

--- a/src/ol/format/topojsonformat.js
+++ b/src/ol/format/topojsonformat.js
@@ -34,7 +34,7 @@ ol.format.TopoJSON = function(opt_options) {
    * @inheritDoc
    */
   this.defaultDataProjection = ol.proj.get(
-      goog.isDefAndNotNull(options.defaultDataProjection) ?
+      options.defaultDataProjection ?
           options.defaultDataProjection : 'EPSG:4326');
 
 };

--- a/src/ol/format/wfsformat.js
+++ b/src/ol/format/wfsformat.js
@@ -475,7 +475,7 @@ ol.format.WFS.writeProperty_ = function(node, pair, objectStack) {
   var name = ol.xml.createElementNS('http://www.opengis.net/wfs', 'Name');
   node.appendChild(name);
   ol.format.XSD.writeStringTextNode(name, pair.name);
-  if (goog.isDefAndNotNull(pair.value)) {
+  if (pair.value !== undefined && pair.value !== null) {
     var value = ol.xml.createElementNS('http://www.opengis.net/wfs', 'Value');
     node.appendChild(value);
     if (pair.value instanceof ol.geom.Geometry) {
@@ -768,8 +768,8 @@ ol.format.WFS.prototype.readProjectionFromNode = function(node) {
   goog.asserts.assert(node.localName == 'FeatureCollection',
       'localName should be FeatureCollection');
 
-  if (goog.isDefAndNotNull(node.firstElementChild) &&
-      goog.isDefAndNotNull(node.firstElementChild.firstElementChild)) {
+  if (node.firstElementChild &&
+      node.firstElementChild.firstElementChild) {
     node = node.firstElementChild.firstElementChild;
     for (var n = node.firstElementChild; !goog.isNull(n);
         n = n.nextElementSibling) {

--- a/src/ol/format/wfsformat.js
+++ b/src/ol/format/wfsformat.js
@@ -697,7 +697,7 @@ ol.format.WFS.prototype.writeTransaction = function(inserts, updates, deletes,
   }
   ol.xml.setAttributeNS(node, 'http://www.w3.org/2001/XMLSchema-instance',
       'xsi:schemaLocation', this.schemaLocation_);
-  if (goog.isDefAndNotNull(inserts)) {
+  if (inserts) {
     obj = {node: node, featureNS: options.featureNS,
       featureType: options.featureType, featurePrefix: options.featurePrefix};
     goog.object.extend(obj, baseObj);
@@ -706,7 +706,7 @@ ol.format.WFS.prototype.writeTransaction = function(inserts, updates, deletes,
         ol.xml.makeSimpleNodeFactory('Insert'), inserts,
         objectStack);
   }
-  if (goog.isDefAndNotNull(updates)) {
+  if (updates) {
     obj = {node: node, featureNS: options.featureNS,
       featureType: options.featureType, featurePrefix: options.featurePrefix};
     goog.object.extend(obj, baseObj);
@@ -715,7 +715,7 @@ ol.format.WFS.prototype.writeTransaction = function(inserts, updates, deletes,
         ol.xml.makeSimpleNodeFactory('Update'), updates,
         objectStack);
   }
-  if (goog.isDefAndNotNull(deletes)) {
+  if (deletes) {
     ol.xml.pushSerializeAndPop({node: node, featureNS: options.featureNS,
       featureType: options.featureType, featurePrefix: options.featurePrefix},
     ol.format.WFS.TRANSACTION_SERIALIZERS_,

--- a/src/ol/geolocation.js
+++ b/src/ol/geolocation.js
@@ -117,7 +117,7 @@ ol.Geolocation.prototype.disposeInternal = function() {
  */
 ol.Geolocation.prototype.handleProjectionChanged_ = function() {
   var projection = this.getProjection();
-  if (goog.isDefAndNotNull(projection)) {
+  if (projection) {
     this.transform_ = ol.proj.getTransformFromProjections(
         ol.proj.get('EPSG:4326'), projection);
     if (!goog.isNull(this.position_)) {

--- a/src/ol/geom/flat/interpolateflatgeom.js
+++ b/src/ol/geom/flat/interpolateflatgeom.js
@@ -61,7 +61,7 @@ ol.geom.flat.interpolate.lineString =
       pointY = flatCoordinates[offset + index * stride + 1];
     }
   }
-  if (goog.isDefAndNotNull(opt_dest)) {
+  if (opt_dest) {
     opt_dest[0] = pointX;
     opt_dest[1] = pointY;
     return opt_dest;

--- a/src/ol/interaction/draganddropinteraction.js
+++ b/src/ol/interaction/draganddropinteraction.js
@@ -121,7 +121,7 @@ ol.interaction.DragAndDrop.prototype.handleResult_ = function(file, result) {
       for (j = 0, jj = readFeatures.length; j < jj; ++j) {
         var feature = readFeatures[j];
         var geometry = feature.getGeometry();
-        if (goog.isDefAndNotNull(geometry)) {
+        if (geometry) {
           geometry.applyTransform(transform);
         }
         features.push(feature);

--- a/src/ol/interaction/drawinteraction.js
+++ b/src/ol/interaction/drawinteraction.js
@@ -723,8 +723,7 @@ ol.interaction.Draw.prototype.extend = function(feature) {
   var geometry = feature.getGeometry();
   goog.asserts.assert(this.mode_ == ol.interaction.DrawMode.LINE_STRING,
       'interaction mode must be "line"');
-  goog.asserts.assert(goog.isDefAndNotNull(geometry),
-      'feature must have a geometry');
+  goog.asserts.assert(geometry, 'feature must have a geometry');
   goog.asserts.assert(geometry.getType() == ol.geom.GeometryType.LINE_STRING,
       'feature geometry must be a line string');
   var lineString = /** @type {ol.geom.LineString} */ (geometry);

--- a/src/ol/interaction/interaction.js
+++ b/src/ol/interaction/interaction.js
@@ -147,7 +147,7 @@ ol.interaction.Interaction.rotate =
  */
 ol.interaction.Interaction.rotateWithoutConstraints =
     function(map, view, rotation, opt_anchor, opt_duration) {
-  if (goog.isDefAndNotNull(rotation)) {
+  if (rotation !== undefined) {
     var currentRotation = view.getRotation();
     var currentCenter = view.getCenter();
     if (currentRotation !== undefined && currentCenter &&
@@ -218,7 +218,7 @@ ol.interaction.Interaction.zoomByDelta =
  */
 ol.interaction.Interaction.zoomWithoutConstraints =
     function(map, view, resolution, opt_anchor, opt_duration) {
-  if (goog.isDefAndNotNull(resolution)) {
+  if (resolution) {
     var currentResolution = view.getResolution();
     var currentCenter = view.getCenter();
     if (currentResolution !== undefined && currentCenter &&
@@ -237,7 +237,7 @@ ol.interaction.Interaction.zoomWithoutConstraints =
         }));
       }
     }
-    if (goog.isDefAndNotNull(opt_anchor)) {
+    if (opt_anchor) {
       var center = view.calculateCenterZoom(resolution, opt_anchor);
       view.setCenter(center);
     }

--- a/src/ol/layer/layergroup.js
+++ b/src/ol/layer/layergroup.js
@@ -61,7 +61,7 @@ ol.layer.Group = function(opt_options) {
       ol.Object.getChangeEventType(ol.layer.GroupProperty.LAYERS),
       this.handleLayersChanged_, false, this);
 
-  if (goog.isDefAndNotNull(layers)) {
+  if (layers) {
     if (goog.isArray(layers)) {
       layers = new ol.Collection(layers.slice());
     } else {

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -1123,7 +1123,7 @@ ol.Map.prototype.handleLayerGroupChanged_ = function() {
     this.layerGroupPropertyListenerKeys_ = null;
   }
   var layerGroup = this.getLayerGroup();
-  if (goog.isDefAndNotNull(layerGroup)) {
+  if (layerGroup) {
     this.layerGroupPropertyListenerKeys_ = [
       goog.events.listen(
           layerGroup, ol.ObjectEventType.PROPERTYCHANGE,

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -1151,7 +1151,7 @@ ol.Map.prototype.isDef = function() {
     return false;
   }
   var size = this.getSize();
-  if (!goog.isDefAndNotNull(size) || size[0] <= 0 || size[1] <= 0) {
+  if (!size || size[0] <= 0 || size[1] <= 0) {
     return false;
   }
   var view = this.getView();

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -372,8 +372,7 @@ ol.Overlay.prototype.panIntoView_ = function() {
 
   var mapRect = this.getRect_(map.getTargetElement(), map.getSize());
   var element = this.getElement();
-  goog.asserts.assert(goog.isDefAndNotNull(element),
-      'element should be defined');
+  goog.asserts.assert(element, 'element should be defined');
   var overlayRect = this.getRect_(element,
       [ol.dom.outerWidth(element), ol.dom.outerHeight(element)]);
 
@@ -428,8 +427,7 @@ ol.Overlay.prototype.panIntoView_ = function() {
  * @private
  */
 ol.Overlay.prototype.getRect_ = function(element, size) {
-  goog.asserts.assert(goog.isDefAndNotNull(element),
-      'element should be defined');
+  goog.asserts.assert(element, 'element should be defined');
   goog.asserts.assert(size !== undefined, 'size should be defined');
 
   var offset = goog.style.getPageOffset(element);

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -244,7 +244,7 @@ ol.Overlay.prototype.getPositioning = function() {
 ol.Overlay.prototype.handleElementChanged = function() {
   goog.dom.removeChildren(this.element_);
   var element = this.getElement();
-  if (goog.isDefAndNotNull(element)) {
+  if (element) {
     goog.dom.append(/** @type {!Node} */ (this.element_), element);
   }
 };
@@ -260,7 +260,7 @@ ol.Overlay.prototype.handleMapChanged = function() {
     this.mapPostrenderListenerKey_ = null;
   }
   var map = this.getMap();
-  if (goog.isDefAndNotNull(map)) {
+  if (map) {
     this.mapPostrenderListenerKey_ = goog.events.listen(map,
         ol.MapEventType.POSTRENDER, this.render, false, this);
     this.updatePixelPosition();

--- a/src/ol/proj/proj.js
+++ b/src/ol/proj/proj.js
@@ -484,7 +484,7 @@ ol.proj.clearAllProjections = function() {
  * @return {ol.proj.Projection} Projection.
  */
 ol.proj.createProjection = function(projection, defaultCode) {
-  if (!goog.isDefAndNotNull(projection)) {
+  if (!projection) {
     return ol.proj.get(defaultCode);
   } else if (goog.isString(projection)) {
     return ol.proj.get(projection);

--- a/src/ol/render/box.js
+++ b/src/ol/render/box.js
@@ -96,8 +96,7 @@ ol.render.Box.prototype.disposeInternal = function() {
  */
 ol.render.Box.prototype.handleMapPostCompose_ = function(event) {
   var geometry = this.geometry_;
-  goog.asserts.assert(goog.isDefAndNotNull(geometry),
-      'geometry should be defined');
+  goog.asserts.assert(geometry, 'geometry should be defined');
   var style = this.style_;
   goog.asserts.assert(!goog.isNull(style), 'style should not be null');
   // use drawAsync(Infinity) to draw above everything

--- a/src/ol/render/canvas/canvasimmediate.js
+++ b/src/ol/render/canvas/canvasimmediate.js
@@ -480,7 +480,7 @@ ol.render.canvas.Immediate.prototype.drawCircleGeometry =
  */
 ol.render.canvas.Immediate.prototype.drawFeature = function(feature, style) {
   var geometry = style.getGeometryFunction()(feature);
-  if (!goog.isDefAndNotNull(geometry) ||
+  if (!geometry ||
       !ol.extent.intersects(this.extent_, geometry.getExtent())) {
     return;
   }
@@ -874,7 +874,7 @@ ol.render.canvas.Immediate.prototype.setFillStrokeStyle =
     this.strokeState_ = {
       lineCap: strokeStyleLineCap !== undefined ?
           strokeStyleLineCap : ol.render.canvas.defaultLineCap,
-      lineDash: goog.isDefAndNotNull(strokeStyleLineDash) ?
+      lineDash: strokeStyleLineDash ?
           strokeStyleLineDash : ol.render.canvas.defaultLineDash,
       lineJoin: strokeStyleLineJoin !== undefined ?
           strokeStyleLineJoin : ol.render.canvas.defaultLineJoin,
@@ -963,7 +963,7 @@ ol.render.canvas.Immediate.prototype.setTextStyle = function(textStyle) {
       this.textStrokeState_ = {
         lineCap: textStrokeStyleLineCap !== undefined ?
             textStrokeStyleLineCap : ol.render.canvas.defaultLineCap,
-        lineDash: goog.isDefAndNotNull(textStrokeStyleLineDash) ?
+        lineDash: textStrokeStyleLineDash ?
             textStrokeStyleLineDash : ol.render.canvas.defaultLineDash,
         lineJoin: textStrokeStyleLineJoin !== undefined ?
             textStrokeStyleLineJoin : ol.render.canvas.defaultLineJoin,

--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -259,7 +259,7 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         feature = /** @type {ol.Feature} */ (instruction[1]);
         var featureUid = goog.getUid(feature).toString();
         if (skippedFeaturesHash[featureUid] !== undefined ||
-            !goog.isDefAndNotNull(feature.getGeometry())) {
+            !feature.getGeometry()) {
           i = /** @type {number} */ (instruction[2]);
         } else if (opt_hitExtent !== undefined && !ol.extent.intersects(
             /** @type {Array<number>} */ (opt_hitExtent),
@@ -1728,7 +1728,7 @@ ol.render.canvas.TextReplay.prototype.setTextStyle = function(textStyle) {
       var textStrokeStyleMiterLimit = textStrokeStyle.getMiterLimit();
       var lineCap = textStrokeStyleLineCap !== undefined ?
           textStrokeStyleLineCap : ol.render.canvas.defaultLineCap;
-      var lineDash = goog.isDefAndNotNull(textStrokeStyleLineDash) ?
+      var lineDash = textStrokeStyleLineDash ?
           textStrokeStyleLineDash.slice() : ol.render.canvas.defaultLineDash;
       var lineJoin = textStrokeStyleLineJoin !== undefined ?
           textStrokeStyleLineJoin : ol.render.canvas.defaultLineJoin;

--- a/src/ol/render/vector.js
+++ b/src/ol/render/vector.js
@@ -121,7 +121,7 @@ ol.renderer.vector.renderFeature = function(
 ol.renderer.vector.renderFeature_ = function(
     replayGroup, feature, style, squaredTolerance) {
   var geometry = style.getGeometryFunction()(feature);
-  if (!goog.isDefAndNotNull(geometry)) {
+  if (!geometry) {
     return;
   }
   var simplifiedGeometry = geometry.getSimplifiedGeometry(squaredTolerance);

--- a/src/ol/render/webgl/webglimmediate.js
+++ b/src/ol/render/webgl/webglimmediate.js
@@ -126,7 +126,7 @@ ol.render.webgl.Immediate.prototype.drawCircleGeometry =
  */
 ol.render.webgl.Immediate.prototype.drawFeature = function(feature, style) {
   var geometry = style.getGeometryFunction()(feature);
-  if (!goog.isDefAndNotNull(geometry) ||
+  if (!geometry ||
       !ol.extent.intersects(this.extent_, geometry.getExtent())) {
     return;
   }

--- a/src/ol/render/webgl/webglreplay.js
+++ b/src/ol/render/webgl/webglreplay.js
@@ -821,7 +821,7 @@ ol.render.webgl.ImageReplay.prototype.drawHitDetectionReplayOneByOne_ =
       featureUid = goog.getUid(feature).toString();
 
       if (skippedFeaturesHash[featureUid] === undefined &&
-          goog.isDefAndNotNull(feature.getGeometry()) &&
+          feature.getGeometry() &&
           (opt_hitExtent === undefined || ol.extent.intersects(
               /** @type {Array<number>} */ (opt_hitExtent),
               feature.getGeometry().getExtent()))) {

--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -328,7 +328,7 @@ ol.renderer.canvas.VectorLayer.prototype.prepareFrame =
  */
 ol.renderer.canvas.VectorLayer.prototype.renderFeature =
     function(feature, resolution, pixelRatio, styles, replayGroup) {
-  if (!goog.isDefAndNotNull(styles)) {
+  if (!styles) {
     return false;
   }
   var i, ii, loading = false;

--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -284,7 +284,7 @@ ol.renderer.canvas.VectorLayer.prototype.prepareFrame =
         styles = styleFunction(feature, resolution);
       }
     }
-    if (goog.isDefAndNotNull(styles)) {
+    if (styles) {
       var dirty = this.renderFeature(
           feature, resolution, pixelRatio, styles, replayGroup);
       this.dirty_ = this.dirty_ || dirty;

--- a/src/ol/renderer/dom/domvectorlayerrenderer.js
+++ b/src/ol/renderer/dom/domvectorlayerrenderer.js
@@ -292,7 +292,7 @@ ol.renderer.dom.VectorLayer.prototype.prepareFrame =
         styles = styleFunction(feature, resolution);
       }
     }
-    if (goog.isDefAndNotNull(styles)) {
+    if (styles) {
       var dirty = this.renderFeature(
           feature, resolution, pixelRatio, styles, replayGroup);
       this.dirty_ = this.dirty_ || dirty;

--- a/src/ol/renderer/dom/domvectorlayerrenderer.js
+++ b/src/ol/renderer/dom/domvectorlayerrenderer.js
@@ -336,7 +336,7 @@ ol.renderer.dom.VectorLayer.prototype.prepareFrame =
  */
 ol.renderer.dom.VectorLayer.prototype.renderFeature =
     function(feature, resolution, pixelRatio, styles, replayGroup) {
-  if (!goog.isDefAndNotNull(styles)) {
+  if (!styles) {
     return false;
   }
   var i, ii, loading = false;

--- a/src/ol/renderer/layerrenderer.js
+++ b/src/ol/renderer/layerrenderer.js
@@ -205,7 +205,7 @@ ol.renderer.Layer.prototype.scheduleExpireCache =
  */
 ol.renderer.Layer.prototype.updateAttributions =
     function(attributionsSet, attributions) {
-  if (goog.isDefAndNotNull(attributions)) {
+  if (attributions) {
     var attribution, i, ii;
     for (i = 0, ii = attributions.length; i < ii; ++i) {
       attribution = attributions[i];

--- a/src/ol/renderer/webgl/webglvectorlayerrenderer.js
+++ b/src/ol/renderer/webgl/webglvectorlayerrenderer.js
@@ -260,7 +260,7 @@ ol.renderer.webgl.VectorLayer.prototype.prepareFrame =
         styles = styleFunction(feature, resolution);
       }
     }
-    if (goog.isDefAndNotNull(styles)) {
+    if (styles) {
       var dirty = this.renderFeature(
           feature, resolution, pixelRatio, styles, replayGroup);
       this.dirty_ = this.dirty_ || dirty;

--- a/src/ol/renderer/webgl/webglvectorlayerrenderer.js
+++ b/src/ol/renderer/webgl/webglvectorlayerrenderer.js
@@ -304,7 +304,7 @@ ol.renderer.webgl.VectorLayer.prototype.prepareFrame =
  */
 ol.renderer.webgl.VectorLayer.prototype.renderFeature =
     function(feature, resolution, pixelRatio, styles, replayGroup) {
-  if (!goog.isDefAndNotNull(styles)) {
+  if (!styles) {
     return false;
   }
   var i, ii, loading = false;

--- a/src/ol/source/imagevectorsource.js
+++ b/src/ol/source/imagevectorsource.js
@@ -265,7 +265,7 @@ ol.source.ImageVector.prototype.renderFeature_ =
   } else if (this.styleFunction_) {
     styles = this.styleFunction_(feature, resolution);
   }
-  if (!goog.isDefAndNotNull(styles)) {
+  if (!styles) {
     return false;
   }
   var i, ii, loading = false;

--- a/src/ol/source/tilearcgisrestsource.js
+++ b/src/ol/source/tilearcgisrestsource.js
@@ -56,7 +56,7 @@ ol.source.TileArcGISRest = function(opt_options) {
    * @private
    * @type {!Array.<string>}
    */
-  this.urls_ = goog.isDefAndNotNull(urls) ? urls : [];
+  this.urls_ = urls || [];
 
   /**
    * @private
@@ -184,7 +184,7 @@ ol.source.TileArcGISRest.prototype.setUrl = function(url) {
  * @api stable
  */
 ol.source.TileArcGISRest.prototype.setUrls = function(urls) {
-  this.urls_ = goog.isDefAndNotNull(urls) ? urls : [];
+  this.urls_ = urls || [];
   this.changed();
 };
 

--- a/src/ol/source/tileutfgridsource.js
+++ b/src/ol/source/tileutfgridsource.js
@@ -131,7 +131,7 @@ ol.source.TileUTFGrid.prototype.handleTileJSONResponse = function(tileJSON) {
   this.template_ = tileJSON.template;
 
   var grids = tileJSON.grids;
-  if (!goog.isDefAndNotNull(grids)) {
+  if (!grids) {
     this.setState(ol.source.State.ERROR);
     return;
   }

--- a/src/ol/source/tileutfgridsource.js
+++ b/src/ol/source/tileutfgridsource.js
@@ -268,8 +268,7 @@ ol.source.TileUTFGridTile_.prototype.getImage = function(opt_context) {
  * @return {Object}
  */
 ol.source.TileUTFGridTile_.prototype.getData = function(coordinate) {
-  if (goog.isNull(this.grid_) || goog.isNull(this.keys_) ||
-      !goog.isDefAndNotNull(this.data_)) {
+  if (goog.isNull(this.grid_) || goog.isNull(this.keys_) || !this.data_) {
     return null;
   }
   var xRelative = (coordinate[0] - this.extent_[0]) /
@@ -292,9 +291,7 @@ ol.source.TileUTFGridTile_.prototype.getData = function(coordinate) {
   }
   code -= 32;
 
-  var key = this.keys_[code];
-
-  return goog.isDefAndNotNull(key) ? this.data_[key] : null;
+  return (code in this.keys_) ? this.data_[this.keys_[code]] : null;
 };
 
 

--- a/src/ol/source/tilevectorsource.js
+++ b/src/ol/source/tilevectorsource.js
@@ -134,8 +134,7 @@ ol.source.TileVector.prototype.forEachFeatureAtCoordinateAndResolution =
     for (i = 0, ii = features.length; i < ii; ++i) {
       var feature = features[i];
       var geometry = feature.getGeometry();
-      goog.asserts.assert(goog.isDefAndNotNull(geometry),
-          'feature geometry is defined and not null');
+      goog.asserts.assert(geometry, 'feature geometry is defined and not null');
       if (geometry.containsCoordinate(coordinate)) {
         var result = callback.call(opt_this, feature);
         if (result) {

--- a/src/ol/source/tilewmssource.js
+++ b/src/ol/source/tilewmssource.js
@@ -60,7 +60,7 @@ ol.source.TileWMS = function(opt_options) {
    * @private
    * @type {!Array.<string>}
    */
-  this.urls_ = goog.isDefAndNotNull(urls) ? urls : [];
+  this.urls_ = urls || [];
 
   /**
    * @private
@@ -348,7 +348,7 @@ ol.source.TileWMS.prototype.setUrl = function(url) {
  * @api stable
  */
 ol.source.TileWMS.prototype.setUrls = function(urls) {
-  this.urls_ = goog.isDefAndNotNull(urls) ? urls : [];
+  this.urls_ = urls || [];
   this.resetCoordKeyPrefix_();
   this.changed();
 };

--- a/src/ol/source/vectorsource.js
+++ b/src/ol/source/vectorsource.js
@@ -705,7 +705,7 @@ ol.source.Vector.prototype.handleFeatureChange_ = function(event) {
   var feature = /** @type {ol.Feature} */ (event.target);
   var featureKey = goog.getUid(feature).toString();
   var geometry = feature.getGeometry();
-  if (!goog.isDefAndNotNull(geometry)) {
+  if (!geometry) {
     if (!(featureKey in this.nullGeometryFeatures_)) {
       if (!goog.isNull(this.featuresRtree_)) {
         this.featuresRtree_.remove(feature);

--- a/src/ol/source/vectorsource.js
+++ b/src/ol/source/vectorsource.js
@@ -450,8 +450,7 @@ ol.source.Vector.prototype.forEachFeatureAtCoordinateDirect =
   var extent = [coordinate[0], coordinate[1], coordinate[0], coordinate[1]];
   return this.forEachFeatureInExtent(extent, function(feature) {
     var geometry = feature.getGeometry();
-    goog.asserts.assert(goog.isDefAndNotNull(geometry),
-        'feature geometry is defined and not null');
+    goog.asserts.assert(geometry, 'feature geometry is defined and not null');
     if (geometry.containsCoordinate(coordinate)) {
       return callback.call(opt_this, feature);
     } else {
@@ -533,7 +532,7 @@ ol.source.Vector.prototype.forEachFeatureIntersectingExtent =
        */
       function(feature) {
         var geometry = feature.getGeometry();
-        goog.asserts.assert(goog.isDefAndNotNull(geometry),
+        goog.asserts.assert(geometry,
             'feature geometry is defined and not null');
         if (geometry.intersectsExtent(extent)) {
           var result = callback.call(opt_this, feature);
@@ -645,7 +644,7 @@ ol.source.Vector.prototype.getClosestFeatureToCoordinate =
        */
       function(feature) {
         var geometry = feature.getGeometry();
-        goog.asserts.assert(goog.isDefAndNotNull(geometry),
+        goog.asserts.assert(geometry,
             'feature geometry is defined and not null');
         var previousMinSquaredDistance = minSquaredDistance;
         minSquaredDistance = geometry.closestPointXY(

--- a/src/ol/source/vectorsource.js
+++ b/src/ol/source/vectorsource.js
@@ -204,7 +204,7 @@ ol.source.Vector.prototype.addFeatureInternal = function(feature) {
   this.setupChangeEvents_(featureKey, feature);
 
   var geometry = feature.getGeometry();
-  if (goog.isDefAndNotNull(geometry)) {
+  if (geometry) {
     var extent = geometry.getExtent();
     if (!goog.isNull(this.featuresRtree_)) {
       this.featuresRtree_.insert(extent, feature);
@@ -299,7 +299,7 @@ ol.source.Vector.prototype.addFeaturesInternal = function(features) {
     this.setupChangeEvents_(featureKey, feature);
 
     var geometry = feature.getGeometry();
-    if (goog.isDefAndNotNull(geometry)) {
+    if (geometry) {
       var extent = geometry.getExtent();
       extents.push(extent);
       geometryFeatures.push(feature);

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -92,7 +92,7 @@ ol.source.WMTS = function(options) {
    * @private
    * @type {!Array.<string>}
    */
-  this.urls_ = goog.isDefAndNotNull(urls) ? urls : [];
+  this.urls_ = urls || [];
 
   // FIXME: should we guess this requestEncoding from options.url(s)
   //        structure? that would mean KVP only if a template is not provided.

--- a/src/ol/style/style.js
+++ b/src/ol/style/style.js
@@ -164,7 +164,7 @@ ol.style.Style.prototype.setGeometry = function(geometry) {
   } else if (goog.isString(geometry)) {
     this.geometryFunction_ = function(feature) {
       var result = feature.get(geometry);
-      if (goog.isDefAndNotNull(result)) {
+      if (result) {
         goog.asserts.assertInstanceof(result, ol.geom.Geometry,
             'feature geometry must be an ol.geom.Geometry instance');
       }

--- a/src/ol/tilegrid/tilegrid.js
+++ b/src/ol/tilegrid/tilegrid.js
@@ -134,7 +134,7 @@ ol.tilegrid.TileGrid = function(options) {
       }
       return tileRange;
     }, this);
-  } else if (goog.isDefAndNotNull(extent)) {
+  } else if (extent) {
     this.calculateTileRanges_(extent);
   }
 

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -275,8 +275,7 @@ ol.View.prototype.getHints = function() {
  */
 ol.View.prototype.calculateExtent = function(size) {
   var center = this.getCenter();
-  goog.asserts.assert(goog.isDefAndNotNull(center),
-      'The view center is not defined');
+  goog.asserts.assert(center, 'The view center is not defined');
   var resolution = this.getResolution();
   goog.asserts.assert(resolution !== undefined,
       'The view resolution is not defined');
@@ -552,8 +551,7 @@ ol.View.prototype.centerOn = function(coordinate, size, position) {
  * @return {boolean} Is defined.
  */
 ol.View.prototype.isDef = function() {
-  return goog.isDefAndNotNull(this.getCenter()) &&
-      this.getResolution() !== undefined;
+  return !!this.getCenter() && this.getResolution() !== undefined;
 };
 
 

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -136,7 +136,7 @@ ol.xml.getLocalNameIE_ = function(node) {
     return localName;
   }
   var baseName = node.baseName;
-  goog.asserts.assert(goog.isDefAndNotNull(baseName),
+  goog.asserts.assert(baseName,
       'Failed to get localName/baseName of node %s', node);
   return baseName;
 };


### PR DESCRIPTION
This removes our use of `goog.isDefAndNotNull()`.  In most cases, simple truthy checks are preferable.

@bartvde another interesting issue revealed by this change.  When I replaced the `goog.isDefAndNotNull(esriJSONFeature.compressedGeometry)` call with a simple truthy check, the compiler discovered that the `compressedGeometry` property is not defined for `EsriJSONFeature`.  Since this was only an assertion and the `compressedGeometry` property was never accessed elsewhere, I removed this part of the assertion.


@fredj (or anyone else) - do we ever expect properties like `alpha` to be `null` for a `DeviceOrientationEvent` (or will these be non-null if defined).  The only remaining use of `goog.isDefAndNotNull()` is in the device orientation code, since I was uncertain if these values could really be `null`.

See #4128 for context.
