### PR TITLE
Remove usage of goog.color and closure named colors

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -1,5 +1,9 @@
 ## Upgrade notes
 
+#### Removal of `ol.ENABLE_NAMED_COLORS`
+
+This option was previously needed to use named colors with the WebGL renderer but is no longer needed.
+
 ### v3.17.0
 
 #### `ol.source.MapQuest` removal

--- a/src/ol/ol.js
+++ b/src/ol/ol.js
@@ -79,16 +79,6 @@ ol.ENABLE_IMAGE = true;
 
 
 /**
- * @define {boolean} Enable Closure named colors (`goog.color.names`).
- *     Enabling these colors adds about 3KB uncompressed / 1.5KB compressed to
- *     the final build size.  Default is `false`. This setting has no effect
- *     with Canvas renderer, which uses its own names, whether this is true or
- *     false.
- */
-ol.ENABLE_NAMED_COLORS = false;
-
-
-/**
  * @define {boolean} Enable integration with the Proj4js library.  Default is
  *     `true`.
  */

--- a/test/spec/ol/color.test.js
+++ b/test/spec/ol/color.test.js
@@ -81,15 +81,13 @@ describe('ol.color', function() {
           [255, 255, 0, 0.1]);
     });
 
-    if (ol.ENABLE_NAMED_COLORS) {
-      it('caches parsed values', function() {
-        var count = ol.color.fromStringInternal_.callCount;
-        ol.color.fromString('aquamarine');
-        expect(ol.color.fromStringInternal_.callCount).to.be(count + 1);
-        ol.color.fromString('aquamarine');
-        expect(ol.color.fromStringInternal_.callCount).to.be(count + 1);
-      });
-    }
+    it('caches parsed values', function() {
+      var count = ol.color.fromStringInternal_.callCount;
+      ol.color.fromString('aquamarine');
+      expect(ol.color.fromStringInternal_.callCount).to.be(count + 1);
+      ol.color.fromString('aquamarine');
+      expect(ol.color.fromStringInternal_.callCount).to.be(count + 1);
+    });
 
     it('throws an error on invalid colors', function() {
       var invalidColors = ['tuesday', '#1234567', 'rgb(255.0,0,0)'];


### PR DESCRIPTION
There are some mentions of goog.color in the comments, perhaps those should be removed too? In that case the private member ol.color.rgbColorRe_ will have no explanation, is that ok?