### PR TITLE
Flag ol.tilegrid.TileGrid getTileCoordExtent as @api

### DIFF
--- a/src/ol/tilegrid/tilegrid.js
+++ b/src/ol/tilegrid/tilegrid.js
@@ -338,9 +338,12 @@ ol.tilegrid.TileGrid.prototype.getTileCoordCenter = function(tileCoord) {
 
 
 /**
+ * Get the extent of a tile coordinate.
+ *
  * @param {ol.TileCoord} tileCoord Tile coordinate.
  * @param {ol.Extent=} opt_extent Temporary extent object.
  * @return {ol.Extent} Extent.
+ * @api
  */
 ol.tilegrid.TileGrid.prototype.getTileCoordExtent =
     function(tileCoord, opt_extent) {


### PR DESCRIPTION
This PR marks the `getTileCoordExtent` method of the `ol.tilegrid.TileGrid` as `@api`.

The reason this is required (in my case) is that I need to build requests to a KaMap server, which uses tile coordinates in pixel values instead of the usual XYZ tile coordinates.  Using `getTileCoordExtent` makes it possible to do so in a `tileUrlFunction` definition.