### PR TITLE
Improve ol.control.Rotate.prototype.resetNorth_ performance

### DIFF
--- a/src/ol/control/rotatecontrol.js
+++ b/src/ol/control/rotatecontrol.js
@@ -119,14 +119,15 @@ ol.control.Rotate.prototype.resetNorth_ = function() {
     return;
   }
   var currentRotation = view.getRotation();
-  while (currentRotation < -Math.PI) {
-    currentRotation += 2 * Math.PI;
-  }
-  while (currentRotation > Math.PI) {
-    currentRotation -= 2 * Math.PI;
-  }
   if (currentRotation !== undefined) {
     if (this.duration_ > 0) {
+      currentRotation = currentRotation % (2 * Math.PI);
+      if (currentRotation < -Math.PI) {
+        currentRotation += 2 * Math.PI;
+      }
+      if (currentRotation > Math.PI) {
+        currentRotation -= 2 * Math.PI;
+      }
       map.beforeRender(ol.animation.rotate({
         rotation: currentRotation,
         duration: this.duration_,


### PR DESCRIPTION
Changing. resetNorth_ function from O(n) to O(1).

To reproduce this issue, open the developer console and execute:

    map.getView().setRotation(5000000000);

Then click on the rotation button. Before the commit, it takes a few
seconds, after this commit it is instantaneous.

In addition, due to limited floating point precision, the previous code
calculates a different value from this one.


Note: I've written this pull request directly in the browser, but I tested it locally.