### PR TITLE
Fix Zoom control duration option - allow `0` as value

### DIFF
--- a/src/ol/control/zoomcontrol.js
+++ b/src/ol/control/zoomcontrol.js
@@ -71,7 +71,7 @@ ol.control.Zoom = function(opt_options) {
    * @type {number}
    * @private
    */
-  this.duration_ = options.duration ? options.duration : 250;
+  this.duration_ = options.duration !== undefined ? options.duration : 250;
 
 };
 goog.inherits(ol.control.Zoom, ol.control.Control);


### PR DESCRIPTION
It used to be possible to set `0` as `duration` option for the zoom control.  This PR fixes this.