### PR TITLE
Raster reprojection: clipping source triangles to projection extent

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "async": "0.9.0",
     "browserify": "9.0.3",
     "closure-util": "1.8.0",
+    "earcut": "1.4.2",
     "fs-extra": "0.12.0",
     "glob": "5.0.3",
     "graceful-fs": "3.0.2",
@@ -62,6 +63,7 @@
     "wrench": "1.5.8"
   },
   "ext": [
+    "earcut",
     "rbush",
     {"module": "pixelworks", "browserify": true}
   ]

--- a/src/ol/coordinate.js
+++ b/src/ol/coordinate.js
@@ -192,6 +192,32 @@ ol.coordinate.equals = function(coordinate1, coordinate2) {
 
 
 /**
+ * Calculates the intersection point between two infinite lines.
+ * Returns null if the lines do not intersect or are identical.
+ *
+ * @param {Array.<ol.Coordinate>} line1 The two coordinates of the line.
+ * @param {Array.<ol.Coordinate>} line2 The two coordinates of the line.
+ * @return {ol.Coordinate} Intersection point (or null)
+ */
+ol.coordinate.getLineIntersection = function(line1, line2) {
+  var a_x = line1[0][0], a_y = line1[0][1];
+  var b_x = line2[0][0], b_y = line2[0][1];
+  var u_x = line1[1][0] - a_x;
+  var u_y = line1[1][1] - a_y;
+  var v_x = line2[1][0] - b_x;
+  var v_y = line2[1][1] - b_y;
+
+  var div = (-v_x * u_y + u_x * v_y);
+  if (div === 0) {
+    return null;
+  }
+  var t = (v_x * (a_y - b_y) - v_y * (a_x - b_x)) / div;
+
+  return [a_x + (t * u_x), a_y + (t * u_y)];
+};
+
+
+/**
  * Rotate `coordinate` by `angle`. `coordinate` is modified in place and
  * returned by the function.
  *

--- a/test/spec/ol/coordinate.test.js
+++ b/test/spec/ol/coordinate.test.js
@@ -128,6 +128,37 @@ describe('ol.coordinate', function() {
         });
   });
 
+  describe('#getLineIntersection', function() {
+    var a = [10, 40], b = [30, 20];
+    var c = [10, 20], d = [30, 40], c2 = [10, 20], d2 = [30, 10];
+    var inter = [20, 30], inter2 = [50, 0];
+
+    it('calculates correctly', function() {
+      var got = ol.coordinate.getLineIntersection([a, b], [c, d]);
+      expect(got[0]).to.be(inter[0]);
+      expect(got[1]).to.be(inter[1]);
+    });
+    it('calculates correctly for different point order', function() {
+      var got = ol.coordinate.getLineIntersection([b, a], [c, d]);
+      expect(got[0]).to.be(inter[0]);
+      expect(got[1]).to.be(inter[1]);
+      got = ol.coordinate.getLineIntersection([d, c], [b, a]);
+      expect(got[0]).to.be(inter[0]);
+      expect(got[1]).to.be(inter[1]);
+    });
+    it('can handle intersections outside the point segments', function() {
+      var got = ol.coordinate.getLineIntersection([a, b], [c2, d2]);
+      expect(got[0]).to.be(inter2[0]);
+      expect(got[1]).to.be(inter2[1]);
+    });
+    it('can handle identical lines', function() {
+      expect(ol.coordinate.getLineIntersection([a, b], [a, b])).to.be(null);
+    });
+    it('can handle parallel lines', function() {
+      expect(ol.coordinate.getLineIntersection([a, c], [b, d])).to.be(null);
+    });
+  });
+
   describe('#rotate', function() {
     it('can rotate point in place', function() {
       var coord = [7.85, 47.983333];


### PR DESCRIPTION
This PR is related to #4122 and is ***not*** intended to be merged.
It is here for future reference and to present developed code in case somebody needs this in the future.

During the development of #4122, the triangles used to be limited to the source projection extent (as transformations can behave unexpectedly outside the projection extents):
When some (not all) triangle vertices (coordinates determined by inverse transformation from **view** projection to **data** projection) are outside the source extent, the triangle was intersected with the source extent and triangulated.
After obtaining the new triangles this way, the forward transformation had to be used to determine the new coordinates of the vertices in the **view** projection.

It turns out the forward transformation occasionally produces undesired results. This is caused by several factors: edges of the projection extent, crossing dateline and numerical precision.

To solve this, we removed the triangle cutting process, which also simplified the code and removed the external dependency.

The **downside** is that sometimes the values outside valid projection extent are used for calculating the affine transformation.

---
### Visual comparison
- **without** triangle clipping (current master) - triangulation process is simpler and without visual artifacts. Proj4js transformation issues result in some triangles on the pole itself.
However, some vertices are outside source projection range, which is not entirely correct.
![screen shot 2015-08-14 at 14 57 19](https://cloud.githubusercontent.com/assets/59284/9274320/09e385ba-4295-11e5-9f63-b3054aa164c0.png)

- **with** (with changes from this PR) - there is a circle at 85 degrees for Mercator tiles, but there are some issues with transforming coordinates at the edges of the projection, which creates unwanted (visually distracting) triangles
![screen shot 2015-08-14 at 14 58 18](https://cloud.githubusercontent.com/assets/59284/9274310/f72fe620-4294-11e5-84b7-0313885d833d.png)

---

This PR re-adds the triangle cutting process in case somebody is interested and/or needs this in the future.