### PR TITLE
Remove @api on getHitDetectionFramebuffer

### DIFF
--- a/src/ol/webgl/context.js
+++ b/src/ol/webgl/context.js
@@ -203,7 +203,6 @@ ol.webgl.Context.prototype.getGL = function() {
 /**
  * Get the frame buffer for hit detection.
  * @return {WebGLFramebuffer} The hit detection frame buffer.
- * @api
  */
 ol.webgl.Context.prototype.getHitDetectionFramebuffer = function() {
   if (goog.isNull(this.hitDetectionFramebuffer_)) {


### PR DESCRIPTION
This removes the `@api` marker on `getHitDetectionFramebuffer`. I think this was added by mistake in 7404204.

CC @tsauerwein.