### PR TITLE
Remove blur action on MOUSEOUT on Zoom Out button

### DIFF
--- a/src/ol/control/zoomcontrol.js
+++ b/src/ol/control/zoomcontrol.js
@@ -58,13 +58,6 @@ ol.control.Zoom = function(opt_options) {
       goog.events.EventType.CLICK, goog.partial(
           ol.control.Zoom.prototype.handleClick_, -delta), false, this);
 
-  goog.events.listen(outElement, [
-    goog.events.EventType.MOUSEOUT,
-    goog.events.EventType.FOCUSOUT
-  ], function() {
-    this.blur();
-  }, false);
-
   var cssClasses = className + ' ' + ol.css.CLASS_UNSELECTABLE + ' ' +
       ol.css.CLASS_CONTROL;
   var element = goog.dom.createDom(goog.dom.TagName.DIV, cssClasses, inElement,


### PR DESCRIPTION
This is a follow up of commit 761aa0ea5cb75478a463c2cd3bac9204a75089d0.
That commit removed ol.control.Control.bindMouseOutFocusOutBlur function,
but forgot to remove this piece of code here.

Currently, clicking on ZoomIn button and moving the mouse away leaves the focus on the element. But clicking on ZoomOut button and moving the mouse also removes the focus.

Note: I've written this pull request directly in the browser, using the GitHub interface.