### PR TITLE
#4171: Prefer current layout as default on MultiLineString.setLineStrings()

### DIFF
--- a/src/ol/geom/multilinestring.js
+++ b/src/ol/geom/multilinestring.js
@@ -311,7 +311,7 @@ ol.geom.MultiLineString.prototype.setFlatCoordinates =
  * @param {Array.<ol.geom.LineString>} lineStrings LineStrings.
  */
 ol.geom.MultiLineString.prototype.setLineStrings = function(lineStrings) {
-  var layout = ol.geom.GeometryLayout.XY;
+  var layout = this.getLayout();
   var flatCoordinates = [];
   var ends = [];
   var i, ii;


### PR DESCRIPTION
Fixed #4171 for MultiLineStrings, too.