### PR TITLE
Resolve path to jsdoc-fork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
 
 before_install:
   - "npm install -g npm && npm install"
+  - "npm prune"
 
 before_script:
   - "rm src/ol/renderer/webgl/*shader.js"

--- a/tasks/generate-info.js
+++ b/tasks/generate-info.js
@@ -15,7 +15,7 @@ var externsPaths = [
 ];
 var infoPath = path.join(__dirname, '..', 'build', 'info.json');
 
-var jsdocResolved = require.resolve('jsdoc/jsdoc.js');
+var jsdocResolved = require.resolve('jsdoc-fork/jsdoc.js');
 var jsdoc = path.resolve(path.dirname(jsdocResolved), '../.bin/jsdoc');
 
 // on Windows, use jsdoc.cmd


### PR DESCRIPTION
It looks like [the build](https://travis-ci.org/openlayers/ol3/builds/88557316) for 85ca4e18888f32ea853d0a47249612807317a0ea only passed because we are using a cached `node_modules` on Travis (where both the `jsdoc` and `jsdoc-fork` packages were found).  I've cleared our Travis cache, so this build will only pass if a clean install works.
