### PR TITLE
Add method for retrieving ol.Overlay by id

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -309,7 +309,8 @@ olx.MapOptions.prototype.view;
 
 /**
  * Object literal with config options for the overlay.
- * @typedef {{element: (Element|undefined),
+ * @typedef {{id: (number|string|undefined),
+ *     element: (Element|undefined),
  *     offset: (Array.<number>|undefined),
  *     position: (ol.Coordinate|undefined),
  *     positioning: (ol.OverlayPositioning|string|undefined),
@@ -321,6 +322,15 @@ olx.MapOptions.prototype.view;
  * @api stable
  */
 olx.OverlayOptions;
+
+
+/**
+ * Set the overlay id. The overlay id can be used with the
+ * {@link ol.Map#getOverlayById} method.
+ * @type {number|string|undefined}
+ * @api
+ */
+olx.OverlayOptions.prototype.id;
 
 
 /**

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -467,21 +467,14 @@ ol.Map = function(options) {
         event.element.setMap(null);
       }, false, this);
 
-  this.overlays_.forEach(
-      /**
-       * @param {ol.Overlay} overlay Overlay.
-       * @this {ol.Map}
-       */
-      function(overlay) {
-        this.addOverlayInternal(overlay);
-      }, this);
+  this.overlays_.forEach(this.addOverlayInternal_, this);
 
   goog.events.listen(this.overlays_, ol.CollectionEventType.ADD,
       /**
        * @param {ol.CollectionEvent} event Collection event.
        */
       function(event) {
-        this.addOverlayInternal(/** @type {ol.Overlay} */ (event.element));
+        this.addOverlayInternal_(/** @type {ol.Overlay} */ (event.element));
       }, false, this);
 
   goog.events.listen(this.overlays_, ol.CollectionEventType.REMOVE,
@@ -489,7 +482,11 @@ ol.Map = function(options) {
        * @param {ol.CollectionEvent} event Collection event.
        */
       function(event) {
-        this.removeOverlayInternal(/** @type {ol.Overlay} */ (event.element));
+        var id = event.element.getId();
+        if (id !== undefined) {
+          delete this.overlayIdIndex_[id.toString()];
+        }
+        event.element.setMap(null);
       }, false, this);
 
 };
