### PR TITLE
Align logos nicely with attribution text

### DIFF
--- a/css/ol.css
+++ b/css/ol.css
@@ -159,6 +159,7 @@
 .ol-attribution img {
   max-height: 2em;
   max-width: inherit;
+  vertical-align: middle;
 }
 .ol-attribution ul, .ol-attribution button {
   display: inline-block;


### PR DESCRIPTION
Currently, when not using Bootstrap and a css like the one we use in the examples, logos in the attribution do not align nicely with the attribution text.

Before:
<img width="218" alt="before" src="https://cloud.githubusercontent.com/assets/211514/10714935/4bdb1ada-7b04-11e5-8679-c9959a0adb61.png">

After:
<img width="215" alt="after" src="https://cloud.githubusercontent.com/assets/211514/10714937/57a3f42c-7b04-11e5-96ee-a00007464e8e.png">
