### PR TITLE
updates to kml to render labels pulled from names if the geometry is a point

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,6 +2,17 @@
 
 ### v3.11.0
 
+#### `ol.format.KML` changes
+
+KML icons are scaled 50% so that the rendering better matches Google Earth rendering.
+
+If a KML placemark has a name and is a point, an `ol.style.Text` is created with the name displayed to the right of the icon (if there is an icon).
+This can be controlled with the showPointNames option which defaults to true.
+
+To disable rendering of the point names for placemarks, use the option:
+new ol.format.KML({ showPointNames: false });
+
+
 #### `ol.interaction.DragBox` and `ol.interaction.DragZoom` changes
 
 Styling is no longer done with `ol.Style`, but with pure CSS. The `style` constructor option is no longer required, and no longer available. Instead, there is a `className` option for the CSS selector. The default for `ol.interaction.DragBox` is `ol-dragbox`, and `ol.interaction.DragZoom` uses `ol-dragzoom`. If you previously had

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -1744,7 +1744,8 @@ olx.format.IGCOptions.prototype.altitudeMode;
 
 /**
  * @typedef {{extractStyles: (boolean|undefined),
- *     defaultStyle: (Array.<ol.style.Style>|undefined)}}
+ *     defaultStyle: (Array.<ol.style.Style>|undefined),
+ *     showPointNames: (boolean|undefined)}}
  * @api
  */
 olx.format.KMLOptions;
@@ -1756,6 +1757,14 @@ olx.format.KMLOptions;
  * @api stable
  */
 olx.format.KMLOptions.prototype.extractStyles;
+
+
+/**
+ * Show names as labels for placemarks which contain points. Default is `true`.
+ * @type {boolean|undefined}
+ * @api stable
+ */
+olx.format.KMLOptions.prototype.showPointNames;
 
 
 /**

--- a/test/spec/ol/format/kmlformat.test.js
+++ b/test/spec/ol/format/kmlformat.test.js
@@ -1632,6 +1632,54 @@ describe('ol.format.KML', function() {
             expect(style.getText()).to.be(ol.format.KML.DEFAULT_TEXT_STYLE_);
             expect(style.getZIndex()).to.be(undefined);
           });
+      
+      it('can create text style for named point placemarks', function() {
+        var text =
+            '<kml xmlns="http://www.opengis.net/kml/2.2"' +
+            ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
+            ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"' +
+            ' xsi:schemaLocation="http://www.opengis.net/kml/2.2' +
+            ' https://developers.google.com/kml/schema/kml22gx.xsd">' +
+            '  <Style id="sh_ylw-pushpin">' +
+            '    <IconStyle>' +
+            '      <scale>0.3</scale>' +
+            '      <Icon>' +
+            '        <href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>' +
+            '      </Icon>' +
+            '      <hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>' +
+            '    </IconStyle>' +
+            '  </Style>' +
+            '  <StyleMap id="msn_ylw-pushpin0">' +
+            '    <Pair>' +
+            '      <key>normal</key>' +
+            '      <styleUrl>#sn_ylw-pushpin</styleUrl>' +
+            '    </Pair>' +
+            '    <Pair>' +
+            '      <key>highlight</key>' +
+            '      <styleUrl>#sh_ylw-pushpin</styleUrl>' +
+            '    </Pair>' +
+            '  </StyleMap>' +
+            '  <Placemark>' +
+            '    <name>Test</name>' +
+            '    <styleUrl>#msn_ylw-pushpin0</styleUrl>' +
+            '    <Point>' +
+            '      <coordinates>1,2</coordinates>' +
+            '    </Point>' +
+            '  </Placemark>' +
+            '</kml>';
+        var fs = format.readFeatures(text);
+        expect(fs).to.have.length(1);
+        var f = fs[0];
+        expect(f).to.be.an(ol.Feature);
+        var styleFunction = f.getStyleFunction();
+        expect(styleFunction).not.to.be(undefined);
+        var styleArray = styleFunction.call(f, 0);
+        expect(styleArray).to.be.an(Array);
+        expect(styleArray).to.have.length(2);
+        var style = styleArray[1];
+        expect(style).to.be.an(ol.style.Style);
+        expect(style.getText().getText()).to.eql(f.getProperties()['name']);
+      });
 
       it('can write an feature\'s icon style', function() {
         var style = new ol.style.Style({


### PR DESCRIPTION
I tried to replicate Google Earth's behavior, which is to render labels based on names for placemarks which are points.  OpenLayers now does this, either using the found style, default style, or custom style.  My new code creates secondary text style which holds the unique text from the name for each placemark.

This only happens if the placemark has a point geometry and if the name is not empty.

Sample screenshot from OpenLayers:
![screen shot 2015-10-22 at 9 38 51 am](https://cloud.githubusercontent.com/assets/5769968/10671697/f5069744-78a0-11e5-849c-13f8fb478a56.png)
