### PR TITLE
Remove unused ol.math-methods

### DIFF
--- a/src/ol/math.js
+++ b/src/ol/math.js
@@ -27,48 +27,11 @@ ol.math.cosh = function(x) {
 
 /**
  * @param {number} x X.
- * @return {number} Hyperbolic cotangent of x.
- */
-ol.math.coth = function(x) {
-  var expMinusTwoX = Math.exp(-2 * x);
-  return (1 + expMinusTwoX) / (1 - expMinusTwoX);
-};
-
-
-/**
- * @param {number} x X.
- * @return {number} Hyperbolic cosecant of x.
- */
-ol.math.csch = function(x) {
-  return 2 / (Math.exp(x) - Math.exp(-x));
-};
-
-
-/**
- * @param {number} x X.
  * @return {number} The smallest power of two greater than or equal to x.
  */
 ol.math.roundUpToPowerOfTwo = function(x) {
   goog.asserts.assert(0 < x, 'x should be larger than 0');
   return Math.pow(2, Math.ceil(Math.log(x) / Math.LN2));
-};
-
-
-/**
- * @param {number} x X.
- * @return {number} Hyperbolic secant of x.
- */
-ol.math.sech = function(x) {
-  return 2 / (Math.exp(x) + Math.exp(-x));
-};
-
-
-/**
- * @param {number} x X.
- * @return {number} Hyperbolic sine of x.
- */
-ol.math.sinh = function(x) {
-  return (Math.exp(x) - Math.exp(-x)) / 2;
 };
 
 
@@ -112,16 +75,6 @@ ol.math.squaredDistance = function(x1, y1, x2, y2) {
   var dx = x2 - x1;
   var dy = y2 - y1;
   return dx * dx + dy * dy;
-};
-
-
-/**
- * @param {number} x X.
- * @return {number} Hyperbolic tangent of x.
- */
-ol.math.tanh = function(x) {
-  var expMinusTwoX = Math.exp(-2 * x);
-  return (1 - expMinusTwoX) / (1 + expMinusTwoX);
 };
 
 

--- a/test/spec/ol/math.test.js
+++ b/test/spec/ol/math.test.js
@@ -51,44 +51,6 @@ describe('ol.math.cosh', function() {
 });
 
 
-describe('ol.math.coth', function() {
-
-  it('returns the correct value at -1', function() {
-    expect(ol.math.coth(-1)).to.roughlyEqual(-1.3130352854993312, 1e-9);
-  });
-
-  it('returns the correct value at 1', function() {
-    expect(ol.math.coth(1)).to.roughlyEqual(1.3130352854993312, 1e-9);
-  });
-
-  it('returns the correct value at Infinity', function() {
-    expect(ol.math.coth(Infinity)).to.eql(1);
-  });
-
-});
-
-
-describe('ol.math.csch', function() {
-
-  it('returns the correct value at -Infinity', function() {
-    expect(ol.math.csch(-Infinity)).to.eql(0);
-  });
-
-  it('returns the correct value at -1', function() {
-    expect(ol.math.csch(-1)).to.roughlyEqual(-0.85091812823932156, 1e-9);
-  });
-
-  it('returns the correct value at 1', function() {
-    expect(ol.math.csch(1)).to.roughlyEqual(0.85091812823932156, 1e-9);
-  });
-
-  it('returns the correct value at Infinity', function() {
-    expect(ol.math.csch(Infinity)).to.eql(0);
-  });
-
-});
-
-
 describe('ol.math.roundUpToPowerOfTwo', function() {
 
   it('raises an exception when x is negative', function() {
@@ -124,73 +86,6 @@ describe('ol.math.roundUpToPowerOfTwo', function() {
     expect(ol.math.roundUpToPowerOfTwo(100000)).to.be(131072);
     expect(ol.math.roundUpToPowerOfTwo(1000000)).to.be(1048576);
     expect(ol.math.roundUpToPowerOfTwo(10000000)).to.be(16777216);
-  });
-
-});
-
-
-describe('ol.math.sech', function() {
-
-  it('returns the correct value at -Infinity', function() {
-    expect(ol.math.sech(-Infinity)).to.eql(0);
-  });
-
-  it('returns the correct value at -1', function() {
-    expect(ol.math.sech(-1)).to.roughlyEqual(0.64805427366388535, 1e-9);
-  });
-
-  it('returns the correct value at 0', function() {
-    expect(ol.math.sech(0)).to.eql(1);
-  });
-
-  it('returns the correct value at 1', function() {
-    expect(ol.math.sech(1)).to.roughlyEqual(0.64805427366388535, 1e-9);
-  });
-
-  it('returns the correct value at Infinity', function() {
-    expect(ol.math.sech(Infinity)).to.eql(0);
-  });
-
-});
-
-
-describe('ol.math.sinh', function() {
-
-  it('returns the correct value at -Infinity', function() {
-    expect(ol.math.sinh(-Infinity)).to.eql(-Infinity);
-  });
-
-  it('returns the correct value at -1', function() {
-    expect(ol.math.sinh(-1)).to.roughlyEqual(-1.1752011936438014, 1e-9);
-  });
-
-  it('returns the correct value at 0', function() {
-    expect(ol.math.sinh(0)).to.eql(0);
-  });
-
-  it('returns the correct value at 1', function() {
-    expect(ol.math.sinh(1)).to.roughlyEqual(1.1752011936438014, 1e-9);
-  });
-
-  it('returns the correct value at Infinity', function() {
-    expect(ol.math.cosh(Infinity)).to.eql(Infinity);
-  });
-
-});
-
-
-describe('ol.math.tanh', function() {
-
-  it('returns the correct value at -1', function() {
-    expect(ol.math.tanh(-1)).to.roughlyEqual(-0.76159415595576485, 1e-9);
-  });
-
-  it('returns the correct value at 0', function() {
-    expect(ol.math.tanh(0)).to.eql(0);
-  });
-
-  it('returns the correct value at 1', function() {
-    expect(ol.math.tanh(1)).to.roughlyEqual(0.76159415595576485, 1e-9);
   });
 
 });


### PR DESCRIPTION
The methods

* `ol.math.coth`,
* `ol.math.csch`,
* `ol.math.sech`,
* `ol.math.sinh` and
* `ol.math.tanh`

Are not used in the library. We should probably remove them.

Please review.