### PR TITLE
Update getExtent return value jsdoc tag

### DIFF
--- a/src/ol/source/vectorsource.js
+++ b/src/ol/source/vectorsource.js
@@ -659,7 +659,7 @@ ol.source.Vector.prototype.getClosestFeatureToCoordinate =
  *
  * This method is not available when the source is configured with
  * `useSpatialIndex` set to `false`.
- * @return {ol.Extent} Extent.
+ * @return {!ol.Extent} Extent.
  * @api stable
  */
 ol.source.Vector.prototype.getExtent = function() {

--- a/src/ol/structs/rbush.js
+++ b/src/ol/structs/rbush.js
@@ -253,7 +253,7 @@ ol.structs.RBush.prototype.clear = function() {
 
 /**
  * @param {ol.Extent=} opt_extent Extent.
- * @return {ol.Extent} Extent.
+ * @return {!ol.Extent} Extent.
  */
 ol.structs.RBush.prototype.getExtent = function(opt_extent) {
   // FIXME add getExtent() to rbush


### PR DESCRIPTION
The extent is never `null`; if the source is empty, the extent is
`[Infinity, Infinity, -Infinity, -Infinity]`

rbush code: https://github.com/mourner/rbush/blob/v1.4.1/rbush.js#L132