### PR TITLE
Restrict maxZoom of the static-image example

### DIFF
--- a/examples/static-image.js
+++ b/examples/static-image.js
@@ -36,6 +36,7 @@ var map = new ol.Map({
   view: new ol.View({
     projection: projection,
     center: ol.extent.getCenter(extent),
-    zoom: 2
+    zoom: 2,
+    maxZoom: 8
   })
 });


### PR DESCRIPTION
Upscaling the image to zoom levels > 8 does not make sense, and it may even cause canvas transformations to fail.

Fixes #4274.
Fixes #3712.