### PR TITLE
Add generic Fill rendering as per #2208

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -5585,6 +5585,16 @@ olx.style.FillOptions.prototype.color;
 
 
 /**
+ * Renderer. A factory function which takes a canvas context and returns 
+ * a pattern. Default null; if null, behavior will be defined by the 
+ * {@link olx.style.FillOptions#color}.
+ * @type {function(CanvasRenderingContext2D):CanvasPattern|undefined}
+ * @api
+ */
+olx.style.FillOptions.prototype.renderer;
+
+
+/**
  * @typedef {{anchor: (Array.<number>|undefined),
  *     anchorOrigin: (ol.style.IconOrigin|undefined),
  *     anchorXUnits: (ol.style.IconAnchorUnits|undefined),

--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -435,12 +435,13 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         ++i;
         break;
       case ol.render.canvas.Instruction.SET_FILL_STYLE:
-        goog.asserts.assert(goog.isString(instruction[1]) || goog.isFunction(instruction[1]),
+        goog.asserts.assert(goog.isString(instruction[1])
+            || goog.isFunction(instruction[1]),
             '2nd instruction should be a string or a function');
         if (goog.isString(instruction[1])) {
-            context.fillStyle = /** @type {string} */ (instruction[1]);
+          context.fillStyle = /** @type {string} */ (instruction[1]);
         } else {
-            context.fillStyle = instruction[1](context);
+          context.fillStyle = instruction[1](context);
         }
         ++i;
         break;
