### PR TITLE
Fix a drawText regression introduced with 31a68e2

### DIFF
--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -1560,10 +1560,8 @@ goog.inherits(ol.render.canvas.TextReplay, ol.render.canvas.Replay);
  */
 ol.render.canvas.TextReplay.prototype.drawText =
     function(flatCoordinates, offset, end, stride, geometry, feature) {
-  if (this.text_ === '' ||
-      !this.textState_ ||
-      (this.textFillState_ &&
-       !this.textStrokeState_)) {
+  if (this.text_ === '' || !this.textState_ ||
+      (!this.textFillState_ && !this.textStrokeState_)) {
     return;
   }
   if (this.textFillState_) {


### PR DESCRIPTION
This PR fixes a regression from 31a68e21a51ee378c3698354523d185eef52f543

Previously the relevant lines looked:

```javascript
  if (this.text_ === '' ||
      goog.isNull(this.textState_) ||
      (goog.isNull(this.textFillState_) &&
       goog.isNull(this.textStrokeState_))) {
    return;
  }
```

after 31a68e21a51ee378c3698354523d185eef52f543

They look like

```javascript
  if (this.text_ === '' ||
      !this.textState_ ||
      (this.textFillState_ &&
       !this.textStrokeState_)) {
    return;
  }
```

I think it should be 

```javascript
  if (this.text_ === '' || !this.textState_ ||
      (!this.textFillState_ && !this.textStrokeState_)) {
    return;
  }
```

Please review.

Thanks @jmekaelthas for noticing this in #4240.

Fixes #4240

/cc @tschaub, @ahocevar 