### PR TITLE
Use Math.cosh of ES6/2015 if available

### DIFF
--- a/src/ol/math.js
+++ b/src/ol/math.js
@@ -21,7 +21,8 @@ ol.math.clamp = function(value, min, max) {
  * @return {number} Hyperbolic cosine of x.
  */
 ol.math.cosh = function(x) {
-  return (Math.exp(x) + Math.exp(-x)) / 2;
+  var y = Math.exp(x);
+  return (y + 1 / y) / 2;
 };
 
 

--- a/src/ol/math.js
+++ b/src/ol/math.js
@@ -17,13 +17,30 @@ ol.math.clamp = function(value, min, max) {
 
 
 /**
+ * Return the hyperbolic cosine of a given number. The method will use the
+ * native `Math.cosh` function if it is available, otherwise the hyperbolic
+ * cosine will be calculated via the reference implementation of the Mozilla
+ * developer network.
+ *
  * @param {number} x X.
  * @return {number} Hyperbolic cosine of x.
  */
-ol.math.cosh = function(x) {
-  var y = Math.exp(x);
-  return (y + 1 / y) / 2;
-};
+ol.math.cosh = (function() {
+  // Wrapped in a iife, to save the overhead of checking for the native
+  // implementation on every invocation.
+  var cosh;
+  if ('cosh' in Math) {
+    // The environment supports the native Math.cosh function, use it…
+    cosh = Math.cosh;
+  } else {
+    // … else, use the reference implementation of MDN:
+    cosh = function(x) {
+      var y = Math.exp(x);
+      return (y + 1 / y) / 2;
+    };
+  }
+  return cosh;
+}());
 
 
 /**


### PR DESCRIPTION
This PR suggests two smaller refactorings with regard to `ol.math.cosh`:

* 449131a516f38e4816905c7db433e92287e20e08 refactors the implementation in a way which saves us one call to `Math.exp`. This variant performs better for me, and the code is taken from [the MDN reference implmentation](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/cosh)
* cd99d44704946519a82d22c89c08aac08e49263b then changes the code again, so that the native method `Math.cosh` (standardized in ES6 / 2015) is used if it is available (Which naturally gives us best prefromance).

Here is a jsperf compairing the implementations: http://jsperf.com/cosh-num-calls-math-exp

Please review.
