### PR TITLE
Check view extent within image extent

### DIFF
--- a/src/ol/source/imagewmssource.js
+++ b/src/ol/source/imagewmssource.js
@@ -201,14 +201,6 @@ ol.source.ImageWMS.prototype.getImageInternal =
   extent = extent.slice();
   var centerX = (extent[0] + extent[2]) / 2;
   var centerY = (extent[1] + extent[3]) / 2;
-  if (this.ratio_ != 1) {
-    var halfWidth = this.ratio_ * ol.extent.getWidth(extent) / 2;
-    var halfHeight = this.ratio_ * ol.extent.getHeight(extent) / 2;
-    extent[0] = centerX - halfWidth;
-    extent[1] = centerY - halfHeight;
-    extent[2] = centerX + halfWidth;
-    extent[3] = centerY + halfHeight;
-  }
 
   var imageResolution = resolution / pixelRatio;
 
@@ -229,6 +221,15 @@ ol.source.ImageWMS.prototype.getImageInternal =
       image.getPixelRatio() == pixelRatio &&
       ol.extent.containsExtent(image.getExtent(), extent)) {
     return image;
+  }
+
+  if (this.ratio_ != 1) {
+    var halfWidth = this.ratio_ * ol.extent.getWidth(extent) / 2;
+    var halfHeight = this.ratio_ * ol.extent.getHeight(extent) / 2;
+    extent[0] = centerX - halfWidth;
+    extent[1] = centerY - halfHeight;
+    extent[2] = centerX + halfWidth;
+    extent[3] = centerY + halfHeight;
   }
 
   var params = {

--- a/test/spec/ol/source/imagewmssource.test.js
+++ b/test/spec/ol/source/imagewmssource.test.js
@@ -163,6 +163,16 @@ describe('ol.source.ImageWMS', function() {
       expect(image1).to.equal(image2);
     });
 
+    it('returns same image for calls with similar extents', function() {
+      options.ratio = 1.5;
+      var source = new ol.source.ImageWMS(options);
+      var extent = [10.01, 20, 30.01, 40];
+      var image1 = source.getImage(extent, resolution, pixelRatio, projection);
+      extent = [10.01, 20.1, 30.01, 40.1];
+      var image2 = source.getImage(extent, resolution, pixelRatio, projection);
+      expect(image1).to.equal(image2);
+    });
+
   });
 
   describe('#getGetFeatureInfo', function() {


### PR DESCRIPTION
When checking whether a view extent is within the buffered WMS image extent, we must not use a buffered view extent.

Fixes #4325.