### PR TITLE
Remove use of goog.dom.appendChild

### DIFF
--- a/src/ol/control/attributioncontrol.js
+++ b/src/ol/control/attributioncontrol.js
@@ -46,7 +46,7 @@ ol.control.Attribution = function(opt_options) {
    */
   this.logoLi_ = goog.dom.createElement(goog.dom.TagName.LI);
 
-  goog.dom.appendChild(this.ulElement_, this.logoLi_);
+  this.ulElement_.appendChild(this.logoLi_);
   goog.style.setElementShown(this.logoLi_, false);
 
   /**
@@ -265,7 +265,7 @@ ol.control.Attribution.prototype.updateElement_ = function(frameState) {
     attributionElement = goog.dom.createElement(goog.dom.TagName.LI);
     attributionElement.innerHTML =
         visibleAttributions[attributionKey].getHTML();
-    goog.dom.appendChild(this.ulElement_, attributionElement);
+    this.ulElement_.appendChild(attributionElement);
     this.attributionElements_[attributionKey] = attributionElement;
     this.attributionElementRenderedVisible_[attributionKey] = true;
   }
@@ -274,7 +274,7 @@ ol.control.Attribution.prototype.updateElement_ = function(frameState) {
     attributionElement.innerHTML =
         hiddenAttributions[attributionKey].getHTML();
     goog.style.setElementShown(attributionElement, false);
-    goog.dom.appendChild(this.ulElement_, attributionElement);
+    this.ulElement_.appendChild(attributionElement);
     this.attributionElements_[attributionKey] = attributionElement;
   }
 
@@ -328,7 +328,7 @@ ol.control.Attribution.prototype.insertLogos_ = function(frameState) {
         });
         logoElement.appendChild(image);
       }
-      goog.dom.appendChild(this.logoLi_, logoElement);
+      this.logoLi_.appendChild(logoElement);
       logoElements[logoKey] = logoElement;
     }
   }

--- a/src/ol/control/control.js
+++ b/src/ol/control/control.js
@@ -116,7 +116,7 @@ ol.control.Control.prototype.setMap = function(map) {
   if (this.map_) {
     var target = this.target_ ?
         this.target_ : map.getOverlayContainerStopEvent();
-    goog.dom.appendChild(target, this.element);
+    target.appendChild(this.element);
     if (this.render !== ol.nullFunction) {
       this.listenerKeys.push(goog.events.listen(map,
           ol.MapEventType.POSTRENDER, this.render, false, this));

--- a/src/ol/dom/dom.js
+++ b/src/ol/dom/dom.js
@@ -54,7 +54,7 @@ ol.dom.canUseCssTransform = (function() {
               'MozTransform': '-moz-transform',
               'transform': 'transform'
             };
-        goog.dom.appendChild(document.body, el);
+        document.body.appendChild(el);
         for (var t in transforms) {
           if (t in el.style) {
             el.style[t] = 'translate(1px,1px)';
@@ -97,7 +97,7 @@ ol.dom.canUseCssTransform3D = (function() {
               'MozTransform': '-moz-transform',
               'transform': 'transform'
             };
-        goog.dom.appendChild(document.body, el);
+        document.body.appendChild(el);
         for (var t in transforms) {
           if (t in el.style) {
             el.style[t] = 'translate3d(1px,1px,1px)';

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -279,7 +279,7 @@ ol.Map = function(options) {
    */
   this.overlayContainer_ = goog.dom.createDom(goog.dom.TagName.DIV,
       'ol-overlaycontainer');
-  goog.dom.appendChild(this.viewport_, this.overlayContainer_);
+  this.viewport_.appendChild(this.overlayContainer_);
 
   /**
    * @private
@@ -296,7 +296,7 @@ ol.Map = function(options) {
     ol.MapBrowserEvent.EventType.POINTERDOWN,
     goog.userAgent.GECKO ? 'DOMMouseScroll' : 'mousewheel'
   ], goog.events.Event.stopPropagation);
-  goog.dom.appendChild(this.viewport_, this.overlayContainerStopEvent_);
+  this.viewport_.appendChild(this.overlayContainerStopEvent_);
 
   var mapBrowserEventHandler = new ol.MapBrowserEventHandler(this);
   goog.events.listen(mapBrowserEventHandler,
@@ -1039,7 +1039,7 @@ ol.Map.prototype.handleTargetChanged_ = function() {
       this.viewportResizeListenerKey_ = null;
     }
   } else {
-    goog.dom.appendChild(targetElement, this.viewport_);
+    targetElement.appendChild(this.viewport_);
 
     var keyboardEventTarget = !this.keyboardEventTarget_ ?
         targetElement : this.keyboardEventTarget_;

--- a/src/ol/renderer/dom/domimagelayerrenderer.js
+++ b/src/ol/renderer/dom/domimagelayerrenderer.js
@@ -136,7 +136,7 @@ ol.renderer.dom.ImageLayer.prototype.prepareFrame =
       imageElement.style.maxWidth = 'none';
       imageElement.style.position = 'absolute';
       goog.dom.removeChildren(this.target);
-      goog.dom.appendChild(this.target, imageElement);
+      this.target.appendChild(imageElement);
       this.image_ = image;
     }
     this.setTransform_(transform);

--- a/src/ol/renderer/dom/domtilelayerrenderer.js
+++ b/src/ol/renderer/dom/domtilelayerrenderer.js
@@ -364,7 +364,7 @@ ol.renderer.dom.TileLayerZ_.prototype.addTile = function(tile, tileGutter) {
     imageStyle.top = -tileGutter + 'px';
     imageStyle.width = (tileSize[0] + 2 * tileGutter) + 'px';
     imageStyle.height = (tileSize[1] + 2 * tileGutter) + 'px';
-    goog.dom.appendChild(tileElement, image);
+    tileElement.appendChild(image);
   } else {
     imageStyle.width = tileSize[0] + 'px';
     imageStyle.height = tileSize[1] + 'px';
@@ -379,7 +379,7 @@ ol.renderer.dom.TileLayerZ_.prototype.addTile = function(tile, tileGutter) {
   if (!this.documentFragment_) {
     this.documentFragment_ = document.createDocumentFragment();
   }
-  goog.dom.appendChild(this.documentFragment_, tileElement);
+  this.documentFragment_.appendChild(tileElement);
   this.tiles_[tileCoordKey] = tile;
 };
 
@@ -389,7 +389,7 @@ ol.renderer.dom.TileLayerZ_.prototype.addTile = function(tile, tileGutter) {
  */
 ol.renderer.dom.TileLayerZ_.prototype.finalizeAddTiles = function() {
   if (this.documentFragment_) {
-    goog.dom.appendChild(this.target, this.documentFragment_);
+    this.target.appendChild(this.documentFragment_);
     this.documentFragment_ = null;
   }
 };


### PR DESCRIPTION
Use `parent.appendChild(child)` instead.

closure-library implementation: 
https://github.com/google/closure-library/blob/master/closure/goog/dom/dom.js#L1049-L1056