@@ -1392,9 +1393,9 @@ ol.render.canvas.PolygonReplay.prototype.setFillStrokeStyle =
     var fillStyleColor = fillStyle.getColor();
     var fillStyleRenderer = fillStyle.getRenderer();
     if (fillStyleRenderer) {
-        this.state_.fillStyle = fillStyleRenderer;
+      this.state_.fillStyle = fillStyleRenderer;
     } else {
-        state.fillStyle = ol.color.asString(fillStyleColor ?
+      state.fillStyle = ol.color.asString(fillStyleColor ?
             fillStyleColor : ol.render.canvas.defaultFillStyle);
     }
   } else {

--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -1133,14 +1133,14 @@ ol.render.canvas.PolygonReplay = function(tolerance, maxExtent, resolution) {
 
   /**
    * @private
-   * @type {{currentFillStyle: (string|function(CanvasRenderingContext2D)|undefined),
+   * @type {{currentFillStyle: (string|function(CanvasRenderingContext2D):CanvasPattern|undefined),
    *         currentStrokeStyle: (string|undefined),
    *         currentLineCap: (string|undefined),
    *         currentLineDash: Array.<number>,
    *         currentLineJoin: (string|undefined),
    *         currentLineWidth: (number|undefined),
    *         currentMiterLimit: (number|undefined),
-   *         fillStyle: (string|function(CanvasRenderingContext2D)|undefined),
+   *         fillStyle: (string|function(CanvasRenderingContext2D):CanvasPattern|undefined),
    *         strokeStyle: (string|undefined),
    *         lineCap: (string|undefined),
    *         lineDash: Array.<number>,

--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -1138,7 +1138,7 @@ ol.render.canvas.PolygonReplay = function(tolerance, maxExtent, resolution) {
    *         currentLineJoin: (string|undefined),
    *         currentLineWidth: (number|undefined),
    *         currentMiterLimit: (number|undefined),
-   *         fillStyle: (string|undefined),
+   *         fillStyle: (string|function(CanvasRenderingContext2D)|undefined),
    *         strokeStyle: (string|undefined),
    *         lineCap: (string|undefined),
    *         lineDash: Array.<number>,

--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -1131,7 +1131,7 @@ ol.render.canvas.PolygonReplay = function(tolerance, maxExtent, resolution) {
 
   /**
    * @private
-   * @type {{currentFillStyle: (string|undefined),
+   * @type {{currentFillStyle: (string|function(CanvasRenderingContext2D)|undefined),
    *         currentStrokeStyle: (string|undefined),
    *         currentLineCap: (string|undefined),
    *         currentLineDash: Array.<number>,

--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -1452,12 +1452,19 @@ ol.render.canvas.PolygonReplay.prototype.setFillStrokeStyles_ = function() {
   var lineWidth = state.lineWidth;
   var miterLimit = state.miterLimit;
   if (fillStyle !== undefined && state.currentFillStyle != fillStyle) {
-      // add instruction for either a normal (e.g. solid) fill, or a fill function (e.g. hook for pattern fill, etc.)
+    // add instruction for either a normal (e.g. solid) fill,
+    // or a fill function (e.g. hook for pattern fill, etc.)
     var setFillStyleInstruction;
     if (goog.isString(fillStyle)) {
-      setFillStyleInstruction = [ol.render.canvas.Instruction.SET_FILL_STYLE, fillStyle];
+      setFillStyleInstruction = [
+        ol.render.canvas.Instruction.SET_FILL_STYLE,
+        fillStyle
+      ];
     } else {
-      setFillStyleInstruction = [ol.render.canvas.Instruction.SET_FILL_STYLE_FUNCTION, fillStyle];
+      setFillStyleInstruction = [
+        ol.render.canvas.Instruction.SET_FILL_STYLE_FUNCTION,
+        fillStyle
+      ];
     }
     this.instructions.push(setFillStyleInstruction);
     state.currentFillStyle = state.fillStyle;
@@ -1619,14 +1626,21 @@ ol.render.canvas.TextReplay.prototype.setReplayFillState_ =
     return;
   }
 
-  // add instruction for either a normal (e.g. solid) fill, or a fill function (e.g. hook for pattern fill, etc.)
+  // add instruction for either a normal (e.g. solid) fill,
+  // or a fill function (e.g. hook for pattern fill, etc.)
   var setFillStyleInstruction;
   if (goog.isString(fillState.fillStyle)) {
-    setFillStyleInstruction = [ol.render.canvas.Instruction.SET_FILL_STYLE, fillState.fillStyle];
+    setFillStyleInstruction = [
+      ol.render.canvas.Instruction.SET_FILL_STYLE,
+      fillState.fillStyle
+    ];
   } else {
-    setFillStyleInstruction = [ol.render.canvas.Instruction.SET_FILL_STYLE_FUNCTION, fillState.fillStyle];
+    setFillStyleInstruction = [
+      ol.render.canvas.Instruction.SET_FILL_STYLE_FUNCTION,
+      fillState.fillStyle
+    ];
   }
-      
+
   this.instructions.push(setFillStyleInstruction);
   this.hitDetectionInstructions.push(setFillStyleInstruction);
   if (!replayFillState) {

--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -435,9 +435,13 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         ++i;
         break;
       case ol.render.canvas.Instruction.SET_FILL_STYLE:
-        goog.asserts.assert(goog.isString(instruction[1]),
-            '2nd instruction should be a string');
-        context.fillStyle = /** @type {string} */ (instruction[1]);
+        goog.asserts.assert(goog.isString(instruction[1]) || goog.isFunction(instruction[1]),
+            '2nd instruction should be a string or a function');
+        if (goog.isString(instruction[1])) {
+            context.fillStyle = /** @type {string} */ (instruction[1]);
+        } else {
+            context.fillStyle = instruction[1](context);
+        }
         ++i;
         break;
       case ol.render.canvas.Instruction.SET_STROKE_STYLE:
@@ -1386,8 +1390,13 @@ ol.render.canvas.PolygonReplay.prototype.setFillStrokeStyle =
   var state = this.state_;
   if (fillStyle) {
     var fillStyleColor = fillStyle.getColor();
-    state.fillStyle = ol.color.asString(fillStyleColor ?
-        fillStyleColor : ol.render.canvas.defaultFillStyle);
+    var fillStyleRenderer = fillStyle.getRenderer();
+    if (fillStyleRenderer) {
+        this.state_.fillStyle = fillStyleRenderer;
+    } else {
+        state.fillStyle = ol.color.asString(fillStyleColor ?
+            fillStyleColor : ol.render.canvas.defaultFillStyle);
+    }
   } else {
     state.fillStyle = undefined;
   }

--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -435,8 +435,8 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         ++i;
         break;
       case ol.render.canvas.Instruction.SET_FILL_STYLE:
-        goog.asserts.assert(goog.isString(instruction[1])
-            || goog.isFunction(instruction[1]),
+        goog.asserts.assert(goog.isString(instruction[1]) ||
+            goog.isFunction(instruction[1]),
             '2nd instruction should be a string or a function');
         if (goog.isString(instruction[1])) {
           context.fillStyle = /** @type {string} */ (instruction[1]);
@@ -1396,7 +1396,7 @@ ol.render.canvas.PolygonReplay.prototype.setFillStrokeStyle =
       this.state_.fillStyle = fillStyleRenderer;
     } else {
       state.fillStyle = ol.color.asString(fillStyleColor ?
-            fillStyleColor : ol.render.canvas.defaultFillStyle);
+          fillStyleColor : ol.render.canvas.defaultFillStyle);
     }
   } else {
     state.fillStyle = undefined;

--- a/src/ol/style/fillstyle.js
+++ b/src/ol/style/fillstyle.js
@@ -26,7 +26,7 @@ ol.style.Fill = function(opt_options) {
 
   /**
    * @private
-   * @type {function}
+   * @type {function()}
    */
   this.renderer_ = options.renderer !== undefined ? options.renderer : null;
 
@@ -62,7 +62,7 @@ ol.style.Fill.prototype.setColor = function(color) {
 
 /**
  * Get the fill renderer.
- * @return {function} Function.
+ * @return {function()} Function.
  * @api
  */
 ol.style.Fill.prototype.getRenderer = function() {
@@ -73,7 +73,7 @@ ol.style.Fill.prototype.getRenderer = function() {
 /**
  * Set the renderer.
  *
- * @param {function} renderer Function.
+ * @param {function()} renderer Function.
  * @api
  */
 ol.style.Fill.prototype.setRenderer = function(renderer) {

--- a/src/ol/style/fillstyle.js
+++ b/src/ol/style/fillstyle.js
@@ -26,7 +26,7 @@ ol.style.Fill = function(opt_options) {
 
   /**
    * @private
-   * @type {function(CanvasRenderingContext2D)}
+   * @type {function(CanvasRenderingContext2D):CanvasPattern}
    */
   this.renderer_ = options.renderer !== undefined ? options.renderer : null;
 

--- a/src/ol/style/fillstyle.js
+++ b/src/ol/style/fillstyle.js
@@ -26,7 +26,7 @@ ol.style.Fill = function(opt_options) {
 
   /**
    * @private
-   * @type {function()}
+   * @type {function(CanvasRenderingContext2D)}
    */
   this.renderer_ = options.renderer !== undefined ? options.renderer : null;
 
@@ -62,7 +62,7 @@ ol.style.Fill.prototype.setColor = function(color) {
 
 /**
  * Get the fill renderer.
- * @return {function()} Function.
+ * @return {function(CanvasRenderingContext2D)} Function.
  * @api
  */
 ol.style.Fill.prototype.getRenderer = function() {
@@ -73,7 +73,7 @@ ol.style.Fill.prototype.getRenderer = function() {
 /**
  * Set the renderer.
  *
- * @param {function()} renderer Function.
+ * @param {function(CanvasRenderingContext2D)} renderer Function.
  * @api
  */
 ol.style.Fill.prototype.setRenderer = function(renderer) {

--- a/src/ol/style/fillstyle.js
+++ b/src/ol/style/fillstyle.js
@@ -26,6 +26,12 @@ ol.style.Fill = function(opt_options) {
 
   /**
    * @private
+   * @type {function}
+   */
+  this.renderer_ = options.renderer !== undefined ? options.renderer : null;
+
+  /**
+   * @private
    * @type {string|undefined}
    */
   this.checksum_ = undefined;
@@ -50,6 +56,28 @@ ol.style.Fill.prototype.getColor = function() {
  */
 ol.style.Fill.prototype.setColor = function(color) {
   this.color_ = color;
+  this.checksum_ = undefined;
+};
+
+
+/**
+ * Get the fill renderer.
+ * @return {function} Function.
+ * @api
+ */
+ol.style.Fill.prototype.getRenderer = function() {
+  return this.renderer_;
+};
+
+
+/**
+ * Set the renderer.
+ *
+ * @param {function} renderer Function.
+ * @api
+ */
+ol.style.Fill.prototype.setRenderer = function(renderer) {
+  this.renderer_ = renderer;
   this.checksum_ = undefined;
 };
 


### PR DESCRIPTION
Hi,

This adds the capability for an ol.style.Fill to render something else than a simple color.

Taking as a building block the MrPl0p and his nice https://github.com/MrPl0p/ol3-aswcr as discussed in  #2208, I extracted all the image processing and simply added a 'renderer' function, which can fill in anything.

For example, look at what it does if you want filling with stripes:
http://jsfiddle.net/dykko7mw/1/
![screen shot 2015-10-09 at 09 37 41](https://cloud.githubusercontent.com/assets/12514040/10388358/7c8cb636-6e69-11e5-9787-077b74033e8e.png)

The code would be:

```js
...
new ol.style.Fill({
    renderer: makeRedStripes
});

function makeRedStripes (context_) {
    var height = 100,
        width  = 56,
        x,
        ctx,
    $pattern = $('<canvas>')
        .attr('height', height)
        .attr('width', width)[0];

    ctx = $pattern.getContext('2d');
    ctx.strokeStyle = 'rgba(255, 0, 0, 0.15)';
    ctx.lineWidth = 3;

    x = 0;
    while(x < width * 2) {
        ctx.beginPath();
        ctx.moveTo(ctx.lineWidth + x, - 1);
        ctx.lineTo(ctx.lineWidth + x - 50, height + 1);
        ctx.stroke();
        x += 7;
    }
    
    return context_.createPattern($pattern, 'repeat');
}
...
```

Not sure if it can be integrated this way directly, but at least it gives you guys a base to work on.
Thanks for all the great work on OL3!

Cheers
Jonathan