### PR TITLE
scale icons by 0.5 so they are not huge

### DIFF
--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -208,7 +208,7 @@ ol.format.KML.DEFAULT_IMAGE_STYLE_SRC_ =
  * @type {number}
  * @private
  */
-ol.format.KML.DEFAULT_IMAGE_SCALE_MULTIPLIER_ = 0.5
+ol.format.KML.DEFAULT_IMAGE_SCALE_MULTIPLIER_ = 0.5;
 
 
 /**

--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -205,6 +205,14 @@ ol.format.KML.DEFAULT_IMAGE_STYLE_SRC_ =
 
 /**
  * @const
+ * @type {number}
+ * @private
+ */
+ol.format.KML.DEFAULT_IMAGE_SCALE_MULTIPLIER_ = 0.5
+
+
+/**
+ * @const
  * @type {ol.style.Image}
  * @private
  */
@@ -215,7 +223,7 @@ ol.format.KML.DEFAULT_IMAGE_STYLE_ = new ol.style.Icon({
   anchorYUnits: ol.format.KML.DEFAULT_IMAGE_STYLE_ANCHOR_Y_UNITS_,
   crossOrigin: 'anonymous',
   rotation: 0,
-  scale: 0.5,
+  scale: ol.format.KML.DEFAULT_IMAGE_SCALE_MULTIPLIER_,
   size: ol.format.KML.DEFAULT_IMAGE_STYLE_SIZE_,
   src: ol.format.KML.DEFAULT_IMAGE_STYLE_SRC_
 });
@@ -551,7 +559,7 @@ ol.format.KML.IconStyleParser_ = function(node, objectStack) {
     offset: offset,
     offsetOrigin: ol.style.IconOrigin.BOTTOM_LEFT,
     rotation: rotation,
-    scale: scale,
+    scale: ol.format.KML.DEFAULT_IMAGE_SCALE_MULTIPLIER_ * scale,
     size: size,
     src: src
   });


### PR DESCRIPTION
Right now OpenLayers3 placemark icons are really huge; when I open a file in Google Earth versus opening them with the KML rendered in OpenLayers.  This patch simply scales them by 50%.

![screen shot 2015-10-21 at 2 33 29 pm](https://cloud.githubusercontent.com/assets/5769968/10650828/99f2a7d0-7800-11e5-8eba-4cc14d683b8a.png)
![screen shot 2015-10-21 at 2 33 21 pm](https://cloud.githubusercontent.com/assets/5769968/10650827/99efaf44-7800-11e5-8a3d-950c4cf2cdaa.png)

