### PR TITLE
Replace goog.isNull() with !== or === checks

### DIFF
--- a/src/ol/animation.js
+++ b/src/ol/animation.js
@@ -115,7 +115,7 @@ ol.animation.rotate = function(options) {
               (sourceRotation - frameState.viewState.rotation) * delta;
           frameState.animate = true;
           frameState.viewState.rotation += deltaRotation;
-          if (!goog.isNull(anchor)) {
+          if (anchor !== null) {
             var center = frameState.viewState.center;
             ol.coordinate.sub(center, anchor);
             ol.coordinate.rotate(center, deltaRotation);

--- a/src/ol/attribution.js
+++ b/src/ol/attribution.js
@@ -61,7 +61,7 @@ ol.Attribution.prototype.getHTML = function() {
  */
 ol.Attribution.prototype.intersectsAnyTileRange =
     function(tileRanges, tileGrid, projection) {
-  if (goog.isNull(this.tileRanges_)) {
+  if (this.tileRanges_ === null) {
     return true;
   }
   var i, ii, tileRange, zKey;

--- a/src/ol/control/attributioncontrol.js
+++ b/src/ol/control/attributioncontrol.js
@@ -164,15 +164,15 @@ ol.control.Attribution.prototype.getSourceAttributions = function(frameState) {
   /** @type {Object.<string, ol.Attribution>} */
   var hiddenAttributions = {};
   var projection = frameState.viewState.projection;
-  goog.asserts.assert(!goog.isNull(projection), 'projection cannot be null');
+  goog.asserts.assert(projection !== null, 'projection cannot be null');
   for (i = 0, ii = layerStatesArray.length; i < ii; i++) {
     source = layerStatesArray[i].layer.getSource();
-    if (goog.isNull(source)) {
+    if (source === null) {
       continue;
     }
     sourceKey = goog.getUid(source).toString();
     sourceAttributions = source.getAttributions();
-    if (goog.isNull(sourceAttributions)) {
+    if (sourceAttributions === null) {
       continue;
     }
     for (j = 0, jj = sourceAttributions.length; j < jj; j++) {
@@ -186,7 +186,7 @@ ol.control.Attribution.prototype.getSourceAttributions = function(frameState) {
         goog.asserts.assertInstanceof(source, ol.source.Tile,
             'source should be an ol.source.Tile');
         var tileGrid = source.getTileGridForProjection(projection);
-        goog.asserts.assert(!goog.isNull(tileGrid), 'tileGrid cannot be null');
+        goog.asserts.assert(tileGrid !== null, 'tileGrid cannot be null');
         intersectsTileRange = sourceAttribution.intersectsAnyTileRange(
             tileRanges, tileGrid, projection);
       } else {
@@ -223,7 +223,7 @@ ol.control.Attribution.render = function(mapEvent) {
  */
 ol.control.Attribution.prototype.updateElement_ = function(frameState) {
 
-  if (goog.isNull(frameState)) {
+  if (frameState === null) {
     if (this.renderedVisible_) {
       goog.style.setElementShown(this.element, false);
       this.renderedVisible_ = false;

--- a/src/ol/control/control.js
+++ b/src/ol/control/control.js
@@ -104,7 +104,7 @@ ol.control.Control.prototype.getMap = function() {
  * @api stable
  */
 ol.control.Control.prototype.setMap = function(map) {
-  if (!goog.isNull(this.map_)) {
+  if (this.map_ !== null) {
     goog.dom.removeNode(this.element);
   }
   if (this.listenerKeys.length > 0) {
@@ -112,8 +112,8 @@ ol.control.Control.prototype.setMap = function(map) {
     this.listenerKeys.length = 0;
   }
   this.map_ = map;
-  if (!goog.isNull(this.map_)) {
-    var target = !goog.isNull(this.target_) ?
+  if (this.map_ !== null) {
+    var target = this.target_ !== null ?
         this.target_ : map.getOverlayContainerStopEvent();
     goog.dom.appendChild(target, this.element);
     if (this.render !== goog.nullFunction) {

--- a/src/ol/control/fullscreencontrol.js
+++ b/src/ol/control/fullscreencontrol.js
@@ -107,7 +107,7 @@ ol.control.FullScreen.prototype.handleFullScreen_ = function() {
     return;
   }
   var map = this.getMap();
-  if (goog.isNull(map)) {
+  if (map === null) {
     return;
   }
   if (goog.dom.fullscreen.isFullScreen()) {
@@ -143,7 +143,7 @@ ol.control.FullScreen.prototype.handleFullScreenChange_ = function() {
     goog.dom.classlist.swap(button, opened, closed);
     goog.dom.replaceNode(this.labelNode_, this.labelActiveNode_);
   }
-  if (!goog.isNull(map)) {
+  if (map !== null) {
     map.updateSize();
   }
 };

--- a/src/ol/control/mousepositioncontrol.js
+++ b/src/ol/control/mousepositioncontrol.js
@@ -108,7 +108,7 @@ goog.inherits(ol.control.MousePosition, ol.control.Control);
  */
 ol.control.MousePosition.render = function(mapEvent) {
   var frameState = mapEvent.frameState;
-  if (goog.isNull(frameState)) {
+  if (frameState === null) {
     this.mapProjection_ = null;
   } else {
     if (this.mapProjection_ != frameState.viewState.projection) {
@@ -182,7 +182,7 @@ ol.control.MousePosition.prototype.handleMouseOut = function(browserEvent) {
  */
 ol.control.MousePosition.prototype.setMap = function(map) {
   goog.base(this, 'setMap', map);
-  if (!goog.isNull(map)) {
+  if (map !== null) {
     var viewport = map.getViewport();
     this.listenerKeys.push(
         goog.events.listen(viewport, goog.events.EventType.MOUSEMOVE,
@@ -224,8 +224,8 @@ ol.control.MousePosition.prototype.setProjection = function(projection) {
  */
 ol.control.MousePosition.prototype.updateHTML_ = function(pixel) {
   var html = this.undefinedHTML_;
-  if (!goog.isNull(pixel) && !goog.isNull(this.mapProjection_)) {
-    if (goog.isNull(this.transform_)) {
+  if (pixel !== null && this.mapProjection_ !== null) {
+    if (this.transform_ === null) {
       var projection = this.getProjection();
       if (projection) {
         this.transform_ = ol.proj.getTransformFromProjections(
@@ -236,7 +236,7 @@ ol.control.MousePosition.prototype.updateHTML_ = function(pixel) {
     }
     var map = this.getMap();
     var coordinate = map.getCoordinateFromPixel(pixel);
-    if (!goog.isNull(coordinate)) {
+    if (coordinate !== null) {
       this.transform_(coordinate, coordinate);
       var coordinateFormat = this.getCoordinateFormat();
       if (coordinateFormat) {

--- a/src/ol/control/rotatecontrol.js
+++ b/src/ol/control/rotatecontrol.js
@@ -113,7 +113,7 @@ ol.control.Rotate.prototype.handleClick_ = function(event) {
 ol.control.Rotate.prototype.resetNorth_ = function() {
   var map = this.getMap();
   var view = map.getView();
-  if (goog.isNull(view)) {
+  if (view === null) {
     // the map does not have a view, so we can't act
     // upon it
     return;
@@ -146,7 +146,7 @@ ol.control.Rotate.prototype.resetNorth_ = function() {
  */
 ol.control.Rotate.render = function(mapEvent) {
   var frameState = mapEvent.frameState;
-  if (goog.isNull(frameState)) {
+  if (frameState === null) {
     return;
   }
   var rotation = frameState.viewState.rotation;

--- a/src/ol/control/scalelinecontrol.js
+++ b/src/ol/control/scalelinecontrol.js
@@ -160,7 +160,7 @@ ol.control.ScaleLine.prototype.getUnits = function() {
  */
 ol.control.ScaleLine.render = function(mapEvent) {
   var frameState = mapEvent.frameState;
-  if (goog.isNull(frameState)) {
+  if (frameState === null) {
     this.viewState_ = null;
   } else {
     this.viewState_ = frameState.viewState;
@@ -194,7 +194,7 @@ ol.control.ScaleLine.prototype.setUnits = function(units) {
 ol.control.ScaleLine.prototype.updateElement_ = function() {
   var viewState = this.viewState_;
 
-  if (goog.isNull(viewState)) {
+  if (viewState === null) {
     if (this.renderedVisible_) {
       goog.style.setElementShown(this.element_, false);
       this.renderedVisible_ = false;
@@ -226,7 +226,7 @@ ol.control.ScaleLine.prototype.updateElement_ = function() {
       units == ol.control.ScaleLineUnits.DEGREES) {
 
     // Convert pointResolution from other units to degrees
-    if (goog.isNull(this.toEPSG4326_)) {
+    if (this.toEPSG4326_ === null) {
       this.toEPSG4326_ = ol.proj.getTransformFromProjections(
           projection, ol.proj.get('EPSG:4326'));
     }

--- a/src/ol/control/zoomcontrol.js
+++ b/src/ol/control/zoomcontrol.js
@@ -103,7 +103,7 @@ ol.control.Zoom.prototype.handleClick_ = function(delta, event) {
 ol.control.Zoom.prototype.zoomByDelta_ = function(delta) {
   var map = this.getMap();
   var view = map.getView();
-  if (goog.isNull(view)) {
+  if (view === null) {
     // the map does not have a view, so we can't act
     // upon it
     return;

--- a/src/ol/control/zoomslidercontrol.js
+++ b/src/ol/control/zoomslidercontrol.js
@@ -130,7 +130,7 @@ ol.control.ZoomSlider.direction = {
  */
 ol.control.ZoomSlider.prototype.setMap = function(map) {
   goog.base(this, 'setMap', map);
-  if (!goog.isNull(map)) {
+  if (map !== null) {
     map.render();
   }
 };
@@ -179,7 +179,7 @@ ol.control.ZoomSlider.prototype.initSlider_ = function() {
  * @api
  */
 ol.control.ZoomSlider.render = function(mapEvent) {
-  if (goog.isNull(mapEvent.frameState)) {
+  if (mapEvent.frameState === null) {
     return;
   }
   goog.asserts.assert(goog.isDefAndNotNull(mapEvent.frameState.viewState),

--- a/src/ol/control/zoomtoextentcontrol.js
+++ b/src/ol/control/zoomtoextentcontrol.js
@@ -71,7 +71,7 @@ ol.control.ZoomToExtent.prototype.handleClick_ = function(event) {
 ol.control.ZoomToExtent.prototype.handleZoomToExtent_ = function() {
   var map = this.getMap();
   var view = map.getView();
-  var extent = goog.isNull(this.extent_) ?
+  var extent = this.extent_ === null ?
       view.getProjection().getExtent() : this.extent_;
   var size = map.getSize();
   goog.asserts.assert(size, 'size should be defined');

--- a/src/ol/deviceorientation.js
+++ b/src/ol/deviceorientation.js
@@ -209,10 +209,10 @@ ol.DeviceOrientation.prototype.getTracking = function() {
 ol.DeviceOrientation.prototype.handleTrackingChanged_ = function() {
   if (ol.has.DEVICE_ORIENTATION) {
     var tracking = this.getTracking();
-    if (tracking && goog.isNull(this.listenerKey_)) {
+    if (tracking && this.listenerKey_ === null) {
       this.listenerKey_ = goog.events.listen(goog.global, 'deviceorientation',
           this.orientationChange_, false, this);
-    } else if (!tracking && !goog.isNull(this.listenerKey_)) {
+    } else if (!tracking && this.listenerKey_ !== null) {
       goog.events.unlistenByKey(this.listenerKey_);
       this.listenerKey_ = null;
     }

--- a/src/ol/dom/dom.js
+++ b/src/ol/dom/dom.js
@@ -39,7 +39,7 @@ ol.dom.canUseCssTransform = (function() {
   var canUseCssTransform;
   return function() {
     if (canUseCssTransform === undefined) {
-      goog.asserts.assert(!goog.isNull(document.body),
+      goog.asserts.assert(document.body !== null,
           'document.body should not be null');
       if (!goog.global.getComputedStyle) {
         // this browser is ancient
@@ -82,7 +82,7 @@ ol.dom.canUseCssTransform3D = (function() {
   var canUseCssTransform3D;
   return function() {
     if (canUseCssTransform3D === undefined) {
-      goog.asserts.assert(!goog.isNull(document.body),
+      goog.asserts.assert(document.body !== null,
           'document.body should not be null');
       if (!goog.global.getComputedStyle) {
         // this browser is ancient

--- a/src/ol/feature.js
+++ b/src/ol/feature.js
@@ -99,7 +99,7 @@ ol.Feature = function(opt_geometryOrProperties) {
 
   if (opt_geometryOrProperties !== undefined) {
     if (opt_geometryOrProperties instanceof ol.geom.Geometry ||
-        goog.isNull(opt_geometryOrProperties)) {
+        opt_geometryOrProperties === null) {
       var geometry = /** @type {ol.geom.Geometry} */ (opt_geometryOrProperties);
       this.setGeometry(geometry);
     } else {
@@ -128,7 +128,7 @@ ol.Feature.prototype.clone = function() {
     clone.setGeometry(geometry.clone());
   }
   var style = this.getStyle();
-  if (!goog.isNull(style)) {
+  if (style !== null) {
     clone.setStyle(style);
   }
   return clone;
@@ -210,7 +210,7 @@ ol.Feature.prototype.handleGeometryChange_ = function() {
  * @private
  */
 ol.Feature.prototype.handleGeometryChanged_ = function() {
-  if (!goog.isNull(this.geometryChangeKey_)) {
+  if (this.geometryChangeKey_ !== null) {
     goog.events.unlistenByKey(this.geometryChangeKey_);
     this.geometryChangeKey_ = null;
   }
@@ -246,7 +246,7 @@ ol.Feature.prototype.setGeometry = function(geometry) {
  */
 ol.Feature.prototype.setStyle = function(style) {
   this.style_ = style;
-  this.styleFunction_ = goog.isNull(style) ?
+  this.styleFunction_ = style === null ?
       undefined : ol.Feature.createStyleFunction(style);
   this.changed();
 };

--- a/src/ol/format/esrijsonformat.js
+++ b/src/ol/format/esrijsonformat.js
@@ -54,7 +54,7 @@ goog.inherits(ol.format.EsriJSON, ol.format.JSONFeature);
  * @return {ol.geom.Geometry} Geometry.
  */
 ol.format.EsriJSON.readGeometry_ = function(object, opt_options) {
-  if (goog.isNull(object)) {
+  if (object === null) {
     return null;
   }
   var type;

--- a/src/ol/format/featureformat.js
+++ b/src/ol/format/featureformat.js
@@ -165,7 +165,7 @@ ol.format.Feature.transformWithOptions = function(
       ol.proj.get(opt_options.featureProjection) : null;
   var dataProjection = opt_options ?
       ol.proj.get(opt_options.dataProjection) : null;
-  if (!goog.isNull(featureProjection) && !goog.isNull(dataProjection) &&
+  if (featureProjection !== null && dataProjection !== null &&
       !ol.proj.equivalent(featureProjection, dataProjection)) {
     if (geometry instanceof ol.geom.Geometry) {
       return (write ? geometry.clone() : geometry).transform(

--- a/src/ol/format/geojsonformat.js
+++ b/src/ol/format/geojsonformat.js
@@ -68,7 +68,7 @@ ol.format.GeoJSON.EXTENSIONS_ = ['.geojson'];
  * @return {ol.geom.Geometry} Geometry.
  */
 ol.format.GeoJSON.readGeometry_ = function(object, opt_options) {
-  if (goog.isNull(object)) {
+  if (object === null) {
     return null;
   }
   var geometryReader = ol.format.GeoJSON.GEOMETRY_READERS_[object.type];

--- a/src/ol/format/gml/gml2format.js
+++ b/src/ol/format/gml/gml2format.js
@@ -62,20 +62,20 @@ ol.format.GML2.prototype.readFlatCoordinates_ = function(node, objectStack) {
   var containerSrs = context['srsName'];
   var containerDimension = node.parentNode.getAttribute('srsDimension');
   var axisOrientation = 'enu';
-  if (!goog.isNull(containerSrs)) {
+  if (containerSrs !== null) {
     var proj = ol.proj.get(containerSrs);
     axisOrientation = proj.getAxisOrientation();
   }
   var coords = s.split(/[\s,]+/);
   // The "dimension" attribute is from the GML 3.0.1 spec.
   var dim = 2;
-  if (!goog.isNull(node.getAttribute('srsDimension'))) {
+  if (node.getAttribute('srsDimension') !== null) {
     dim = ol.format.XSD.readNonNegativeIntegerString(
         node.getAttribute('srsDimension'));
-  } else if (!goog.isNull(node.getAttribute('dimension'))) {
+  } else if (node.getAttribute('dimension') !== null) {
     dim = ol.format.XSD.readNonNegativeIntegerString(
         node.getAttribute('dimension'));
-  } else if (!goog.isNull(containerDimension)) {
+  } else if (containerDimension !== null) {
     dim = ol.format.XSD.readNonNegativeIntegerString(containerDimension);
   }
   var x, y, z;

--- a/src/ol/format/gml/gml3format.js
+++ b/src/ol/format/gml/gml3format.js
@@ -301,7 +301,7 @@ ol.format.GML3.prototype.readSurface_ = function(node, objectStack) {
   var flatLinearRings = ol.xml.pushParseAndPop(
       /** @type {Array.<Array.<number>>} */ ([null]),
       this.SURFACE_PARSERS_, node, objectStack, this);
-  if (flatLinearRings && !goog.isNull(flatLinearRings[0])) {
+  if (flatLinearRings && flatLinearRings[0] !== null) {
     var polygon = new ol.geom.Polygon(null);
     var flatCoordinates = flatLinearRings[0];
     var ends = [flatCoordinates.length];
@@ -385,7 +385,7 @@ ol.format.GML3.prototype.readFlatPos_ = function(node, objectStack) {
   goog.asserts.assert(goog.isObject(context), 'context should be an Object');
   var containerSrs = context['srsName'];
   var axisOrientation = 'enu';
-  if (!goog.isNull(containerSrs)) {
+  if (containerSrs !== null) {
     var proj = ol.proj.get(containerSrs);
     axisOrientation = proj.getAxisOrientation();
   }
@@ -422,20 +422,20 @@ ol.format.GML3.prototype.readFlatPosList_ = function(node, objectStack) {
   var containerSrs = context['srsName'];
   var containerDimension = node.parentNode.getAttribute('srsDimension');
   var axisOrientation = 'enu';
-  if (!goog.isNull(containerSrs)) {
+  if (containerSrs !== null) {
     var proj = ol.proj.get(containerSrs);
     axisOrientation = proj.getAxisOrientation();
   }
   var coords = s.split(/\s+/);
   // The "dimension" attribute is from the GML 3.0.1 spec.
   var dim = 2;
-  if (!goog.isNull(node.getAttribute('srsDimension'))) {
+  if (node.getAttribute('srsDimension') !== null) {
     dim = ol.format.XSD.readNonNegativeIntegerString(
         node.getAttribute('srsDimension'));
-  } else if (!goog.isNull(node.getAttribute('dimension'))) {
+  } else if (node.getAttribute('dimension') !== null) {
     dim = ol.format.XSD.readNonNegativeIntegerString(
         node.getAttribute('dimension'));
-  } else if (!goog.isNull(containerDimension)) {
+  } else if (containerDimension !== null) {
     dim = ol.format.XSD.readNonNegativeIntegerString(containerDimension);
   }
   var x, y, z;
@@ -1068,7 +1068,7 @@ ol.format.GML3.prototype.writeFeatureElement =
   var keys = [], values = [];
   for (var key in properties) {
     var value = properties[key];
-    if (!goog.isNull(value)) {
+    if (value !== null) {
       keys.push(key);
       values.push(value);
       if (key == geometryName) {

--- a/src/ol/format/gml/gmlbaseformat.js
+++ b/src/ol/format/gml/gmlbaseformat.js
@@ -199,8 +199,7 @@ ol.format.GMLBase.prototype.readFeatureElement = function(node, objectStack) {
   var fid = node.getAttribute('fid') ||
       ol.xml.getAttributeNS(node, ol.format.GMLBase.GMLNS, 'id');
   var values = {}, geometryName;
-  for (n = node.firstElementChild; !goog.isNull(n);
-      n = n.nextElementSibling) {
+  for (n = node.firstElementChild; n !== null; n = n.nextElementSibling) {
     var localName = ol.xml.getLocalName(n);
     // Assume attribute elements have one child node and that the child
     // is a text or CDATA node (to be treated as text).
@@ -449,8 +448,7 @@ ol.format.GMLBase.prototype.readPolygon = function(node, objectStack) {
   var flatLinearRings = ol.xml.pushParseAndPop(
       /** @type {Array.<Array.<number>>} */ ([null]),
       this.FLAT_LINEAR_RINGS_PARSERS_, node, objectStack, this);
-  if (flatLinearRings &&
-      !goog.isNull(flatLinearRings[0])) {
+  if (flatLinearRings && flatLinearRings[0] !== null) {
     var polygon = new ol.geom.Polygon(null);
     var flatCoordinates = flatLinearRings[0];
     var ends = [flatCoordinates.length];

--- a/src/ol/format/gpxformat.js
+++ b/src/ol/format/gpxformat.js
@@ -97,7 +97,7 @@ ol.format.GPX.parseLink_ = function(node, objectStack) {
   goog.asserts.assert(node.localName == 'link', 'localName should be link');
   var values = /** @type {Object} */ (objectStack[objectStack.length - 1]);
   var href = node.getAttribute('href');
-  if (!goog.isNull(href)) {
+  if (href !== null) {
     values['link'] = href;
   }
   ol.xml.parseNode(ol.format.GPX.LINK_PARSERS_, node, objectStack);
@@ -417,7 +417,7 @@ ol.format.GPX.WPT_PARSERS_ = ol.xml.makeStructureNS(
  * @private
  */
 ol.format.GPX.prototype.handleReadExtensions_ = function(features) {
-  if (goog.isNull(features)) {
+  if (features === null) {
     features = [];
   }
   for (var i = 0, ii = features.length; i < ii; ++i) {

--- a/src/ol/format/igcformat.js
+++ b/src/ol/format/igcformat.js
@@ -202,7 +202,7 @@ ol.format.IGC.prototype.readFeatures;
  */
 ol.format.IGC.prototype.readFeaturesFromText = function(text, opt_options) {
   var feature = this.readFeatureFromText(text, opt_options);
-  if (!goog.isNull(feature)) {
+  if (feature !== null) {
     return [feature];
   } else {
     return [];

--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -980,8 +980,7 @@ ol.format.KML.readPolygon_ = function(node, objectStack) {
   var flatLinearRings = ol.xml.pushParseAndPop(
       /** @type {Array.<Array.<number>>} */ ([null]),
       ol.format.KML.FLAT_LINEAR_RINGS_PARSERS_, node, objectStack);
-  if (goog.isDefAndNotNull(flatLinearRings) &&
-      !goog.isNull(flatLinearRings[0])) {
+  if (goog.isDefAndNotNull(flatLinearRings) && flatLinearRings[0] !== null) {
     var polygon = new ol.geom.Polygon(null);
     var flatCoordinates = flatLinearRings[0];
     var ends = [flatCoordinates.length];
@@ -1084,7 +1083,7 @@ ol.format.KML.DataParser_ = function(node, objectStack) {
       'node.nodeType should be ELEMENT');
   goog.asserts.assert(node.localName == 'Data', 'localName should be Data');
   var name = node.getAttribute('name');
-  if (!goog.isNull(name)) {
+  if (name !== null) {
     var data = ol.xml.pushParseAndPop(
         undefined, ol.format.KML.DATA_PARSERS_, node, objectStack);
     if (data) {
@@ -1195,7 +1194,7 @@ ol.format.KML.SimpleDataParser_ = function(node, objectStack) {
   goog.asserts.assert(node.localName == 'SimpleData',
       'localName should be SimpleData');
   var name = node.getAttribute('name');
-  if (!goog.isNull(name)) {
+  if (name !== null) {
     var data = ol.format.XSD.readString(node);
     var featureObject =
         /** @type {Object} */ (objectStack[objectStack.length - 1]);
@@ -1678,7 +1677,7 @@ ol.format.KML.prototype.readPlacemark_ = function(node, objectStack) {
   }
   var feature = new ol.Feature();
   var id = node.getAttribute('id');
-  if (!goog.isNull(id)) {
+  if (id !== null) {
     feature.setId(id);
   }
   var options = /** @type {olx.format.ReadOptions} */ (objectStack[0]);
@@ -1717,7 +1716,7 @@ ol.format.KML.prototype.readSharedStyle_ = function(node, objectStack) {
       'node.nodeType should be ELEMENT');
   goog.asserts.assert(node.localName == 'Style', 'localName should be Style');
   var id = node.getAttribute('id');
-  if (!goog.isNull(id)) {
+  if (id !== null) {
     var style = ol.format.KML.readStyle_(node, objectStack);
     if (style) {
       var styleUri;
@@ -1743,7 +1742,7 @@ ol.format.KML.prototype.readSharedStyleMap_ = function(node, objectStack) {
   goog.asserts.assert(node.localName == 'StyleMap',
       'localName should be StyleMap');
   var id = node.getAttribute('id');
-  if (goog.isNull(id)) {
+  if (id === null) {
     return;
   }
   var styleMapValue = ol.format.KML.readStyleMapValue_(node, objectStack);
@@ -1835,8 +1834,7 @@ ol.format.KML.prototype.readFeaturesFromNode = function(node, opt_options) {
   } else if (localName == 'kml') {
     features = [];
     var n;
-    for (n = node.firstElementChild; !goog.isNull(n);
-         n = n.nextElementSibling) {
+    for (n = node.firstElementChild; n !== null; n = n.nextElementSibling) {
       var fs = this.readFeaturesFromNode(n, opt_options);
       if (fs) {
         goog.array.extend(features, fs);
@@ -1877,7 +1875,7 @@ ol.format.KML.prototype.readName = function(source) {
  */
 ol.format.KML.prototype.readNameFromDocument = function(doc) {
   var n;
-  for (n = doc.firstChild; !goog.isNull(n); n = n.nextSibling) {
+  for (n = doc.firstChild; n !== null; n = n.nextSibling) {
     if (n.nodeType == goog.dom.NodeType.ELEMENT) {
       var name = this.readNameFromNode(n);
       if (name) {
@@ -1895,13 +1893,13 @@ ol.format.KML.prototype.readNameFromDocument = function(doc) {
  */
 ol.format.KML.prototype.readNameFromNode = function(node) {
   var n;
-  for (n = node.firstElementChild; !goog.isNull(n); n = n.nextElementSibling) {
+  for (n = node.firstElementChild; n !== null; n = n.nextElementSibling) {
     if (ol.array.includes(ol.format.KML.NAMESPACE_URIS_, n.namespaceURI) &&
         n.localName == 'name') {
       return ol.format.XSD.readString(n);
     }
   }
-  for (n = node.firstElementChild; !goog.isNull(n); n = n.nextElementSibling) {
+  for (n = node.firstElementChild; n !== null; n = n.nextElementSibling) {
     var localName = ol.xml.getLocalName(n);
     if (ol.array.includes(ol.format.KML.NAMESPACE_URIS_, n.namespaceURI) &&
         (localName == 'Document' ||
@@ -1949,7 +1947,7 @@ ol.format.KML.prototype.readNetworkLinks = function(source) {
  */
 ol.format.KML.prototype.readNetworkLinksFromDocument = function(doc) {
   var n, networkLinks = [];
-  for (n = doc.firstChild; !goog.isNull(n); n = n.nextSibling) {
+  for (n = doc.firstChild; n !== null; n = n.nextSibling) {
     if (n.nodeType == goog.dom.NodeType.ELEMENT) {
       goog.array.extend(networkLinks, this.readNetworkLinksFromNode(n));
     }
@@ -1964,7 +1962,7 @@ ol.format.KML.prototype.readNetworkLinksFromDocument = function(doc) {
  */
 ol.format.KML.prototype.readNetworkLinksFromNode = function(node) {
   var n, networkLinks = [];
-  for (n = node.firstElementChild; !goog.isNull(n); n = n.nextElementSibling) {
+  for (n = node.firstElementChild; n !== null; n = n.nextElementSibling) {
     if (ol.array.includes(ol.format.KML.NAMESPACE_URIS_, n.namespaceURI) &&
         n.localName == 'NetworkLink') {
       var obj = ol.xml.pushParseAndPop({}, ol.format.KML.NETWORK_LINK_PARSERS_,
@@ -1972,7 +1970,7 @@ ol.format.KML.prototype.readNetworkLinksFromNode = function(node) {
       networkLinks.push(obj);
     }
   }
-  for (n = node.firstElementChild; !goog.isNull(n); n = n.nextElementSibling) {
+  for (n = node.firstElementChild; n !== null; n = n.nextElementSibling) {
     var localName = ol.xml.getLocalName(n);
     if (ol.array.includes(ol.format.KML.NAMESPACE_URIS_, n.namespaceURI) &&
         (localName == 'Document' ||
@@ -2109,20 +2107,19 @@ ol.format.KML.writeIconStyle_ = function(node, style, objectStack) {
     'href': src
   };
 
-  if (!goog.isNull(size)) {
+  if (size !== null) {
     iconProperties['w'] = size[0];
     iconProperties['h'] = size[1];
     var anchor = style.getAnchor(); // top-left
     var origin = style.getOrigin(); // top-left
 
-    if (!goog.isNull(origin) && !goog.isNull(iconImageSize) &&
+    if (origin !== null && iconImageSize !== null &&
         origin[0] !== 0 && origin[1] !== size[1]) {
       iconProperties['x'] = origin[0];
       iconProperties['y'] = iconImageSize[1] - (origin[1] + size[1]);
     }
 
-    if (!goog.isNull(anchor) &&
-        anchor[0] !== 0 && anchor[1] !== size[1]) {
+    if (anchor !== null && anchor[0] !== 0 && anchor[1] !== size[1]) {
       var /** @type {ol.format.KMLVec2_} */ hotSpot = {
         x: anchor[0],
         xunits: ol.style.IconAnchorUnits.PIXELS,
@@ -2163,7 +2160,7 @@ ol.format.KML.writeLabelStyle_ = function(node, style, objectStack) {
   var /** @type {ol.xml.NodeStackItem} */ context = {node: node};
   var properties = {};
   var fill = style.getFill();
-  if (!goog.isNull(fill)) {
+  if (fill !== null) {
     properties['color'] = fill.getColor();
   }
   var scale = style.getScale();
@@ -2278,10 +2275,10 @@ ol.format.KML.writePlacemark_ = function(node, feature, objectStack) {
     // FIXME the styles returned by the style function are supposed to be
     // resolution-independent here
     var styles = styleFunction.call(feature, 0);
-    if (!goog.isNull(styles) && styles.length > 0) {
+    if (styles !== null && styles.length > 0) {
       properties['Style'] = styles[0];
       var textStyle = styles[0].getText();
-      if (!goog.isNull(textStyle)) {
+      if (textStyle !== null) {
         properties['name'] = textStyle.getText();
       }
     }
@@ -2391,16 +2388,16 @@ ol.format.KML.writeStyle_ = function(node, style, objectStack) {
   var strokeStyle = style.getStroke();
   var imageStyle = style.getImage();
   var textStyle = style.getText();
-  if (!goog.isNull(imageStyle)) {
+  if (imageStyle !== null) {
     properties['IconStyle'] = imageStyle;
   }
-  if (!goog.isNull(textStyle)) {
+  if (textStyle !== null) {
     properties['LabelStyle'] = textStyle;
   }
-  if (!goog.isNull(strokeStyle)) {
+  if (strokeStyle !== null) {
     properties['LineStyle'] = strokeStyle;
   }
-  if (!goog.isNull(fillStyle)) {
+  if (fillStyle !== null) {
     properties['PolyStyle'] = fillStyle;
   }
   var parentNode = objectStack[objectStack.length - 1].node;

--- a/src/ol/format/owsformat.js
+++ b/src/ol/format/owsformat.js
@@ -26,7 +26,7 @@ goog.inherits(ol.format.OWS, ol.format.XML);
 ol.format.OWS.prototype.readFromDocument = function(doc) {
   goog.asserts.assert(doc.nodeType == goog.dom.NodeType.DOCUMENT,
       'doc.nodeType should be DOCUMENT');
-  for (var n = doc.firstChild; !goog.isNull(n); n = n.nextSibling) {
+  for (var n = doc.firstChild; n !== null; n = n.nextSibling) {
     if (n.nodeType == goog.dom.NodeType.ELEMENT) {
       return this.readFromNode(n);
     }

--- a/src/ol/format/topojsonformat.js
+++ b/src/ol/format/topojsonformat.js
@@ -97,7 +97,7 @@ ol.format.TopoJSON.concatenateArcs_ = function(indices, arcs) {
  */
 ol.format.TopoJSON.readPointGeometry_ = function(object, scale, translate) {
   var coordinates = object.coordinates;
-  if (!goog.isNull(scale) && !goog.isNull(translate)) {
+  if (scale !== null && translate !== null) {
     ol.format.TopoJSON.transformVertex_(coordinates, scale, translate);
   }
   return new ol.geom.Point(coordinates);
@@ -117,7 +117,7 @@ ol.format.TopoJSON.readMultiPointGeometry_ = function(object, scale,
     translate) {
   var coordinates = object.coordinates;
   var i, ii;
-  if (!goog.isNull(scale) && !goog.isNull(translate)) {
+  if (scale !== null && translate !== null) {
     for (i = 0, ii = coordinates.length; i < ii; ++i) {
       ol.format.TopoJSON.transformVertex_(coordinates[i], scale, translate);
     }

--- a/src/ol/format/wfsformat.js
+++ b/src/ol/format/wfsformat.js
@@ -196,7 +196,7 @@ ol.format.WFS.prototype.readFeatureCollectionMetadataFromDocument =
     function(doc) {
   goog.asserts.assert(doc.nodeType == goog.dom.NodeType.DOCUMENT,
       'doc.nodeType should be DOCUMENT');
-  for (var n = doc.firstChild; !goog.isNull(n); n = n.nextSibling) {
+  for (var n = doc.firstChild; n !== null; n = n.nextSibling) {
     if (n.nodeType == goog.dom.NodeType.ELEMENT) {
       return this.readFeatureCollectionMetadataFromNode(n);
     }
@@ -337,7 +337,7 @@ ol.format.WFS.TRANSACTION_RESPONSE_PARSERS_ = {
 ol.format.WFS.prototype.readTransactionResponseFromDocument = function(doc) {
   goog.asserts.assert(doc.nodeType == goog.dom.NodeType.DOCUMENT,
       'doc.nodeType should be DOCUMENT');
-  for (var n = doc.firstChild; !goog.isNull(n); n = n.nextSibling) {
+  for (var n = doc.firstChild; n !== null; n = n.nextSibling) {
     if (n.nodeType == goog.dom.NodeType.ELEMENT) {
       return this.readTransactionResponseFromNode(n);
     }
@@ -750,7 +750,7 @@ ol.format.WFS.prototype.readProjection;
 ol.format.WFS.prototype.readProjectionFromDocument = function(doc) {
   goog.asserts.assert(doc.nodeType == goog.dom.NodeType.DOCUMENT,
       'doc.nodeType should be a DOCUMENT');
-  for (var n = doc.firstChild; !goog.isNull(n); n = n.nextSibling) {
+  for (var n = doc.firstChild; n !== null; n = n.nextSibling) {
     if (n.nodeType == goog.dom.NodeType.ELEMENT) {
       return this.readProjectionFromNode(n);
     }
@@ -771,8 +771,7 @@ ol.format.WFS.prototype.readProjectionFromNode = function(node) {
   if (goog.isDefAndNotNull(node.firstElementChild) &&
       goog.isDefAndNotNull(node.firstElementChild.firstElementChild)) {
     node = node.firstElementChild.firstElementChild;
-    for (var n = node.firstElementChild; !goog.isNull(n);
-        n = n.nextElementSibling) {
+    for (var n = node.firstElementChild; n !== null; n = n.nextElementSibling) {
       if (!(n.childNodes.length === 0 ||
           (n.childNodes.length === 1 &&
           n.firstChild.nodeType === 3))) {

--- a/src/ol/format/wmscapabilitiesformat.js
+++ b/src/ol/format/wmscapabilitiesformat.js
@@ -50,7 +50,7 @@ ol.format.WMSCapabilities.prototype.read;
 ol.format.WMSCapabilities.prototype.readFromDocument = function(doc) {
   goog.asserts.assert(doc.nodeType == goog.dom.NodeType.DOCUMENT,
       'doc.nodeType should be DOCUMENT');
-  for (var n = doc.firstChild; !goog.isNull(n); n = n.nextSibling) {
+  for (var n = doc.firstChild; n !== null; n = n.nextSibling) {
     if (n.nodeType == goog.dom.NodeType.ELEMENT) {
       return this.readFromNode(n);
     }

--- a/src/ol/format/wmtscapabilitiesformat.js
+++ b/src/ol/format/wmtscapabilitiesformat.js
@@ -50,7 +50,7 @@ ol.format.WMTSCapabilities.prototype.read;
 ol.format.WMTSCapabilities.prototype.readFromDocument = function(doc) {
   goog.asserts.assert(doc.nodeType == goog.dom.NodeType.DOCUMENT,
       'doc.nodeType should be DOCUMENT');
-  for (var n = doc.firstChild; !goog.isNull(n); n = n.nextSibling) {
+  for (var n = doc.firstChild; n !== null; n = n.nextSibling) {
     if (n.nodeType == goog.dom.NodeType.ELEMENT) {
       return this.readFromNode(n);
     }

--- a/src/ol/format/xmlfeatureformat.js
+++ b/src/ol/format/xmlfeatureformat.js
@@ -107,7 +107,7 @@ ol.format.XMLFeature.prototype.readFeaturesFromDocument = function(
   /** @type {Array.<ol.Feature>} */
   var features = [];
   var n;
-  for (n = doc.firstChild; !goog.isNull(n); n = n.nextSibling) {
+  for (n = doc.firstChild; n !== null; n = n.nextSibling) {
     if (n.nodeType == goog.dom.NodeType.ELEMENT) {
       goog.array.extend(features, this.readFeaturesFromNode(n, opt_options));
     }

--- a/src/ol/geolocation.js
+++ b/src/ol/geolocation.js
@@ -120,7 +120,7 @@ ol.Geolocation.prototype.handleProjectionChanged_ = function() {
   if (goog.isDefAndNotNull(projection)) {
     this.transform_ = ol.proj.getTransformFromProjections(
         ol.proj.get('EPSG:4326'), projection);
-    if (!goog.isNull(this.position_)) {
+    if (this.position_ !== null) {
       this.set(
           ol.GeolocationProperty.POSITION, this.transform_(this.position_));
     }
@@ -155,13 +155,13 @@ ol.Geolocation.prototype.positionChange_ = function(position) {
   var coords = position.coords;
   this.set(ol.GeolocationProperty.ACCURACY, coords.accuracy);
   this.set(ol.GeolocationProperty.ALTITUDE,
-      goog.isNull(coords.altitude) ? undefined : coords.altitude);
+      coords.altitude === null ? undefined : coords.altitude);
   this.set(ol.GeolocationProperty.ALTITUDE_ACCURACY,
-      goog.isNull(coords.altitudeAccuracy) ?
+      coords.altitudeAccuracy === null ?
       undefined : coords.altitudeAccuracy);
-  this.set(ol.GeolocationProperty.HEADING, goog.isNull(coords.heading) ?
+  this.set(ol.GeolocationProperty.HEADING, coords.heading === null ?
       undefined : goog.math.toRadians(coords.heading));
-  if (goog.isNull(this.position_)) {
+  if (this.position_ === null) {
     this.position_ = [coords.longitude, coords.latitude];
   } else {
     this.position_[0] = coords.longitude;
@@ -170,7 +170,7 @@ ol.Geolocation.prototype.positionChange_ = function(position) {
   var projectedPosition = this.transform_(this.position_);
   this.set(ol.GeolocationProperty.POSITION, projectedPosition);
   this.set(ol.GeolocationProperty.SPEED,
-      goog.isNull(coords.speed) ? undefined : coords.speed);
+      coords.speed === null ? undefined : coords.speed);
   var geometry = ol.geom.Polygon.circular(
       ol.sphere.WGS84, this.position_, coords.accuracy);
   geometry.applyTransform(this.transform_);

--- a/src/ol/geom/circle.js
+++ b/src/ol/geom/circle.js
@@ -189,11 +189,11 @@ ol.geom.Circle.prototype.setCenter = function(center) {
  */
 ol.geom.Circle.prototype.setCenterAndRadius =
     function(center, radius, opt_layout) {
-  if (goog.isNull(center)) {
+  if (center === null) {
     this.setFlatCoordinates(ol.geom.GeometryLayout.XY, null);
   } else {
     this.setLayout(opt_layout, center, 0);
-    if (goog.isNull(this.flatCoordinates)) {
+    if (this.flatCoordinates === null) {
       this.flatCoordinates = [];
     }
     /** @type {Array.<number>} */
@@ -228,7 +228,7 @@ ol.geom.Circle.prototype.setFlatCoordinates =
  * @api
  */
 ol.geom.Circle.prototype.setRadius = function(radius) {
-  goog.asserts.assert(!goog.isNull(this.flatCoordinates),
+  goog.asserts.assert(this.flatCoordinates !== null,
       'this.flatCoordinates cannot be null');
   this.flatCoordinates[this.stride] = this.flatCoordinates[0] + radius;
   this.changed();

--- a/src/ol/geom/geometrycollection.js
+++ b/src/ol/geom/geometrycollection.js
@@ -53,7 +53,7 @@ ol.geom.GeometryCollection.cloneGeometries_ = function(geometries) {
  */
 ol.geom.GeometryCollection.prototype.unlistenGeometriesChange_ = function() {
   var i, ii;
-  if (goog.isNull(this.geometries_)) {
+  if (this.geometries_ === null) {
     return;
   }
   for (i = 0, ii = this.geometries_.length; i < ii; ++i) {
@@ -69,7 +69,7 @@ ol.geom.GeometryCollection.prototype.unlistenGeometriesChange_ = function() {
  */
 ol.geom.GeometryCollection.prototype.listenGeometriesChange_ = function() {
   var i, ii;
-  if (goog.isNull(this.geometries_)) {
+  if (this.geometries_ === null) {
     return;
   }
   for (i = 0, ii = this.geometries_.length; i < ii; ++i) {

--- a/src/ol/geom/linearring.js
+++ b/src/ol/geom/linearring.js
@@ -132,11 +132,11 @@ ol.geom.LinearRing.prototype.getType = function() {
  */
 ol.geom.LinearRing.prototype.setCoordinates =
     function(coordinates, opt_layout) {
-  if (goog.isNull(coordinates)) {
+  if (coordinates === null) {
     this.setFlatCoordinates(ol.geom.GeometryLayout.XY, null);
   } else {
     this.setLayout(opt_layout, coordinates, 1);
-    if (goog.isNull(this.flatCoordinates)) {
+    if (this.flatCoordinates === null) {
       this.flatCoordinates = [];
     }
     this.flatCoordinates.length = ol.geom.flat.deflate.coordinates(

--- a/src/ol/geom/linestring.js
+++ b/src/ol/geom/linestring.js
@@ -70,7 +70,7 @@ goog.inherits(ol.geom.LineString, ol.geom.SimpleGeometry);
 ol.geom.LineString.prototype.appendCoordinate = function(coordinate) {
   goog.asserts.assert(coordinate.length == this.stride,
       'length of coordinate array should match stride');
-  if (goog.isNull(this.flatCoordinates)) {
+  if (this.flatCoordinates === null) {
     this.flatCoordinates = coordinate.slice();
   } else {
     goog.array.extend(this.flatCoordinates, coordinate);
@@ -235,11 +235,11 @@ ol.geom.LineString.prototype.intersectsExtent = function(extent) {
  */
 ol.geom.LineString.prototype.setCoordinates =
     function(coordinates, opt_layout) {
-  if (goog.isNull(coordinates)) {
+  if (coordinates === null) {
     this.setFlatCoordinates(ol.geom.GeometryLayout.XY, null);
   } else {
     this.setLayout(opt_layout, coordinates, 1);
-    if (goog.isNull(this.flatCoordinates)) {
+    if (this.flatCoordinates === null) {
       this.flatCoordinates = [];
     }
     this.flatCoordinates.length = ol.geom.flat.deflate.coordinates(

--- a/src/ol/geom/multilinestring.js
+++ b/src/ol/geom/multilinestring.js
@@ -63,7 +63,7 @@ goog.inherits(ol.geom.MultiLineString, ol.geom.SimpleGeometry);
 ol.geom.MultiLineString.prototype.appendLineString = function(lineString) {
   goog.asserts.assert(lineString.getLayout() == this.layout,
       'layout of lineString should match the layout');
-  if (goog.isNull(this.flatCoordinates)) {
+  if (this.flatCoordinates === null) {
     this.flatCoordinates = lineString.getFlatCoordinates().slice();
   } else {
     goog.array.extend(
@@ -270,11 +270,11 @@ ol.geom.MultiLineString.prototype.intersectsExtent = function(extent) {
  */
 ol.geom.MultiLineString.prototype.setCoordinates =
     function(coordinates, opt_layout) {
-  if (goog.isNull(coordinates)) {
+  if (coordinates === null) {
     this.setFlatCoordinates(ol.geom.GeometryLayout.XY, null, this.ends_);
   } else {
     this.setLayout(opt_layout, coordinates, 2);
-    if (goog.isNull(this.flatCoordinates)) {
+    if (this.flatCoordinates === null) {
       this.flatCoordinates = [];
     }
     var ends = ol.geom.flat.deflate.coordinatess(
@@ -292,8 +292,8 @@ ol.geom.MultiLineString.prototype.setCoordinates =
  */
 ol.geom.MultiLineString.prototype.setFlatCoordinates =
     function(layout, flatCoordinates, ends) {
-  if (goog.isNull(flatCoordinates)) {
-    goog.asserts.assert(!goog.isNull(ends) && ends.length === 0,
+  if (flatCoordinates === null) {
+    goog.asserts.assert(ends !== null && ends.length === 0,
         'ends cannot be null and ends.length should be 0');
   } else if (ends.length === 0) {
     goog.asserts.assert(flatCoordinates.length === 0,

--- a/src/ol/geom/multipoint.js
+++ b/src/ol/geom/multipoint.js
@@ -38,7 +38,7 @@ goog.inherits(ol.geom.MultiPoint, ol.geom.SimpleGeometry);
 ol.geom.MultiPoint.prototype.appendPoint = function(point) {
   goog.asserts.assert(point.getLayout() == this.layout,
       'the layout of point should match layout');
-  if (goog.isNull(this.flatCoordinates)) {
+  if (this.flatCoordinates === null) {
     this.flatCoordinates = point.getFlatCoordinates().slice();
   } else {
     goog.array.extend(this.flatCoordinates, point.getFlatCoordinates());
@@ -104,7 +104,7 @@ ol.geom.MultiPoint.prototype.getCoordinates = function() {
  * @api stable
  */
 ol.geom.MultiPoint.prototype.getPoint = function(index) {
-  var n = goog.isNull(this.flatCoordinates) ?
+  var n = this.flatCoordinates === null ?
       0 : this.flatCoordinates.length / this.stride;
   goog.asserts.assert(0 <= index && index < n,
       'index should be in between 0 and n');
@@ -175,11 +175,11 @@ ol.geom.MultiPoint.prototype.intersectsExtent = function(extent) {
  */
 ol.geom.MultiPoint.prototype.setCoordinates =
     function(coordinates, opt_layout) {
-  if (goog.isNull(coordinates)) {
+  if (coordinates === null) {
     this.setFlatCoordinates(ol.geom.GeometryLayout.XY, null);
   } else {
     this.setLayout(opt_layout, coordinates, 1);
-    if (goog.isNull(this.flatCoordinates)) {
+    if (this.flatCoordinates === null) {
       this.flatCoordinates = [];
     }
     this.flatCoordinates.length = ol.geom.flat.deflate.coordinates(

--- a/src/ol/geom/multipolygon.js
+++ b/src/ol/geom/multipolygon.js
@@ -95,7 +95,7 @@ ol.geom.MultiPolygon.prototype.appendPolygon = function(polygon) {
       'layout of polygon should match layout');
   /** @type {Array.<number>} */
   var ends;
-  if (goog.isNull(this.flatCoordinates)) {
+  if (this.flatCoordinates === null) {
     this.flatCoordinates = polygon.getFlatCoordinates().slice();
     ends = polygon.getEnds().slice();
     this.endss_.push();
@@ -363,11 +363,11 @@ ol.geom.MultiPolygon.prototype.intersectsExtent = function(extent) {
  */
 ol.geom.MultiPolygon.prototype.setCoordinates =
     function(coordinates, opt_layout) {
-  if (goog.isNull(coordinates)) {
+  if (coordinates === null) {
     this.setFlatCoordinates(ol.geom.GeometryLayout.XY, null, this.endss_);
   } else {
     this.setLayout(opt_layout, coordinates, 3);
-    if (goog.isNull(this.flatCoordinates)) {
+    if (this.flatCoordinates === null) {
       this.flatCoordinates = [];
     }
     var endss = ol.geom.flat.deflate.coordinatesss(
@@ -391,8 +391,8 @@ ol.geom.MultiPolygon.prototype.setCoordinates =
  */
 ol.geom.MultiPolygon.prototype.setFlatCoordinates =
     function(layout, flatCoordinates, endss) {
-  goog.asserts.assert(!goog.isNull(endss), 'endss cannot be null');
-  if (goog.isNull(flatCoordinates) || flatCoordinates.length === 0) {
+  goog.asserts.assert(endss !== null, 'endss cannot be null');
+  if (flatCoordinates === null || flatCoordinates.length === 0) {
     goog.asserts.assert(endss.length === 0, 'the length of endss should be 0');
   } else {
     goog.asserts.assert(endss.length > 0, 'endss cannot be an empty array');

--- a/src/ol/geom/point.js
+++ b/src/ol/geom/point.js
@@ -66,7 +66,7 @@ ol.geom.Point.prototype.closestPointXY =
  * @api stable
  */
 ol.geom.Point.prototype.getCoordinates = function() {
-  return goog.isNull(this.flatCoordinates) ? [] : this.flatCoordinates.slice();
+  return this.flatCoordinates === null ? [] : this.flatCoordinates.slice();
 };
 
 
@@ -104,11 +104,11 @@ ol.geom.Point.prototype.intersectsExtent = function(extent) {
  * @api stable
  */
 ol.geom.Point.prototype.setCoordinates = function(coordinates, opt_layout) {
-  if (goog.isNull(coordinates)) {
+  if (coordinates === null) {
     this.setFlatCoordinates(ol.geom.GeometryLayout.XY, null);
   } else {
     this.setLayout(opt_layout, coordinates, 0);
-    if (goog.isNull(this.flatCoordinates)) {
+    if (this.flatCoordinates === null) {
       this.flatCoordinates = [];
     }
     this.flatCoordinates.length = ol.geom.flat.deflate.coordinate(

--- a/src/ol/geom/polygon.js
+++ b/src/ol/geom/polygon.js
@@ -92,7 +92,7 @@ goog.inherits(ol.geom.Polygon, ol.geom.SimpleGeometry);
 ol.geom.Polygon.prototype.appendLinearRing = function(linearRing) {
   goog.asserts.assert(linearRing.getLayout() == this.layout,
       'layout of linearRing should match layout');
-  if (goog.isNull(this.flatCoordinates)) {
+  if (this.flatCoordinates === null) {
     this.flatCoordinates = linearRing.getFlatCoordinates().slice();
   } else {
     goog.array.extend(this.flatCoordinates, linearRing.getFlatCoordinates());
@@ -339,11 +339,11 @@ ol.geom.Polygon.prototype.intersectsExtent = function(extent) {
  * @api stable
  */
 ol.geom.Polygon.prototype.setCoordinates = function(coordinates, opt_layout) {
-  if (goog.isNull(coordinates)) {
+  if (coordinates === null) {
     this.setFlatCoordinates(ol.geom.GeometryLayout.XY, null, this.ends_);
   } else {
     this.setLayout(opt_layout, coordinates, 2);
-    if (goog.isNull(this.flatCoordinates)) {
+    if (this.flatCoordinates === null) {
       this.flatCoordinates = [];
     }
     var ends = ol.geom.flat.deflate.coordinatess(
@@ -361,8 +361,8 @@ ol.geom.Polygon.prototype.setCoordinates = function(coordinates, opt_layout) {
  */
 ol.geom.Polygon.prototype.setFlatCoordinates =
     function(layout, flatCoordinates, ends) {
-  if (goog.isNull(flatCoordinates)) {
-    goog.asserts.assert(!goog.isNull(ends) && ends.length === 0,
+  if (flatCoordinates === null) {
+    goog.asserts.assert(ends !== null && ends.length === 0,
         'ends cannot be null and should be an empty array');
   } else if (ends.length === 0) {
     goog.asserts.assert(flatCoordinates.length === 0,

--- a/src/ol/geom/simplegeometry.js
+++ b/src/ol/geom/simplegeometry.js
@@ -258,7 +258,7 @@ ol.geom.SimpleGeometry.prototype.setLayout =
  * @api stable
  */
 ol.geom.SimpleGeometry.prototype.applyTransform = function(transformFn) {
-  if (!goog.isNull(this.flatCoordinates)) {
+  if (this.flatCoordinates !== null) {
     transformFn(this.flatCoordinates, this.flatCoordinates, this.stride);
     this.changed();
   }
@@ -271,7 +271,7 @@ ol.geom.SimpleGeometry.prototype.applyTransform = function(transformFn) {
  */
 ol.geom.SimpleGeometry.prototype.translate = function(deltaX, deltaY) {
   var flatCoordinates = this.getFlatCoordinates();
-  if (!goog.isNull(flatCoordinates)) {
+  if (flatCoordinates !== null) {
     var stride = this.getStride();
     ol.geom.flat.transform.translate(
         flatCoordinates, 0, flatCoordinates.length, stride,
@@ -290,7 +290,7 @@ ol.geom.SimpleGeometry.prototype.translate = function(deltaX, deltaY) {
 ol.geom.transformSimpleGeometry2D =
     function(simpleGeometry, transform, opt_dest) {
   var flatCoordinates = simpleGeometry.getFlatCoordinates();
-  if (goog.isNull(flatCoordinates)) {
+  if (flatCoordinates === null) {
     return null;
   } else {
     var stride = simpleGeometry.getStride();

--- a/src/ol/graticule.js
+++ b/src/ol/graticule.js
@@ -415,7 +415,7 @@ ol.Graticule.prototype.handlePostCompose_ = function(e) {
   var squaredTolerance =
       resolution * resolution / (4 * pixelRatio * pixelRatio);
 
-  var updateProjectionInfo = goog.isNull(this.projection_) ||
+  var updateProjectionInfo = this.projection_ === null ||
       !ol.proj.equivalent(this.projection_, projection);
 
   if (updateProjectionInfo) {
@@ -443,7 +443,7 @@ ol.Graticule.prototype.handlePostCompose_ = function(e) {
  * @private
  */
 ol.Graticule.prototype.updateProjectionInfo_ = function(projection) {
-  goog.asserts.assert(!goog.isNull(projection), 'projection cannot be null');
+  goog.asserts.assert(projection !== null, 'projection cannot be null');
 
   var epsg4326Projection = ol.proj.get('EPSG:4326');
 
@@ -462,7 +462,7 @@ ol.Graticule.prototype.updateProjectionInfo_ = function(projection) {
   var minLatP = worldExtentP[1];
   var minLonP = worldExtentP[0];
 
-  goog.asserts.assert(!goog.isNull(extent), 'extent cannot be null');
+  goog.asserts.assert(extent !== null, 'extent cannot be null');
   goog.asserts.assert(maxLat !== undefined, 'maxLat should be defined');
   goog.asserts.assert(maxLon !== undefined, 'maxLon should be defined');
   goog.asserts.assert(minLat !== undefined, 'minLat should be defined');
@@ -508,12 +508,12 @@ ol.Graticule.prototype.updateProjectionInfo_ = function(projection) {
  * @api
  */
 ol.Graticule.prototype.setMap = function(map) {
-  if (!goog.isNull(this.map_)) {
+  if (this.map_ !== null) {
     this.map_.un(ol.render.EventType.POSTCOMPOSE,
         this.handlePostCompose_, this);
     this.map_.render();
   }
-  if (!goog.isNull(map)) {
+  if (map !== null) {
     map.on(ol.render.EventType.POSTCOMPOSE,
         this.handlePostCompose_, this);
     map.render();

--- a/src/ol/has.js
+++ b/src/ol/has.js
@@ -41,7 +41,7 @@ ol.has.CANVAS = ol.ENABLE_CANVAS && (
       }
       try {
         var context = ol.dom.createCanvasContext2D();
-        if (goog.isNull(context)) {
+        if (context === null) {
           return false;
         } else {
           if (context.setLineDash !== undefined) {
@@ -129,7 +129,7 @@ ol.has.WEBGL;
         var gl = ol.webgl.getContext(canvas, {
           failIfMajorPerformanceCaveat: true
         });
-        if (!goog.isNull(gl)) {
+        if (gl !== null) {
           hasWebGL = true;
           textureSize = /** @type {number} */
               (gl.getParameter(gl.MAX_TEXTURE_SIZE));

--- a/src/ol/image.js
+++ b/src/ol/image.js
@@ -38,7 +38,7 @@ ol.Image = function(extent, resolution, pixelRatio, attributions, src,
    * @type {Image}
    */
   this.image_ = new Image();
-  if (!goog.isNull(crossOrigin)) {
+  if (crossOrigin !== null) {
     this.image_.crossOrigin = crossOrigin;
   }
 
@@ -129,7 +129,7 @@ ol.Image.prototype.load = function() {
   if (this.state == ol.ImageState.IDLE) {
     this.state = ol.ImageState.LOADING;
     this.changed();
-    goog.asserts.assert(goog.isNull(this.imageListenerKeys_),
+    goog.asserts.assert(this.imageListenerKeys_ === null,
         'this.imageListenerKeys_ should be null');
     this.imageListenerKeys_ = [
       goog.events.listenOnce(this.image_, goog.events.EventType.ERROR,
@@ -148,7 +148,7 @@ ol.Image.prototype.load = function() {
  * @private
  */
 ol.Image.prototype.unlistenImage_ = function() {
-  goog.asserts.assert(!goog.isNull(this.imageListenerKeys_),
+  goog.asserts.assert(this.imageListenerKeys_ !== null,
       'this.imageListenerKeys_ should not be null');
   this.imageListenerKeys_.forEach(goog.events.unlistenByKey);
   this.imageListenerKeys_ = null;

--- a/src/ol/imagecanvas.js
+++ b/src/ol/imagecanvas.js
@@ -78,7 +78,7 @@ ol.ImageCanvas.prototype.handleLoad_ = function(err) {
  */
 ol.ImageCanvas.prototype.load = function() {
   if (this.state == ol.ImageState.IDLE) {
-    goog.asserts.assert(!goog.isNull(this.loader_));
+    goog.asserts.assert(this.loader_ !== null, 'this.loader_ must not be null');
     this.state = ol.ImageState.LOADING;
     this.changed();
     this.loader_(goog.bind(this.handleLoad_, this));

--- a/src/ol/imagetile.js
+++ b/src/ol/imagetile.js
@@ -37,7 +37,7 @@ ol.ImageTile = function(tileCoord, state, src, crossOrigin, tileLoadFunction) {
    * @type {Image}
    */
   this.image_ = new Image();
-  if (!goog.isNull(crossOrigin)) {
+  if (crossOrigin !== null) {
     this.image_.crossOrigin = crossOrigin;
   }
 
@@ -141,7 +141,7 @@ ol.ImageTile.prototype.load = function() {
   if (this.state == ol.TileState.IDLE) {
     this.state = ol.TileState.LOADING;
     this.changed();
-    goog.asserts.assert(goog.isNull(this.imageListenerKeys_),
+    goog.asserts.assert(this.imageListenerKeys_ === null,
         'this.imageListenerKeys_ should be null');
     this.imageListenerKeys_ = [
       goog.events.listenOnce(this.image_, goog.events.EventType.ERROR,
@@ -160,7 +160,7 @@ ol.ImageTile.prototype.load = function() {
  * @private
  */
 ol.ImageTile.prototype.unlistenImage_ = function() {
-  goog.asserts.assert(!goog.isNull(this.imageListenerKeys_),
+  goog.asserts.assert(this.imageListenerKeys_ !== null,
       'this.imageListenerKeys_ should not be null');
   this.imageListenerKeys_.forEach(goog.events.unlistenByKey);
   this.imageListenerKeys_ = null;

--- a/src/ol/interaction/doubleclickzoominteraction.js
+++ b/src/ol/interaction/doubleclickzoominteraction.js
@@ -56,7 +56,7 @@ ol.interaction.DoubleClickZoom.handleEvent = function(mapBrowserEvent) {
     var anchor = mapBrowserEvent.coordinate;
     var delta = browserEvent.shiftKey ? -this.delta_ : this.delta_;
     var view = map.getView();
-    goog.asserts.assert(!goog.isNull(view), 'view should not be null');
+    goog.asserts.assert(view !== null, 'view should not be null');
     ol.interaction.Interaction.zoomByDelta(
         map, view, delta, anchor, this.duration_);
     mapBrowserEvent.preventDefault();

--- a/src/ol/interaction/draganddropinteraction.js
+++ b/src/ol/interaction/draganddropinteraction.js
@@ -98,11 +98,11 @@ ol.interaction.DragAndDrop.prototype.handleDrop_ = function(event) {
  */
 ol.interaction.DragAndDrop.prototype.handleResult_ = function(file, result) {
   var map = this.getMap();
-  goog.asserts.assert(!goog.isNull(map), 'map should not be null');
+  goog.asserts.assert(map !== null, 'map should not be null');
   var projection = this.projection_;
-  if (goog.isNull(projection)) {
+  if (projection === null) {
     var view = map.getView();
-    goog.asserts.assert(!goog.isNull(view), 'view should not be null');
+    goog.asserts.assert(view !== null, 'view should not be null');
     projection = view.getProjection();
     goog.asserts.assert(projection !== undefined,
         'projection should be defined');
@@ -114,7 +114,7 @@ ol.interaction.DragAndDrop.prototype.handleResult_ = function(file, result) {
     var formatConstructor = formatConstructors[i];
     var format = new formatConstructor();
     var readFeatures = this.tryReadFeatures_(format, result);
-    if (!goog.isNull(readFeatures)) {
+    if (readFeatures !== null) {
       var featureProjection = format.readProjection(result);
       var transform = ol.proj.getTransform(featureProjection, projection);
       var j, jj;
@@ -154,14 +154,14 @@ ol.interaction.DragAndDrop.prototype.setMap = function(map) {
     goog.events.unlistenByKey(this.dropListenKey_);
     this.dropListenKey_ = undefined;
   }
-  if (!goog.isNull(this.fileDropHandler_)) {
+  if (this.fileDropHandler_ !== null) {
     goog.dispose(this.fileDropHandler_);
     this.fileDropHandler_ = null;
   }
   goog.asserts.assert(this.dropListenKey_ === undefined,
       'this.dropListenKey_ should be undefined');
   goog.base(this, 'setMap', map);
-  if (!goog.isNull(map)) {
+  if (map !== null) {
     this.fileDropHandler_ = new goog.events.FileDropHandler(map.getViewport());
     this.dropListenKey_ = goog.events.listen(
         this.fileDropHandler_, goog.events.FileDropHandler.EventType.DROP,

--- a/src/ol/interaction/dragpaninteraction.js
+++ b/src/ol/interaction/dragpaninteraction.js
@@ -77,7 +77,7 @@ ol.interaction.DragPan.handleDragEvent_ = function(mapBrowserEvent) {
   if (this.kinetic_) {
     this.kinetic_.update(centroid[0], centroid[1]);
   }
-  if (!goog.isNull(this.lastCentroid)) {
+  if (this.lastCentroid !== null) {
     var deltaX = this.lastCentroid[0] - centroid[0];
     var deltaY = centroid[1] - this.lastCentroid[1];
     var map = mapBrowserEvent.map;
@@ -145,7 +145,7 @@ ol.interaction.DragPan.handleDownEvent_ = function(mapBrowserEvent) {
       view.setHint(ol.ViewHint.INTERACTING, 1);
     }
     map.render();
-    if (!goog.isNull(this.kineticPreRenderFn_) &&
+    if (this.kineticPreRenderFn_ !== null &&
         map.removePreRenderFunction(this.kineticPreRenderFn_)) {
       view.setCenter(mapBrowserEvent.frameState.viewState.center);
       this.kineticPreRenderFn_ = null;

--- a/src/ol/interaction/dragzoominteraction.js
+++ b/src/ol/interaction/dragzoominteraction.js
@@ -61,7 +61,7 @@ ol.interaction.DragZoom.prototype.onBoxEnd = function() {
   var map = this.getMap();
 
   var view = map.getView();
-  goog.asserts.assert(!goog.isNull(view), 'view should not be null');
+  goog.asserts.assert(view !== null, 'view should not be null');
 
   var size = map.getSize();
   goog.asserts.assert(size !== undefined, 'size should be defined');

--- a/src/ol/interaction/drawinteraction.js
+++ b/src/ol/interaction/drawinteraction.js
@@ -367,7 +367,7 @@ ol.interaction.Draw.handleDownEvent_ = function(event) {
       this.freehandCondition_(event)) {
     this.downPx_ = event.pixel;
     this.freehand_ = true;
-    if (goog.isNull(this.finishCoordinate_)) {
+    if (this.finishCoordinate_ === null) {
       this.startDrawing_(event);
     }
     return true;
@@ -393,7 +393,7 @@ ol.interaction.Draw.handleUpEvent_ = function(event) {
   var pass = true;
   if (squaredDistance <= this.squaredClickTolerance_) {
     this.handlePointerMove_(event);
-    if (goog.isNull(this.finishCoordinate_)) {
+    if (this.finishCoordinate_ === null) {
       this.startDrawing_(event);
       if (this.mode_ === ol.interaction.DrawMode.POINT) {
         this.finishDrawing();
@@ -418,7 +418,7 @@ ol.interaction.Draw.handleUpEvent_ = function(event) {
  * @private
  */
 ol.interaction.Draw.prototype.handlePointerMove_ = function(event) {
-  if (!goog.isNull(this.finishCoordinate_)) {
+  if (this.finishCoordinate_ !== null) {
     this.modifyDrawing_(event);
   } else {
     this.createOrUpdateSketchPoint_(event);
@@ -435,7 +435,7 @@ ol.interaction.Draw.prototype.handlePointerMove_ = function(event) {
  */
 ol.interaction.Draw.prototype.atFinish_ = function(event) {
   var at = false;
-  if (!goog.isNull(this.sketchFeature_)) {
+  if (this.sketchFeature_ !== null) {
     var potentiallyDone = false;
     var potentiallyFinishCoordinates = [this.finishCoordinate_];
     if (this.mode_ === ol.interaction.DrawMode.LINE_STRING) {
@@ -474,7 +474,7 @@ ol.interaction.Draw.prototype.atFinish_ = function(event) {
  */
 ol.interaction.Draw.prototype.createOrUpdateSketchPoint_ = function(event) {
   var coordinates = event.coordinate.slice();
-  if (goog.isNull(this.sketchPoint_)) {
+  if (this.sketchPoint_ === null) {
     this.sketchPoint_ = new ol.Feature(new ol.geom.Point(coordinates));
     this.updateSketchFeatures_();
   } else {
@@ -505,7 +505,7 @@ ol.interaction.Draw.prototype.startDrawing_ = function(event) {
       this.sketchLineCoords_ = this.sketchCoords_;
     }
   }
-  if (!goog.isNull(this.sketchLineCoords_)) {
+  if (this.sketchLineCoords_ !== null) {
     this.sketchLine_ = new ol.Feature(
         new ol.geom.LineString(this.sketchLineCoords_));
   }
@@ -548,10 +548,10 @@ ol.interaction.Draw.prototype.modifyDrawing_ = function(event) {
   }
   last[0] = coordinate[0];
   last[1] = coordinate[1];
-  goog.asserts.assert(!goog.isNull(this.sketchCoords_),
+  goog.asserts.assert(this.sketchCoords_ !== null,
       'sketchCoords_ must not be null');
   this.geometryFunction_(this.sketchCoords_, geometry);
-  if (!goog.isNull(this.sketchPoint_)) {
+  if (this.sketchPoint_ !== null) {
     var sketchPointGeom = this.sketchPoint_.getGeometry();
     goog.asserts.assertInstanceof(sketchPointGeom, ol.geom.Point,
         'sketchPointGeom should be an ol.geom.Point');
@@ -560,7 +560,7 @@ ol.interaction.Draw.prototype.modifyDrawing_ = function(event) {
   var sketchLineGeom;
   if (geometry instanceof ol.geom.Polygon &&
       this.mode_ !== ol.interaction.DrawMode.POLYGON) {
-    if (goog.isNull(this.sketchLine_)) {
+    if (this.sketchLine_ === null) {
       this.sketchLine_ = new ol.Feature(new ol.geom.LineString(null));
     }
     var ring = geometry.getLinearRing(0);
@@ -569,7 +569,7 @@ ol.interaction.Draw.prototype.modifyDrawing_ = function(event) {
         'sketchLineGeom must be an ol.geom.LineString');
     sketchLineGeom.setFlatCoordinates(
         ring.getLayout(), ring.getFlatCoordinates());
-  } else if (!goog.isNull(this.sketchLineCoords_)) {
+  } else if (this.sketchLineCoords_ !== null) {
     sketchLineGeom = this.sketchLine_.getGeometry();
     goog.asserts.assertInstanceof(sketchLineGeom, ol.geom.LineString,
         'sketchLineGeom must be an ol.geom.LineString');
@@ -652,7 +652,7 @@ ol.interaction.Draw.prototype.removeLastPoint = function() {
  */
 ol.interaction.Draw.prototype.finishDrawing = function() {
   var sketchFeature = this.abortDrawing_();
-  goog.asserts.assert(!goog.isNull(sketchFeature),
+  goog.asserts.assert(sketchFeature !== null,
       'sketchFeature should not be null');
   var coordinates = this.sketchCoords_;
   var geometry = sketchFeature.getGeometry();
@@ -685,10 +685,10 @@ ol.interaction.Draw.prototype.finishDrawing = function() {
       ol.interaction.DrawEventType.DRAWEND, sketchFeature));
 
   // Then insert feature
-  if (!goog.isNull(this.features_)) {
+  if (this.features_ !== null) {
     this.features_.push(sketchFeature);
   }
-  if (!goog.isNull(this.source_)) {
+  if (this.source_ !== null) {
     this.source_.addFeature(sketchFeature);
   }
 };
@@ -702,7 +702,7 @@ ol.interaction.Draw.prototype.finishDrawing = function() {
 ol.interaction.Draw.prototype.abortDrawing_ = function() {
   this.finishCoordinate_ = null;
   var sketchFeature = this.sketchFeature_;
-  if (!goog.isNull(sketchFeature)) {
+  if (sketchFeature !== null) {
     this.sketchFeature_ = null;
     this.sketchPoint_ = null;
     this.sketchLine_ = null;
@@ -751,13 +751,13 @@ ol.interaction.Draw.prototype.shouldStopEvent = goog.functions.FALSE;
  */
 ol.interaction.Draw.prototype.updateSketchFeatures_ = function() {
   var sketchFeatures = [];
-  if (!goog.isNull(this.sketchFeature_)) {
+  if (this.sketchFeature_ !== null) {
     sketchFeatures.push(this.sketchFeature_);
   }
-  if (!goog.isNull(this.sketchLine_)) {
+  if (this.sketchLine_ !== null) {
     sketchFeatures.push(this.sketchLine_);
   }
-  if (!goog.isNull(this.sketchPoint_)) {
+  if (this.sketchPoint_ !== null) {
     sketchFeatures.push(this.sketchPoint_);
   }
   var overlaySource = this.overlay_.getSource();
@@ -772,7 +772,7 @@ ol.interaction.Draw.prototype.updateSketchFeatures_ = function() {
 ol.interaction.Draw.prototype.updateState_ = function() {
   var map = this.getMap();
   var active = this.getActive();
-  if (goog.isNull(map) || !active) {
+  if (map === null || !active) {
     this.abortDrawing_();
   }
   this.overlay_.setMap(active ? map : null);

--- a/src/ol/interaction/keyboardpaninteraction.js
+++ b/src/ol/interaction/keyboardpaninteraction.js
@@ -85,7 +85,7 @@ ol.interaction.KeyboardPan.handleEvent = function(mapBrowserEvent) {
         keyCode == goog.events.KeyCodes.UP)) {
       var map = mapBrowserEvent.map;
       var view = map.getView();
-      goog.asserts.assert(!goog.isNull(view), 'view should not be null');
+      goog.asserts.assert(view !== null, 'view should not be null');
       var mapUnitsDelta = view.getResolution() * this.pixelDelta_;
       var deltaX = 0, deltaY = 0;
       if (keyCode == goog.events.KeyCodes.DOWN) {

--- a/src/ol/interaction/keyboardzoominteraction.js
+++ b/src/ol/interaction/keyboardzoominteraction.js
@@ -77,7 +77,7 @@ ol.interaction.KeyboardZoom.handleEvent = function(mapBrowserEvent) {
       var delta = (charCode == '+'.charCodeAt(0)) ? this.delta_ : -this.delta_;
       map.render();
       var view = map.getView();
-      goog.asserts.assert(!goog.isNull(view), 'view should not be null');
+      goog.asserts.assert(view !== null, 'view should not be null');
       ol.interaction.Interaction.zoomByDelta(
           map, view, delta, undefined, this.duration_);
       mapBrowserEvent.preventDefault();

--- a/src/ol/interaction/modifyinteraction.js
+++ b/src/ol/interaction/modifyinteraction.js
@@ -243,7 +243,7 @@ ol.interaction.Modify.prototype.addFeature_ = function(feature) {
     this.SEGMENT_WRITERS_[geometry.getType()].call(this, feature, geometry);
   }
   var map = this.getMap();
-  if (!goog.isNull(map)) {
+  if (map !== null) {
     this.handlePointerAtPixel_(this.lastPixel_, map);
   }
   goog.events.listen(feature, goog.events.EventType.CHANGE,
@@ -259,8 +259,7 @@ ol.interaction.Modify.prototype.removeFeature_ = function(feature) {
   this.removeFeatureSegmentData_(feature);
   // Remove the vertex feature if the collection of canditate features
   // is empty.
-  if (!goog.isNull(this.vertexFeature_) &&
-      this.features_.getLength() === 0) {
+  if (this.vertexFeature_ !== null && this.features_.getLength() === 0) {
     this.overlay_.getSource().removeFeature(this.vertexFeature_);
     this.vertexFeature_ = null;
   }
@@ -501,7 +500,7 @@ ol.interaction.Modify.prototype.writeGeometryCollectionGeometry_ =
 ol.interaction.Modify.prototype.createOrUpdateVertexFeature_ =
     function(coordinates) {
   var vertexFeature = this.vertexFeature_;
-  if (goog.isNull(vertexFeature)) {
+  if (vertexFeature === null) {
     vertexFeature = new ol.Feature(new ol.geom.Point(coordinates));
     this.vertexFeature_ = vertexFeature;
     this.overlay_.getSource().addFeature(vertexFeature);
@@ -534,7 +533,7 @@ ol.interaction.Modify.handleDownEvent_ = function(evt) {
   this.handlePointerAtPixel_(evt.pixel, evt.map);
   this.dragSegments_ = [];
   var vertexFeature = this.vertexFeature_;
-  if (!goog.isNull(vertexFeature)) {
+  if (vertexFeature !== null) {
     var insertVertices = [];
     var geometry = /** @type {ol.geom.Point} */ (vertexFeature.getGeometry());
     var vertex = geometry.getCoordinates();
@@ -584,7 +583,7 @@ ol.interaction.Modify.handleDownEvent_ = function(evt) {
         new ol.interaction.ModifyEvent(ol.ModifyEventType.MODIFYSTART,
         this.features_, evt));
   }
-  return !goog.isNull(this.vertexFeature_);
+  return this.vertexFeature_ !== null;
 };
 
 
@@ -678,8 +677,7 @@ ol.interaction.Modify.handleEvent = function(mapBrowserEvent) {
       !this.handlingDownUpSequence) {
     this.handlePointerMove_(mapBrowserEvent);
   }
-  if (!goog.isNull(this.vertexFeature_) &&
-      this.deleteCondition_(mapBrowserEvent)) {
+  if (this.vertexFeature_ !== null && this.deleteCondition_(mapBrowserEvent)) {
     if (mapBrowserEvent.type != ol.MapBrowserEvent.EventType.SINGLECLICK ||
         !this.ignoreNextSingleClick_) {
       var geometry = this.vertexFeature_.getGeometry();
@@ -768,7 +766,7 @@ ol.interaction.Modify.prototype.handlePointerAtPixel_ = function(pixel, map) {
       return;
     }
   }
-  if (!goog.isNull(this.vertexFeature_)) {
+  if (this.vertexFeature_ !== null) {
     this.overlay_.getSource().removeFeature(this.vertexFeature_);
     this.vertexFeature_ = null;
   }
@@ -940,7 +938,7 @@ ol.interaction.Modify.prototype.removeVertex_ = function() {
             newSegmentData);
         this.updateSegmentIndices_(geometry, index, segmentData.depth, -1);
 
-        if (!goog.isNull(this.vertexFeature_)) {
+        if (this.vertexFeature_ !== null) {
           this.overlay_.getSource().removeFeature(this.vertexFeature_);
           this.vertexFeature_ = null;
         }

--- a/src/ol/interaction/mousewheelzoominteraction.js
+++ b/src/ol/interaction/mousewheelzoominteraction.js
@@ -117,7 +117,7 @@ ol.interaction.MouseWheelZoom.prototype.doZoom_ = function(map) {
   var delta = ol.math.clamp(this.delta_, -maxDelta, maxDelta);
 
   var view = map.getView();
-  goog.asserts.assert(!goog.isNull(view), 'view should not be null');
+  goog.asserts.assert(view !== null, 'view should not be null');
 
   map.render();
   ol.interaction.Interaction.zoomByDelta(map, view, -delta, this.lastAnchor_,

--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -305,12 +305,12 @@ ol.interaction.Select.prototype.setMap = function(map) {
   var currentMap = this.getMap();
   var selectedFeatures =
       this.featureOverlay_.getSource().getFeaturesCollection();
-  if (!goog.isNull(currentMap)) {
+  if (currentMap !== null) {
     selectedFeatures.forEach(currentMap.unskipFeature, currentMap);
   }
   goog.base(this, 'setMap', map);
   this.featureOverlay_.setMap(map);
-  if (!goog.isNull(map)) {
+  if (map !== null) {
     selectedFeatures.forEach(map.skipFeature, map);
   }
 };
@@ -341,7 +341,7 @@ ol.interaction.Select.prototype.addFeature_ = function(evt) {
   var map = this.getMap();
   goog.asserts.assertInstanceof(feature, ol.Feature,
       'feature should be an ol.Feature');
-  if (!goog.isNull(map)) {
+  if (map !== null) {
     map.skipFeature(feature);
   }
 };
@@ -356,7 +356,7 @@ ol.interaction.Select.prototype.removeFeature_ = function(evt) {
   var map = this.getMap();
   goog.asserts.assertInstanceof(feature, ol.Feature,
       'feature should be an ol.Feature');
-  if (!goog.isNull(map)) {
+  if (map !== null) {
     map.unskipFeature(feature);
   }
 };

--- a/src/ol/interaction/snapinteraction.js
+++ b/src/ol/interaction/snapinteraction.js
@@ -205,9 +205,9 @@ ol.interaction.Snap.prototype.forEachFeatureRemove_ = function(feature) {
  */
 ol.interaction.Snap.prototype.getFeatures_ = function() {
   var features;
-  if (!goog.isNull(this.features_)) {
+  if (this.features_ !== null) {
     features = this.features_;
-  } else if (!goog.isNull(this.source_)) {
+  } else if (this.source_ !== null) {
     features = this.source_.getFeatures();
   }
   goog.asserts.assert(features !== undefined, 'features should be defined');
@@ -328,12 +328,12 @@ ol.interaction.Snap.prototype.setMap = function(map) {
   goog.base(this, 'setMap', map);
 
   if (map) {
-    if (!goog.isNull(this.features_)) {
+    if (this.features_ !== null) {
       keys.push(this.features_.on(ol.CollectionEventType.ADD,
           this.handleFeatureAdd_, this));
       keys.push(this.features_.on(ol.CollectionEventType.REMOVE,
           this.handleFeatureRemove_, this));
-    } else if (!goog.isNull(this.source_)) {
+    } else if (this.source_ !== null) {
       keys.push(this.source_.on(ol.source.VectorEventType.ADDFEATURE,
           this.handleFeatureAdd_, this));
       keys.push(this.source_.on(ol.source.VectorEventType.REMOVEFEATURE,

--- a/src/ol/interaction/translateinteraction.js
+++ b/src/ol/interaction/translateinteraction.js
@@ -61,7 +61,7 @@ goog.inherits(ol.interaction.Translate, ol.interaction.Pointer);
  */
 ol.interaction.Translate.handleDownEvent_ = function(event) {
   this.lastFeature_ = this.featuresAtPixel_(event.pixel, event.map);
-  if (goog.isNull(this.lastCoordinate_) && !goog.isNull(this.lastFeature_)) {
+  if (this.lastCoordinate_ === null && this.lastFeature_ !== null) {
     this.lastCoordinate_ = event.coordinate;
     ol.interaction.Translate.handleMoveEvent_.call(this, event);
     return true;
@@ -77,7 +77,7 @@ ol.interaction.Translate.handleDownEvent_ = function(event) {
  * @private
  */
 ol.interaction.Translate.handleUpEvent_ = function(event) {
-  if (!goog.isNull(this.lastCoordinate_)) {
+  if (this.lastCoordinate_ !== null) {
     this.lastCoordinate_ = null;
     ol.interaction.Translate.handleMoveEvent_.call(this, event);
     return true;
@@ -92,18 +92,18 @@ ol.interaction.Translate.handleUpEvent_ = function(event) {
  * @private
  */
 ol.interaction.Translate.handleDragEvent_ = function(event) {
-  if (!goog.isNull(this.lastCoordinate_)) {
+  if (this.lastCoordinate_ !== null) {
     var newCoordinate = event.coordinate;
     var deltaX = newCoordinate[0] - this.lastCoordinate_[0];
     var deltaY = newCoordinate[1] - this.lastCoordinate_[1];
 
-    if (!goog.isNull(this.features_)) {
+    if (this.features_ !== null) {
       this.features_.forEach(function(feature) {
         var geom = feature.getGeometry();
         geom.translate(deltaX, deltaY);
         feature.setGeometry(geom);
       });
-    } else if (goog.isNull(this.lastFeature_)) {
+    } else if (this.lastFeature_ === null) {
       var geom = this.lastFeature_.getGeometry();
       geom.translate(deltaX, deltaY);
       this.lastFeature_.setGeometry(geom);
@@ -130,7 +130,7 @@ ol.interaction.Translate.handleMoveEvent_ = function(event)
   if (intersectingFeature) {
     var isSelected = false;
 
-    if (!goog.isNull(this.features_) &&
+    if (this.features_ !== null &&
         ol.array.includes(this.features_.getArray(), intersectingFeature)) {
       isSelected = true;
     }
@@ -138,12 +138,12 @@ ol.interaction.Translate.handleMoveEvent_ = function(event)
     this.previousCursor_ = elem.style.cursor;
 
     // WebKit browsers don't support the grab icons without a prefix
-    elem.style.cursor = !goog.isNull(this.lastCoordinate_) ?
+    elem.style.cursor = this.lastCoordinate_ !== null ?
         '-webkit-grabbing' : (isSelected ? '-webkit-grab' : 'pointer');
 
     // Thankfully, attempting to set the standard ones will silently fail,
     // keeping the prefixed icons
-    elem.style.cursor = goog.isNull(this.lastCoordinate_) ?
+    elem.style.cursor = this.lastCoordinate_ === null ?
         'grabbing' : (isSelected ? 'grab' : 'pointer');
 
   } else {
@@ -171,7 +171,7 @@ ol.interaction.Translate.prototype.featuresAtPixel_ = function(pixel, map) {
         return feature;
       });
 
-  if (!goog.isNull(this.features_) &&
+  if (this.features_ !== null &&
       ol.array.includes(this.features_.getArray(), intersectingFeature)) {
     found = intersectingFeature;
   }

--- a/src/ol/layer/heatmaplayer.js
+++ b/src/ol/layer/heatmaplayer.js
@@ -106,7 +106,7 @@ ol.layer.Heatmap = function(opt_options) {
       'weightFunction should be a function');
 
   this.setStyle(goog.bind(function(feature, resolution) {
-    goog.asserts.assert(!goog.isNull(this.styleCache_),
+    goog.asserts.assert(this.styleCache_ !== null,
         'this.styleCache_ should not be null');
     goog.asserts.assert(this.circleImage_ !== undefined,
         'this.circleImage_ should be defined');
@@ -252,7 +252,7 @@ ol.layer.Heatmap.prototype.handleStyleChanged_ = function() {
 ol.layer.Heatmap.prototype.handleRender_ = function(event) {
   goog.asserts.assert(event.type == ol.render.EventType.RENDER,
       'event.type should be RENDER');
-  goog.asserts.assert(!goog.isNull(this.gradient_),
+  goog.asserts.assert(this.gradient_ !== null,
       'this.gradient_ should not be null');
   var context = event.context;
   var canvas = context.canvas;

--- a/src/ol/layer/layer.js
+++ b/src/ol/layer/layer.js
@@ -118,7 +118,7 @@ ol.layer.Layer.prototype.getSource = function() {
   */
 ol.layer.Layer.prototype.getSourceState = function() {
   var source = this.getSource();
-  return goog.isNull(source) ? ol.source.State.UNDEFINED : source.getState();
+  return source === null ? ol.source.State.UNDEFINED : source.getState();
 };
 
 
@@ -134,12 +134,12 @@ ol.layer.Layer.prototype.handleSourceChange_ = function() {
  * @private
  */
 ol.layer.Layer.prototype.handleSourcePropertyChange_ = function() {
-  if (!goog.isNull(this.sourceChangeKey_)) {
+  if (this.sourceChangeKey_ !== null) {
     goog.events.unlistenByKey(this.sourceChangeKey_);
     this.sourceChangeKey_ = null;
   }
   var source = this.getSource();
-  if (!goog.isNull(source)) {
+  if (source !== null) {
     this.sourceChangeKey_ = goog.events.listen(source,
         goog.events.EventType.CHANGE, this.handleSourceChange_, false, this);
   }
@@ -162,12 +162,12 @@ ol.layer.Layer.prototype.handleSourcePropertyChange_ = function() {
 ol.layer.Layer.prototype.setMap = function(map) {
   goog.events.unlistenByKey(this.mapPrecomposeKey_);
   this.mapPrecomposeKey_ = null;
-  if (goog.isNull(map)) {
+  if (map === null) {
     this.changed();
   }
   goog.events.unlistenByKey(this.mapRenderKey_);
   this.mapRenderKey_ = null;
-  if (!goog.isNull(map)) {
+  if (map !== null) {
     this.mapPrecomposeKey_ = goog.events.listen(
         map, ol.render.EventType.PRECOMPOSE, function(evt) {
           var layerState = this.getLayerState();

--- a/src/ol/layer/vectorlayer.js
+++ b/src/ol/layer/vectorlayer.js
@@ -35,7 +35,7 @@ ol.layer.Vector = function(opt_options) {
       opt_options : /** @type {olx.layer.VectorOptions} */ ({});
 
   goog.asserts.assert(
-      options.renderOrder === undefined || goog.isNull(options.renderOrder) ||
+      options.renderOrder === undefined || options.renderOrder === null ||
       goog.isFunction(options.renderOrder),
       'renderOrder must be a comparator function');
 
@@ -161,7 +161,7 @@ ol.layer.Vector.prototype.getUpdateWhileInteracting = function() {
  */
 ol.layer.Vector.prototype.setRenderOrder = function(renderOrder) {
   goog.asserts.assert(
-      renderOrder === undefined || goog.isNull(renderOrder) ||
+      renderOrder === undefined || renderOrder === null ||
       goog.isFunction(renderOrder),
       'renderOrder must be a comparator function');
   this.set(ol.layer.VectorProperty.RENDER_ORDER, renderOrder);
@@ -181,7 +181,7 @@ ol.layer.Vector.prototype.setRenderOrder = function(renderOrder) {
  */
 ol.layer.Vector.prototype.setStyle = function(style) {
   this.style_ = style !== undefined ? style : ol.style.defaultStyleFunction;
-  this.styleFunction_ = goog.isNull(style) ?
+  this.styleFunction_ = style === null ?
       undefined : ol.style.createStyleFunction(this.style_);
   this.changed();
 };

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -597,7 +597,7 @@ ol.Map.prototype.disposeInternal = function() {
  */
 ol.Map.prototype.forEachFeatureAtPixel =
     function(pixel, callback, opt_this, opt_layerFilter, opt_this2) {
-  if (goog.isNull(this.frameState_)) {
+  if (this.frameState_ === null) {
     return;
   }
   var coordinate = this.getCoordinateFromPixel(pixel);
@@ -635,7 +635,7 @@ ol.Map.prototype.forEachFeatureAtPixel =
  */
 ol.Map.prototype.forEachLayerAtPixel =
     function(pixel, callback, opt_this, opt_layerFilter, opt_this2) {
-  if (goog.isNull(this.frameState_)) {
+  if (this.frameState_ === null) {
     return;
   }
   var thisArg = opt_this !== undefined ? opt_this : null;
@@ -665,7 +665,7 @@ ol.Map.prototype.forEachLayerAtPixel =
  */
 ol.Map.prototype.hasFeatureAtPixel =
     function(pixel, opt_layerFilter, opt_this) {
-  if (goog.isNull(this.frameState_)) {
+  if (this.frameState_ === null) {
     return false;
   }
   var coordinate = this.getCoordinateFromPixel(pixel);
@@ -737,7 +737,7 @@ ol.Map.prototype.getTargetElement = function() {
  */
 ol.Map.prototype.getCoordinateFromPixel = function(pixel) {
   var frameState = this.frameState_;
-  if (goog.isNull(frameState)) {
+  if (frameState === null) {
     return null;
   } else {
     var vec2 = pixel.slice();
@@ -812,7 +812,7 @@ ol.Map.prototype.getLayers = function() {
  */
 ol.Map.prototype.getPixelFromCoordinate = function(coordinate) {
   var frameState = this.frameState_;
-  if (goog.isNull(frameState)) {
+  if (frameState === null) {
     return null;
   } else {
     var vec2 = coordinate.slice(0, 2);
@@ -899,7 +899,7 @@ ol.Map.prototype.getTilePriority =
   // Filter out tiles at higher zoom levels than the current zoom level, or that
   // are outside the visible extent.
   var frameState = this.frameState_;
-  if (goog.isNull(frameState) || !(tileSourceKey in frameState.wantedTiles)) {
+  if (frameState === null || !(tileSourceKey in frameState.wantedTiles)) {
     return ol.structs.PriorityQueue.DROP;
   }
   var coordKey = ol.tilecoord.toString(tile.tileCoord);
@@ -934,7 +934,7 @@ ol.Map.prototype.handleBrowserEvent = function(browserEvent, opt_type) {
  * @param {ol.MapBrowserEvent} mapBrowserEvent The event to handle.
  */
 ol.Map.prototype.handleMapBrowserEvent = function(mapBrowserEvent) {
-  if (goog.isNull(this.frameState_)) {
+  if (this.frameState_ === null) {
     // With no view defined, we cannot translate pixels into geographical
     // coordinates so interactions cannot be used.
     return;
@@ -982,7 +982,7 @@ ol.Map.prototype.handlePostRender = function() {
     var maxTotalLoading = 16;
     var maxNewLoads = maxTotalLoading;
     var tileSourceCount = 0;
-    if (!goog.isNull(frameState)) {
+    if (frameState !== null) {
       var hints = frameState.viewHints;
       if (hints[ol.ViewHint.ANIMATING]) {
         maxTotalLoading = this.loadTilesWhileAnimating_ ? 8 : 0;
@@ -1032,20 +1032,20 @@ ol.Map.prototype.handleTargetChanged_ = function() {
 
   this.keyHandler_.detach();
 
-  if (goog.isNull(targetElement)) {
+  if (targetElement === null) {
     goog.dom.removeNode(this.viewport_);
-    if (!goog.isNull(this.viewportResizeListenerKey_)) {
+    if (this.viewportResizeListenerKey_ !== null) {
       goog.events.unlistenByKey(this.viewportResizeListenerKey_);
       this.viewportResizeListenerKey_ = null;
     }
   } else {
     goog.dom.appendChild(targetElement, this.viewport_);
 
-    var keyboardEventTarget = goog.isNull(this.keyboardEventTarget_) ?
+    var keyboardEventTarget = this.keyboardEventTarget_ === null ?
         targetElement : this.keyboardEventTarget_;
     this.keyHandler_.attach(keyboardEventTarget);
 
-    if (goog.isNull(this.viewportResizeListenerKey_)) {
+    if (this.viewportResizeListenerKey_ === null) {
       this.viewportResizeListenerKey_ = goog.events.listen(
           this.viewportSizeMonitor_, goog.events.EventType.RESIZE,
           this.updateSize, false, this);
@@ -1078,12 +1078,12 @@ ol.Map.prototype.handleViewPropertyChanged_ = function() {
  * @private
  */
 ol.Map.prototype.handleViewChanged_ = function() {
-  if (!goog.isNull(this.viewPropertyListenerKey_)) {
+  if (this.viewPropertyListenerKey_ !== null) {
     goog.events.unlistenByKey(this.viewPropertyListenerKey_);
     this.viewPropertyListenerKey_ = null;
   }
   var view = this.getView();
-  if (!goog.isNull(view)) {
+  if (view !== null) {
     this.viewPropertyListenerKey_ = goog.events.listen(
         view, ol.ObjectEventType.PROPERTYCHANGE,
         this.handleViewPropertyChanged_, false, this);
@@ -1118,7 +1118,7 @@ ol.Map.prototype.handleLayerGroupPropertyChanged_ = function(event) {
  * @private
  */
 ol.Map.prototype.handleLayerGroupChanged_ = function() {
-  if (!goog.isNull(this.layerGroupPropertyListenerKeys_)) {
+  if (this.layerGroupPropertyListenerKeys_ !== null) {
     this.layerGroupPropertyListenerKeys_.forEach(goog.events.unlistenByKey);
     this.layerGroupPropertyListenerKeys_ = null;
   }
@@ -1155,7 +1155,7 @@ ol.Map.prototype.isDef = function() {
     return false;
   }
   var view = this.getView();
-  if (goog.isNull(view) || !view.isDef()) {
+  if (view === null || !view.isDef()) {
     return false;
   }
   return true;
@@ -1166,7 +1166,7 @@ ol.Map.prototype.isDef = function() {
  * @return {boolean} Is rendered.
  */
 ol.Map.prototype.isRendered = function() {
-  return !goog.isNull(this.frameState_);
+  return this.frameState_ !== null;
 };
 
 
@@ -1259,7 +1259,7 @@ ol.Map.prototype.renderFrame_ = function(time) {
   /** @type {?olx.FrameState} */
   var frameState = null;
   if (size !== undefined && ol.size.hasArea(size) &&
-      !goog.isNull(view) && view.isDef()) {
+      view !== null && view.isDef()) {
     var viewHints = view.getHints();
     var layerStatesArray = this.getLayerGroup().getLayerStatesArray();
     var layerStates = {};
@@ -1272,7 +1272,7 @@ ol.Map.prototype.renderFrame_ = function(time) {
       attributions: {},
       coordinateToPixelMatrix: this.coordinateToPixelMatrix_,
       extent: null,
-      focus: goog.isNull(this.focus_) ? viewState.center : this.focus_,
+      focus: this.focus_ === null ? viewState.center : this.focus_,
       index: this.frameIndex_++,
       layerStates: layerStates,
       layerStatesArray: layerStatesArray,
@@ -1291,7 +1291,7 @@ ol.Map.prototype.renderFrame_ = function(time) {
     });
   }
 
-  if (!goog.isNull(frameState)) {
+  if (frameState !== null) {
     var preRenderFunctions = this.preRenderFunctions_;
     var n = 0, preRenderFunction;
     for (i = 0, ii = preRenderFunctions.length; i < ii; ++i) {
@@ -1309,7 +1309,7 @@ ol.Map.prototype.renderFrame_ = function(time) {
   this.frameState_ = frameState;
   this.renderer_.renderFrame(frameState);
 
-  if (!goog.isNull(frameState)) {
+  if (frameState !== null) {
     if (frameState.animate) {
       this.render();
     }
@@ -1400,7 +1400,7 @@ ol.Map.prototype.skipFeature = function(feature) {
 ol.Map.prototype.updateSize = function() {
   var targetElement = this.getTargetElement();
 
-  if (goog.isNull(targetElement)) {
+  if (targetElement === null) {
     this.setSize(undefined);
   } else {
     var size = goog.style.getContentBoxSize(targetElement);

--- a/src/ol/mapbrowserevent.js
+++ b/src/ol/mapbrowserevent.js
@@ -284,8 +284,7 @@ ol.MapBrowserEventHandler.prototype.handlePointerUp_ = function(pointerEvent) {
   // to 0).
   // See http://www.w3.org/TR/pointerevents/#button-states
   if (!this.dragging_ && this.isMouseActionButton_(pointerEvent)) {
-    goog.asserts.assert(!goog.isNull(this.down_),
-        'this.down_ should not be null');
+    goog.asserts.assert(this.down_ !== null, 'this.down_ should not be null');
     this.emulateClick_(this.down_);
   }
 
@@ -326,7 +325,7 @@ ol.MapBrowserEventHandler.prototype.handlePointerDown_ =
 
   this.down_ = pointerEvent;
 
-  if (goog.isNull(this.dragListenerKeys_)) {
+  if (this.dragListenerKeys_ === null) {
     /* Set up a pointer event handler on the `document`,
      * which is required when the pointer is moved outside
      * the viewport when dragging.
@@ -396,7 +395,7 @@ ol.MapBrowserEventHandler.prototype.handlePointerMove_ =
  * @private
  */
 ol.MapBrowserEventHandler.prototype.relayEvent_ = function(pointerEvent) {
-  var dragging = !goog.isNull(this.down_) && this.isMoving_(pointerEvent);
+  var dragging = this.down_ !== null && this.isMoving_(pointerEvent);
   this.dispatchEvent(new ol.MapBrowserPointerEvent(
       pointerEvent.type, this.map_, pointerEvent, dragging));
 };
@@ -417,23 +416,23 @@ ol.MapBrowserEventHandler.prototype.isMoving_ = function(pointerEvent) {
  * @inheritDoc
  */
 ol.MapBrowserEventHandler.prototype.disposeInternal = function() {
-  if (!goog.isNull(this.relayedListenerKey_)) {
+  if (this.relayedListenerKey_ !== null) {
     goog.events.unlistenByKey(this.relayedListenerKey_);
     this.relayedListenerKey_ = null;
   }
-  if (!goog.isNull(this.pointerdownListenerKey_)) {
+  if (this.pointerdownListenerKey_ !== null) {
     goog.events.unlistenByKey(this.pointerdownListenerKey_);
     this.pointerdownListenerKey_ = null;
   }
-  if (!goog.isNull(this.dragListenerKeys_)) {
+  if (this.dragListenerKeys_ !== null) {
     this.dragListenerKeys_.forEach(goog.events.unlistenByKey);
     this.dragListenerKeys_ = null;
   }
-  if (!goog.isNull(this.documentPointerEventHandler_)) {
+  if (this.documentPointerEventHandler_ !== null) {
     goog.dispose(this.documentPointerEventHandler_);
     this.documentPointerEventHandler_ = null;
   }
-  if (!goog.isNull(this.pointerEventHandler_)) {
+  if (this.pointerEventHandler_ !== null) {
     goog.dispose(this.pointerEventHandler_);
     this.pointerEventHandler_ = null;
   }

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -254,7 +254,7 @@ ol.Overlay.prototype.handleElementChanged = function() {
  * @protected
  */
 ol.Overlay.prototype.handleMapChanged = function() {
-  if (!goog.isNull(this.mapPostrenderListenerKey_)) {
+  if (this.mapPostrenderListenerKey_ !== null) {
     goog.dom.removeNode(this.element_);
     goog.events.unlistenByKey(this.mapPostrenderListenerKey_);
     this.mapPostrenderListenerKey_ = null;
@@ -366,7 +366,7 @@ ol.Overlay.prototype.panIntoView_ = function() {
   goog.asserts.assert(this.autoPan, 'this.autoPan should be true');
   var map = this.getMap();
 
-  if (map === undefined || goog.isNull(map.getTargetElement())) {
+  if (map === undefined || map.getTargetElement() === null) {
     return;
   }
 
@@ -410,7 +410,7 @@ ol.Overlay.prototype.panIntoView_ = function() {
         centerPx[1] + delta[1]
       ];
 
-      if (!goog.isNull(this.autoPanAnimation_)) {
+      if (this.autoPanAnimation_ !== null) {
         this.autoPanAnimation_.source = center;
         map.beforeRender(ol.animation.pan(this.autoPanAnimation_));
       }
@@ -491,7 +491,7 @@ ol.Overlay.prototype.updatePixelPosition = function() {
  * @protected
  */
 ol.Overlay.prototype.updateRenderedPosition = function(pixel, mapSize) {
-  goog.asserts.assert(!goog.isNull(pixel), 'pixel should not be null');
+  goog.asserts.assert(pixel !== null, 'pixel should not be null');
   goog.asserts.assert(mapSize !== undefined, 'mapSize should be defined');
   var style = this.element_.style;
   var offset = this.getOffset();

--- a/src/ol/pointer/pointereventhandler.js
+++ b/src/ol/pointer/pointereventhandler.js
@@ -366,7 +366,7 @@ ol.pointer.PointerEventHandler.prototype.enterOver =
  */
 ol.pointer.PointerEventHandler.prototype.contains_ =
     function(container, contained) {
-  if (goog.isNull(contained)) {
+  if (contained === null) {
     return false;
   }
   return goog.dom.contains(container, contained);

--- a/src/ol/proj/proj.js
+++ b/src/ol/proj/proj.js
@@ -125,7 +125,7 @@ ol.proj.Projection = function(options) {
    * @private
    * @type {boolean}
    */
-  this.canWrapX_ = this.global_ && !goog.isNull(this.extent_);
+  this.canWrapX_ = this.global_ && this.extent_ !== null;
 
   /**
   * @private
@@ -272,7 +272,7 @@ ol.proj.Projection.prototype.isGlobal = function() {
 */
 ol.proj.Projection.prototype.setGlobal = function(global) {
   this.global_ = global;
-  this.canWrapX_ = global && !goog.isNull(this.extent_);
+  this.canWrapX_ = global && this.extent_ !== null;
 };
 
 
@@ -299,7 +299,7 @@ ol.proj.Projection.prototype.setDefaultTileGrid = function(tileGrid) {
  */
 ol.proj.Projection.prototype.setExtent = function(extent) {
   this.extent_ = extent;
-  this.canWrapX_ = this.global_ && !goog.isNull(extent);
+  this.canWrapX_ = this.global_ && extent !== null;
 };
 
 

--- a/src/ol/render/box.js
+++ b/src/ol/render/box.js
@@ -62,11 +62,11 @@ goog.inherits(ol.render.Box, goog.Disposable);
  * @return {ol.geom.Polygon} Geometry.
  */
 ol.render.Box.prototype.createGeometry_ = function() {
-  goog.asserts.assert(!goog.isNull(this.startPixel_),
+  goog.asserts.assert(this.startPixel_ !== null,
       'this.startPixel_ should not be null');
-  goog.asserts.assert(!goog.isNull(this.endPixel_),
+  goog.asserts.assert(this.endPixel_ !== null,
       'this.endPixel_ should not be null');
-  goog.asserts.assert(!goog.isNull(this.map_), 'this.map_ should not be null');
+  goog.asserts.assert(this.map_ !== null, 'this.map_ should not be null');
   var startPixel = this.startPixel_;
   var endPixel = this.endPixel_;
   var pixels = [
@@ -99,7 +99,7 @@ ol.render.Box.prototype.handleMapPostCompose_ = function(event) {
   goog.asserts.assert(goog.isDefAndNotNull(geometry),
       'geometry should be defined');
   var style = this.style_;
-  goog.asserts.assert(!goog.isNull(style), 'style should not be null');
+  goog.asserts.assert(style !== null, 'style should not be null');
   // use drawAsync(Infinity) to draw above everything
   event.vectorContext.drawAsync(Infinity, function(render) {
     render.setFillStrokeStyle(style.getFill(), style.getStroke());
@@ -121,9 +121,9 @@ ol.render.Box.prototype.getGeometry = function() {
  * @private
  */
 ol.render.Box.prototype.requestMapRenderFrame_ = function() {
-  if (!goog.isNull(this.map_) &&
-      !goog.isNull(this.startPixel_) &&
-      !goog.isNull(this.endPixel_)) {
+  if (this.map_ !== null &&
+      this.startPixel_ !== null &&
+      this.endPixel_ !== null) {
     this.map_.render();
   }
 };
@@ -133,14 +133,14 @@ ol.render.Box.prototype.requestMapRenderFrame_ = function() {
  * @param {ol.Map} map Map.
  */
 ol.render.Box.prototype.setMap = function(map) {
-  if (!goog.isNull(this.postComposeListenerKey_)) {
+  if (this.postComposeListenerKey_ !== null) {
     goog.events.unlistenByKey(this.postComposeListenerKey_);
     this.postComposeListenerKey_ = null;
     this.map_.render();
     this.map_ = null;
   }
   this.map_ = map;
-  if (!goog.isNull(this.map_)) {
+  if (this.map_ !== null) {
     this.postComposeListenerKey_ = goog.events.listen(
         map, ol.render.EventType.POSTCOMPOSE, this.handleMapPostCompose_, false,
         this);

--- a/src/ol/render/canvas/canvasimmediate.js
+++ b/src/ol/render/canvas/canvasimmediate.js
@@ -250,7 +250,7 @@ ol.render.canvas.Immediate =
  */
 ol.render.canvas.Immediate.prototype.drawImages_ =
     function(flatCoordinates, offset, end, stride) {
-  if (goog.isNull(this.image_)) {
+  if (this.image_ === null) {
     return;
   }
   goog.asserts.assert(offset === 0, 'offset should be 0');
@@ -313,13 +313,13 @@ ol.render.canvas.Immediate.prototype.drawImages_ =
  */
 ol.render.canvas.Immediate.prototype.drawText_ =
     function(flatCoordinates, offset, end, stride) {
-  if (goog.isNull(this.textState_) || this.text_ === '') {
+  if (this.textState_ === null || this.text_ === '') {
     return;
   }
-  if (!goog.isNull(this.textFillState_)) {
+  if (this.textFillState_ !== null) {
     this.setContextFillState_(this.textFillState_);
   }
-  if (!goog.isNull(this.textStrokeState_)) {
+  if (this.textStrokeState_ !== null) {
     this.setContextStrokeState_(this.textStrokeState_);
   }
   this.setContextTextState_(this.textState_);
@@ -344,10 +344,10 @@ ol.render.canvas.Immediate.prototype.drawText_ =
           goog.vec.Mat4.getElement(localTransform, 0, 3),
           goog.vec.Mat4.getElement(localTransform, 1, 3));
     }
-    if (!goog.isNull(this.textStrokeState_)) {
+    if (this.textStrokeState_ !== null) {
       context.strokeText(this.text_, x, y);
     }
-    if (!goog.isNull(this.textFillState_)) {
+    if (this.textFillState_ !== null) {
       context.fillText(this.text_, x, y);
     }
   }
@@ -438,11 +438,11 @@ ol.render.canvas.Immediate.prototype.drawCircleGeometry =
   if (!ol.extent.intersects(this.extent_, circleGeometry.getExtent())) {
     return;
   }
-  if (!goog.isNull(this.fillState_) || !goog.isNull(this.strokeState_)) {
-    if (!goog.isNull(this.fillState_)) {
+  if (this.fillState_ !== null || this.strokeState_ !== null) {
+    if (this.fillState_ !== null) {
       this.setContextFillState_(this.fillState_);
     }
-    if (!goog.isNull(this.strokeState_)) {
+    if (this.strokeState_ !== null) {
       this.setContextStrokeState_(this.strokeState_);
     }
     var pixelCoordinates = ol.geom.transformSimpleGeometry2D(
@@ -454,10 +454,10 @@ ol.render.canvas.Immediate.prototype.drawCircleGeometry =
     context.beginPath();
     context.arc(
         pixelCoordinates[0], pixelCoordinates[1], radius, 0, 2 * Math.PI);
-    if (!goog.isNull(this.fillState_)) {
+    if (this.fillState_ !== null) {
       context.fill();
     }
-    if (!goog.isNull(this.strokeState_)) {
+    if (this.strokeState_ !== null) {
       context.stroke();
     }
   }
@@ -536,7 +536,7 @@ ol.render.canvas.Immediate.prototype.drawPointGeometry =
     function(pointGeometry, feature) {
   var flatCoordinates = pointGeometry.getFlatCoordinates();
   var stride = pointGeometry.getStride();
-  if (!goog.isNull(this.image_)) {
+  if (this.image_ !== null) {
     this.drawImages_(flatCoordinates, 0, flatCoordinates.length, stride);
   }
   if (this.text_ !== '') {
@@ -557,7 +557,7 @@ ol.render.canvas.Immediate.prototype.drawMultiPointGeometry =
     function(multiPointGeometry, feature) {
   var flatCoordinates = multiPointGeometry.getFlatCoordinates();
   var stride = multiPointGeometry.getStride();
-  if (!goog.isNull(this.image_)) {
+  if (this.image_ !== null) {
     this.drawImages_(flatCoordinates, 0, flatCoordinates.length, stride);
   }
   if (this.text_ !== '') {
@@ -579,7 +579,7 @@ ol.render.canvas.Immediate.prototype.drawLineStringGeometry =
   if (!ol.extent.intersects(this.extent_, lineStringGeometry.getExtent())) {
     return;
   }
-  if (!goog.isNull(this.strokeState_)) {
+  if (this.strokeState_ !== null) {
     this.setContextStrokeState_(this.strokeState_);
     var context = this.context_;
     var flatCoordinates = lineStringGeometry.getFlatCoordinates();
@@ -610,7 +610,7 @@ ol.render.canvas.Immediate.prototype.drawMultiLineStringGeometry =
   if (!ol.extent.intersects(this.extent_, geometryExtent)) {
     return;
   }
-  if (!goog.isNull(this.strokeState_)) {
+  if (this.strokeState_ !== null) {
     this.setContextStrokeState_(this.strokeState_);
     var context = this.context_;
     var flatCoordinates = multiLineStringGeometry.getFlatCoordinates();
@@ -645,21 +645,21 @@ ol.render.canvas.Immediate.prototype.drawPolygonGeometry =
   if (!ol.extent.intersects(this.extent_, polygonGeometry.getExtent())) {
     return;
   }
-  if (!goog.isNull(this.strokeState_) || !goog.isNull(this.fillState_)) {
-    if (!goog.isNull(this.fillState_)) {
+  if (this.strokeState_ !== null || this.fillState_ !== null) {
+    if (this.fillState_ !== null) {
       this.setContextFillState_(this.fillState_);
     }
-    if (!goog.isNull(this.strokeState_)) {
+    if (this.strokeState_ !== null) {
       this.setContextStrokeState_(this.strokeState_);
     }
     var context = this.context_;
     context.beginPath();
     this.drawRings_(polygonGeometry.getOrientedFlatCoordinates(),
         0, polygonGeometry.getEnds(), polygonGeometry.getStride());
-    if (!goog.isNull(this.fillState_)) {
+    if (this.fillState_ !== null) {
       context.fill();
     }
-    if (!goog.isNull(this.strokeState_)) {
+    if (this.strokeState_ !== null) {
       context.stroke();
     }
   }
@@ -682,11 +682,11 @@ ol.render.canvas.Immediate.prototype.drawMultiPolygonGeometry =
   if (!ol.extent.intersects(this.extent_, multiPolygonGeometry.getExtent())) {
     return;
   }
-  if (!goog.isNull(this.strokeState_) || !goog.isNull(this.fillState_)) {
-    if (!goog.isNull(this.fillState_)) {
+  if (this.strokeState_ !== null || this.fillState_ !== null) {
+    if (this.fillState_ !== null) {
       this.setContextFillState_(this.fillState_);
     }
-    if (!goog.isNull(this.strokeState_)) {
+    if (this.strokeState_ !== null) {
       this.setContextStrokeState_(this.strokeState_);
     }
     var context = this.context_;
@@ -699,10 +699,10 @@ ol.render.canvas.Immediate.prototype.drawMultiPolygonGeometry =
       var ends = endss[i];
       context.beginPath();
       offset = this.drawRings_(flatCoordinates, offset, ends, stride);
-      if (!goog.isNull(this.fillState_)) {
+      if (this.fillState_ !== null) {
         context.fill();
       }
-      if (!goog.isNull(this.strokeState_)) {
+      if (this.strokeState_ !== null) {
         context.stroke();
       }
     }
@@ -745,7 +745,7 @@ ol.render.canvas.Immediate.prototype.setContextFillState_ =
     function(fillState) {
   var context = this.context_;
   var contextFillState = this.contextFillState_;
-  if (goog.isNull(contextFillState)) {
+  if (contextFillState === null) {
     context.fillStyle = fillState.fillStyle;
     this.contextFillState_ = {
       fillStyle: fillState.fillStyle
@@ -766,7 +766,7 @@ ol.render.canvas.Immediate.prototype.setContextStrokeState_ =
     function(strokeState) {
   var context = this.context_;
   var contextStrokeState = this.contextStrokeState_;
-  if (goog.isNull(contextStrokeState)) {
+  if (contextStrokeState === null) {
     context.lineCap = strokeState.lineCap;
     if (ol.has.CANVAS_LINE_DASH) {
       context.setLineDash(strokeState.lineDash);
@@ -819,7 +819,7 @@ ol.render.canvas.Immediate.prototype.setContextTextState_ =
     function(textState) {
   var context = this.context_;
   var contextTextState = this.contextTextState_;
-  if (goog.isNull(contextTextState)) {
+  if (contextTextState === null) {
     context.font = textState.font;
     context.textAlign = textState.textAlign;
     context.textBaseline = textState.textBaseline;
@@ -853,16 +853,16 @@ ol.render.canvas.Immediate.prototype.setContextTextState_ =
  */
 ol.render.canvas.Immediate.prototype.setFillStrokeStyle =
     function(fillStyle, strokeStyle) {
-  if (goog.isNull(fillStyle)) {
+  if (fillStyle === null) {
     this.fillState_ = null;
   } else {
     var fillStyleColor = fillStyle.getColor();
     this.fillState_ = {
-      fillStyle: ol.color.asString(!goog.isNull(fillStyleColor) ?
+      fillStyle: ol.color.asString(fillStyleColor !== null ?
           fillStyleColor : ol.render.canvas.defaultFillStyle)
     };
   }
-  if (goog.isNull(strokeStyle)) {
+  if (strokeStyle === null) {
     this.strokeState_ = null;
   } else {
     var strokeStyleColor = strokeStyle.getColor();
@@ -882,7 +882,7 @@ ol.render.canvas.Immediate.prototype.setFillStrokeStyle =
           strokeStyleWidth : ol.render.canvas.defaultLineWidth),
       miterLimit: strokeStyleMiterLimit !== undefined ?
           strokeStyleMiterLimit : ol.render.canvas.defaultMiterLimit,
-      strokeStyle: ol.color.asString(!goog.isNull(strokeStyleColor) ?
+      strokeStyle: ol.color.asString(strokeStyleColor !== null ?
           strokeStyleColor : ol.render.canvas.defaultStrokeStyle)
     };
   }
@@ -897,7 +897,7 @@ ol.render.canvas.Immediate.prototype.setFillStrokeStyle =
  * @api
  */
 ol.render.canvas.Immediate.prototype.setImageStyle = function(imageStyle) {
-  if (goog.isNull(imageStyle)) {
+  if (imageStyle === null) {
     this.image_ = null;
   } else {
     var imageAnchor = imageStyle.getAnchor();
@@ -905,14 +905,10 @@ ol.render.canvas.Immediate.prototype.setImageStyle = function(imageStyle) {
     var imageImage = imageStyle.getImage(1);
     var imageOrigin = imageStyle.getOrigin();
     var imageSize = imageStyle.getSize();
-    goog.asserts.assert(!goog.isNull(imageAnchor),
-        'imageAnchor should not be null');
-    goog.asserts.assert(!goog.isNull(imageImage),
-        'imageImage should not be null');
-    goog.asserts.assert(!goog.isNull(imageOrigin),
-        'imageOrigin should not be null');
-    goog.asserts.assert(!goog.isNull(imageSize),
-        'imageSize should not be null');
+    goog.asserts.assert(imageAnchor !== null, 'imageAnchor should not be null');
+    goog.asserts.assert(imageImage !== null, 'imageImage should not be null');
+    goog.asserts.assert(imageOrigin !== null, 'imageOrigin should not be null');
+    goog.asserts.assert(imageSize !== null, 'imageSize should not be null');
     this.imageAnchorX_ = imageAnchor[0];
     this.imageAnchorY_ = imageAnchor[1];
     this.imageHeight_ = imageSize[1];
@@ -937,21 +933,21 @@ ol.render.canvas.Immediate.prototype.setImageStyle = function(imageStyle) {
  * @api
  */
 ol.render.canvas.Immediate.prototype.setTextStyle = function(textStyle) {
-  if (goog.isNull(textStyle)) {
+  if (textStyle === null) {
     this.text_ = '';
   } else {
     var textFillStyle = textStyle.getFill();
-    if (goog.isNull(textFillStyle)) {
+    if (textFillStyle === null) {
       this.textFillState_ = null;
     } else {
       var textFillStyleColor = textFillStyle.getColor();
       this.textFillState_ = {
-        fillStyle: ol.color.asString(!goog.isNull(textFillStyleColor) ?
+        fillStyle: ol.color.asString(textFillStyleColor !== null ?
             textFillStyleColor : ol.render.canvas.defaultFillStyle)
       };
     }
     var textStrokeStyle = textStyle.getStroke();
-    if (goog.isNull(textStrokeStyle)) {
+    if (textStrokeStyle === null) {
       this.textStrokeState_ = null;
     } else {
       var textStrokeStyleColor = textStrokeStyle.getColor();
@@ -971,7 +967,7 @@ ol.render.canvas.Immediate.prototype.setTextStyle = function(textStyle) {
             textStrokeStyleWidth : ol.render.canvas.defaultLineWidth,
         miterLimit: textStrokeStyleMiterLimit !== undefined ?
             textStrokeStyleMiterLimit : ol.render.canvas.defaultMiterLimit,
-        strokeStyle: ol.color.asString(!goog.isNull(textStrokeStyleColor) ?
+        strokeStyle: ol.color.asString(textStrokeStyleColor !== null ?
             textStrokeStyleColor : ol.render.canvas.defaultStrokeStyle)
       };
     }

--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -450,7 +450,7 @@ ol.render.canvas.Replay.prototype.replay_ = function(
             '5th instruction should be a string');
         goog.asserts.assert(goog.isNumber(instruction[5]),
             '6th instruction should be a number');
-        goog.asserts.assert(!goog.isNull(instruction[6]),
+        goog.asserts.assert(instruction[6] !== null,
             '7th instruction should not be null');
         var usePixelRatio = instruction[7] !== undefined ?
             instruction[7] : true;
@@ -567,11 +567,11 @@ ol.render.canvas.Replay.prototype.reverseHitDetectionInstructions_ =
  * @param {ol.Feature} feature Feature.
  */
 ol.render.canvas.Replay.prototype.endGeometry = function(geometry, feature) {
-  goog.asserts.assert(!goog.isNull(this.beginGeometryInstruction1_),
+  goog.asserts.assert(this.beginGeometryInstruction1_ !== null,
       'this.beginGeometryInstruction1_ should not be null');
   this.beginGeometryInstruction1_[2] = this.instructions.length;
   this.beginGeometryInstruction1_ = null;
-  goog.asserts.assert(!goog.isNull(this.beginGeometryInstruction2_),
+  goog.asserts.assert(this.beginGeometryInstruction2_ !== null,
       'this.beginGeometryInstruction2_ should not be null');
   this.beginGeometryInstruction2_[2] = this.hitDetectionInstructions.length;
   this.beginGeometryInstruction2_ = null;
@@ -715,7 +715,7 @@ ol.render.canvas.ImageReplay.prototype.drawCoordinates_ =
  */
 ol.render.canvas.ImageReplay.prototype.drawPointGeometry =
     function(pointGeometry, feature) {
-  if (goog.isNull(this.image_)) {
+  if (this.image_ === null) {
     return;
   }
   goog.asserts.assert(this.anchorX_ !== undefined,
@@ -768,7 +768,7 @@ ol.render.canvas.ImageReplay.prototype.drawPointGeometry =
  */
 ol.render.canvas.ImageReplay.prototype.drawMultiPointGeometry =
     function(multiPointGeometry, feature) {
-  if (goog.isNull(this.image_)) {
+  if (this.image_ === null) {
     return;
   }
   goog.asserts.assert(this.anchorX_ !== undefined,
@@ -842,19 +842,18 @@ ol.render.canvas.ImageReplay.prototype.finish = function() {
  * @inheritDoc
  */
 ol.render.canvas.ImageReplay.prototype.setImageStyle = function(imageStyle) {
-  goog.asserts.assert(!goog.isNull(imageStyle),
-      'imageStyle should not be null');
+  goog.asserts.assert(imageStyle !== null, 'imageStyle should not be null');
   var anchor = imageStyle.getAnchor();
-  goog.asserts.assert(!goog.isNull(anchor), 'anchor should not be null');
+  goog.asserts.assert(anchor !== null, 'anchor should not be null');
   var size = imageStyle.getSize();
-  goog.asserts.assert(!goog.isNull(size), 'size should not be null');
+  goog.asserts.assert(size !== null, 'size should not be null');
   var hitDetectionImage = imageStyle.getHitDetectionImage(1);
-  goog.asserts.assert(!goog.isNull(hitDetectionImage),
+  goog.asserts.assert(hitDetectionImage !== null,
       'hitDetectionImage should not be null');
   var image = imageStyle.getImage(1);
-  goog.asserts.assert(!goog.isNull(image), 'image should not be null');
+  goog.asserts.assert(image !== null, 'image should not be null');
   var origin = imageStyle.getOrigin();
-  goog.asserts.assert(!goog.isNull(origin), 'origin should not be null');
+  goog.asserts.assert(origin !== null, 'origin should not be null');
   this.anchorX_ = anchor[0];
   this.anchorY_ = anchor[1];
   this.hitDetectionImage_ = hitDetectionImage;
@@ -946,7 +945,7 @@ ol.render.canvas.LineStringReplay.prototype.drawFlatCoordinates_ =
  * @inheritDoc
  */
 ol.render.canvas.LineStringReplay.prototype.getBufferedMaxExtent = function() {
-  if (goog.isNull(this.bufferedMaxExtent_)) {
+  if (this.bufferedMaxExtent_ === null) {
     this.bufferedMaxExtent_ = ol.extent.clone(this.maxExtent);
     if (this.maxLineWidth > 0) {
       var width = this.resolution * (this.maxLineWidth + 1) / 2;
@@ -971,7 +970,7 @@ ol.render.canvas.LineStringReplay.prototype.setStrokeStyle_ = function() {
   goog.asserts.assert(strokeStyle !== undefined,
       'strokeStyle should be defined');
   goog.asserts.assert(lineCap !== undefined, 'lineCap should be defined');
-  goog.asserts.assert(!goog.isNull(lineDash), 'lineDash should not be null');
+  goog.asserts.assert(lineDash !== null, 'lineDash should not be null');
   goog.asserts.assert(lineJoin !== undefined, 'lineJoin should be defined');
   goog.asserts.assert(lineWidth !== undefined, 'lineWidth should be defined');
   goog.asserts.assert(miterLimit !== undefined, 'miterLimit should be defined');
@@ -1006,7 +1005,7 @@ ol.render.canvas.LineStringReplay.prototype.setStrokeStyle_ = function() {
 ol.render.canvas.LineStringReplay.prototype.drawLineStringGeometry =
     function(lineStringGeometry, feature) {
   var state = this.state_;
-  goog.asserts.assert(!goog.isNull(state), 'state should not be null');
+  goog.asserts.assert(state !== null, 'state should not be null');
   var strokeStyle = state.strokeStyle;
   var lineWidth = state.lineWidth;
   if (strokeStyle === undefined || lineWidth === undefined) {
@@ -1034,7 +1033,7 @@ ol.render.canvas.LineStringReplay.prototype.drawLineStringGeometry =
 ol.render.canvas.LineStringReplay.prototype.drawMultiLineStringGeometry =
     function(multiLineStringGeometry, feature) {
   var state = this.state_;
-  goog.asserts.assert(!goog.isNull(state), 'state should not be null');
+  goog.asserts.assert(state !== null, 'state should not be null');
   var strokeStyle = state.strokeStyle;
   var lineWidth = state.lineWidth;
   if (strokeStyle === undefined || lineWidth === undefined) {
@@ -1066,7 +1065,7 @@ ol.render.canvas.LineStringReplay.prototype.drawMultiLineStringGeometry =
  */
 ol.render.canvas.LineStringReplay.prototype.finish = function() {
   var state = this.state_;
-  goog.asserts.assert(!goog.isNull(state), 'state should not be null');
+  goog.asserts.assert(state !== null, 'state should not be null');
   if (state.lastStroke != this.coordinates.length) {
     this.instructions.push([ol.render.canvas.Instruction.STROKE]);
   }
@@ -1080,19 +1079,17 @@ ol.render.canvas.LineStringReplay.prototype.finish = function() {
  */
 ol.render.canvas.LineStringReplay.prototype.setFillStrokeStyle =
     function(fillStyle, strokeStyle) {
-  goog.asserts.assert(!goog.isNull(this.state_),
-      'this.state_ should not be null');
-  goog.asserts.assert(goog.isNull(fillStyle), 'fillStyle should be null');
-  goog.asserts.assert(!goog.isNull(strokeStyle),
-      'strokeStyle should not be null');
+  goog.asserts.assert(this.state_ !== null, 'this.state_ should not be null');
+  goog.asserts.assert(fillStyle === null, 'fillStyle should be null');
+  goog.asserts.assert(strokeStyle !== null, 'strokeStyle should not be null');
   var strokeStyleColor = strokeStyle.getColor();
-  this.state_.strokeStyle = ol.color.asString(!goog.isNull(strokeStyleColor) ?
+  this.state_.strokeStyle = ol.color.asString(strokeStyleColor !== null ?
       strokeStyleColor : ol.render.canvas.defaultStrokeStyle);
   var strokeStyleLineCap = strokeStyle.getLineCap();
   this.state_.lineCap = strokeStyleLineCap !== undefined ?
       strokeStyleLineCap : ol.render.canvas.defaultLineCap;
   var strokeStyleLineDash = strokeStyle.getLineDash();
-  this.state_.lineDash = !goog.isNull(strokeStyleLineDash) ?
+  this.state_.lineDash = strokeStyleLineDash !== null ?
       strokeStyleLineDash : ol.render.canvas.defaultLineDash;
   var strokeStyleLineJoin = strokeStyle.getLineJoin();
   this.state_.lineJoin = strokeStyleLineJoin !== undefined ?
@@ -1216,7 +1213,7 @@ ol.render.canvas.PolygonReplay.prototype.drawFlatCoordinatess_ =
 ol.render.canvas.PolygonReplay.prototype.drawCircleGeometry =
     function(circleGeometry, feature) {
   var state = this.state_;
-  goog.asserts.assert(!goog.isNull(state), 'state should not be null');
+  goog.asserts.assert(state !== null, 'state should not be null');
   var fillStyle = state.fillStyle;
   var strokeStyle = state.strokeStyle;
   if (fillStyle === undefined && strokeStyle === undefined) {
@@ -1269,7 +1266,7 @@ ol.render.canvas.PolygonReplay.prototype.drawCircleGeometry =
 ol.render.canvas.PolygonReplay.prototype.drawPolygonGeometry =
     function(polygonGeometry, feature) {
   var state = this.state_;
-  goog.asserts.assert(!goog.isNull(state), 'state should not be null');
+  goog.asserts.assert(state !== null, 'state should not be null');
   var fillStyle = state.fillStyle;
   var strokeStyle = state.strokeStyle;
   if (fillStyle === undefined && strokeStyle === undefined) {
@@ -1305,7 +1302,7 @@ ol.render.canvas.PolygonReplay.prototype.drawPolygonGeometry =
 ol.render.canvas.PolygonReplay.prototype.drawMultiPolygonGeometry =
     function(multiPolygonGeometry, feature) {
   var state = this.state_;
-  goog.asserts.assert(!goog.isNull(state), 'state should not be null');
+  goog.asserts.assert(state !== null, 'state should not be null');
   var fillStyle = state.fillStyle;
   var strokeStyle = state.strokeStyle;
   if (fillStyle === undefined && strokeStyle === undefined) {
@@ -1344,8 +1341,7 @@ ol.render.canvas.PolygonReplay.prototype.drawMultiPolygonGeometry =
  * @inheritDoc
  */
 ol.render.canvas.PolygonReplay.prototype.finish = function() {
-  goog.asserts.assert(!goog.isNull(this.state_),
-      'this.state_ should not be null');
+  goog.asserts.assert(this.state_ !== null, 'this.state_ should not be null');
   this.reverseHitDetectionInstructions_();
   this.state_ = null;
   // We want to preserve topology when drawing polygons.  Polygons are
@@ -1367,7 +1363,7 @@ ol.render.canvas.PolygonReplay.prototype.finish = function() {
  * @inheritDoc
  */
 ol.render.canvas.PolygonReplay.prototype.getBufferedMaxExtent = function() {
-  if (goog.isNull(this.bufferedMaxExtent_)) {
+  if (this.bufferedMaxExtent_ === null) {
     this.bufferedMaxExtent_ = ol.extent.clone(this.maxExtent);
     if (this.maxLineWidth > 0) {
       var width = this.resolution * (this.maxLineWidth + 1) / 2;
@@ -1383,27 +1379,26 @@ ol.render.canvas.PolygonReplay.prototype.getBufferedMaxExtent = function() {
  */
 ol.render.canvas.PolygonReplay.prototype.setFillStrokeStyle =
     function(fillStyle, strokeStyle) {
-  goog.asserts.assert(!goog.isNull(this.state_),
-      'this.state_ should not be null');
-  goog.asserts.assert(!goog.isNull(fillStyle) || !goog.isNull(strokeStyle),
+  goog.asserts.assert(this.state_ !== null, 'this.state_ should not be null');
+  goog.asserts.assert(fillStyle !== null || strokeStyle !== null,
       'fillStyle or strokeStyle should not be null');
   var state = this.state_;
-  if (!goog.isNull(fillStyle)) {
+  if (fillStyle !== null) {
     var fillStyleColor = fillStyle.getColor();
-    state.fillStyle = ol.color.asString(!goog.isNull(fillStyleColor) ?
+    state.fillStyle = ol.color.asString(fillStyleColor !== null ?
         fillStyleColor : ol.render.canvas.defaultFillStyle);
   } else {
     state.fillStyle = undefined;
   }
-  if (!goog.isNull(strokeStyle)) {
+  if (strokeStyle !== null) {
     var strokeStyleColor = strokeStyle.getColor();
-    state.strokeStyle = ol.color.asString(!goog.isNull(strokeStyleColor) ?
+    state.strokeStyle = ol.color.asString(strokeStyleColor !== null ?
         strokeStyleColor : ol.render.canvas.defaultStrokeStyle);
     var strokeStyleLineCap = strokeStyle.getLineCap();
     state.lineCap = strokeStyleLineCap !== undefined ?
         strokeStyleLineCap : ol.render.canvas.defaultLineCap;
     var strokeStyleLineDash = strokeStyle.getLineDash();
-    state.lineDash = !goog.isNull(strokeStyleLineDash) ?
+    state.lineDash = strokeStyleLineDash !== null ?
         strokeStyleLineDash.slice() : ol.render.canvas.defaultLineDash;
     var strokeStyleLineJoin = strokeStyle.getLineJoin();
     state.lineJoin = strokeStyleLineJoin !== undefined ?
@@ -1450,7 +1445,7 @@ ol.render.canvas.PolygonReplay.prototype.setFillStrokeStyles_ = function() {
   }
   if (strokeStyle !== undefined) {
     goog.asserts.assert(lineCap !== undefined, 'lineCap should be defined');
-    goog.asserts.assert(!goog.isNull(lineDash), 'lineDash should not be null');
+    goog.asserts.assert(lineDash !== null, 'lineDash should not be null');
     goog.asserts.assert(lineJoin !== undefined, 'lineJoin should be defined');
     goog.asserts.assert(lineWidth !== undefined, 'lineWidth should be defined');
     goog.asserts.assert(miterLimit !== undefined,
@@ -1565,15 +1560,15 @@ goog.inherits(ol.render.canvas.TextReplay, ol.render.canvas.Replay);
 ol.render.canvas.TextReplay.prototype.drawText =
     function(flatCoordinates, offset, end, stride, geometry, feature) {
   if (this.text_ === '' ||
-      goog.isNull(this.textState_) ||
-      (goog.isNull(this.textFillState_) &&
-       goog.isNull(this.textStrokeState_))) {
+      this.textState_ === null ||
+      (this.textFillState_ &&
+       this.textStrokeState_ === null)) {
     return;
   }
-  if (!goog.isNull(this.textFillState_)) {
+  if (this.textFillState_ !== null) {
     this.setReplayFillState_(this.textFillState_);
   }
-  if (!goog.isNull(this.textStrokeState_)) {
+  if (this.textStrokeState_ !== null) {
     this.setReplayStrokeState_(this.textStrokeState_);
   }
   this.setReplayTextState_(this.textState_);
@@ -1581,8 +1576,8 @@ ol.render.canvas.TextReplay.prototype.drawText =
   var myBegin = this.coordinates.length;
   var myEnd =
       this.appendFlatCoordinates(flatCoordinates, offset, end, stride, false);
-  var fill = !goog.isNull(this.textFillState_);
-  var stroke = !goog.isNull(this.textStrokeState_);
+  var fill = this.textFillState_ !== null;
+  var stroke = this.textStrokeState_ !== null;
   var drawTextInstruction = [
     ol.render.canvas.Instruction.DRAW_TEXT, myBegin, myEnd, this.text_,
     this.textOffsetX_, this.textOffsetY_, this.textRotation_, this.textScale_,
@@ -1600,7 +1595,7 @@ ol.render.canvas.TextReplay.prototype.drawText =
 ol.render.canvas.TextReplay.prototype.setReplayFillState_ =
     function(fillState) {
   var replayFillState = this.replayFillState_;
-  if (!goog.isNull(replayFillState) &&
+  if (replayFillState !== null &&
       replayFillState.fillStyle == fillState.fillStyle) {
     return;
   }
@@ -1608,7 +1603,7 @@ ol.render.canvas.TextReplay.prototype.setReplayFillState_ =
       [ol.render.canvas.Instruction.SET_FILL_STYLE, fillState.fillStyle];
   this.instructions.push(setFillStyleInstruction);
   this.hitDetectionInstructions.push(setFillStyleInstruction);
-  if (goog.isNull(replayFillState)) {
+  if (replayFillState === null) {
     this.replayFillState_ = {
       fillStyle: fillState.fillStyle
     };
@@ -1625,7 +1620,7 @@ ol.render.canvas.TextReplay.prototype.setReplayFillState_ =
 ol.render.canvas.TextReplay.prototype.setReplayStrokeState_ =
     function(strokeState) {
   var replayStrokeState = this.replayStrokeState_;
-  if (!goog.isNull(replayStrokeState) &&
+  if (replayStrokeState !== null &&
       replayStrokeState.lineCap == strokeState.lineCap &&
       replayStrokeState.lineDash == strokeState.lineDash &&
       replayStrokeState.lineJoin == strokeState.lineJoin &&
@@ -1641,7 +1636,7 @@ ol.render.canvas.TextReplay.prototype.setReplayStrokeState_ =
   ];
   this.instructions.push(setStrokeStyleInstruction);
   this.hitDetectionInstructions.push(setStrokeStyleInstruction);
-  if (goog.isNull(replayStrokeState)) {
+  if (replayStrokeState === null) {
     this.replayStrokeState_ = {
       lineCap: strokeState.lineCap,
       lineDash: strokeState.lineDash,
@@ -1668,7 +1663,7 @@ ol.render.canvas.TextReplay.prototype.setReplayStrokeState_ =
 ol.render.canvas.TextReplay.prototype.setReplayTextState_ =
     function(textState) {
   var replayTextState = this.replayTextState_;
-  if (!goog.isNull(replayTextState) &&
+  if (replayTextState !== null &&
       replayTextState.font == textState.font &&
       replayTextState.textAlign == textState.textAlign &&
       replayTextState.textBaseline == textState.textBaseline) {
@@ -1678,7 +1673,7 @@ ol.render.canvas.TextReplay.prototype.setReplayTextState_ =
     textState.font, textState.textAlign, textState.textBaseline];
   this.instructions.push(setTextStyleInstruction);
   this.hitDetectionInstructions.push(setTextStyleInstruction);
-  if (goog.isNull(replayTextState)) {
+  if (replayTextState === null) {
     this.replayTextState_ = {
       font: textState.font,
       textAlign: textState.textAlign,
@@ -1696,17 +1691,17 @@ ol.render.canvas.TextReplay.prototype.setReplayTextState_ =
  * @inheritDoc
  */
 ol.render.canvas.TextReplay.prototype.setTextStyle = function(textStyle) {
-  if (goog.isNull(textStyle)) {
+  if (textStyle === null) {
     this.text_ = '';
   } else {
     var textFillStyle = textStyle.getFill();
-    if (goog.isNull(textFillStyle)) {
+    if (textFillStyle === null) {
       this.textFillState_ = null;
     } else {
       var textFillStyleColor = textFillStyle.getColor();
-      var fillStyle = ol.color.asString(!goog.isNull(textFillStyleColor) ?
+      var fillStyle = ol.color.asString(textFillStyleColor !== null ?
           textFillStyleColor : ol.render.canvas.defaultFillStyle);
-      if (goog.isNull(this.textFillState_)) {
+      if (this.textFillState_ === null) {
         this.textFillState_ = {
           fillStyle: fillStyle
         };
@@ -1716,7 +1711,7 @@ ol.render.canvas.TextReplay.prototype.setTextStyle = function(textStyle) {
       }
     }
     var textStrokeStyle = textStyle.getStroke();
-    if (goog.isNull(textStrokeStyle)) {
+    if (textStrokeStyle === null) {
       this.textStrokeState_ = null;
     } else {
       var textStrokeStyleColor = textStrokeStyle.getColor();
@@ -1735,9 +1730,9 @@ ol.render.canvas.TextReplay.prototype.setTextStyle = function(textStyle) {
           textStrokeStyleWidth : ol.render.canvas.defaultLineWidth;
       var miterLimit = textStrokeStyleMiterLimit !== undefined ?
           textStrokeStyleMiterLimit : ol.render.canvas.defaultMiterLimit;
-      var strokeStyle = ol.color.asString(!goog.isNull(textStrokeStyleColor) ?
+      var strokeStyle = ol.color.asString(textStrokeStyleColor !== null ?
           textStrokeStyleColor : ol.render.canvas.defaultStrokeStyle);
-      if (goog.isNull(this.textStrokeState_)) {
+      if (this.textStrokeState_ === null) {
         this.textStrokeState_ = {
           lineCap: lineCap,
           lineDash: lineDash,
@@ -1770,7 +1765,7 @@ ol.render.canvas.TextReplay.prototype.setTextStyle = function(textStyle) {
         textTextAlign : ol.render.canvas.defaultTextAlign;
     var textBaseline = textTextBaseline !== undefined ?
         textTextBaseline : ol.render.canvas.defaultTextBaseline;
-    if (goog.isNull(this.textState_)) {
+    if (this.textState_ === null) {
       this.textState_ = {
         font: font,
         textAlign: textAlign,

--- a/src/ol/render/vector.js
+++ b/src/ol/render/vector.js
@@ -58,14 +58,14 @@ ol.renderer.vector.renderCircleGeometry_ =
       'geometry should be an ol.geom.Circle');
   var fillStyle = style.getFill();
   var strokeStyle = style.getStroke();
-  if (!goog.isNull(fillStyle) || !goog.isNull(strokeStyle)) {
+  if (fillStyle !== null || strokeStyle !== null) {
     var polygonReplay = replayGroup.getReplay(
         style.getZIndex(), ol.render.ReplayType.POLYGON);
     polygonReplay.setFillStrokeStyle(fillStyle, strokeStyle);
     polygonReplay.drawCircleGeometry(geometry, feature);
   }
   var textStyle = style.getText();
-  if (!goog.isNull(textStyle)) {
+  if (textStyle !== null) {
     var textReplay = replayGroup.getReplay(
         style.getZIndex(), ol.render.ReplayType.TEXT);
     textReplay.setTextStyle(textStyle);
@@ -89,7 +89,7 @@ ol.renderer.vector.renderFeature = function(
   var loading = false;
   var imageStyle, imageState;
   imageStyle = style.getImage();
-  if (!goog.isNull(imageStyle)) {
+  if (imageStyle !== null) {
     imageState = imageStyle.getImageState();
     if (imageState == ol.style.ImageState.LOADED ||
         imageState == ol.style.ImageState.ERROR) {
@@ -168,14 +168,14 @@ ol.renderer.vector.renderLineStringGeometry_ =
   goog.asserts.assertInstanceof(geometry, ol.geom.LineString,
       'geometry should be an ol.geom.LineString');
   var strokeStyle = style.getStroke();
-  if (!goog.isNull(strokeStyle)) {
+  if (strokeStyle !== null) {
     var lineStringReplay = replayGroup.getReplay(
         style.getZIndex(), ol.render.ReplayType.LINE_STRING);
     lineStringReplay.setFillStrokeStyle(null, strokeStyle);
     lineStringReplay.drawLineStringGeometry(geometry, feature);
   }
   var textStyle = style.getText();
-  if (!goog.isNull(textStyle)) {
+  if (textStyle !== null) {
     var textReplay = replayGroup.getReplay(
         style.getZIndex(), ol.render.ReplayType.TEXT);
     textReplay.setTextStyle(textStyle);
@@ -196,14 +196,14 @@ ol.renderer.vector.renderMultiLineStringGeometry_ =
   goog.asserts.assertInstanceof(geometry, ol.geom.MultiLineString,
       'geometry should be an ol.geom.MultiLineString');
   var strokeStyle = style.getStroke();
-  if (!goog.isNull(strokeStyle)) {
+  if (strokeStyle !== null) {
     var lineStringReplay = replayGroup.getReplay(
         style.getZIndex(), ol.render.ReplayType.LINE_STRING);
     lineStringReplay.setFillStrokeStyle(null, strokeStyle);
     lineStringReplay.drawMultiLineStringGeometry(geometry, feature);
   }
   var textStyle = style.getText();
-  if (!goog.isNull(textStyle)) {
+  if (textStyle !== null) {
     var textReplay = replayGroup.getReplay(
         style.getZIndex(), ol.render.ReplayType.TEXT);
     textReplay.setTextStyle(textStyle);
@@ -227,14 +227,14 @@ ol.renderer.vector.renderMultiPolygonGeometry_ =
       'geometry should be an ol.geom.MultiPolygon');
   var fillStyle = style.getFill();
   var strokeStyle = style.getStroke();
-  if (!goog.isNull(strokeStyle) || !goog.isNull(fillStyle)) {
+  if (strokeStyle !== null || fillStyle !== null) {
     var polygonReplay = replayGroup.getReplay(
         style.getZIndex(), ol.render.ReplayType.POLYGON);
     polygonReplay.setFillStrokeStyle(fillStyle, strokeStyle);
     polygonReplay.drawMultiPolygonGeometry(geometry, feature);
   }
   var textStyle = style.getText();
-  if (!goog.isNull(textStyle)) {
+  if (textStyle !== null) {
     var textReplay = replayGroup.getReplay(
         style.getZIndex(), ol.render.ReplayType.TEXT);
     textReplay.setTextStyle(textStyle);
@@ -257,7 +257,7 @@ ol.renderer.vector.renderPointGeometry_ =
   goog.asserts.assertInstanceof(geometry, ol.geom.Point,
       'geometry should be an ol.geom.Point');
   var imageStyle = style.getImage();
-  if (!goog.isNull(imageStyle)) {
+  if (imageStyle !== null) {
     if (imageStyle.getImageState() != ol.style.ImageState.LOADED) {
       return;
     }
@@ -267,7 +267,7 @@ ol.renderer.vector.renderPointGeometry_ =
     imageReplay.drawPointGeometry(geometry, feature);
   }
   var textStyle = style.getText();
-  if (!goog.isNull(textStyle)) {
+  if (textStyle !== null) {
     var textReplay = replayGroup.getReplay(
         style.getZIndex(), ol.render.ReplayType.TEXT);
     textReplay.setTextStyle(textStyle);
@@ -288,7 +288,7 @@ ol.renderer.vector.renderMultiPointGeometry_ =
   goog.asserts.assertInstanceof(geometry, ol.geom.MultiPoint,
       'geometry should be an ol.goem.MultiPoint');
   var imageStyle = style.getImage();
-  if (!goog.isNull(imageStyle)) {
+  if (imageStyle !== null) {
     if (imageStyle.getImageState() != ol.style.ImageState.LOADED) {
       return;
     }
@@ -298,7 +298,7 @@ ol.renderer.vector.renderMultiPointGeometry_ =
     imageReplay.drawMultiPointGeometry(geometry, feature);
   }
   var textStyle = style.getText();
-  if (!goog.isNull(textStyle)) {
+  if (textStyle !== null) {
     var textReplay = replayGroup.getReplay(
         style.getZIndex(), ol.render.ReplayType.TEXT);
     textReplay.setTextStyle(textStyle);
@@ -322,14 +322,14 @@ ol.renderer.vector.renderPolygonGeometry_ =
       'geometry should be an ol.geom.Polygon');
   var fillStyle = style.getFill();
   var strokeStyle = style.getStroke();
-  if (!goog.isNull(fillStyle) || !goog.isNull(strokeStyle)) {
+  if (fillStyle !== null || strokeStyle !== null) {
     var polygonReplay = replayGroup.getReplay(
         style.getZIndex(), ol.render.ReplayType.POLYGON);
     polygonReplay.setFillStrokeStyle(fillStyle, strokeStyle);
     polygonReplay.drawPolygonGeometry(geometry, feature);
   }
   var textStyle = style.getText();
-  if (!goog.isNull(textStyle)) {
+  if (textStyle !== null) {
     var textReplay = replayGroup.getReplay(
         style.getZIndex(), ol.render.ReplayType.TEXT);
     textReplay.setTextStyle(textStyle);

--- a/src/ol/render/webgl/webglreplay.js
+++ b/src/ol/render/webgl/webglreplay.js
@@ -222,9 +222,9 @@ ol.render.webgl.ImageReplay.prototype.getDeleteResourcesFunction =
   // be used by other ImageReplay instances (for other layers). And
   // they will be deleted when disposing of the ol.webgl.Context
   // object.
-  goog.asserts.assert(!goog.isNull(this.verticesBuffer_),
+  goog.asserts.assert(this.verticesBuffer_ !== null,
       'verticesBuffer must not be null');
-  goog.asserts.assert(!goog.isNull(this.indicesBuffer_),
+  goog.asserts.assert(this.indicesBuffer_ !== null,
       'indicesBuffer must not be null');
   var verticesBuffer = this.verticesBuffer_;
   var indicesBuffer = this.indicesBuffer_;
@@ -514,12 +514,12 @@ ol.render.webgl.ImageReplay.prototype.replay = function(context,
   var gl = context.getGL();
 
   // bind the vertices buffer
-  goog.asserts.assert(!goog.isNull(this.verticesBuffer_),
+  goog.asserts.assert(this.verticesBuffer_ !== null,
       'verticesBuffer must not be null');
   context.bindBuffer(goog.webgl.ARRAY_BUFFER, this.verticesBuffer_);
 
   // bind the indices buffer
-  goog.asserts.assert(!goog.isNull(this.indicesBuffer_),
+  goog.asserts.assert(this.indicesBuffer_ !== null,
       'indecesBuffer must not be null');
   context.bindBuffer(goog.webgl.ELEMENT_ARRAY_BUFFER, this.indicesBuffer_);
 
@@ -532,7 +532,7 @@ ol.render.webgl.ImageReplay.prototype.replay = function(context,
 
   // get the locations
   var locations;
-  if (goog.isNull(this.defaultLocations_)) {
+  if (this.defaultLocations_ === null) {
     locations =
         new ol.render.webgl.imagereplay.shader.Default.Locations(gl, program);
     this.defaultLocations_ = locations;
@@ -863,20 +863,20 @@ ol.render.webgl.ImageReplay.prototype.setImageStyle = function(imageStyle) {
   var rotation = imageStyle.getRotation();
   var size = imageStyle.getSize();
   var scale = imageStyle.getScale();
-  goog.asserts.assert(!goog.isNull(anchor), 'imageStyle anchor is not null');
-  goog.asserts.assert(!goog.isNull(image), 'imageStyle image is not null');
-  goog.asserts.assert(!goog.isNull(imageSize),
+  goog.asserts.assert(anchor !== null, 'imageStyle anchor is not null');
+  goog.asserts.assert(image !== null, 'imageStyle image is not null');
+  goog.asserts.assert(imageSize !== null,
       'imageStyle imageSize is not null');
-  goog.asserts.assert(!goog.isNull(hitDetectionImage),
+  goog.asserts.assert(hitDetectionImage !== null,
       'imageStyle hitDetectionImage is not null');
-  goog.asserts.assert(!goog.isNull(hitDetectionImageSize),
+  goog.asserts.assert(hitDetectionImageSize !== null,
       'imageStyle hitDetectionImageSize is not null');
   goog.asserts.assert(opacity !== undefined, 'imageStyle opacity is defined');
-  goog.asserts.assert(!goog.isNull(origin), 'imageStyle origin is not null');
+  goog.asserts.assert(origin !== null, 'imageStyle origin is not null');
   goog.asserts.assert(rotateWithView !== undefined,
       'imageStyle rotateWithView is defined');
   goog.asserts.assert(rotation !== undefined, 'imageStyle rotation is defined');
-  goog.asserts.assert(!goog.isNull(size), 'imageStyle size is not null');
+  goog.asserts.assert(size !== null, 'imageStyle size is not null');
   goog.asserts.assert(scale !== undefined, 'imageStyle scale is defined');
 
   var currentImage;

--- a/src/ol/renderer/canvas/canvasimagelayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasimagelayerrenderer.js
@@ -79,7 +79,7 @@ ol.renderer.canvas.ImageLayer.prototype.forEachFeatureAtCoordinate =
  */
 ol.renderer.canvas.ImageLayer.prototype.forEachLayerAtPixel =
     function(pixel, frameState, callback, thisArg) {
-  if (goog.isNull(this.getImage())) {
+  if (this.getImage() === null) {
     return undefined;
   }
 
@@ -99,7 +99,7 @@ ol.renderer.canvas.ImageLayer.prototype.forEachLayerAtPixel =
     }
   } else {
     // for all other image sources directly check the image
-    if (goog.isNull(this.imageTransformInv_)) {
+    if (this.imageTransformInv_ === null) {
       this.imageTransformInv_ = goog.vec.Mat4.createNumber();
       goog.vec.Mat4.invert(this.imageTransform_, this.imageTransformInv_);
     }
@@ -107,7 +107,7 @@ ol.renderer.canvas.ImageLayer.prototype.forEachLayerAtPixel =
     var pixelOnCanvas =
         this.getPixelOnCanvas(pixel, this.imageTransformInv_);
 
-    if (goog.isNull(this.hitCanvasContext_)) {
+    if (this.hitCanvasContext_ === null) {
       this.hitCanvasContext_ = ol.dom.createCanvasContext2D(1, 1);
     }
 
@@ -129,8 +129,7 @@ ol.renderer.canvas.ImageLayer.prototype.forEachLayerAtPixel =
  * @inheritDoc
  */
 ol.renderer.canvas.ImageLayer.prototype.getImage = function() {
-  return goog.isNull(this.image_) ?
-      null : this.image_.getImage();
+  return this.image_ === null ? null : this.image_.getImage();
 };
 
 
@@ -172,14 +171,14 @@ ol.renderer.canvas.ImageLayer.prototype.prepareFrame =
       !ol.extent.isEmpty(renderedExtent)) {
     var projection = viewState.projection;
     var sourceProjection = imageSource.getProjection();
-    if (!goog.isNull(sourceProjection)) {
+    if (sourceProjection !== null) {
       goog.asserts.assert(ol.proj.equivalent(projection, sourceProjection),
           'projection and sourceProjection are equivalent');
       projection = sourceProjection;
     }
     image = imageSource.getImage(
         renderedExtent, viewResolution, pixelRatio, projection);
-    if (!goog.isNull(image)) {
+    if (image !== null) {
       var loaded = this.loadImage(image);
       if (loaded) {
         this.image_ = image;
@@ -187,7 +186,7 @@ ol.renderer.canvas.ImageLayer.prototype.prepareFrame =
     }
   }
 
-  if (!goog.isNull(this.image_)) {
+  if (this.image_ !== null) {
     image = this.image_;
     var imageExtent = image.getExtent();
     var imageResolution = image.getResolution();

--- a/src/ol/renderer/canvas/canvaslayerrenderer.js
+++ b/src/ol/renderer/canvas/canvaslayerrenderer.js
@@ -44,7 +44,7 @@ ol.renderer.canvas.Layer.prototype.composeFrame =
   this.dispatchPreComposeEvent(context, frameState);
 
   var image = this.getImage();
-  if (!goog.isNull(image)) {
+  if (image !== null) {
 
     // clipped rendering if layer extent is set
     var extent = layerState.extent;
@@ -252,7 +252,7 @@ ol.renderer.canvas.Layer.testCanvasSize = (function() {
   var imageData = null;
 
   return function(size) {
-    if (goog.isNull(context)) {
+    if (context === null) {
       context = ol.dom.createCanvasContext2D(1, 1);
       imageData = context.createImageData(1, 1);
       var data = imageData.data;

--- a/src/ol/renderer/canvas/canvasmaprenderer.js
+++ b/src/ol/renderer/canvas/canvasmaprenderer.js
@@ -146,7 +146,7 @@ ol.renderer.canvas.Map.prototype.getType = function() {
  */
 ol.renderer.canvas.Map.prototype.renderFrame = function(frameState) {
 
-  if (goog.isNull(frameState)) {
+  if (frameState === null) {
     if (this.renderedVisible_) {
       goog.style.setElementShown(this.canvas_, false);
       this.renderedVisible_ = false;

--- a/src/ol/renderer/canvas/canvastilelayerrenderer.js
+++ b/src/ol/renderer/canvas/canvastilelayerrenderer.js
@@ -232,12 +232,12 @@ ol.renderer.canvas.TileLayer.prototype.prepareFrame =
   var canvasHeight = tilePixelSize[1] * tileRange.getHeight();
 
   var canvas, context;
-  if (goog.isNull(this.canvas_)) {
-    goog.asserts.assert(goog.isNull(this.canvasSize_),
+  if (this.canvas_ === null) {
+    goog.asserts.assert(this.canvasSize_ === null,
         'canvasSize is null (because canvas is null)');
-    goog.asserts.assert(goog.isNull(this.context_),
+    goog.asserts.assert(this.context_ === null,
         'context is null (because canvas is null)');
-    goog.asserts.assert(goog.isNull(this.renderedCanvasTileRange_),
+    goog.asserts.assert(this.renderedCanvasTileRange_ === null,
         'renderedCanvasTileRange is null (because canvas is null)');
     context = ol.dom.createCanvasContext2D(canvasWidth, canvasHeight);
     this.canvas_ = context.canvas;
@@ -246,9 +246,9 @@ ol.renderer.canvas.TileLayer.prototype.prepareFrame =
     this.canvasTooBig_ =
         !ol.renderer.canvas.Layer.testCanvasSize(this.canvasSize_);
   } else {
-    goog.asserts.assert(!goog.isNull(this.canvasSize_),
+    goog.asserts.assert(this.canvasSize_ !== null,
         'non-null canvasSize (because canvas is not null)');
-    goog.asserts.assert(!goog.isNull(this.context_),
+    goog.asserts.assert(this.context_ !== null,
         'non-null context (because canvas is not null)');
     canvas = this.canvas_;
     context = this.context_;
@@ -278,7 +278,7 @@ ol.renderer.canvas.TileLayer.prototype.prepareFrame =
   }
 
   var canvasTileRange, canvasTileRangeWidth, minX, minY;
-  if (goog.isNull(this.renderedCanvasTileRange_)) {
+  if (this.renderedCanvasTileRange_ === null) {
     canvasTileRangeWidth = canvasWidth / tilePixelSize[0];
     var canvasTileRangeHeight = canvasHeight / tilePixelSize[1];
     minX = tileRange.minX -
@@ -337,7 +337,7 @@ ol.renderer.canvas.TileLayer.prototype.prepareFrame =
         tilesToClear.push(tile);
         childTileRange = tileGrid.getTileCoordChildTileRange(
             tile.tileCoord, tmpTileRange, tmpExtent);
-        if (!goog.isNull(childTileRange)) {
+        if (childTileRange !== null) {
           findLoadedTiles(z + 1, childTileRange);
         }
       }
@@ -451,11 +451,11 @@ ol.renderer.canvas.TileLayer.prototype.prepareFrame =
  */
 ol.renderer.canvas.TileLayer.prototype.forEachLayerAtPixel =
     function(pixel, frameState, callback, thisArg) {
-  if (goog.isNull(this.context_)) {
+  if (this.context_ === null) {
     return undefined;
   }
 
-  if (goog.isNull(this.imageTransformInv_)) {
+  if (this.imageTransformInv_ === null) {
     this.imageTransformInv_ = goog.vec.Mat4.createNumber();
     goog.vec.Mat4.invert(this.imageTransform_, this.imageTransformInv_);
   }

--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -92,7 +92,7 @@ ol.renderer.canvas.VectorLayer.prototype.composeFrame =
   this.dispatchPreComposeEvent(context, frameState, transform);
 
   var replayGroup = this.replayGroup_;
-  if (!goog.isNull(replayGroup) && !replayGroup.isEmpty()) {
+  if (replayGroup !== null && !replayGroup.isEmpty()) {
     var layer = this.getLayer();
     var replayContext;
     if (layer.hasListener(ol.render.EventType.RENDER)) {
@@ -156,7 +156,7 @@ ol.renderer.canvas.VectorLayer.prototype.composeFrame =
  */
 ol.renderer.canvas.VectorLayer.prototype.forEachFeatureAtCoordinate =
     function(coordinate, frameState, callback, thisArg) {
-  if (goog.isNull(this.replayGroup_)) {
+  if (this.replayGroup_ === null) {
     return undefined;
   } else {
     var resolution = frameState.viewState.resolution;
@@ -290,7 +290,7 @@ ol.renderer.canvas.VectorLayer.prototype.prepareFrame =
       this.dirty_ = this.dirty_ || dirty;
     }
   };
-  if (!goog.isNull(vectorLayerRenderOrder)) {
+  if (vectorLayerRenderOrder !== null) {
     /** @type {Array.<ol.Feature>} */
     var features = [];
     vectorSource.forEachFeatureInExtentAtResolution(extent, resolution,

--- a/src/ol/renderer/dom/domimagelayerrenderer.js
+++ b/src/ol/renderer/dom/domimagelayerrenderer.js
@@ -103,14 +103,14 @@ ol.renderer.dom.ImageLayer.prototype.prepareFrame =
       !ol.extent.isEmpty(renderedExtent)) {
     var projection = viewState.projection;
     var sourceProjection = imageSource.getProjection();
-    if (!goog.isNull(sourceProjection)) {
+    if (sourceProjection !== null) {
       goog.asserts.assert(ol.proj.equivalent(projection, sourceProjection),
           'projection and sourceProjection are equivalent');
       projection = sourceProjection;
     }
     var image_ = imageSource.getImage(renderedExtent, viewResolution,
         frameState.pixelRatio, projection);
-    if (!goog.isNull(image_)) {
+    if (image_ !== null) {
       var loaded = this.loadImage(image_);
       if (loaded) {
         image = image_;
@@ -118,7 +118,7 @@ ol.renderer.dom.ImageLayer.prototype.prepareFrame =
     }
   }
 
-  if (!goog.isNull(image)) {
+  if (image !== null) {
     var imageExtent = image.getExtent();
     var imageResolution = image.getResolution();
     var transform = goog.vec.Mat4.createNumber();

--- a/src/ol/renderer/dom/dommaprenderer.js
+++ b/src/ol/renderer/dom/dommaprenderer.js
@@ -159,7 +159,7 @@ ol.renderer.dom.Map.prototype.getType = function() {
  */
 ol.renderer.dom.Map.prototype.renderFrame = function(frameState) {
 
-  if (goog.isNull(frameState)) {
+  if (frameState === null) {
     if (this.renderedVisible_) {
       goog.style.setElementShown(this.layersPane_, false);
       this.renderedVisible_ = false;

--- a/src/ol/renderer/dom/domtilelayerrenderer.js
+++ b/src/ol/renderer/dom/domtilelayerrenderer.js
@@ -149,7 +149,7 @@ ol.renderer.dom.TileLayer.prototype.prepareFrame =
       if (!fullyLoaded) {
         childTileRange = tileGrid.getTileCoordChildTileRange(
             tile.tileCoord, tmpTileRange, tmpExtent);
-        if (!goog.isNull(childTileRange)) {
+        if (childTileRange !== null) {
           findLoadedTiles(z + 1, childTileRange);
         }
       }
@@ -377,7 +377,7 @@ ol.renderer.dom.TileLayerZ_.prototype.addTile = function(tile, tileGutter) {
       ((tileCoordX - this.tileCoordOrigin_[1]) * tileSize[0]) + 'px';
   tileElementStyle.top =
       ((this.tileCoordOrigin_[2] - tileCoordY) * tileSize[1]) + 'px';
-  if (goog.isNull(this.documentFragment_)) {
+  if (this.documentFragment_ === null) {
     this.documentFragment_ = document.createDocumentFragment();
   }
   goog.dom.appendChild(this.documentFragment_, tileElement);
@@ -389,7 +389,7 @@ ol.renderer.dom.TileLayerZ_.prototype.addTile = function(tile, tileGutter) {
  * FIXME empty description for jsdoc
  */
 ol.renderer.dom.TileLayerZ_.prototype.finalizeAddTiles = function() {
-  if (!goog.isNull(this.documentFragment_)) {
+  if (this.documentFragment_ !== null) {
     goog.dom.appendChild(this.target, this.documentFragment_);
     this.documentFragment_ = null;
   }

--- a/src/ol/renderer/dom/domvectorlayerrenderer.js
+++ b/src/ol/renderer/dom/domvectorlayerrenderer.js
@@ -138,7 +138,7 @@ ol.renderer.dom.VectorLayer.prototype.composeFrame =
 
   var replayGroup = this.replayGroup_;
 
-  if (!goog.isNull(replayGroup) && !replayGroup.isEmpty()) {
+  if (replayGroup !== null && !replayGroup.isEmpty()) {
 
     context.globalAlpha = layerState.opacity;
     replayGroup.replay(context, pixelRatio, transform, viewRotation,
@@ -178,7 +178,7 @@ ol.renderer.dom.VectorLayer.prototype.dispatchEvent_ =
  */
 ol.renderer.dom.VectorLayer.prototype.forEachFeatureAtCoordinate =
     function(coordinate, frameState, callback, thisArg) {
-  if (goog.isNull(this.replayGroup_)) {
+  if (this.replayGroup_ === null) {
     return undefined;
   } else {
     var resolution = frameState.viewState.resolution;
@@ -298,7 +298,7 @@ ol.renderer.dom.VectorLayer.prototype.prepareFrame =
       this.dirty_ = this.dirty_ || dirty;
     }
   };
-  if (!goog.isNull(vectorLayerRenderOrder)) {
+  if (vectorLayerRenderOrder !== null) {
     /** @type {Array.<ol.Feature>} */
     var features = [];
     vectorSource.forEachFeatureInExtentAtResolution(extent, resolution,

--- a/src/ol/renderer/maprenderer.js
+++ b/src/ol/renderer/maprenderer.js
@@ -71,7 +71,7 @@ goog.inherits(ol.renderer.Map, goog.Disposable);
 ol.renderer.Map.prototype.calculateMatrices2D = function(frameState) {
   var viewState = frameState.viewState;
   var coordinateToPixelMatrix = frameState.coordinateToPixelMatrix;
-  goog.asserts.assert(!goog.isNull(coordinateToPixelMatrix),
+  goog.asserts.assert(coordinateToPixelMatrix !== null,
       'frameState has non-null coordinateToPixelMatrix');
   ol.vec.Mat4.makeTransform2D(coordinateToPixelMatrix,
       frameState.size[0] / 2, frameState.size[1] / 2,
@@ -171,7 +171,7 @@ ol.renderer.Map.prototype.forEachFeatureAtCoordinate =
         (ol.layer.Layer.visibleAtResolution(layerState, viewResolution) &&
         layerFilter.call(thisArg2, layer))) {
       var layerRenderer = this.getLayerRenderer(layer);
-      if (!goog.isNull(layer.getSource())) {
+      if (layer.getSource() !== null) {
         result = layerRenderer.forEachFeatureAtCoordinate(
             layer.getSource().getWrapX() ? translatedCoordinate : coordinate,
             frameState, callback, thisArg);
@@ -347,7 +347,7 @@ ol.renderer.Map.prototype.removeUnusedLayerRenderers_ =
     function(map, frameState) {
   var layerKey;
   for (layerKey in this.layerRenderers_) {
-    if (goog.isNull(frameState) || !(layerKey in frameState.layerStates)) {
+    if (frameState === null || !(layerKey in frameState.layerStates)) {
       goog.dispose(this.removeLayerRendererByKey_(layerKey));
     }
   }

--- a/src/ol/renderer/webgl/webglimagelayerrenderer.js
+++ b/src/ol/renderer/webgl/webglimagelayerrenderer.js
@@ -126,19 +126,19 @@ ol.renderer.webgl.ImageLayer.prototype.prepareFrame =
       !ol.extent.isEmpty(renderedExtent)) {
     var projection = viewState.projection;
     var sourceProjection = imageSource.getProjection();
-    if (!goog.isNull(sourceProjection)) {
+    if (sourceProjection !== null) {
       goog.asserts.assert(ol.proj.equivalent(projection, sourceProjection),
           'projection and sourceProjection are equivalent');
       projection = sourceProjection;
     }
     var image_ = imageSource.getImage(renderedExtent, viewResolution,
         pixelRatio, projection);
-    if (!goog.isNull(image_)) {
+    if (image_ !== null) {
       var loaded = this.loadImage(image_);
       if (loaded) {
         image = image_;
         texture = this.createTexture_(image_);
-        if (!goog.isNull(this.texture)) {
+        if (this.texture !== null) {
           frameState.postRenderFunctions.push(
               goog.partial(
                   /**
@@ -155,8 +155,8 @@ ol.renderer.webgl.ImageLayer.prototype.prepareFrame =
     }
   }
 
-  if (!goog.isNull(image)) {
-    goog.asserts.assert(!goog.isNull(texture), 'texture is not null');
+  if (image !== null) {
+    goog.asserts.assert(texture !== null, 'texture is not null');
 
     var canvas = this.mapRenderer.getContext().getCanvas();
 
@@ -234,7 +234,7 @@ ol.renderer.webgl.ImageLayer.prototype.hasFeatureAtCoordinate =
  */
 ol.renderer.webgl.ImageLayer.prototype.forEachLayerAtPixel =
     function(pixel, frameState, callback, thisArg) {
-  if (goog.isNull(this.image_) || goog.isNull(this.image_.getImage())) {
+  if (this.image_ === null || this.image_.getImage() === null) {
     return undefined;
   }
 
@@ -256,7 +256,7 @@ ol.renderer.webgl.ImageLayer.prototype.forEachLayerAtPixel =
     var imageSize =
         [this.image_.getImage().width, this.image_.getImage().height];
 
-    if (goog.isNull(this.hitTransformationMatrix_)) {
+    if (this.hitTransformationMatrix_ === null) {
       this.hitTransformationMatrix_ = this.getHitTransformationMatrix_(
           frameState.size, imageSize);
     }
@@ -271,7 +271,7 @@ ol.renderer.webgl.ImageLayer.prototype.forEachLayerAtPixel =
       return undefined;
     }
 
-    if (goog.isNull(this.hitCanvasContext_)) {
+    if (this.hitCanvasContext_ === null) {
       this.hitCanvasContext_ = ol.dom.createCanvasContext2D(1, 1);
     }
 

--- a/src/ol/renderer/webgl/webgllayerrenderer.js
+++ b/src/ol/renderer/webgl/webgllayerrenderer.js
@@ -151,7 +151,7 @@ ol.renderer.webgl.Layer.prototype.composeFrame =
   var program = context.getProgram(fragmentShader, vertexShader);
 
   var locations;
-  if (goog.isNull(this.defaultLocations_)) {
+  if (this.defaultLocations_ === null) {
     locations =
         new ol.renderer.webgl.map.shader.Default.Locations(gl, program);
     this.defaultLocations_ = locations;

--- a/src/ol/renderer/webgl/webglmaprenderer.js
+++ b/src/ol/renderer/webgl/webglmaprenderer.js
@@ -100,7 +100,7 @@ ol.renderer.webgl.Map = function(container, map) {
     preserveDrawingBuffer: false,
     stencil: true
   });
-  goog.asserts.assert(!goog.isNull(this.gl_), 'got a WebGLRenderingContext');
+  goog.asserts.assert(this.gl_ !== null, 'got a WebGLRenderingContext');
 
   /**
    * @private
@@ -194,7 +194,7 @@ ol.renderer.webgl.Map.prototype.bindTileTexture =
   var tileKey = tile.getKey();
   if (this.textureCache_.containsKey(tileKey)) {
     var textureCacheEntry = this.textureCache_.get(tileKey);
-    goog.asserts.assert(!goog.isNull(textureCacheEntry),
+    goog.asserts.assert(textureCacheEntry !== null,
         'a texture cache entry exists for key %s', tileKey);
     gl.bindTexture(goog.webgl.TEXTURE_2D, textureCacheEntry.texture);
     if (textureCacheEntry.magFilter != magFilter) {
@@ -309,7 +309,7 @@ ol.renderer.webgl.Map.prototype.disposeInternal = function() {
          *     Texture cache entry.
          */
         function(textureCacheEntry) {
-          if (!goog.isNull(textureCacheEntry)) {
+          if (textureCacheEntry !== null) {
             gl.deleteTexture(textureCacheEntry.texture);
           }
         });
@@ -330,7 +330,7 @@ ol.renderer.webgl.Map.prototype.expireCache_ = function(map, frameState) {
   while (this.textureCache_.getCount() - this.textureCacheFrameMarkerCount_ >
       ol.WEBGL_TEXTURE_CACHE_HIGH_WATER_MARK) {
     textureCacheEntry = this.textureCache_.peekLast();
-    if (goog.isNull(textureCacheEntry)) {
+    if (textureCacheEntry) {
       if (+this.textureCache_.peekLastKey() == frameState.index) {
         break;
       } else {
@@ -452,7 +452,7 @@ ol.renderer.webgl.Map.prototype.renderFrame = function(frameState) {
     return false;
   }
 
-  if (goog.isNull(frameState)) {
+  if (frameState === null) {
     if (this.renderedVisible_) {
       goog.style.setElementShown(this.canvas_, false);
       this.renderedVisible_ = false;

--- a/src/ol/renderer/webgl/webgltilelayerrenderer.js
+++ b/src/ol/renderer/webgl/webgltilelayerrenderer.js
@@ -187,7 +187,7 @@ ol.renderer.webgl.TileLayer.prototype.prepareFrame =
       extent, tileResolution);
 
   var framebufferExtent;
-  if (!goog.isNull(this.renderedTileRange_) &&
+  if (this.renderedTileRange_ !== null &&
       this.renderedTileRange_.equals(tileRange) &&
       this.renderedRevision_ == tileSource.getRevision()) {
     framebufferExtent = this.renderedFramebufferExtent_;
@@ -219,7 +219,7 @@ ol.renderer.webgl.TileLayer.prototype.prepareFrame =
 
     var program = context.getProgram(this.fragmentShader_, this.vertexShader_);
     context.useProgram(program);
-    if (goog.isNull(this.locations_)) {
+    if (this.locations_ === null) {
       this.locations_ =
           new ol.renderer.webgl.tilelayer.shader.Locations(gl, program);
     }
@@ -276,7 +276,7 @@ ol.renderer.webgl.TileLayer.prototype.prepareFrame =
         if (!fullyLoaded) {
           childTileRange = tileGrid.getTileCoordChildTileRange(
               tile.tileCoord, tmpTileRange, tmpExtent);
-          if (!goog.isNull(childTileRange)) {
+          if (childTileRange !== null) {
             findLoadedTiles(z + 1, childTileRange);
           }
         }
@@ -378,7 +378,7 @@ ol.renderer.webgl.TileLayer.prototype.prepareFrame =
  */
 ol.renderer.webgl.TileLayer.prototype.forEachLayerAtPixel =
     function(pixel, frameState, callback, thisArg) {
-  if (goog.isNull(this.framebuffer)) {
+  if (this.framebuffer === null) {
     return undefined;
   }
 

--- a/src/ol/renderer/webgl/webglvectorlayerrenderer.js
+++ b/src/ol/renderer/webgl/webglvectorlayerrenderer.js
@@ -78,7 +78,7 @@ ol.renderer.webgl.VectorLayer.prototype.composeFrame =
   this.layerState_ = layerState;
   var viewState = frameState.viewState;
   var replayGroup = this.replayGroup_;
-  if (!goog.isNull(replayGroup) && !replayGroup.isEmpty()) {
+  if (replayGroup !== null && !replayGroup.isEmpty()) {
     replayGroup.replay(context,
         viewState.center, viewState.resolution, viewState.rotation,
         frameState.size, frameState.pixelRatio, layerState.opacity,
@@ -93,7 +93,7 @@ ol.renderer.webgl.VectorLayer.prototype.composeFrame =
  */
 ol.renderer.webgl.VectorLayer.prototype.disposeInternal = function() {
   var replayGroup = this.replayGroup_;
-  if (!goog.isNull(replayGroup)) {
+  if (replayGroup !== null) {
     var context = this.mapRenderer.getContext();
     replayGroup.getDeleteResourcesFunction(context)();
     this.replayGroup_ = null;
@@ -107,7 +107,7 @@ ol.renderer.webgl.VectorLayer.prototype.disposeInternal = function() {
  */
 ol.renderer.webgl.VectorLayer.prototype.forEachFeatureAtCoordinate =
     function(coordinate, frameState, callback, thisArg) {
-  if (goog.isNull(this.replayGroup_) || goog.isNull(this.layerState_)) {
+  if (this.replayGroup_ === null || this.layerState_ === null) {
     return undefined;
   } else {
     var context = this.mapRenderer.getContext();
@@ -141,7 +141,7 @@ ol.renderer.webgl.VectorLayer.prototype.forEachFeatureAtCoordinate =
  */
 ol.renderer.webgl.VectorLayer.prototype.hasFeatureAtCoordinate =
     function(coordinate, frameState) {
-  if (goog.isNull(this.replayGroup_) || goog.isNull(this.layerState_)) {
+  if (this.replayGroup_ === null || this.layerState_ === null) {
     return false;
   } else {
     var context = this.mapRenderer.getContext();
@@ -233,7 +233,7 @@ ol.renderer.webgl.VectorLayer.prototype.prepareFrame =
     return true;
   }
 
-  if (!goog.isNull(this.replayGroup_)) {
+  if (this.replayGroup_ !== null) {
     frameState.postRenderFunctions.push(
         this.replayGroup_.getDeleteResourcesFunction(context));
   }
@@ -266,7 +266,7 @@ ol.renderer.webgl.VectorLayer.prototype.prepareFrame =
       this.dirty_ = this.dirty_ || dirty;
     }
   };
-  if (!goog.isNull(vectorLayerRenderOrder)) {
+  if (vectorLayerRenderOrder !== null) {
     /** @type {Array.<ol.Feature>} */
     var features = [];
     vectorSource.forEachFeatureInExtentAtResolution(extent, resolution,

--- a/src/ol/source/bingmapssource.js
+++ b/src/ol/source/bingmapssource.js
@@ -130,7 +130,7 @@ ol.source.BingMaps.prototype.handleImageryMetadataResponse =
               goog.asserts.assert(ol.proj.equivalent(
                   projection, sourceProjection),
                   'projections are equivalent');
-              if (goog.isNull(tileCoord)) {
+              if (tileCoord === null) {
                 return undefined;
               } else {
                 ol.tilecoord.createOrUpdate(tileCoord[0], tileCoord[1],

--- a/src/ol/source/imagecanvassource.js
+++ b/src/ol/source/imagecanvassource.js
@@ -64,7 +64,7 @@ ol.source.ImageCanvas.prototype.getImage =
   resolution = this.findNearestResolution(resolution);
 
   var canvas = this.canvas_;
-  if (!goog.isNull(canvas) &&
+  if (canvas !== null &&
       this.renderedRevision_ == this.getRevision() &&
       canvas.getResolution() == resolution &&
       canvas.getPixelRatio() == pixelRatio &&
@@ -80,7 +80,7 @@ ol.source.ImageCanvas.prototype.getImage =
 
   var canvasElement = this.canvasFunction_(
       extent, resolution, pixelRatio, size, projection);
-  if (!goog.isNull(canvasElement)) {
+  if (canvasElement !== null) {
     canvas = new ol.ImageCanvas(extent, resolution, pixelRatio,
         this.getAttributions(), canvasElement);
   }

--- a/src/ol/source/imagemapguidesource.js
+++ b/src/ol/source/imagemapguidesource.js
@@ -132,7 +132,7 @@ ol.source.ImageMapGuide.prototype.getImage =
   pixelRatio = this.hidpi_ ? pixelRatio : 1;
 
   var image = this.image_;
-  if (!goog.isNull(image) &&
+  if (image !== null &&
       this.renderedRevision_ == this.getRevision() &&
       image.getResolution() == resolution &&
       image.getPixelRatio() == pixelRatio &&

--- a/src/ol/source/imagesource.js
+++ b/src/ol/source/imagesource.js
@@ -50,7 +50,7 @@ ol.source.Image = function(options) {
    */
   this.resolutions_ = options.resolutions !== undefined ?
       options.resolutions : null;
-  goog.asserts.assert(goog.isNull(this.resolutions_) ||
+  goog.asserts.assert(this.resolutions_ === null ||
       goog.array.isSorted(this.resolutions_,
           function(a, b) {
             return b - a;
@@ -75,7 +75,7 @@ ol.source.Image.prototype.getResolutions = function() {
  */
 ol.source.Image.prototype.findNearestResolution =
     function(resolution) {
-  if (!goog.isNull(this.resolutions_)) {
+  if (this.resolutions_ !== null) {
     var idx = ol.array.linearFindNearest(this.resolutions_, resolution, 0);
     resolution = this.resolutions_[idx];
   }

--- a/src/ol/source/imagevectorsource.js
+++ b/src/ol/source/imagevectorsource.js
@@ -154,7 +154,7 @@ ol.source.ImageVector.prototype.canvasFunctionInternal_ =
  */
 ol.source.ImageVector.prototype.forEachFeatureAtCoordinate = function(
     coordinate, resolution, rotation, skippedFeatureUids, callback) {
-  if (goog.isNull(this.replayGroup_)) {
+  if (this.replayGroup_ === null) {
     return undefined;
   } else {
     /** @type {Object.<string, boolean>} */
@@ -292,7 +292,7 @@ ol.source.ImageVector.prototype.renderFeature_ =
  */
 ol.source.ImageVector.prototype.setStyle = function(style) {
   this.style_ = style !== undefined ? style : ol.style.defaultStyleFunction;
-  this.styleFunction_ = goog.isNull(style) ?
+  this.styleFunction_ = style === null ?
       undefined : ol.style.createStyleFunction(this.style_);
   this.changed();
 };

--- a/src/ol/source/imagewmssource.js
+++ b/src/ol/source/imagewmssource.js
@@ -223,7 +223,7 @@ ol.source.ImageWMS.prototype.getImage =
   extent[3] = centerY + imageResolution * height / 2;
 
   var image = this.image_;
-  if (!goog.isNull(image) &&
+  if (image !== null &&
       this.renderedRevision_ == this.getRevision() &&
       image.getResolution() == resolution &&
       image.getPixelRatio() == pixelRatio &&

--- a/src/ol/source/rastersource.js
+++ b/src/ol/source/rastersource.js
@@ -320,7 +320,7 @@ ol.source.Raster.prototype.onWorkerComplete_ =
     callback(err);
     return;
   }
-  if (goog.isNull(output)) {
+  if (output === null) {
     // job aborted
     return;
   }

--- a/src/ol/source/tilearcgisrestsource.js
+++ b/src/ol/source/tilearcgisrestsource.js
@@ -200,7 +200,7 @@ ol.source.TileArcGISRest.prototype.tileUrlFunction_ =
     function(tileCoord, pixelRatio, projection) {
 
   var tileGrid = this.getTileGrid();
-  if (goog.isNull(tileGrid)) {
+  if (tileGrid === null) {
     tileGrid = this.getTileGridForProjection(projection);
   }
 

--- a/src/ol/source/tiledebugsource.js
+++ b/src/ol/source/tiledebugsource.js
@@ -110,7 +110,7 @@ ol.source.TileDebug.prototype.getTile = function(z, x, y) {
     var tileSize = ol.size.toSize(this.tileGrid.getTileSize(z));
     var tileCoord = [z, x, y];
     var textTileCoord = this.getTileCoordForTileUrlFunction(tileCoord);
-    var text = goog.isNull(textTileCoord) ? '' : ol.tilecoord.toString(
+    var text = textTileCoord === null ? '' : ol.tilecoord.toString(
         this.getTileCoordForTileUrlFunction(textTileCoord));
     var tile = new ol.DebugTile_(tileCoord, tileSize, text);
     this.tileCache.set(tileCoordKey, tile);

--- a/src/ol/source/tileimagesource.js
+++ b/src/ol/source/tileimagesource.js
@@ -95,7 +95,7 @@ ol.source.TileImage.prototype.getTile =
     var tileCoord = [z, x, y];
     var urlTileCoord = this.getTileCoordForTileUrlFunction(
         tileCoord, projection);
-    var tileUrl = goog.isNull(urlTileCoord) ? undefined :
+    var tileUrl = urlTileCoord === null ? undefined :
         this.tileUrlFunction(urlTileCoord, pixelRatio, projection);
     var tile = new this.tileClass(
         tileCoord,

--- a/src/ol/source/tilejsonsource.js
+++ b/src/ol/source/tilejsonsource.js
@@ -77,8 +77,7 @@ ol.source.TileJSON.prototype.handleTileJSONResponse = function(tileJSON) {
 
   this.tileUrlFunction = ol.TileUrlFunction.createFromTemplates(tileJSON.tiles);
 
-  if (tileJSON.attribution !== undefined &&
-      goog.isNull(this.getAttributions())) {
+  if (tileJSON.attribution !== undefined && this.getAttributions() === null) {
     var attributionExtent = extent !== undefined ?
         extent : epsg4326Projection.getExtent();
     /** @type {Object.<string, Array.<ol.TileRange>>} */

--- a/src/ol/source/tilesource.js
+++ b/src/ol/source/tilesource.js
@@ -194,7 +194,7 @@ ol.source.Tile.prototype.getTileGrid = function() {
  * @return {ol.tilegrid.TileGrid} Tile grid.
  */
 ol.source.Tile.prototype.getTileGridForProjection = function(projection) {
-  if (goog.isNull(this.tileGrid)) {
+  if (this.tileGrid === null) {
     return ol.tilegrid.getForProjection(projection);
   } else {
     return this.tileGrid;
@@ -230,7 +230,7 @@ ol.source.Tile.prototype.getTileCoordForTileUrlFunction =
   var projection = opt_projection !== undefined ?
       opt_projection : this.getProjection();
   var tileGrid = this.getTileGridForProjection(projection);
-  goog.asserts.assert(!goog.isNull(tileGrid), 'tile grid needed');
+  goog.asserts.assert(tileGrid !== null, 'tile grid needed');
   if (this.getWrapX() && projection.isGlobal()) {
     tileCoord = ol.tilecoord.wrapX(tileCoord, tileGrid, projection);
   }

--- a/src/ol/source/tileutfgridsource.js
+++ b/src/ol/source/tileutfgridsource.js
@@ -81,7 +81,7 @@ ol.source.TileUTFGrid.prototype.getTemplate = function() {
  */
 ol.source.TileUTFGrid.prototype.forDataAtCoordinateAndResolution = function(
     coordinate, resolution, callback, opt_this, opt_request) {
-  if (!goog.isNull(this.tileGrid)) {
+  if (this.tileGrid !== null) {
     var tileCoord = this.tileGrid.getTileCoordForCoordAndResolution(
         coordinate, resolution);
     var tile = /** @type {!ol.source.TileUTFGridTile_} */(this.getTile(
@@ -268,7 +268,7 @@ ol.source.TileUTFGridTile_.prototype.getImage = function(opt_context) {
  * @return {Object}
  */
 ol.source.TileUTFGridTile_.prototype.getData = function(coordinate) {
-  if (goog.isNull(this.grid_) || goog.isNull(this.keys_) ||
+  if (this.grid_ === null || this.keys_ === null ||
       !goog.isDefAndNotNull(this.data_)) {
     return null;
   }

--- a/src/ol/source/tilevectorsource.js
+++ b/src/ol/source/tilevectorsource.js
@@ -57,8 +57,7 @@ ol.source.TileVector = function(options) {
   this.tileLoadFunction_ = options.tileLoadFunction !== undefined ?
       options.tileLoadFunction : null;
 
-  goog.asserts.assert(!goog.isNull(this.format_) ||
-      !goog.isNull(this.tileLoadFunction_),
+  goog.asserts.assert(this.format_ !== null || this.tileLoadFunction_ !== null,
       'Either format or tileLoadFunction are required');
 
   /**
@@ -253,7 +252,7 @@ ol.source.TileVector.prototype.getFeaturesInExtent = goog.abstractMethod;
 ol.source.TileVector.prototype.getTileCoordForTileUrlFunction =
     function(tileCoord, projection) {
   var tileGrid = this.tileGrid_;
-  goog.asserts.assert(!goog.isNull(tileGrid), 'tile grid needed');
+  goog.asserts.assert(tileGrid !== null, 'tile grid needed');
   if (this.getWrapX() && projection.isGlobal()) {
     tileCoord = ol.tilecoord.wrapX(tileCoord, tileGrid, projection);
   }
@@ -303,12 +302,12 @@ ol.source.TileVector.prototype.loadFeatures =
         tileCoord[2] = y;
         var urlTileCoord = this.getTileCoordForTileUrlFunction(
             tileCoord, projection);
-        var url = goog.isNull(urlTileCoord) ? undefined :
+        var url = urlTileCoord === null ? undefined :
             tileUrlFunction(urlTileCoord, 1, projection);
         if (url !== undefined) {
           tiles[tileKey] = [];
           var tileSuccess = goog.partial(success, tileKey);
-          if (!goog.isNull(this.tileLoadFunction_)) {
+          if (this.tileLoadFunction_ !== null) {
             this.tileLoadFunction_(url, goog.bind(tileSuccess, this));
           } else {
             var loader = ol.featureloader.loadFeaturesXhr(url,

--- a/src/ol/source/tilewmssource.js
+++ b/src/ol/source/tilewmssource.js
@@ -135,7 +135,7 @@ ol.source.TileWMS.prototype.getGetFeatureInfoUrl =
   var projectionObj = ol.proj.get(projection);
 
   var tileGrid = this.getTileGrid();
-  if (goog.isNull(tileGrid)) {
+  if (tileGrid === null) {
     tileGrid = this.getTileGridForProjection(projectionObj);
   }
 
@@ -365,7 +365,7 @@ ol.source.TileWMS.prototype.tileUrlFunction_ =
     function(tileCoord, pixelRatio, projection) {
 
   var tileGrid = this.getTileGrid();
-  if (goog.isNull(tileGrid)) {
+  if (tileGrid === null) {
     tileGrid = this.getTileGridForProjection(projection);
   }
 

--- a/src/ol/source/vectorsource.js
+++ b/src/ol/source/vectorsource.js
@@ -205,7 +205,7 @@ ol.source.Vector.prototype.addFeatureInternal = function(feature) {
   var geometry = feature.getGeometry();
   if (goog.isDefAndNotNull(geometry)) {
     var extent = geometry.getExtent();
-    if (!goog.isNull(this.featuresRtree_)) {
+    if (this.featuresRtree_ !== null) {
       this.featuresRtree_.insert(extent, feature);
     }
   } else {
@@ -306,7 +306,7 @@ ol.source.Vector.prototype.addFeaturesInternal = function(features) {
       this.nullGeometryFeatures_[featureKey] = feature;
     }
   }
-  if (!goog.isNull(this.featuresRtree_)) {
+  if (this.featuresRtree_ !== null) {
     this.featuresRtree_.load(extents, geometryFeatures);
   }
 
@@ -322,7 +322,7 @@ ol.source.Vector.prototype.addFeaturesInternal = function(features) {
  * @private
  */
 ol.source.Vector.prototype.bindFeaturesCollection_ = function(collection) {
-  goog.asserts.assert(goog.isNull(this.featuresCollection_),
+  goog.asserts.assert(this.featuresCollection_ === null,
       'bindFeaturesCollection can only be called once');
   var modifyingCollection = false;
   goog.events.listen(this, ol.source.VectorEventType.ADDFEATURE,
@@ -376,19 +376,19 @@ ol.source.Vector.prototype.clear = function(opt_fast) {
       var keys = this.featureChangeKeys_[featureId];
       keys.forEach(goog.events.unlistenByKey);
     }
-    if (goog.isNull(this.featuresCollection_)) {
+    if (this.featuresCollection_ === null) {
       this.featureChangeKeys_ = {};
       this.idIndex_ = {};
       this.undefIdIndex_ = {};
     }
   } else {
     var rmFeatureInternal = this.removeFeatureInternal;
-    if (!goog.isNull(this.featuresRtree_)) {
+    if (this.featuresRtree_ !== null) {
       this.featuresRtree_.forEach(rmFeatureInternal, this);
       goog.object.forEach(this.nullGeometryFeatures_, rmFeatureInternal, this);
     }
   }
-  if (!goog.isNull(this.featuresCollection_)) {
+  if (this.featuresCollection_ !== null) {
     this.featuresCollection_.clear();
   }
   goog.asserts.assert(goog.object.isEmpty(this.featureChangeKeys_),
@@ -398,7 +398,7 @@ ol.source.Vector.prototype.clear = function(opt_fast) {
   goog.asserts.assert(goog.object.isEmpty(this.undefIdIndex_),
       'undefIdIndex is an empty object now');
 
-  if (!goog.isNull(this.featuresRtree_)) {
+  if (this.featuresRtree_ !== null) {
     this.featuresRtree_.clear();
   }
   this.loadedExtentsRtree_.clear();
@@ -423,9 +423,9 @@ ol.source.Vector.prototype.clear = function(opt_fast) {
  * @api stable
  */
 ol.source.Vector.prototype.forEachFeature = function(callback, opt_this) {
-  if (!goog.isNull(this.featuresRtree_)) {
+  if (this.featuresRtree_ !== null) {
     return this.featuresRtree_.forEach(callback, opt_this);
-  } else if (!goog.isNull(this.featuresCollection_)) {
+  } else if (this.featuresCollection_ !== null) {
     return this.featuresCollection_.forEach(callback, opt_this);
   }
 };
@@ -483,9 +483,9 @@ ol.source.Vector.prototype.forEachFeatureAtCoordinateDirect =
  */
 ol.source.Vector.prototype.forEachFeatureInExtent =
     function(extent, callback, opt_this) {
-  if (!goog.isNull(this.featuresRtree_)) {
+  if (this.featuresRtree_ !== null) {
     return this.featuresRtree_.forEachInExtent(extent, callback, opt_this);
-  } else if (!goog.isNull(this.featuresCollection_)) {
+  } else if (this.featuresCollection_ !== null) {
     return this.featuresCollection_.forEach(callback, opt_this);
   }
 };
@@ -563,9 +563,9 @@ ol.source.Vector.prototype.getFeaturesCollection = function() {
  */
 ol.source.Vector.prototype.getFeatures = function() {
   var features;
-  if (!goog.isNull(this.featuresCollection_)) {
+  if (this.featuresCollection_ !== null) {
     features = this.featuresCollection_.getArray();
-  } else if (!goog.isNull(this.featuresRtree_)) {
+  } else if (this.featuresRtree_ !== null) {
     features = this.featuresRtree_.getAll();
     if (!goog.object.isEmpty(this.nullGeometryFeatures_)) {
       goog.array.extend(
@@ -605,7 +605,7 @@ ol.source.Vector.prototype.getFeaturesAtCoordinate = function(coordinate) {
  * @api
  */
 ol.source.Vector.prototype.getFeaturesInExtent = function(extent) {
-  goog.asserts.assert(!goog.isNull(this.featuresRtree_),
+  goog.asserts.assert(this.featuresRtree_ !== null,
       'getFeaturesInExtent does not work when useSpatialIndex is set to false');
   return this.featuresRtree_.getInExtent(extent);
 };
@@ -635,7 +635,7 @@ ol.source.Vector.prototype.getClosestFeatureToCoordinate =
   var closestPoint = [NaN, NaN];
   var minSquaredDistance = Infinity;
   var extent = [-Infinity, -Infinity, Infinity, Infinity];
-  goog.asserts.assert(!goog.isNull(this.featuresRtree_),
+  goog.asserts.assert(this.featuresRtree_ !== null,
       'getClosestFeatureToCoordinate does not work with useSpatialIndex set ' +
       'to false');
   this.featuresRtree_.forEachInExtent(extent,
@@ -675,7 +675,7 @@ ol.source.Vector.prototype.getClosestFeatureToCoordinate =
  * @api stable
  */
 ol.source.Vector.prototype.getExtent = function() {
-  goog.asserts.assert(!goog.isNull(this.featuresRtree_),
+  goog.asserts.assert(this.featuresRtree_ !== null,
       'getExtent does not work when useSpatialIndex is set to false');
   return this.featuresRtree_.getExtent();
 };
@@ -706,7 +706,7 @@ ol.source.Vector.prototype.handleFeatureChange_ = function(event) {
   var geometry = feature.getGeometry();
   if (!goog.isDefAndNotNull(geometry)) {
     if (!(featureKey in this.nullGeometryFeatures_)) {
-      if (!goog.isNull(this.featuresRtree_)) {
+      if (this.featuresRtree_ !== null) {
         this.featuresRtree_.remove(feature);
       }
       this.nullGeometryFeatures_[featureKey] = feature;
@@ -715,11 +715,11 @@ ol.source.Vector.prototype.handleFeatureChange_ = function(event) {
     var extent = geometry.getExtent();
     if (featureKey in this.nullGeometryFeatures_) {
       delete this.nullGeometryFeatures_[featureKey];
-      if (!goog.isNull(this.featuresRtree_)) {
+      if (this.featuresRtree_ !== null) {
         this.featuresRtree_.insert(extent, feature);
       }
     } else {
-      if (!goog.isNull(this.featuresRtree_)) {
+      if (this.featuresRtree_ !== null) {
         this.featuresRtree_.update(extent, feature);
       }
     }
@@ -805,7 +805,7 @@ ol.source.Vector.prototype.removeFeature = function(feature) {
   if (featureKey in this.nullGeometryFeatures_) {
     delete this.nullGeometryFeatures_[featureKey];
   } else {
-    if (!goog.isNull(this.featuresRtree_)) {
+    if (this.featuresRtree_ !== null) {
       this.featuresRtree_.remove(feature);
     }
   }

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -154,7 +154,7 @@ ol.source.WMTS = function(options) {
          * @return {string|undefined} Tile URL.
          */
         function(tileCoord, pixelRatio, projection) {
-          if (goog.isNull(tileCoord)) {
+          if (tileCoord === null) {
             return undefined;
           } else {
             var localContext = {
@@ -341,15 +341,14 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
   /* jshint -W069 */
 
   // TODO: add support for TileMatrixLimits
-  goog.asserts.assert(!goog.isNull(config['layer']),
+  goog.asserts.assert(config['layer'] !== null,
       'config "layer" must not be null');
 
   var layers = wmtsCap['Contents']['Layer'];
   var l = goog.array.find(layers, function(elt, index, array) {
     return elt['Identifier'] == config['layer'];
   });
-  goog.asserts.assert(!goog.isNull(l),
-      'found a matching layer in Contents/Layer');
+  goog.asserts.assert(l !== null, 'found a matching layer in Contents/Layer');
 
   goog.asserts.assert(l['TileMatrixSetLink'].length > 0,
       'layer has TileMatrixSetLink');
@@ -381,8 +380,7 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
   matrixSet = /** @type {string} */
       (l['TileMatrixSetLink'][idx]['TileMatrixSet']);
 
-  goog.asserts.assert(!goog.isNull(matrixSet),
-      'TileMatrixSet must not be null');
+  goog.asserts.assert(matrixSet !== null, 'TileMatrixSet must not be null');
 
   var format = /** @type {string} */ (l['Format'][0]);
   if ('format' in config) {
@@ -420,7 +418,7 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
   var matrixSetObj = goog.array.find(matrixSets, function(elt, index, array) {
     return elt['Identifier'] == matrixSet;
   });
-  goog.asserts.assert(!goog.isNull(matrixSetObj),
+  goog.asserts.assert(matrixSetObj !== null,
       'found matrixSet in Contents/TileMatrixSet');
 
   var projection;
@@ -440,7 +438,7 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
     extent = ol.proj.transformExtent(
         wgs84BoundingBox, 'EPSG:4326', projection);
     var projectionExtent = projection.getExtent();
-    if (!goog.isNull(projectionExtent)) {
+    if (projectionExtent !== null) {
       // If possible, do a sanity check on the extent - it should never be
       // bigger than the validity extent of the projection of a matrix set.
       if (!ol.extent.containsExtent(projectionExtent, extent)) {

--- a/src/ol/source/zoomifysource.js
+++ b/src/ol/source/zoomifysource.js
@@ -104,7 +104,7 @@ ol.source.Zoomify = function(opt_options) {
    * @return {string|undefined} Tile URL.
    */
   function tileUrlFunction(tileCoord, pixelRatio, projection) {
-    if (goog.isNull(tileCoord)) {
+    if (tileCoord === null) {
       return undefined;
     } else {
       var tileCoordZ = tileCoord[0];

--- a/src/ol/structs/lrucache.js
+++ b/src/ol/structs/lrucache.js
@@ -49,25 +49,25 @@ ol.structs.LRUCache.prototype.assertValid = function() {
   if (this.count_ === 0) {
     goog.asserts.assert(goog.object.isEmpty(this.entries_),
         'entries must be an empty object (count = 0)');
-    goog.asserts.assert(goog.isNull(this.oldest_),
+    goog.asserts.assert(this.oldest_ === null,
         'oldest must be null (count = 0)');
-    goog.asserts.assert(goog.isNull(this.newest_),
+    goog.asserts.assert(this.newest_ === null,
         'newest must be null (count = 0)');
   } else {
     goog.asserts.assert(goog.object.getCount(this.entries_) == this.count_,
         'number of entries matches count');
-    goog.asserts.assert(!goog.isNull(this.oldest_),
+    goog.asserts.assert(this.oldest_ !== null,
         'we have an oldest entry');
-    goog.asserts.assert(goog.isNull(this.oldest_.older),
+    goog.asserts.assert(this.oldest_.older === null,
         'no entry is older than oldest');
-    goog.asserts.assert(!goog.isNull(this.newest_),
+    goog.asserts.assert(this.newest_,
         'we have a newest entry');
-    goog.asserts.assert(goog.isNull(this.newest_.newer),
+    goog.asserts.assert(this.newest_.newer === null,
         'no entry is newer than newest');
     var i, entry;
     var older = null;
     i = 0;
-    for (entry = this.oldest_; !goog.isNull(entry); entry = entry.newer) {
+    for (entry = this.oldest_; entry !== null; entry = entry.newer) {
       goog.asserts.assert(entry.older === older,
           'entry.older links to correct older');
       older = entry;
@@ -76,7 +76,7 @@ ol.structs.LRUCache.prototype.assertValid = function() {
     goog.asserts.assert(i == this.count_, 'iterated correct amount of times');
     var newer = null;
     i = 0;
-    for (entry = this.newest_; !goog.isNull(entry); entry = entry.older) {
+    for (entry = this.newest_; entry !== null; entry = entry.older) {
       goog.asserts.assert(entry.newer === newer,
           'entry.newer links to correct newer');
       newer = entry;
@@ -117,7 +117,7 @@ ol.structs.LRUCache.prototype.containsKey = function(key) {
  */
 ol.structs.LRUCache.prototype.forEach = function(f, opt_this) {
   var entry = this.oldest_;
-  while (!goog.isNull(entry)) {
+  while (entry !== null) {
     f.call(opt_this, entry.value_, entry.key_, this);
     entry = entry.newer;
   }
@@ -163,7 +163,7 @@ ol.structs.LRUCache.prototype.getKeys = function() {
   var keys = new Array(this.count_);
   var i = 0;
   var entry;
-  for (entry = this.newest_; !goog.isNull(entry); entry = entry.older) {
+  for (entry = this.newest_; entry !== null; entry = entry.older) {
     keys[i++] = entry.key_;
   }
   goog.asserts.assert(i == this.count_, 'iterated correct number of times');
@@ -178,7 +178,7 @@ ol.structs.LRUCache.prototype.getValues = function() {
   var values = new Array(this.count_);
   var i = 0;
   var entry;
-  for (entry = this.newest_; !goog.isNull(entry); entry = entry.older) {
+  for (entry = this.newest_; entry !== null; entry = entry.older) {
     values[i++] = entry.value_;
   }
   goog.asserts.assert(i == this.count_, 'iterated correct number of times');
@@ -190,7 +190,7 @@ ol.structs.LRUCache.prototype.getValues = function() {
  * @return {T} Last value.
  */
 ol.structs.LRUCache.prototype.peekLast = function() {
-  goog.asserts.assert(!goog.isNull(this.oldest_), 'oldest must not be null');
+  goog.asserts.assert(this.oldest_ !== null, 'oldest must not be null');
   return this.oldest_.value_;
 };
 
@@ -199,7 +199,7 @@ ol.structs.LRUCache.prototype.peekLast = function() {
  * @return {string} Last key.
  */
 ol.structs.LRUCache.prototype.peekLastKey = function() {
-  goog.asserts.assert(!goog.isNull(this.oldest_), 'oldest must not be null');
+  goog.asserts.assert(this.oldest_ !== null, 'oldest must not be null');
   return this.oldest_.key_;
 };
 
@@ -208,17 +208,17 @@ ol.structs.LRUCache.prototype.peekLastKey = function() {
  * @return {T} value Value.
  */
 ol.structs.LRUCache.prototype.pop = function() {
-  goog.asserts.assert(!goog.isNull(this.oldest_), 'oldest must not be null');
-  goog.asserts.assert(!goog.isNull(this.newest_), 'newest must not be null');
+  goog.asserts.assert(this.oldest_ !== null, 'oldest must not be null');
+  goog.asserts.assert(this.newest_ !== null, 'newest must not be null');
   var entry = this.oldest_;
   goog.asserts.assert(entry.key_ in this.entries_,
       'oldest is indexed in entries');
   delete this.entries_[entry.key_];
-  if (!goog.isNull(entry.newer)) {
+  if (entry.newer !== null) {
     entry.newer.older = null;
   }
   this.oldest_ = entry.newer;
-  if (goog.isNull(this.oldest_)) {
+  if (this.oldest_ === null) {
     this.newest_ = null;
   }
   --this.count_;
@@ -241,7 +241,7 @@ ol.structs.LRUCache.prototype.set = function(key, value) {
     older: this.newest_,
     value_: value
   };
-  if (goog.isNull(this.newest_)) {
+  if (this.newest_ === null) {
     this.oldest_ = entry;
   } else {
     this.newest_.newer = entry;

--- a/src/ol/style/atlasmanager.js
+++ b/src/ol/style/atlasmanager.js
@@ -97,13 +97,12 @@ ol.style.AtlasManager.prototype.getInfo = function(id) {
   /** @type {?ol.style.AtlasInfo} */
   var info = this.getInfo_(this.atlases_, id);
 
-  if (goog.isNull(info)) {
+  if (info === null) {
     return null;
   }
   /** @type {?ol.style.AtlasInfo} */
   var hitInfo = this.getInfo_(this.hitAtlases_, id);
-  goog.asserts.assert(!goog.isNull(hitInfo),
-      'hitInfo must not be null');
+  goog.asserts.assert(hitInfo !== null, 'hitInfo must not be null');
 
   return this.mergeInfos_(info, hitInfo);
 };
@@ -121,7 +120,7 @@ ol.style.AtlasManager.prototype.getInfo_ = function(atlases, id) {
   for (i = 0, ii = atlases.length; i < ii; ++i) {
     atlas = atlases[i];
     info = atlas.get(id);
-    if (!goog.isNull(info)) {
+    if (info !== null) {
       return info;
     }
   }
@@ -184,7 +183,7 @@ ol.style.AtlasManager.prototype.add =
   /** @type {?ol.style.AtlasInfo} */
   var info = this.add_(false,
       id, width, height, renderCallback, opt_this);
-  if (goog.isNull(info)) {
+  if (info === null) {
     return null;
   }
 
@@ -197,8 +196,7 @@ ol.style.AtlasManager.prototype.add =
   /** @type {?ol.style.AtlasInfo} */
   var hitInfo = this.add_(true,
       id, width, height, renderHitCallback, opt_this);
-  goog.asserts.assert(!goog.isNull(hitInfo),
-      'hitInfo must not be null');
+  goog.asserts.assert(hitInfo, 'hitInfo must not be null');
 
   return this.mergeInfos_(info, hitInfo);
 };
@@ -225,9 +223,9 @@ ol.style.AtlasManager.prototype.add_ =
   for (i = 0, ii = atlases.length; i < ii; ++i) {
     atlas = atlases[i];
     info = atlas.add(id, width, height, renderCallback, opt_this);
-    if (!goog.isNull(info)) {
+    if (info !== null) {
       return info;
-    } else if (goog.isNull(info) && i === ii - 1) {
+    } else if (info === null && i === ii - 1) {
       // the entry could not be added to one of the existing atlases,
       // create a new atlas that is twice as big and try to add to this one.
       var size;

--- a/src/ol/style/circlestyle.js
+++ b/src/ol/style/circlestyle.js
@@ -246,7 +246,7 @@ ol.style.Circle.prototype.render_ = function(atlasManager) {
   var strokeStyle;
   var strokeWidth = 0;
 
-  if (!goog.isNull(this.stroke_)) {
+  if (this.stroke_ !== null) {
     strokeStyle = ol.color.asString(this.stroke_.getColor());
     strokeWidth = this.stroke_.getWidth();
     if (strokeWidth === undefined) {
@@ -290,7 +290,7 @@ ol.style.Circle.prototype.render_ = function(atlasManager) {
     // an atlas manager is used, add the symbol to an atlas
     size = Math.round(size);
 
-    var hasCustomHitDetectionImage = goog.isNull(this.fill_);
+    var hasCustomHitDetectionImage = this.fill_ === null;
     var renderHitDetectionCallback;
     if (hasCustomHitDetectionImage) {
       // render the hit-detection image into a separate atlas image
@@ -343,14 +343,14 @@ ol.style.Circle.prototype.draw_ = function(renderOptions, context, x, y) {
       renderOptions.size / 2, renderOptions.size / 2,
       this.radius_, 0, 2 * Math.PI, true);
 
-  if (!goog.isNull(this.fill_)) {
+  if (this.fill_ !== null) {
     context.fillStyle = ol.color.asString(this.fill_.getColor());
     context.fill();
   }
-  if (!goog.isNull(this.stroke_)) {
+  if (this.stroke_ !== null) {
     context.strokeStyle = renderOptions.strokeStyle;
     context.lineWidth = renderOptions.strokeWidth;
-    if (!goog.isNull(renderOptions.lineDash)) {
+    if (renderOptions.lineDash !== null) {
       context.setLineDash(renderOptions.lineDash);
     }
     context.stroke();
@@ -365,7 +365,7 @@ ol.style.Circle.prototype.draw_ = function(renderOptions, context, x, y) {
  */
 ol.style.Circle.prototype.createHitDetectionCanvas_ = function(renderOptions) {
   this.hitDetectionImageSize_ = [renderOptions.size, renderOptions.size];
-  if (!goog.isNull(this.fill_)) {
+  if (this.fill_ !== null) {
     this.hitDetectionCanvas_ = this.canvas_;
     return;
   }
@@ -407,10 +407,10 @@ ol.style.Circle.prototype.drawHitDetectionCanvas_ =
 
   context.fillStyle = ol.color.asString(ol.render.canvas.defaultFillStyle);
   context.fill();
-  if (!goog.isNull(this.stroke_)) {
+  if (this.stroke_ !== null) {
     context.strokeStyle = renderOptions.strokeStyle;
     context.lineWidth = renderOptions.strokeWidth;
-    if (!goog.isNull(renderOptions.lineDash)) {
+    if (renderOptions.lineDash !== null) {
       context.setLineDash(renderOptions.lineDash);
     }
     context.stroke();
@@ -423,12 +423,12 @@ ol.style.Circle.prototype.drawHitDetectionCanvas_ =
  * @inheritDoc
  */
 ol.style.Circle.prototype.getChecksum = function() {
-  var strokeChecksum = !goog.isNull(this.stroke_) ?
+  var strokeChecksum = this.stroke_ !== null ?
       this.stroke_.getChecksum() : '-';
-  var fillChecksum = !goog.isNull(this.fill_) ?
+  var fillChecksum = this.fill_ !== null ?
       this.fill_.getChecksum() : '-';
 
-  var recalculate = goog.isNull(this.checksums_) ||
+  var recalculate = this.checksums_ === null ||
       (strokeChecksum != this.checksums_[1] ||
       fillChecksum != this.checksums_[2] ||
       this.radius_ != this.checksums_[3]);

--- a/src/ol/style/fillstyle.js
+++ b/src/ol/style/fillstyle.js
@@ -59,7 +59,7 @@ ol.style.Fill.prototype.setColor = function(color) {
  */
 ol.style.Fill.prototype.getChecksum = function() {
   if (this.checksum_ === undefined) {
-    this.checksum_ = 'f' + (!goog.isNull(this.color_) ?
+    this.checksum_ = 'f' + (this.color_ !== null ?
         ol.color.asString(this.color_) : '-');
   }
 

--- a/src/ol/style/iconstyle.js
+++ b/src/ol/style/iconstyle.js
@@ -104,16 +104,16 @@ ol.style.Icon = function(opt_options) {
    */
   var src = options.src;
 
-  goog.asserts.assert(!(src !== undefined && !goog.isNull(image)),
+  goog.asserts.assert(!(src !== undefined && image !== null),
       'image and src can not provided at the same time');
   goog.asserts.assert(
-      src === undefined || (src !== undefined && goog.isNull(imgSize)),
+      src === undefined || (src !== undefined && imgSize === null),
       'imgSize should not be set when src is provided');
   goog.asserts.assert(
-      goog.isNull(image) || (!goog.isNull(image) && !goog.isNull(imgSize)),
+      image === null || (image !== null && imgSize !== null),
       'imgSize must be set when image is provided');
 
-  if ((src === undefined || src.length === 0) && !goog.isNull(image)) {
+  if ((src === undefined || src.length === 0) && image !== null) {
     src = image.src;
   }
   goog.asserts.assert(src !== undefined && src.length > 0,
@@ -201,14 +201,14 @@ goog.inherits(ol.style.Icon, ol.style.Image);
  * @api
  */
 ol.style.Icon.prototype.getAnchor = function() {
-  if (!goog.isNull(this.normalizedAnchor_)) {
+  if (this.normalizedAnchor_ !== null) {
     return this.normalizedAnchor_;
   }
   var anchor = this.anchor_;
   var size = this.getSize();
   if (this.anchorXUnits_ == ol.style.IconAnchorUnits.FRACTION ||
       this.anchorYUnits_ == ol.style.IconAnchorUnits.FRACTION) {
-    if (goog.isNull(size)) {
+    if (size === null) {
       return null;
     }
     anchor = this.anchor_.slice();
@@ -221,7 +221,7 @@ ol.style.Icon.prototype.getAnchor = function() {
   }
 
   if (this.anchorOrigin_ != ol.style.IconOrigin.TOP_LEFT) {
-    if (goog.isNull(size)) {
+    if (size === null) {
       return null;
     }
     if (anchor === this.anchor_) {
@@ -290,7 +290,7 @@ ol.style.Icon.prototype.getHitDetectionImage = function(pixelRatio) {
  * @api
  */
 ol.style.Icon.prototype.getOrigin = function() {
-  if (!goog.isNull(this.origin_)) {
+  if (this.origin_ !== null) {
     return this.origin_;
   }
   var offset = this.offset_;
@@ -298,7 +298,7 @@ ol.style.Icon.prototype.getOrigin = function() {
   if (this.offsetOrigin_ != ol.style.IconOrigin.TOP_LEFT) {
     var size = this.getSize();
     var iconImageSize = this.iconImage_.getSize();
-    if (goog.isNull(size) || goog.isNull(iconImageSize)) {
+    if (size === null || iconImageSize === null) {
       return null;
     }
     offset = offset.slice();
@@ -331,7 +331,7 @@ ol.style.Icon.prototype.getSrc = function() {
  * @api
  */
 ol.style.Icon.prototype.getSize = function() {
-  return goog.isNull(this.size_) ? this.iconImage_.getSize() : this.size_;
+  return this.size_ === null ? this.iconImage_.getSize() : this.size_;
 };
 
 
@@ -390,9 +390,9 @@ ol.style.IconImage_ = function(image, src, size, crossOrigin, imageState) {
    * @private
    * @type {Image}
    */
-  this.image_ = goog.isNull(image) ? new Image() : image;
+  this.image_ = image === null ? new Image() : image;
 
-  if (!goog.isNull(crossOrigin)) {
+  if (crossOrigin !== null) {
     this.image_.crossOrigin = crossOrigin;
   }
 
@@ -441,7 +441,7 @@ goog.inherits(ol.style.IconImage_, goog.events.EventTarget);
 ol.style.IconImage_.get = function(image, src, size, crossOrigin, imageState) {
   var iconImageCache = ol.style.IconImageCache.getInstance();
   var iconImage = iconImageCache.get(src, crossOrigin);
-  if (goog.isNull(iconImage)) {
+  if (iconImage === null) {
     iconImage = new ol.style.IconImage_(
         image, src, size, crossOrigin, imageState);
     iconImageCache.set(src, crossOrigin, iconImage);
@@ -516,7 +516,7 @@ ol.style.IconImage_.prototype.getImageState = function() {
  * @return {Image|HTMLCanvasElement} Image element.
  */
 ol.style.IconImage_.prototype.getHitDetectionImage = function(pixelRatio) {
-  if (goog.isNull(this.hitDetectionImage_)) {
+  if (this.hitDetectionImage_ === null) {
     if (this.tainting_) {
       var width = this.size_[0];
       var height = this.size_[1];
@@ -554,7 +554,7 @@ ol.style.IconImage_.prototype.load = function() {
   if (this.imageState_ == ol.style.ImageState.IDLE) {
     goog.asserts.assert(this.src_ !== undefined,
         'this.src_ must not be undefined');
-    goog.asserts.assert(goog.isNull(this.imageListenerKeys_),
+    goog.asserts.assert(this.imageListenerKeys_ === null,
         'no listener keys existing');
     this.imageState_ = ol.style.ImageState.LOADING;
     this.imageListenerKeys_ = [
@@ -578,7 +578,7 @@ ol.style.IconImage_.prototype.load = function() {
  * @private
  */
 ol.style.IconImage_.prototype.unlistenImage_ = function() {
-  goog.asserts.assert(!goog.isNull(this.imageListenerKeys_),
+  goog.asserts.assert(this.imageListenerKeys_ !== null,
       'we must have listeners registered');
   this.imageListenerKeys_.forEach(goog.events.unlistenByKey);
   this.imageListenerKeys_ = null;

--- a/src/ol/style/regularshapestyle.js
+++ b/src/ol/style/regularshapestyle.js
@@ -312,7 +312,7 @@ ol.style.RegularShape.prototype.render_ = function(atlasManager) {
   var strokeStyle;
   var strokeWidth = 0;
 
-  if (!goog.isNull(this.stroke_)) {
+  if (this.stroke_ !== null) {
     strokeStyle = ol.color.asString(this.stroke_.getColor());
     strokeWidth = this.stroke_.getWidth();
     if (strokeWidth === undefined) {
@@ -370,7 +370,7 @@ ol.style.RegularShape.prototype.render_ = function(atlasManager) {
     // an atlas manager is used, add the symbol to an atlas
     size = Math.round(size);
 
-    var hasCustomHitDetectionImage = goog.isNull(this.fill_);
+    var hasCustomHitDetectionImage = this.fill_ === null;
     var renderHitDetectionCallback;
     if (hasCustomHitDetectionImage) {
       // render the hit-detection image into a separate atlas image
@@ -382,7 +382,7 @@ ol.style.RegularShape.prototype.render_ = function(atlasManager) {
     var info = atlasManager.add(
         id, size, size, goog.bind(this.draw_, this, renderOptions),
         renderHitDetectionCallback);
-    goog.asserts.assert(!goog.isNull(info), 'shape size is too large');
+    goog.asserts.assert(info !== null, 'shape size is too large');
 
     this.canvas_ = info.image;
     this.origin_ = [info.offsetX, info.offsetY];
@@ -430,14 +430,14 @@ ol.style.RegularShape.prototype.draw_ = function(renderOptions, context, x, y) {
                    renderOptions.size / 2 + radiusC * Math.sin(angle0));
   }
 
-  if (!goog.isNull(this.fill_)) {
+  if (this.fill_ !== null) {
     context.fillStyle = ol.color.asString(this.fill_.getColor());
     context.fill();
   }
-  if (!goog.isNull(this.stroke_)) {
+  if (this.stroke_ !== null) {
     context.strokeStyle = renderOptions.strokeStyle;
     context.lineWidth = renderOptions.strokeWidth;
-    if (!goog.isNull(renderOptions.lineDash)) {
+    if (renderOptions.lineDash !== null) {
       context.setLineDash(renderOptions.lineDash);
     }
     context.lineCap = renderOptions.lineCap;
@@ -456,7 +456,7 @@ ol.style.RegularShape.prototype.draw_ = function(renderOptions, context, x, y) {
 ol.style.RegularShape.prototype.createHitDetectionCanvas_ =
     function(renderOptions) {
   this.hitDetectionImageSize_ = [renderOptions.size, renderOptions.size];
-  if (!goog.isNull(this.fill_)) {
+  if (this.fill_ !== null) {
     this.hitDetectionCanvas_ = this.canvas_;
     return;
   }
@@ -505,10 +505,10 @@ ol.style.RegularShape.prototype.drawHitDetectionCanvas_ =
 
   context.fillStyle = ol.render.canvas.defaultFillStyle;
   context.fill();
-  if (!goog.isNull(this.stroke_)) {
+  if (this.stroke_ !== null) {
     context.strokeStyle = renderOptions.strokeStyle;
     context.lineWidth = renderOptions.strokeWidth;
-    if (!goog.isNull(renderOptions.lineDash)) {
+    if (renderOptions.lineDash !== null) {
       context.setLineDash(renderOptions.lineDash);
     }
     context.stroke();
@@ -521,12 +521,12 @@ ol.style.RegularShape.prototype.drawHitDetectionCanvas_ =
  * @inheritDoc
  */
 ol.style.RegularShape.prototype.getChecksum = function() {
-  var strokeChecksum = !goog.isNull(this.stroke_) ?
+  var strokeChecksum = this.stroke_ !== null ?
       this.stroke_.getChecksum() : '-';
-  var fillChecksum = !goog.isNull(this.fill_) ?
+  var fillChecksum = this.fill_ !== null ?
       this.fill_.getChecksum() : '-';
 
-  var recalculate = goog.isNull(this.checksums_) ||
+  var recalculate = this.checksums_ === null ||
       (strokeChecksum != this.checksums_[1] ||
       fillChecksum != this.checksums_[2] ||
       this.radius_ != this.checksums_[3] ||

--- a/src/ol/style/strokestyle.js
+++ b/src/ol/style/strokestyle.js
@@ -205,11 +205,11 @@ ol.style.Stroke.prototype.setWidth = function(width) {
 ol.style.Stroke.prototype.getChecksum = function() {
   if (this.checksum_ === undefined) {
     var raw = 's' +
-        (!goog.isNull(this.color_) ?
+        (this.color_ !== null ?
             ol.color.asString(this.color_) : '-') + ',' +
         (this.lineCap_ !== undefined ?
             this.lineCap_.toString() : '-') + ',' +
-        (!goog.isNull(this.lineDash_) ?
+        (this.lineDash_ !== null ?
             this.lineDash_.toString() : '-') + ',' +
         (this.lineJoin_ !== undefined ?
             this.lineJoin_ : '-') + ',' +

--- a/src/ol/style/style.js
+++ b/src/ol/style/style.js
@@ -170,7 +170,7 @@ ol.style.Style.prototype.setGeometry = function(geometry) {
       }
       return result;
     };
-  } else if (goog.isNull(geometry)) {
+  } else if (geometry === null) {
     this.geometryFunction_ = ol.style.defaultGeometryFunction;
   } else if (geometry !== undefined) {
     goog.asserts.assertInstanceof(geometry, ol.geom.Geometry,
@@ -254,7 +254,7 @@ ol.style.defaultStyleFunction = function(feature, resolution) {
   // browsers that do not support Canvas. (ol.style.Circle does
   // canvas.getContext('2d') at construction time, which will cause an.error
   // in such browsers.)
-  if (goog.isNull(ol.style.defaultStyle_)) {
+  if (ol.style.defaultStyle_ === null) {
     var fill = new ol.style.Fill({
       color: 'rgba(255,255,255,0.4)'
     });
@@ -365,7 +365,6 @@ ol.style.GeometryFunction;
  * @return {ol.geom.Geometry|undefined} Geometry to render.
  */
 ol.style.defaultGeometryFunction = function(feature) {
-  goog.asserts.assert(!goog.isNull(feature),
-      'feature must not be null');
+  goog.asserts.assert(feature !== null, 'feature must not be null');
   return feature.getGeometry();
 };

--- a/src/ol/tilecoord.js
+++ b/src/ol/tilecoord.js
@@ -148,12 +148,12 @@ ol.tilecoord.withinExtentAndZ = function(tileCoord, tileGrid) {
   }
   var extent = tileGrid.getExtent();
   var tileRange;
-  if (goog.isNull(extent)) {
+  if (extent === null) {
     tileRange = tileGrid.getFullTileRange(z);
   } else {
     tileRange = tileGrid.getTileRangeForExtentAndZ(extent, z);
   }
-  if (goog.isNull(tileRange)) {
+  if (tileRange === null) {
     return true;
   } else {
     return tileRange.containsXY(x, y);

--- a/src/ol/tilegrid/tilegrid.js
+++ b/src/ol/tilegrid/tilegrid.js
@@ -73,13 +73,13 @@ ol.tilegrid.TileGrid = function(options) {
   var extent = options.extent;
 
   if (extent !== undefined &&
-      goog.isNull(this.origin_) && goog.isNull(this.origins_)) {
+      this.origin_ === null && this.origins_ === null) {
     this.origin_ = ol.extent.getTopLeft(extent);
   }
 
   goog.asserts.assert(
-      (goog.isNull(this.origin_) && !goog.isNull(this.origins_)) ||
-      (!goog.isNull(this.origin_) && goog.isNull(this.origins_)),
+      (this.origin_ === null && this.origins_ !== null) ||
+      (this.origin_ !== null && this.origins_ === null),
       'either origin or origins must be configured, never both');
 
   /**
@@ -99,10 +99,10 @@ ol.tilegrid.TileGrid = function(options) {
    */
   this.tileSize_ = options.tileSize !== undefined ?
       options.tileSize :
-      goog.isNull(this.tileSizes_) ? ol.DEFAULT_TILE_SIZE : null;
+      this.tileSizes_ === null ? ol.DEFAULT_TILE_SIZE : null;
   goog.asserts.assert(
-      (goog.isNull(this.tileSize_) && !goog.isNull(this.tileSizes_)) ||
-      (!goog.isNull(this.tileSize_) && goog.isNull(this.tileSizes_)),
+      (this.tileSize_ === null && this.tileSizes_ !== null) ||
+      (this.tileSize_ !== null && this.tileSizes_ === null),
       'either tileSize or tileSizes must be configured, never both');
 
   /**
@@ -214,10 +214,10 @@ ol.tilegrid.TileGrid.prototype.getMinZoom = function() {
  * @api stable
  */
 ol.tilegrid.TileGrid.prototype.getOrigin = function(z) {
-  if (!goog.isNull(this.origin_)) {
+  if (this.origin_ !== null) {
     return this.origin_;
   } else {
-    goog.asserts.assert(!goog.isNull(this.origins_),
+    goog.asserts.assert(this.origins_ !== null,
         'origins cannot be null if origin is null');
     goog.asserts.assert(this.minZoom <= z && z <= this.maxZoom,
         'given z is not in allowed range (%s <= %s <= %s)',
@@ -448,10 +448,10 @@ ol.tilegrid.TileGrid.prototype.getTileCoordResolution = function(tileCoord) {
  * @api stable
  */
 ol.tilegrid.TileGrid.prototype.getTileSize = function(z) {
-  if (!goog.isNull(this.tileSize_)) {
+  if (this.tileSize_ !== null) {
     return this.tileSize_;
   } else {
-    goog.asserts.assert(!goog.isNull(this.tileSizes_),
+    goog.asserts.assert(this.tileSizes_ !== null,
         'tileSizes cannot be null if tileSize is null');
     goog.asserts.assert(this.minZoom <= z && z <= this.maxZoom,
         'z is not in allowed range (%s <= %s <= %s',
@@ -466,7 +466,7 @@ ol.tilegrid.TileGrid.prototype.getTileSize = function(z) {
  * @return {ol.TileRange} Extent tile range for the specified zoom level.
  */
 ol.tilegrid.TileGrid.prototype.getFullTileRange = function(z) {
-  if (goog.isNull(this.fullTileRanges_)) {
+  if (this.fullTileRanges_ === null) {
     return null;
   } else {
     goog.asserts.assert(this.minZoom <= z && z <= this.maxZoom,
@@ -507,7 +507,7 @@ ol.tilegrid.TileGrid.prototype.calculateTileRanges_ = function(extent) {
  */
 ol.tilegrid.getForProjection = function(projection) {
   var tileGrid = projection.getDefaultTileGrid();
-  if (goog.isNull(tileGrid)) {
+  if (tileGrid === null) {
     tileGrid = ol.tilegrid.createForProjection(projection);
     projection.setDefaultTileGrid(tileGrid);
   }
@@ -620,7 +620,7 @@ ol.tilegrid.createForProjection =
 ol.tilegrid.extentFromProjection = function(projection) {
   projection = ol.proj.get(projection);
   var extent = projection.getExtent();
-  if (goog.isNull(extent)) {
+  if (extent === null) {
     var half = 180 * ol.proj.METERS_PER_UNIT[ol.proj.Units.DEGREES] /
         projection.getMetersPerUnit();
     extent = ol.extent.createOrUpdate(-half, -half, half, half);

--- a/src/ol/tileurlfunction.js
+++ b/src/ol/tileurlfunction.js
@@ -48,7 +48,7 @@ ol.TileUrlFunction.createFromTemplate = function(template) {
        * @return {string|undefined} Tile URL.
        */
       function(tileCoord, pixelRatio, projection) {
-        if (goog.isNull(tileCoord)) {
+        if (tileCoord === null) {
           return undefined;
         } else {
           return template.replace(zRegEx, tileCoord[0].toString())
@@ -94,7 +94,7 @@ ol.TileUrlFunction.createFromTileUrlFunctions = function(tileUrlFunctions) {
        * @return {string|undefined} Tile URL.
        */
       function(tileCoord, pixelRatio, projection) {
-        if (goog.isNull(tileCoord)) {
+        if (tileCoord === null) {
           return undefined;
         } else {
           var h = ol.tilecoord.hash(tileCoord);

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -681,7 +681,7 @@ ol.View.createResolutionConstraint_ = function(options) {
     // calculate the default min and max resolution
     var projection = ol.proj.createProjection(options.projection, 'EPSG:3857');
     var extent = projection.getExtent();
-    var size = goog.isNull(extent) ?
+    var size = extent === null ?
         // use an extent that can fit the whole world if need be
         360 * ol.proj.METERS_PER_UNIT[ol.proj.Units.DEGREES] /
             ol.proj.METERS_PER_UNIT[projection.getUnits()] :

--- a/src/ol/webgl/context.js
+++ b/src/ol/webgl/context.js
@@ -93,7 +93,7 @@ ol.webgl.Context = function(canvas, gl) {
   // use the OES_element_index_uint extension if available
   if (this.hasOESElementIndexUint) {
     var ext = gl.getExtension('OES_element_index_uint');
-    goog.asserts.assert(!goog.isNull(ext),
+    goog.asserts.assert(ext !== null,
         'Failed to get extension "OES_element_index_uint"');
   }
 
@@ -205,7 +205,7 @@ ol.webgl.Context.prototype.getGL = function() {
  * @return {WebGLFramebuffer} The hit detection frame buffer.
  */
 ol.webgl.Context.prototype.getHitDetectionFramebuffer = function() {
-  if (goog.isNull(this.hitDetectionFramebuffer_)) {
+  if (this.hitDetectionFramebuffer_ === null) {
     this.initHitDetectionFramebuffer_();
   }
   return this.hitDetectionFramebuffer_;

--- a/src/ol/webgl/webgl.js
+++ b/src/ol/webgl/webgl.js
@@ -34,7 +34,7 @@ ol.webgl.getContext = function(canvas, opt_attributes) {
   for (i = 0; i < ii; ++i) {
     try {
       context = canvas.getContext(ol.webgl.CONTEXT_IDS_[i], opt_attributes);
-      if (!goog.isNull(context)) {
+      if (context !== null) {
         return /** @type {!WebGLRenderingContext} */ (context);
       }
     } catch (e) {

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -57,7 +57,7 @@ ol.xml.createElementNS_ = function(namespaceURI, qualifiedName) {
  * @private
  */
 ol.xml.createElementNSActiveX_ = function(namespaceURI, qualifiedName) {
-  if (goog.isNull(namespaceURI)) {
+  if (namespaceURI === null) {
     namespaceURI = '';
   }
   return ol.xml.DOCUMENT.createNode(1, qualifiedName, namespaceURI);
@@ -107,7 +107,7 @@ ol.xml.getAllTextContent_ = function(node, normalizeWhitespace, accumulator) {
     }
   } else {
     var n;
-    for (n = node.firstChild; !goog.isNull(n); n = n.nextSibling) {
+    for (n = node.firstChild; n !== null; n = n.nextSibling) {
       ol.xml.getAllTextContent_(n, normalizeWhitespace, accumulator);
     }
   }
@@ -314,7 +314,7 @@ ol.xml.setAttributeNS_ = function(node, namespaceURI, name, value) {
  * @private
  */
 ol.xml.setAttributeNSActiveX_ = function(node, namespaceURI, name, value) {
-  if (!goog.isNull(namespaceURI)) {
+  if (namespaceURI !== null) {
     var attribute = node.ownerDocument.createNode(2, name, namespaceURI);
     attribute.nodeValue = value;
     node.setAttributeNode(attribute);
@@ -656,7 +656,7 @@ ol.xml.makeStructureNS = function(namespaceURIs, structure, opt_structureNS) {
  */
 ol.xml.parseNode = function(parsersNS, node, objectStack, opt_this) {
   var n;
-  for (n = node.firstElementChild; !goog.isNull(n); n = n.nextElementSibling) {
+  for (n = node.firstElementChild; n !== null; n = n.nextElementSibling) {
     var parsers = parsersNS[n.namespaceURI];
     if (parsers !== undefined) {
       var parser = parsers[n.localName];


### PR DESCRIPTION
This PR includes commits that replace the use of `goog.isNull` with either `expression === null` or `expression !== null`.

I have split the commits in to multiple smaller groups, so reviewing is made easier.

Please review.

See #4128