### PR TITLE
Do not export ol.webgl.Context

### DIFF
--- a/src/ol/webgl/context.js
+++ b/src/ol/webgl/context.js
@@ -26,7 +26,6 @@ ol.webgl.BufferCacheEntry;
  * @extends {goog.events.EventTarget}
  * @param {HTMLCanvasElement} canvas Canvas.
  * @param {WebGLRenderingContext} gl GL.
- * @api
  */
 ol.webgl.Context = function(canvas, gl) {
 


### PR DESCRIPTION
We don't need to export the `ol.export.Context` constructor as users won't create `ol.webgl.Context` instances themselves.

I suppose we added an `@api` annotation on `ol.webgl.Context` for documentation purposes. This is a shame that we need to add `@api` annotations on things we don't want to export. We increase the build size just for the purpose of the documentation!