### PR TITLE
optional silent mode for set and setProperties

### DIFF
--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -202,12 +202,12 @@ ol.Object.prototype.notify = function(key, oldValue) {
  */
 ol.Object.prototype.set = function(key, value, notify) {
   if (goog.isDef(notify) && notify === false) {
-      this.values_[key] = value;
+    this.values_[key] = value;
   }
   else {
-      var oldValue = this.values_[key];
-      this.values_[key] = value;
-      this.notify(key, oldValue);
+    var oldValue = this.values_[key];
+    this.values_[key] = value;
+    this.notify(key, oldValue);
   }
 };
 

--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -197,7 +197,7 @@ ol.Object.prototype.notify = function(key, oldValue) {
  * Sets a value.
  * @param {string} key Key name.
  * @param {*} value Value.
- * @param {boolean=} notify update propertie silently
+ * @param {boolean=} opt_notify update propertie silently
  * @api stable
  */
 ol.Object.prototype.set = function(key, value, notify) {
@@ -216,7 +216,7 @@ ol.Object.prototype.set = function(key, value, notify) {
  * Sets a collection of key-value pairs.  Note that this changes any existing
  * properties and adds new ones (it does not remove any existing properties).
  * @param {Object.<string, *>} values Values.
- * @param {boolean=} notify update propertie silently
+ * @param {boolean=} opt_notify update propertie silently
  * @api stable
  */
 ol.Object.prototype.setProperties = function(values, notify) {
@@ -230,7 +230,7 @@ ol.Object.prototype.setProperties = function(values, notify) {
 /**
  * Unsets a property.
  * @param {string} key Key name.
- * @param {boolean=} notify update propertie silently
+ * @param {boolean=} opt_notify update propertie silently
  * @api stable
  */
 ol.Object.prototype.unset = function(key, notify) {

--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -197,12 +197,18 @@ ol.Object.prototype.notify = function(key, oldValue) {
  * Sets a value.
  * @param {string} key Key name.
  * @param {*} value Value.
+ * @param {boolean} notify update propertie silently
  * @api stable
  */
-ol.Object.prototype.set = function(key, value) {
-  var oldValue = this.values_[key];
-  this.values_[key] = value;
-  this.notify(key, oldValue);
+ol.Object.prototype.set = function (key, value, notify) {
+    if (goog.isDef(notify) && notify === false) {
+        this.values_[key] = value;
+    }
+    else {
+        var oldValue = this.values_[key];
+        this.values_[key] = value;
+        this.notify(key, oldValue);
+    }
 };
 
 
@@ -210,12 +216,13 @@ ol.Object.prototype.set = function(key, value) {
  * Sets a collection of key-value pairs.  Note that this changes any existing
  * properties and adds new ones (it does not remove any existing properties).
  * @param {Object.<string, *>} values Values.
+ * @param {boolean} notify update propertie silently
  * @api stable
  */
-ol.Object.prototype.setProperties = function(values) {
+ol.Object.prototype.setProperties = function(values,notify) {
   var key;
   for (key in values) {
-    this.set(key, values[key]);
+    this.set(key, values[key],notify);
   }
 };
 

--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -200,8 +200,8 @@ ol.Object.prototype.notify = function(key, oldValue) {
  * @param {boolean=} opt_notify update propertie silently
  * @api stable
  */
-ol.Object.prototype.set = function(key, value, notify) {
-  if (goog.isDef(notify) && notify === false) {
+ol.Object.prototype.set = function(key, value, opt_notify=) {
+  if (goog.isDef(opt_notify) && opt_notify === false) {
     this.values_[key] = value;
   }
   else {
@@ -219,10 +219,10 @@ ol.Object.prototype.set = function(key, value, notify) {
  * @param {boolean=} opt_notify update propertie silently
  * @api stable
  */
-ol.Object.prototype.setProperties = function(values, notify) {
+ol.Object.prototype.setProperties = function(values, opt_notify=) {
   var key;
   for (key in values) {
-    this.set(key, values[key], notify);
+    this.set(key, values[key], opt_notify);
   }
 };
 
@@ -233,11 +233,11 @@ ol.Object.prototype.setProperties = function(values, notify) {
  * @param {boolean=} opt_notify update propertie silently
  * @api stable
  */
-ol.Object.prototype.unset = function(key, notify) {
+ol.Object.prototype.unset = function(key, opt_notify=) {
   if (key in this.values_) {
     var oldValue = this.values_[key];
     delete this.values_[key];
-    if (!goog.isDef(notify) || notify !== false) {
+    if (!goog.isDef(opt_notify) || opt_notify !== false) {
       this.notify(key, oldValue);
     }
   }

--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -200,15 +200,15 @@ ol.Object.prototype.notify = function(key, oldValue) {
  * @param {boolean} notify update propertie silently
  * @api stable
  */
-ol.Object.prototype.set = function (key, value, notify) {
-    if (goog.isDef(notify) && notify === false) {
-        this.values_[key] = value;
-    }
-    else {
-        var oldValue = this.values_[key];
-        this.values_[key] = value;
-        this.notify(key, oldValue);
-    }
+ol.Object.prototype.set = function(key, value, notify) {
+  if (goog.isDef(notify) && notify === false) {
+      this.values_[key] = value;
+  }
+  else {
+      var oldValue = this.values_[key];
+      this.values_[key] = value;
+      this.notify(key, oldValue);
+  }
 };
 
 
@@ -219,10 +219,10 @@ ol.Object.prototype.set = function (key, value, notify) {
  * @param {boolean} notify update propertie silently
  * @api stable
  */
-ol.Object.prototype.setProperties = function(values,notify) {
+ol.Object.prototype.setProperties = function(values, notify) {
   var key;
   for (key in values) {
-    this.set(key, values[key],notify);
+    this.set(key, values[key], notify);
   }
 };
 
@@ -233,12 +233,12 @@ ol.Object.prototype.setProperties = function(values,notify) {
  * @param {boolean} notify update propertie silently
  * @api stable
  */
-ol.Object.prototype.unset = function(key) {
+ol.Object.prototype.unset = function(key, notify) {
   if (key in this.values_) {
     var oldValue = this.values_[key];
     delete this.values_[key];
     if (!goog.isDef(notify) || notify !== false) {
-+      this.notify(key, oldValue);
-+   }
+      this.notify(key, oldValue);
+    }
   }
 };

--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -230,12 +230,15 @@ ol.Object.prototype.setProperties = function(values,notify) {
 /**
  * Unsets a property.
  * @param {string} key Key name.
+ * @param {boolean} notify update propertie silently
  * @api stable
  */
 ol.Object.prototype.unset = function(key) {
   if (key in this.values_) {
     var oldValue = this.values_[key];
     delete this.values_[key];
-    this.notify(key, oldValue);
+    if (!goog.isDef(notify) || notify !== false) {
++      this.notify(key, oldValue);
++   }
   }
 };

--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -197,11 +197,11 @@ ol.Object.prototype.notify = function(key, oldValue) {
  * Sets a value.
  * @param {string} key Key name.
  * @param {*} value Value.
- * @param {boolean=} opt_notify update propertie silently
+ * @param {boolean=} opt_silent update propertie silently
  * @api stable
  */
-ol.Object.prototype.set = function(key, value, opt_notify) {
-  if (goog.isDef(opt_notify) && opt_notify === false) {
+ol.Object.prototype.set = function(key, value, opt_silent) {
+  if (goog.isDef(opt_silent) && opt_silent === true) {
     this.values_[key] = value;
   }
   else {
@@ -216,13 +216,13 @@ ol.Object.prototype.set = function(key, value, opt_notify) {
  * Sets a collection of key-value pairs.  Note that this changes any existing
  * properties and adds new ones (it does not remove any existing properties).
  * @param {Object.<string, *>} values Values.
- * @param {boolean=} opt_notify update propertie silently
+ * @param {boolean=} opt_silent update propertie silently
  * @api stable
  */
-ol.Object.prototype.setProperties = function(values, opt_notify) {
+ol.Object.prototype.setProperties = function(values, opt_silent) {
   var key;
   for (key in values) {
-    this.set(key, values[key], opt_notify);
+    this.set(key, values[key], opt_silent);
   }
 };
 
@@ -230,14 +230,14 @@ ol.Object.prototype.setProperties = function(values, opt_notify) {
 /**
  * Unsets a property.
  * @param {string} key Key name.
- * @param {boolean=} opt_notify update propertie silently
+ * @param {boolean=} opt_silent update propertie silently
  * @api stable
  */
-ol.Object.prototype.unset = function(key, opt_notify) {
+ol.Object.prototype.unset = function(key, opt_silent) {
   if (key in this.values_) {
     var oldValue = this.values_[key];
     delete this.values_[key];
-    if (!goog.isDef(opt_notify) || opt_notify !== false) {
+    if (!goog.isDef(opt_silent) || opt_silent !== true) {
       this.notify(key, oldValue);
     }
   }

--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -197,14 +197,13 @@ ol.Object.prototype.notify = function(key, oldValue) {
  * Sets a value.
  * @param {string} key Key name.
  * @param {*} value Value.
- * @param {boolean=} opt_silent update propertie silently
+ * @param {boolean=} opt_silent Update property without triggering notification.
  * @api stable
  */
 ol.Object.prototype.set = function(key, value, opt_silent) {
-  if (goog.isDef(opt_silent) && opt_silent === true) {
+  if (opt_silent === true) {
     this.values_[key] = value;
-  }
-  else {
+  } else {
     var oldValue = this.values_[key];
     this.values_[key] = value;
     this.notify(key, oldValue);
@@ -237,7 +236,7 @@ ol.Object.prototype.unset = function(key, opt_silent) {
   if (key in this.values_) {
     var oldValue = this.values_[key];
     delete this.values_[key];
-    if (!goog.isDef(opt_silent) || opt_silent !== true) {
+    if (!opt_silent) {
       this.notify(key, oldValue);
     }
   }

--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -197,7 +197,7 @@ ol.Object.prototype.notify = function(key, oldValue) {
  * Sets a value.
  * @param {string} key Key name.
  * @param {*} value Value.
- * @param {boolean} notify update propertie silently
+ * @param {boolean=} notify update propertie silently
  * @api stable
  */
 ol.Object.prototype.set = function(key, value, notify) {
@@ -216,7 +216,7 @@ ol.Object.prototype.set = function(key, value, notify) {
  * Sets a collection of key-value pairs.  Note that this changes any existing
  * properties and adds new ones (it does not remove any existing properties).
  * @param {Object.<string, *>} values Values.
- * @param {boolean} notify update propertie silently
+ * @param {boolean=} notify update propertie silently
  * @api stable
  */
 ol.Object.prototype.setProperties = function(values, notify) {
@@ -230,7 +230,7 @@ ol.Object.prototype.setProperties = function(values, notify) {
 /**
  * Unsets a property.
  * @param {string} key Key name.
- * @param {boolean} notify update propertie silently
+ * @param {boolean=} notify update propertie silently
  * @api stable
  */
 ol.Object.prototype.unset = function(key, notify) {

--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -200,7 +200,7 @@ ol.Object.prototype.notify = function(key, oldValue) {
  * @param {boolean=} opt_notify update propertie silently
  * @api stable
  */
-ol.Object.prototype.set = function(key, value, opt_notify=) {
+ol.Object.prototype.set = function(key, value, opt_notify) {
   if (goog.isDef(opt_notify) && opt_notify === false) {
     this.values_[key] = value;
   }
@@ -219,7 +219,7 @@ ol.Object.prototype.set = function(key, value, opt_notify=) {
  * @param {boolean=} opt_notify update propertie silently
  * @api stable
  */
-ol.Object.prototype.setProperties = function(values, opt_notify=) {
+ol.Object.prototype.setProperties = function(values, opt_notify) {
   var key;
   for (key in values) {
     this.set(key, values[key], opt_notify);
@@ -233,7 +233,7 @@ ol.Object.prototype.setProperties = function(values, opt_notify=) {
  * @param {boolean=} opt_notify update propertie silently
  * @api stable
  */
-ol.Object.prototype.unset = function(key, opt_notify=) {
+ol.Object.prototype.unset = function(key, opt_notify) {
   if (key in this.values_) {
     var oldValue = this.values_[key];
     delete this.values_[key];


### PR DESCRIPTION
Hi, 

I had to update 200+ features (geometry + 10~20 properties) each 2 seconds. The number of notify event's caused the map to hang on every updates. 

I modified the set and setProperties method with an optional parameter that allow the user to choose if he wan't to be notified of updated properties (in real usage: when you programatically update features, you know that properties ares updated, so being notified is useless)

Compatibility : if not provided, Object.set and setProperties will notify event, no adaptation is needed.


