### PR TITLE
ol.events.condition.mouseOnly may be wrong

### DIFF
--- a/src/ol/events/condition.js
+++ b/src/ol/events/condition.js
@@ -203,8 +203,6 @@ ol.events.condition.targetNotEditable = function(mapBrowserEvent) {
 ol.events.condition.mouseOnly = function(mapBrowserEvent) {
   goog.asserts.assertInstanceof(mapBrowserEvent, ol.MapBrowserPointerEvent,
       'mapBrowserEvent should be an instance of ol.MapBrowserPointerEvent');
-  /* pointerId must be 1 for mouse devices,
-   * see: http://www.w3.org/Submission/pointer-events/#pointerevent-interface
-   */
-  return mapBrowserEvent.pointerEvent.pointerId == 1;
+  // see http://www.w3.org/TR/pointerevents/#widl-PointerEvent-pointerType
+  return mapBrowserEvent.pointerEvent.pointerType == 'mouse';
 };


### PR DESCRIPTION
[The comment inside the function](https://github.com/openlayers/ol3/blob/master/src/ol/events/condition.js#L206-L208) says that if `pointerId` is `1` the event was triggered by a mouse. The [finalized version](http://www.w3.org/TR/pointerevents/#widl-PointerEventInit-pointerId) of the specification do not mention it.