@@ -549,9 +546,9 @@ ol.Map.prototype.addOverlay = function(overlay) {
 /**
  * This deals with map's overlay collection changes.
  * @param {ol.Overlay} overlay Overlay.
- * @protected
+ * @private
  */
-ol.Map.prototype.addOverlayInternal = function(overlay) {
+ol.Map.prototype.addOverlayInternal_ = function(overlay) {
   var id = overlay.getId();
   if (id !== undefined) {
     this.overlayIdIndex_[id.toString()] = overlay;
@@ -1277,20 +1274,6 @@ ol.Map.prototype.removeOverlay = function(overlay) {
   var overlays = this.getOverlays();
   goog.asserts.assert(overlays !== undefined, 'overlays should be defined');
   return overlays.remove(overlay);
-};
-
-
-/**
- * This deals with map's overlay collection changes.
- * @param {ol.Overlay} overlay Overlay.
- * @protected
- */
-ol.Map.prototype.removeOverlayInternal = function(overlay) {
-  var id = overlay.getId();
-  if (id !== undefined) {
-    delete this.overlayIdIndex_[id.toString()];
-  }
-  overlay.setMap(null);
 };
 
 

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -557,9 +557,6 @@ ol.Map.prototype.addOverlayInternal = function(overlay) {
     this.overlayIdIndex_[id.toString()] = overlay;
   }
   overlay.setMap(this);
-  goog.events.listen(
-      overlay, ol.Object.getChangeEventType(overlay.getOverlayIdProperty()),
-      this.handleOverlayIdChange_, false, this);
 };
 
 
@@ -1100,28 +1097,6 @@ ol.Map.prototype.handleTargetChanged_ = function() {
  */
 ol.Map.prototype.handleTileChange_ = function() {
   this.render();
-};
-
-
-/**
- * @param {goog.events.Event} event Event.
- * @private
- */
-ol.Map.prototype.handleOverlayIdChange_ = function(event) {
-  var overlay = /** @type {ol.Overlay} */ (event.target);
-  var id = overlay.getId().toString();
-  var oldId = event.oldValue;
-  if (oldId && oldId != id) {
-    delete this.overlayIdIndex_[oldId];
-  }
-  if (id in this.overlayIdIndex_) {
-    if (this.overlayIdIndex_[id] !== overlay) {
-      delete this.overlayIdIndex_[id];
-      this.overlayIdIndex_[id] = overlay;
-    }
-  } else {
-    this.overlayIdIndex_[id] = overlay;
-  }
 };
 
 

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -19,7 +19,6 @@ goog.require('ol.extent');
  * @enum {string}
  */
 ol.OverlayProperty = {
-  ID: 'id',
   ELEMENT: 'element',
   MAP: 'map',
   OFFSET: 'offset',
@@ -78,7 +77,7 @@ ol.Overlay = function(options) {
    * @private
    * @type {number|string|undefined}
    */
-  this.id_ = undefined;
+  this.id_ = options.id;
 
   /**
    * @private
@@ -195,8 +194,7 @@ ol.Overlay.prototype.getElement = function() {
 
 
 /**
- * Get the feature identifier.  This is an identifier for the overlay and
- * is set explicitly by calling {@link ol.Overlay#setId}.
+ * Get the feature identifier which is set on constructor.
  * @return {number|string|undefined} Id.
  * @api
  */
@@ -226,15 +224,6 @@ ol.Overlay.prototype.getMap = function() {
 ol.Overlay.prototype.getOffset = function() {
   return /** @type {Array.<number>} */ (
       this.get(ol.OverlayProperty.OFFSET));
-};
-
-
-/**
- * Workaround to overcome circular dependency.
- * @return {ol.OverlayProperty}
- */
-ol.Overlay.prototype.getOverlayIdProperty = function() {
-  return ol.OverlayProperty.ID;
 };
 
 
@@ -345,22 +334,6 @@ ol.Overlay.prototype.handlePositioningChanged = function() {
  */
 ol.Overlay.prototype.setElement = function(element) {
   this.set(ol.OverlayProperty.ELEMENT, element);
-};
-
-
-/**
- * Set the feature id. The feature id can be used with the
- * {@link ol.Map#getOverlayById} method.
- * @param {number|string} id The feature id.
- * @observable
- * @api
- */
-ol.Overlay.prototype.setId = function(id) {
-  goog.asserts.assert(id !== undefined, 'overlay id should be defined');
-  if (id != this.id_) {
-    this.id_ = id;
-    this.set(ol.OverlayProperty.ID, id);
-  }
 };
 
 

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -194,7 +194,7 @@ ol.Overlay.prototype.getElement = function() {
 
 
 /**
- * Get the feature identifier which is set on constructor.
+ * Get the overlay identifier which is set on constructor.
  * @return {number|string|undefined} Id.
  * @api
  */

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -19,6 +19,7 @@ goog.require('ol.extent');
  * @enum {string}
  */
 ol.OverlayProperty = {
+  ID: 'id',
   ELEMENT: 'element',
   MAP: 'map',
   OFFSET: 'offset',
@@ -72,6 +73,12 @@ ol.OverlayPositioning = {
 ol.Overlay = function(options) {
 
   goog.base(this);
+
+  /**
+   * @private
+   * @type {number|string|undefined}
+   */
+  this.id_ = undefined;
 
   /**
    * @private
@@ -188,6 +195,17 @@ ol.Overlay.prototype.getElement = function() {
 
 
 /**
+ * Get the feature identifier.  This is an identifier for the overlay and
+ * is set explicitly by calling {@link ol.Overlay#setId}.
+ * @return {number|string|undefined} Id.
+ * @api
+ */
+ol.Overlay.prototype.getId = function() {
+  return this.id_;
+};
+
+
+/**
  * Get the map associated with this overlay.
  * @return {ol.Map|undefined} The map that the overlay is part of.
  * @observable
@@ -208,6 +226,15 @@ ol.Overlay.prototype.getMap = function() {
 ol.Overlay.prototype.getOffset = function() {
   return /** @type {Array.<number>} */ (
       this.get(ol.OverlayProperty.OFFSET));
+};
+
+
+/**
+ * Workaround to overcome circular dependency.
+ * @return {ol.OverlayProperty}
+ */
+ol.Overlay.prototype.getOverlayIdProperty = function() {
+  return ol.OverlayProperty.ID;
 };
 
 
@@ -318,6 +345,22 @@ ol.Overlay.prototype.handlePositioningChanged = function() {
  */
 ol.Overlay.prototype.setElement = function(element) {
   this.set(ol.OverlayProperty.ELEMENT, element);
+};
+
+
+/**
+ * Set the feature id. The feature id can be used with the
+ * {@link ol.Map#getOverlayById} method.
+ * @param {number|string} id The feature id.
+ * @observable
+ * @api
+ */
+ol.Overlay.prototype.setId = function(id) {
+  goog.asserts.assert(id !== undefined, 'overlay id should be defined');
+  if (id != this.id_) {
+    this.id_ = id;
+    this.set(ol.OverlayProperty.ID, id);
+  }
 };
 
 

--- a/test/spec/ol/map.test.js
+++ b/test/spec/ol/map.test.js
@@ -346,80 +346,36 @@ describe('ol.Map', function() {
 
       it('returns an overlay by id', function() {
         overlay = new ol.Overlay({
-          element: overlay_target,
-          position: [0, 0]
-        });
-        overlay.setId('foo');
-        map.addOverlay(overlay);
-        expect(map.getOverlayById('foo')).to.be(overlay);
-      });
-
-      it('returns an overlay by id (set after add)', function() {
-        overlay = new ol.Overlay({
+          id: 'foo',
           element: overlay_target,
           position: [0, 0]
         });
         map.addOverlay(overlay);
-        expect(map.getOverlayById('foo')).to.be(null);
-        overlay.setId('foo');
         expect(map.getOverlayById('foo')).to.be(overlay);
       });
 
       it('returns null when no overlay is found', function() {
         overlay = new ol.Overlay({
+          id: 'foo',
           element: overlay_target,
           position: [0, 0]
         });
-        overlay.setId('foo');
         map.addOverlay(overlay);
         expect(map.getOverlayById('bar')).to.be(null);
       });
 
       it('returns null after removing overlay', function() {
         overlay = new ol.Overlay({
+          id: 'foo',
           element: overlay_target,
           position: [0, 0]
         });
-        overlay.setId('foo');
         map.addOverlay(overlay);
         expect(map.getOverlayById('foo')).to.be(overlay);
         map.removeOverlay(overlay);
         expect(map.getOverlayById('foo')).to.be(null);
       });
 
-      it('returns correct overlay after add/remove/add', function() {
-        expect(map.getOverlayById('foo')).to.be(null);
-        var first = new ol.Overlay({
-          element: overlay_target,
-          position: [0, 0]
-        });
-        first.setId('foo');
-        map.addOverlay(first);
-        expect(map.getOverlayById('foo')).to.be(first);
-        map.removeOverlay(first);
-        expect(map.getOverlayById('foo')).to.be(null);
-        var second = new ol.Overlay({
-          element: overlay_target,
-          position: [0, 0]
-        });
-        second.setId('foo');
-        map.addOverlay(second);
-        expect(map.getOverlayById('foo')).to.be(second);
-      });
-
-      it('returns correct overlay after add/change', function() {
-        expect(map.getOverlayById('foo')).to.be(null);
-        overlay = new ol.Overlay({
-          element: overlay_target,
-          position: [0, 0]
-        });
-        overlay.setId('foo');
-        map.addOverlay(overlay);
-        expect(map.getOverlayById('foo')).to.be(overlay);
-        overlay.setId('bar');
-        expect(map.getOverlayById('foo')).to.be(null);
-        expect(map.getOverlayById('bar')).to.be(overlay);
-      });
     });
 
   });

--- a/test/spec/ol/map.test.js
+++ b/test/spec/ol/map.test.js
@@ -315,6 +315,113 @@ describe('ol.Map', function() {
       });
     });
 
+    describe('#getOverlayById()', function() {
+      var target, map, overlay, overlay_target;
+
+      beforeEach(function() {
+        target = document.createElement('div');
+        var style = target.style;
+        style.position = 'absolute';
+        style.left = '-1000px';
+        style.top = '-1000px';
+        style.width = '360px';
+        style.height = '180px';
+        document.body.appendChild(target);
+        map = new ol.Map({
+          target: target,
+          view: new ol.View({
+            projection: 'EPSG:4326',
+            center: [0, 0],
+            resolution: 1
+          })
+        });
+        overlay_target = document.createElement('div');
+      });
+
+      afterEach(function() {
+        map.removeOverlay(overlay);
+        goog.dispose(map);
+        document.body.removeChild(target);
+      });
+
+      it('returns an overlay by id', function() {
+        overlay = new ol.Overlay({
+          element: overlay_target,
+          position: [0, 0]
+        });
+        overlay.setId('foo');
+        map.addOverlay(overlay);
+        expect(map.getOverlayById('foo')).to.be(overlay);
+      });
+
+      it('returns an overlay by id (set after add)', function() {
+        overlay = new ol.Overlay({
+          element: overlay_target,
+          position: [0, 0]
+        });
+        map.addOverlay(overlay);
+        expect(map.getOverlayById('foo')).to.be(null);
+        overlay.setId('foo');
+        expect(map.getOverlayById('foo')).to.be(overlay);
+      });
+
+      it('returns null when no overlay is found', function() {
+        overlay = new ol.Overlay({
+          element: overlay_target,
+          position: [0, 0]
+        });
+        overlay.setId('foo');
+        map.addOverlay(overlay);
+        expect(map.getOverlayById('bar')).to.be(null);
+      });
+
+      it('returns null after removing overlay', function() {
+        overlay = new ol.Overlay({
+          element: overlay_target,
+          position: [0, 0]
+        });
+        overlay.setId('foo');
+        map.addOverlay(overlay);
+        expect(map.getOverlayById('foo')).to.be(overlay);
+        map.removeOverlay(overlay);
+        expect(map.getOverlayById('foo')).to.be(null);
+      });
+
+      it('returns correct overlay after add/remove/add', function() {
+        expect(map.getOverlayById('foo')).to.be(null);
+        var first = new ol.Overlay({
+          element: overlay_target,
+          position: [0, 0]
+        });
+        first.setId('foo');
+        map.addOverlay(first);
+        expect(map.getOverlayById('foo')).to.be(first);
+        map.removeOverlay(first);
+        expect(map.getOverlayById('foo')).to.be(null);
+        var second = new ol.Overlay({
+          element: overlay_target,
+          position: [0, 0]
+        });
+        second.setId('foo');
+        map.addOverlay(second);
+        expect(map.getOverlayById('foo')).to.be(second);
+      });
+
+      it('returns correct overlay after add/change', function() {
+        expect(map.getOverlayById('foo')).to.be(null);
+        overlay = new ol.Overlay({
+          element: overlay_target,
+          position: [0, 0]
+        });
+        overlay.setId('foo');
+        map.addOverlay(overlay);
+        expect(map.getOverlayById('foo')).to.be(overlay);
+        overlay.setId('bar');
+        expect(map.getOverlayById('foo')).to.be(null);
+        expect(map.getOverlayById('bar')).to.be(overlay);
+      });
+    });
+
   });
 
 });
@@ -325,6 +432,7 @@ goog.require('goog.events.BrowserEvent');
 goog.require('goog.events.EventType');
 goog.require('ol.Map');
 goog.require('ol.MapEvent');
+goog.require('ol.Overlay');
 goog.require('ol.View');
 goog.require('ol.interaction');
 goog.require('ol.interaction.Interaction');

--- a/test/spec/ol/overlay.test.js
+++ b/test/spec/ol/overlay.test.js
@@ -1,6 +1,36 @@
 goog.provide('ol.test.Overlay');
 
 describe('ol.Overlay', function() {
+  var target, map;
+
+  var width = 360;
+  var height = 180;
+
+  beforeEach(function() {
+    target = document.createElement('div');
+
+    var style = target.style;
+    style.position = 'absolute';
+    style.left = '-1000px';
+    style.top = '-1000px';
+    style.width = width + 'px';
+    style.height = height + 'px';
+    document.body.appendChild(target);
+
+    map = new ol.Map({
+      target: target,
+      view: new ol.View({
+        projection: 'EPSG:4326',
+        center: [0, 0],
+        resolution: 1
+      })
+    });
+  });
+
+  afterEach(function() {
+    goog.dispose(map);
+    document.body.removeChild(target);
+  });
 
   describe('constructor', function() {
 
@@ -11,6 +41,39 @@ describe('ol.Overlay', function() {
 
   });
 
+  describe('#setId()', function() {
+    var overlay, target;
+
+    beforeEach(function() {
+      target = document.createElement('div');
+      overlay = new ol.Overlay({
+        element: target,
+        position: [0, 0]
+      });
+      map.addOverlay(overlay);
+    });
+    afterEach(function() {
+      map.removeOverlay(overlay);
+    });
+
+    it('sets the overlay identifier', function() {
+      expect(overlay.getId()).to.be(undefined);
+      overlay.setId('foo');
+      expect(overlay.getId()).to.be('foo');
+    });
+
+    it('accepts a string or number', function() {
+      overlay.setId('foo');
+      expect(overlay.getId()).to.be('foo');
+      overlay.setId(2);
+      expect(overlay.getId()).to.be(2);
+    });
+
+  });
+
 });
 
+goog.require('goog.dispose');
+goog.require('ol.Map');
 goog.require('ol.Overlay');
+goog.require('ol.View');

--- a/test/spec/ol/overlay.test.js
+++ b/test/spec/ol/overlay.test.js
@@ -41,32 +41,31 @@ describe('ol.Overlay', function() {
 
   });
 
-  describe('#setId()', function() {
+  describe('#getId()', function() {
     var overlay, target;
 
     beforeEach(function() {
       target = document.createElement('div');
-      overlay = new ol.Overlay({
-        element: target,
-        position: [0, 0]
-      });
-      map.addOverlay(overlay);
     });
     afterEach(function() {
       map.removeOverlay(overlay);
     });
 
-    it('sets the overlay identifier', function() {
+    it('returns the overlay identifier', function() {
+      overlay = new ol.Overlay({
+        element: target,
+        position: [0, 0]
+      });
+      map.addOverlay(overlay);
       expect(overlay.getId()).to.be(undefined);
-      overlay.setId('foo');
+      map.removeOverlay(overlay);
+      overlay = new ol.Overlay({
+        id: 'foo',
+        element: target,
+        position: [0, 0]
+      });
+      map.addOverlay(overlay);
       expect(overlay.getId()).to.be('foo');
-    });
-
-    it('accepts a string or number', function() {
-      overlay.setId('foo');
-      expect(overlay.getId()).to.be('foo');
-      overlay.setId(2);
-      expect(overlay.getId()).to.be(2);
     });
 
   });


### PR DESCRIPTION
~~This PR follows the same guidelines of https://github.com/openlayers/ol3/pull/2087.~~

This PR adds:
- [x] ol.Overlay.id
- [x] ol.Overlay#getId
- [x] ol.Map#getOverlayById

The reason is pretty obvious: Get an overlay without a loop iteration.