### PR TITLE
fix UMD header to handle proj4

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -18,13 +18,13 @@ var root = path.join(__dirname, '..');
 
 var umdWrapper = '(function (root, factory) {\n' +
     '  if (typeof exports === "object") {\n' +
-    '    module.exports = factory();\n' +
+    '    module.exports = factory(require("proj4"));\n' +
     '  } else if (typeof define === "function" && define.amd) {\n' +
-    '    define([], factory);\n' +
+    '    define(["proj4"], factory);\n' +
     '  } else {\n' +
-    '    root.ol = factory();\n' +
+    '    root.ol = factory(root.proj4);\n' +
     '  }\n' +
-    '}(this, function () {\n' +
+    '}(this, function (proj4) {\n' +
     '  var OPENLAYERS = {};\n' +
     '  %output%\n' +
     '  return OPENLAYERS.ol;\n' +


### PR DESCRIPTION
The UMD header previously did not handle the inclusion of proj4 which had
to be exposed globally and thus didn't work in a UMD/AMD environment such as
when loading with RequireJS.

More in issue #3990 .