### PR TITLE
Remove ol.LEGACY_IE_SUPPORT

### DIFF
--- a/src/ol/dom/dom.js
+++ b/src/ol/dom/dom.js
@@ -30,15 +30,6 @@ ol.dom.createCanvasContext2D = function(opt_width, opt_height) {
 
 
 /**
- * @enum {boolean}
- */
-ol.dom.BrowserFeature = {
-  USE_MS_MATRIX_TRANSFORM: ol.LEGACY_IE_SUPPORT && ol.IS_LEGACY_IE,
-  USE_MS_ALPHA_FILTER: ol.LEGACY_IE_SUPPORT && ol.IS_LEGACY_IE
-};
-
-
-/**
  * Detect 2d transform.
  * Adapted from http://stackoverflow.com/q/5661671/130442
  * http://caniuse.com/#feat=transforms2d
@@ -137,75 +128,8 @@ ol.dom.setTransform = function(element, value) {
   style.transform = value;
 
   // IE 9+ seems to assume transform-origin: 100% 100%; for some unknown reason
-  if (goog.userAgent.IE && !ol.IS_LEGACY_IE) {
+  if (goog.userAgent.IE && goog.userAgent.isVersionOrHigher('9.0')) {
     element.style.transformOrigin = '0 0';
-  }
-};
-
-
-/**
- * Sets the opacity of an element, in an IE-compatible way
- * @param {!Element} element Element
- * @param {number} value Opacity, [0..1]
- */
-ol.dom.setOpacity = function(element, value) {
-  if (ol.dom.BrowserFeature.USE_MS_ALPHA_FILTER) {
-    /** @type {string} */
-    var filter = element.currentStyle.filter;
-
-    /** @type {RegExp} */
-    var regex;
-
-    /** @type {string} */
-    var alpha;
-
-    if (goog.userAgent.VERSION == '8.0') {
-      regex = /progid:DXImageTransform\.Microsoft\.Alpha\(.*?\)/i;
-      alpha = 'progid:DXImageTransform.Microsoft.Alpha(Opacity=' +
-          (value * 100) + ')';
-    } else {
-      regex = /alpha\(.*?\)/i;
-      alpha = 'alpha(opacity=' + (value * 100) + ')';
-    }
-
-    var newFilter = filter.replace(regex, alpha);
-    if (newFilter === filter) {
-      // no replace was made? just append the new alpha filter instead
-      newFilter += ' ' + alpha;
-    }
-
-    element.style.filter = newFilter;
-
-    // Fix to apply filter to absolutely-positioned children element
-    if (element.currentStyle.zIndex === 'auto') {
-      element.style.zIndex = 0;
-    }
-  } else {
-    element.style.opacity = value;
-  }
-};
-
-
-/**
- * Sets the IE matrix transform without replacing other filters
- * @private
- * @param {!Element} element Element
- * @param {string} value The new progid string
- */
-ol.dom.setIEMatrix_ = function(element, value) {
-  var filter = element.currentStyle.filter;
-  var newFilter =
-      filter.replace(/progid:DXImageTransform.Microsoft.Matrix\(.*?\)/i, value);
-
-  if (newFilter === filter) {
-    newFilter = ' ' + value;
-  }
-
-  element.style.filter = newFilter;
-
-  // Fix to apply filter to absolutely-positioned children element
-  if (element.currentStyle.zIndex === 'auto') {
-    element.style.zIndex = 0;
   }
 };
 
@@ -214,10 +138,8 @@ ol.dom.setIEMatrix_ = function(element, value) {
  * @param {!Element} element Element.
  * @param {goog.vec.Mat4.Number} transform Matrix.
  * @param {number=} opt_precision Precision.
- * @param {Element=} opt_translationElement Required for IE7-8
  */
-ol.dom.transformElement2D =
-    function(element, transform, opt_precision, opt_translationElement) {
+ol.dom.transformElement2D = function(element, transform, opt_precision) {
   // using matrix() causes gaps in Chrome and Firefox on Mac OS X, so prefer
   // matrix3d()
   var i;
@@ -257,38 +179,6 @@ ol.dom.transformElement2D =
       value2D = transform2D.join(',');
     }
     ol.dom.setTransform(element, 'matrix(' + value2D + ')');
-  } else if (ol.dom.BrowserFeature.USE_MS_MATRIX_TRANSFORM) {
-    var m11 = goog.vec.Mat4.getElement(transform, 0, 0),
-        m12 = goog.vec.Mat4.getElement(transform, 0, 1),
-        m21 = goog.vec.Mat4.getElement(transform, 1, 0),
-        m22 = goog.vec.Mat4.getElement(transform, 1, 1),
-        dx = goog.vec.Mat4.getElement(transform, 0, 3),
-        dy = goog.vec.Mat4.getElement(transform, 1, 3);
-
-    // See: http://msdn.microsoft.com/en-us/library/ms533014(v=vs.85).aspx
-    // and: http://extremelysatisfactorytotalitarianism.com/blog/?p=1002
-    // @TODO: fix terrible IE bbox rotation issue.
-    var s = 'progid:DXImageTransform.Microsoft.Matrix(';
-    s += 'sizingMethod="auto expand"';
-    s += ',M11=' + m11.toFixed(opt_precision || 20);
-    s += ',M12=' + m12.toFixed(opt_precision || 20);
-    s += ',M21=' + m21.toFixed(opt_precision || 20);
-    s += ',M22=' + m22.toFixed(opt_precision || 20);
-    s += ')';
-    ol.dom.setIEMatrix_(element, s);
-
-    // scale = m11 = m22 = target resolution [m/px] / current res [m/px]
-    // dx = (viewport width [px] / 2) * scale
-    //      + (layer.x [m] - view.x [m]) / target resolution [m / px]
-    // except that we're positioning the child element relative to the
-    // viewport, not the map.
-    // dividing by the scale factor isn't the exact correction, but it's
-    // close enough that you can barely tell unless you're looking for it
-    dx /= m11;
-    dy /= m22;
-
-    opt_translationElement.style.left = Math.round(dx) + 'px';
-    opt_translationElement.style.top = Math.round(dy) + 'px';
   } else {
     element.style.left =
         Math.round(goog.vec.Mat4.getElement(transform, 0, 3)) + 'px';

--- a/src/ol/imagetile.js
+++ b/src/ol/imagetile.js
@@ -125,13 +125,6 @@ ol.ImageTile.prototype.handleImageError_ = function() {
  * @private
  */
 ol.ImageTile.prototype.handleImageLoad_ = function() {
-  if (ol.LEGACY_IE_SUPPORT && ol.IS_LEGACY_IE) {
-    if (this.image_.naturalWidth === undefined) {
-      this.image_.naturalWidth = this.image_.width;
-      this.image_.naturalHeight = this.image_.height;
-    }
-  }
-
   if (this.image_.naturalWidth && this.image_.naturalHeight) {
     this.state = ol.TileState.LOADED;
   } else {

--- a/src/ol/mapbrowserevent.js
+++ b/src/ol/mapbrowserevent.js
@@ -170,14 +170,6 @@ ol.MapBrowserEventHandler = function(map) {
    */
   this.pointerdownListenerKey_ = null;
 
-  if (ol.LEGACY_IE_SUPPORT && ol.IS_LEGACY_IE) {
-    /**
-     * @type {goog.events.Key}
-     * @private
-     */
-    this.ieDblclickListenerKey_ = null;
-  }
-
   /**
    * The most recent "down" type event (or null if none have occurred).
    * Set on pointerdown.
@@ -226,33 +218,8 @@ ol.MapBrowserEventHandler = function(map) {
       ol.pointer.EventType.POINTERMOVE,
       this.relayEvent_, false, this);
 
-  if (ol.LEGACY_IE_SUPPORT && ol.IS_LEGACY_IE) {
-    /*
-     * On legacy IE, double clicks do not produce two mousedown and
-     * mouseup events. That is why a separate DBLCLICK event listener
-     * is used.
-     */
-    this.ieDblclickListenerKey_ = goog.events.listen(element,
-        goog.events.EventType.DBLCLICK,
-        this.emulateClickLegacyIE_, false, this);
-  }
-
 };
 goog.inherits(ol.MapBrowserEventHandler, goog.events.EventTarget);
-
-
-/**
- * @param {goog.events.BrowserEvent} browserEvent Pointer event.
- * @private
- */
-ol.MapBrowserEventHandler.prototype.emulateClickLegacyIE_ =
-    function(browserEvent) {
-  var pointerEvent = this.pointerEventHandler_.wrapMouseEvent(
-      ol.MapBrowserEvent.EventType.POINTERUP,
-      browserEvent
-      );
-  this.emulateClick_(pointerEvent);
-};
 
 
 /**
@@ -343,11 +310,7 @@ ol.MapBrowserEventHandler.prototype.handlePointerUp_ = function(pointerEvent) {
  */
 ol.MapBrowserEventHandler.prototype.isMouseActionButton_ =
     function(pointerEvent) {
-  if (ol.LEGACY_IE_SUPPORT && ol.IS_LEGACY_IE) {
-    return pointerEvent.button == 1;
-  } else {
-    return pointerEvent.button === 0;
-  }
+  return pointerEvent.button === 0;
 };
 
 
@@ -474,11 +437,6 @@ ol.MapBrowserEventHandler.prototype.disposeInternal = function() {
   if (!goog.isNull(this.pointerEventHandler_)) {
     goog.dispose(this.pointerEventHandler_);
     this.pointerEventHandler_ = null;
-  }
-  if (ol.LEGACY_IE_SUPPORT && ol.IS_LEGACY_IE &&
-      !goog.isNull(this.ieDblclickListenerKey_)) {
-    goog.events.unlistenByKey(this.ieDblclickListenerKey_);
-    this.ieDblclickListenerKey_ = null;
   }
   goog.base(this, 'disposeInternal');
 };

--- a/src/ol/ol.js
+++ b/src/ol/ol.js
@@ -1,5 +1,3 @@
-goog.require('goog.userAgent');
-
 goog.provide('ol');
 
 
@@ -121,27 +119,10 @@ ol.ENABLE_WEBGL = true;
 
 
 /**
- * @define {boolean} Support legacy IE (7-8).  Default is `false`.
- *     If set to `true`, `goog.array.ASSUME_NATIVE_FUNCTIONS` must be set
- *     to `false` because legacy IE do not support ECMAScript 5 array functions.
- */
-ol.LEGACY_IE_SUPPORT = false;
-
-
-/**
  * @define {number} The size in pixels of the first atlas image. Default is
  * `256`.
  */
 ol.INITIAL_ATLAS_SIZE = 256;
-
-
-/**
- * Whether the current browser is legacy IE
- * @const
- * @type {boolean}
- */
-ol.IS_LEGACY_IE = goog.userAgent.IE &&
-    !goog.userAgent.isVersionOrHigher('9.0') && goog.userAgent.VERSION !== '';
 
 
 /**

--- a/src/ol/renderer/dom/domtilelayerrenderer.js
+++ b/src/ol/renderer/dom/domtilelayerrenderer.js
@@ -17,7 +17,6 @@ goog.require('ol.TileRange');
 goog.require('ol.TileState');
 goog.require('ol.ViewHint');
 goog.require('ol.dom');
-goog.require('ol.dom.BrowserFeature');
 goog.require('ol.extent');
 goog.require('ol.layer.Tile');
 goog.require('ol.renderer.dom.Layer');
@@ -37,12 +36,6 @@ ol.renderer.dom.TileLayer = function(tileLayer) {
 
   var target = goog.dom.createElement(goog.dom.TagName.DIV);
   target.style.position = 'absolute';
-
-  // Needed for IE7-8 to render a transformed element correctly
-  if (ol.dom.BrowserFeature.USE_MS_MATRIX_TRANSFORM) {
-    target.style.width = '100%';
-    target.style.height = '100%';
-  }
 
   goog.base(this, tileLayer, target);
 
@@ -249,7 +242,7 @@ ol.renderer.dom.TileLayer.prototype.prepareFrame =
   }
 
   if (layerState.opacity != this.renderedOpacity_) {
-    ol.dom.setOpacity(this.target, layerState.opacity);
+    this.target.style.opacity = layerState.opacity;
     this.renderedOpacity_ = layerState.opacity;
   }
 
@@ -284,21 +277,6 @@ ol.renderer.dom.TileLayerZ_ = function(tileGrid, tileCoordOrigin) {
   this.target.style.position = 'absolute';
   this.target.style.width = '100%';
   this.target.style.height = '100%';
-
-  if (ol.LEGACY_IE_SUPPORT && ol.IS_LEGACY_IE) {
-    /**
-     * Needed due to issues with IE7-8 clipping of transformed elements
-     * Solution is to translate separately from the scaled/rotated elements
-     * @private
-     * @type {!Element}
-     */
-    this.translateTarget_ = goog.dom.createElement(goog.dom.TagName.DIV);
-    this.translateTarget_.style.position = 'absolute';
-    this.translateTarget_.style.width = '100%';
-    this.translateTarget_.style.height = '100%';
-
-    goog.dom.appendChild(this.target, this.translateTarget_);
-  }
 
   /**
    * @private
@@ -413,11 +391,7 @@ ol.renderer.dom.TileLayerZ_.prototype.addTile = function(tile, tileGutter) {
  */
 ol.renderer.dom.TileLayerZ_.prototype.finalizeAddTiles = function() {
   if (!goog.isNull(this.documentFragment_)) {
-    if (ol.LEGACY_IE_SUPPORT && ol.IS_LEGACY_IE) {
-      goog.dom.appendChild(this.translateTarget_, this.documentFragment_);
-    } else {
-      goog.dom.appendChild(this.target, this.documentFragment_);
-    }
+    goog.dom.appendChild(this.target, this.documentFragment_);
     this.documentFragment_ = null;
   }
 };
@@ -471,12 +445,7 @@ ol.renderer.dom.TileLayerZ_.prototype.removeTilesOutsideExtent =
  */
 ol.renderer.dom.TileLayerZ_.prototype.setTransform = function(transform) {
   if (!ol.vec.Mat4.equals2D(transform, this.transform_)) {
-    if (ol.LEGACY_IE_SUPPORT && ol.IS_LEGACY_IE) {
-      ol.dom.transformElement2D(this.target, transform, 6,
-          this.translateTarget_);
-    } else {
-      ol.dom.transformElement2D(this.target, transform, 6);
-    }
+    ol.dom.transformElement2D(this.target, transform, 6);
     goog.vec.Mat4.setFromArray(this.transform_, transform);
   }
 };


### PR DESCRIPTION
Remove the optional IE 7-8 support and convert our code base to ECMAScript 5.

This will allow us to use the native `Array.prototype.forEach` instead of `goog.array.forEach` (same for `goog.array.map`, `goog.object.getKeys`, ...)