### PR TITLE
Remove use of goog.object.getKeys

### DIFF
--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -4,7 +4,6 @@ goog.provide('ol.ObjectEventType');
 
 goog.require('goog.events');
 goog.require('goog.events.Event');
-goog.require('goog.object');
 goog.require('ol.Observable');
 
 
@@ -112,7 +111,7 @@ ol.Object = function(opt_values) {
 
   /**
    * @private
-   * @type {Object.<string, *>}
+   * @type {!Object.<string, *>}
    */
   this.values_ = {};
 
@@ -162,7 +161,7 @@ ol.Object.prototype.get = function(key) {
  * @api stable
  */
 ol.Object.prototype.getKeys = function() {
-  return goog.object.getKeys(this.values_);
+  return Object.keys(this.values_);
 };
 
 

--- a/src/ol/pointer/eventsource.js
+++ b/src/ol/pointer/eventsource.js
@@ -1,13 +1,12 @@
 goog.provide('ol.pointer.EventSource');
 
 goog.require('goog.events.BrowserEvent');
-goog.require('goog.object');
 
 
 
 /**
  * @param {ol.pointer.PointerEventHandler} dispatcher
- * @param {Object.<string, function(goog.events.BrowserEvent)>} mapping
+ * @param {!Object.<string, function(goog.events.BrowserEvent)>} mapping
  * @constructor
  */
 ol.pointer.EventSource = function(dispatcher, mapping) {
@@ -19,7 +18,7 @@ ol.pointer.EventSource = function(dispatcher, mapping) {
   /**
    * @private
    * @const
-   * @type {Object.<string, function(goog.events.BrowserEvent)>}
+   * @type {!Object.<string, function(goog.events.BrowserEvent)>}
    */
   this.mapping_ = mapping;
 };
@@ -30,7 +29,7 @@ ol.pointer.EventSource = function(dispatcher, mapping) {
  * @return {Array.<string>} Event names
  */
 ol.pointer.EventSource.prototype.getEvents = function() {
-  return goog.object.getKeys(this.mapping_);
+  return Object.keys(this.mapping_);
 };
 
 

--- a/src/ol/proj/proj.js
+++ b/src/ol/proj/proj.js
@@ -597,8 +597,7 @@ ol.proj.removeTransform = function(source, destination) {
       'destinationCode should be in transforms of sourceCode');
   var transform = transforms[sourceCode][destinationCode];
   delete transforms[sourceCode][destinationCode];
-  var keys = goog.object.getKeys(transforms[sourceCode]);
-  if (keys.length === 0) {
+  if (goog.object.isEmpty(transforms[sourceCode])) {
     delete transforms[sourceCode];
   }
   return transform;

--- a/src/ol/render/canvas/canvasimmediate.js
+++ b/src/ol/render/canvas/canvasimmediate.js
@@ -6,7 +6,6 @@ goog.provide('ol.render.canvas.Immediate');
 
 goog.require('goog.array');
 goog.require('goog.asserts');
-goog.require('goog.object');
 goog.require('goog.vec.Mat4');
 goog.require('ol.color');
 goog.require('ol.extent');
@@ -41,7 +40,7 @@ ol.render.canvas.Immediate =
 
   /**
    * @private
-   * @type {Object.<string,
+   * @type {!Object.<string,
    *        Array.<function(ol.render.canvas.Immediate)>>}
    */
   this.callbacksByZIndex_ = {};
@@ -725,7 +724,7 @@ ol.render.canvas.Immediate.prototype.drawText = goog.abstractMethod;
  */
 ol.render.canvas.Immediate.prototype.flush = function() {
   /** @type {Array.<number>} */
-  var zs = goog.object.getKeys(this.callbacksByZIndex_).map(Number);
+  var zs = Object.keys(this.callbacksByZIndex_).map(Number);
   goog.array.sort(zs);
   var i, ii, callbacks, j, jj;
   for (i = 0, ii = zs.length; i < ii; ++i) {

--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -1830,7 +1830,7 @@ ol.render.canvas.ReplayGroup = function(
 
   /**
    * @private
-   * @type {Object.<string,
+   * @type {!Object.<string,
    *        Object.<ol.render.ReplayType, ol.render.canvas.Replay>>}
    */
   this.replaysByZIndex_ = {};
@@ -1960,7 +1960,7 @@ ol.render.canvas.ReplayGroup.prototype.replay = function(
     context, pixelRatio, transform, viewRotation, skippedFeaturesHash) {
 
   /** @type {Array.<number>} */
-  var zs = goog.object.getKeys(this.replaysByZIndex_).map(Number);
+  var zs = Object.keys(this.replaysByZIndex_).map(Number);
   goog.array.sort(zs);
 
   // setup clipping so that the parts of over-simplified geometries are not
@@ -2015,7 +2015,7 @@ ol.render.canvas.ReplayGroup.prototype.replayHitDetection_ = function(
     context, transform, viewRotation, skippedFeaturesHash,
     featureCallback, opt_hitExtent) {
   /** @type {Array.<number>} */
-  var zs = goog.object.getKeys(this.replaysByZIndex_).map(Number);
+  var zs = Object.keys(this.replaysByZIndex_).map(Number);
   goog.array.sort(zs, function(a, b) { return b - a; });
 
   var i, ii, j, replays, replay, result;

--- a/src/ol/render/webgl/webglimmediate.js
+++ b/src/ol/render/webgl/webglimmediate.js
@@ -1,6 +1,5 @@
 goog.provide('ol.render.webgl.Immediate');
 goog.require('goog.array');
-goog.require('goog.object');
 goog.require('ol.extent');
 goog.require('ol.render.VectorContext');
 goog.require('ol.render.webgl.ImageReplay');
@@ -67,7 +66,7 @@ ol.render.webgl.Immediate = function(context,
 
   /**
    * @private
-   * @type {Object.<string,
+   * @type {!Object.<string,
    *        Array.<function(ol.render.webgl.Immediate)>>}
    */
   this.callbacksByZIndex_ = {};
@@ -80,7 +79,7 @@ goog.inherits(ol.render.webgl.Immediate, ol.render.VectorContext);
  */
 ol.render.webgl.Immediate.prototype.flush = function() {
   /** @type {Array.<number>} */
-  var zs = goog.object.getKeys(this.callbacksByZIndex_).map(Number);
+  var zs = Object.keys(this.callbacksByZIndex_).map(Number);
   goog.array.sort(zs);
   var i, ii, callbacks, j, jj;
   for (i = 0, ii = zs.length; i < ii; ++i) {

--- a/src/ol/renderer/canvas/canvastilelayerrenderer.js
+++ b/src/ol/renderer/canvas/canvastilelayerrenderer.js
@@ -5,7 +5,6 @@ goog.provide('ol.renderer.canvas.TileLayer');
 
 goog.require('goog.array');
 goog.require('goog.asserts');
-goog.require('goog.object');
 goog.require('goog.vec.Mat4');
 goog.require('ol.Size');
 goog.require('ol.TileRange');
@@ -354,7 +353,7 @@ ol.renderer.canvas.TileLayer.prototype.prepareFrame =
   }
 
   /** @type {Array.<number>} */
-  var zs = goog.object.getKeys(tilesToDrawByZ).map(Number);
+  var zs = Object.keys(tilesToDrawByZ).map(Number);
   goog.array.sort(zs);
   var opaque = tileSource.getOpaque();
   var origin = ol.extent.getTopLeft(tileGrid.getTileCoordExtent(

--- a/src/ol/renderer/dom/domtilelayerrenderer.js
+++ b/src/ol/renderer/dom/domtilelayerrenderer.js
@@ -7,7 +7,6 @@ goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.dom');
 goog.require('goog.dom.TagName');
-goog.require('goog.object');
 goog.require('goog.style');
 goog.require('goog.vec.Mat4');
 goog.require('ol');
@@ -59,7 +58,7 @@ ol.renderer.dom.TileLayer = function(tileLayer) {
 
   /**
    * @private
-   * @type {Object.<number, ol.renderer.dom.TileLayerZ_>}
+   * @type {!Object.<number, ol.renderer.dom.TileLayerZ_>}
    */
   this.tileLayerZs_ = {};
 
@@ -172,7 +171,7 @@ ol.renderer.dom.TileLayer.prototype.prepareFrame =
   }
 
   /** @type {Array.<number>} */
-  var zs = goog.object.getKeys(tilesToDrawByZ).map(Number);
+  var zs = Object.keys(tilesToDrawByZ).map(Number);
   goog.array.sort(zs);
 
   /** @type {Object.<number, boolean>} */
@@ -198,7 +197,7 @@ ol.renderer.dom.TileLayer.prototype.prepareFrame =
   }
 
   /** @type {Array.<number>} */
-  var tileLayerZKeys = goog.object.getKeys(this.tileLayerZs_).map(Number);
+  var tileLayerZKeys = Object.keys(this.tileLayerZs_).map(Number);
   goog.array.sort(tileLayerZKeys);
 
   var i, ii, j, origin, resolution;

--- a/src/ol/renderer/webgl/webgltilelayerrenderer.js
+++ b/src/ol/renderer/webgl/webgltilelayerrenderer.js
@@ -5,7 +5,6 @@ goog.provide('ol.renderer.webgl.TileLayer');
 
 goog.require('goog.array');
 goog.require('goog.asserts');
-goog.require('goog.object');
 goog.require('goog.vec.Mat4');
 goog.require('goog.vec.Vec4');
 goog.require('goog.webgl');
@@ -286,7 +285,7 @@ ol.renderer.webgl.TileLayer.prototype.prepareFrame =
     }
 
     /** @type {Array.<number>} */
-    var zs = goog.object.getKeys(tilesToDrawByZ).map(Number);
+    var zs = Object.keys(tilesToDrawByZ).map(Number);
     goog.array.sort(zs);
     var u_tileOffset = goog.vec.Vec4.createFloat32();
     var i, ii, sx, sy, tileKey, tilesToDraw, tx, ty;

--- a/test/spec/ol/feature.test.js
+++ b/test/spec/ol/feature.test.js
@@ -70,7 +70,7 @@ describe('ol.Feature', function() {
 
       var attributes = feature.getProperties();
 
-      var keys = goog.object.getKeys(attributes);
+      var keys = Object.keys(attributes);
       expect(keys.sort()).to.eql(['foo', 'geometry', 'ten']);
 
       expect(attributes.foo).to.be('bar');


### PR DESCRIPTION
Use `Object.keys` instead.
See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys