### PR TITLE
Allow the DragZoom interaction created in defaults to use zoomDuration option.

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -2366,7 +2366,7 @@ olx.interaction.DragRotateOptions.prototype.duration;
 /**
  * @typedef {{condition: (ol.events.ConditionType|undefined),
  *     duration: (number|undefined),
- *     style: ol.style.Style}}
+ *     style: (ol.style.Style|undefined)}}
  * @api
  */
 olx.interaction.DragZoomOptions;
@@ -2392,7 +2392,7 @@ olx.interaction.DragZoomOptions.prototype.duration;
 
 /**
  * Style for the box.
- * @type {ol.style.Style}
+ * @type {ol.style.Style|undefined}
  * @api
  */
 olx.interaction.DragZoomOptions.prototype.style;

--- a/src/ol/interaction/interactiondefaults.js
+++ b/src/ol/interaction/interactiondefaults.js
@@ -103,7 +103,9 @@ ol.interaction.defaults = function(opt_options) {
   var shiftDragZoom = options.shiftDragZoom !== undefined ?
       options.shiftDragZoom : true;
   if (shiftDragZoom) {
-    interactions.push(new ol.interaction.DragZoom());
+    interactions.push(new ol.interaction.DragZoom({
+      duration: options.zoomDuration
+    }));
   }
 
   return interactions;


### PR DESCRIPTION
This fix allows the DragZoom interaction created in the default
interactions to use the zoom duration defined in the options, if
set.

It also includes a fix for the externals of `olx.interaction.DragZoomOptions`: the `style` option can be undefined.