### PR TITLE
Use overlay container instead of viewport for ol.render.Box

### DIFF
--- a/src/ol/render/box.js
+++ b/src/ol/render/box.js
@@ -82,13 +82,13 @@ ol.render.Box.prototype.render_ = function() {
  */
 ol.render.Box.prototype.setMap = function(map) {
   if (this.map_) {
-    this.map_.getViewport().removeChild(this.element_);
+    this.map_.getOverlayContainer().removeChild(this.element_);
     var style = this.element_.style;
     style.left = style.top = style.width = style.height = 'inherit';
   }
   this.map_ = map;
   if (this.map_) {
-    this.map_.getViewport().appendChild(this.element_);
+    this.map_.getOverlayContainer().appendChild(this.element_);
   }
 };
 

--- a/test/spec/ol/render/box.test.js
+++ b/test/spec/ol/render/box.test.js
@@ -26,12 +26,15 @@ describe('ol.render.Box', function() {
     document.body.removeChild(target);
   });
 
-  describe('Constructor', function() {
+  describe('constructor', function() {
     it('creates an absolutely positioned DIV with a className', function() {
       expect(box.element_).to.be.a(HTMLDivElement);
       expect(box.element_.style.position).to.be('absolute');
       expect(box.element_.className).to.be('ol-box test-box');
       expect(box.element_.style.position).to.be('absolute');
+    });
+    it('appends the DIV to the map\'s overlay container', function() {
+      expect(box.element_.parentNode).to.equal(map.getOverlayContainer());
     });
   });
 


### PR DESCRIPTION
This improves the drag box experience by not rendering it on top of controls.