### PR TITLE
Use Date.now() instead of goog.now()

### DIFF
--- a/src/ol/animation.js
+++ b/src/ol/animation.js
@@ -16,7 +16,7 @@ goog.require('ol.easing');
  */
 ol.animation.bounce = function(options) {
   var resolution = options.resolution;
-  var start = options.start ? options.start : goog.now();
+  var start = options.start ? options.start : Date.now();
   var duration = options.duration !== undefined ? options.duration : 1000;
   var easing = options.easing ?
       options.easing : ol.easing.upAndDown;
@@ -52,7 +52,7 @@ ol.animation.bounce = function(options) {
  */
 ol.animation.pan = function(options) {
   var source = options.source;
-  var start = options.start ? options.start : goog.now();
+  var start = options.start ? options.start : Date.now();
   var sourceX = source[0];
   var sourceY = source[1];
   var duration = options.duration !== undefined ? options.duration : 1000;
@@ -92,7 +92,7 @@ ol.animation.pan = function(options) {
  */
 ol.animation.rotate = function(options) {
   var sourceRotation = options.rotation ? options.rotation : 0;
-  var start = options.start ? options.start : goog.now();
+  var start = options.start ? options.start : Date.now();
   var duration = options.duration !== undefined ? options.duration : 1000;
   var easing = options.easing ?
       options.easing : ol.easing.inAndOut;
@@ -138,7 +138,7 @@ ol.animation.rotate = function(options) {
  */
 ol.animation.zoom = function(options) {
   var sourceResolution = options.resolution;
-  var start = options.start ? options.start : goog.now();
+  var start = options.start ? options.start : Date.now();
   var duration = options.duration !== undefined ? options.duration : 1000;
   var easing = options.easing ?
       options.easing : ol.easing.inAndOut;

--- a/src/ol/interaction/mousewheelzoominteraction.js
+++ b/src/ol/interaction/mousewheelzoominteraction.js
@@ -91,11 +91,11 @@ ol.interaction.MouseWheelZoom.handleEvent = function(mapBrowserEvent) {
     this.delta_ += mouseWheelEvent.deltaY;
 
     if (this.startTime_ === undefined) {
-      this.startTime_ = goog.now();
+      this.startTime_ = Date.now();
     }
 
     var duration = ol.MOUSEWHEELZOOM_TIMEOUT_DURATION;
-    var timeLeft = Math.max(duration - (goog.now() - this.startTime_), 0);
+    var timeLeft = Math.max(duration - (Date.now() - this.startTime_), 0);
 
     goog.global.clearTimeout(this.timeoutId_);
     this.timeoutId_ = goog.global.setTimeout(

--- a/src/ol/kinetic.js
+++ b/src/ol/kinetic.js
@@ -73,7 +73,7 @@ ol.Kinetic.prototype.begin = function() {
  * @param {number} y Y.
  */
 ol.Kinetic.prototype.update = function(x, y) {
-  this.points_.push(x, y, goog.now());
+  this.points_.push(x, y, Date.now());
 };
 
 
@@ -86,7 +86,7 @@ ol.Kinetic.prototype.end = function() {
     // in the array)
     return false;
   }
-  var delay = goog.now() - this.delay_;
+  var delay = Date.now() - this.delay_;
   var lastIndex = this.points_.length - 3;
   if (this.points_[lastIndex + 2] < delay) {
     // the last tracked point is too old, which means that the user stopped


### PR DESCRIPTION
This PR suggests using `Date.now()` instead of `goog.now()`.

Date.now() is supported in all major browsers (IE from v9 onwards): http://kangax.github.io/compat-table/es5/#Date.now

The current implementation of `goog.now` is a little bit more complicated, but I feel we do not want to copy their implementation: https://github.com/google/closure-library/blob/master/closure/goog/base.js#L1884-L1888

The closure library (optionally) guards against non-trusted sites (in which some other code may have changed e.g. `Date.now`) and falls back to using `+new Date()` in those cases or IE < 9.

Please review.

See #4128