### PR TITLE
Append KML placemark text style to existing styles

### DIFF
--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -394,7 +394,7 @@ ol.format.KML.createFeatureStyleFunction_ = function(style, styleUrl,
           if (drawName) {
             nameStyle = ol.format.KML.createNameStyleFunction_(style[0],
                 name);
-            return [style, nameStyle];
+            return style.concat(nameStyle);
           }
           return style;
         }

--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -342,11 +342,7 @@ ol.format.KML.createNameStyleFunction_ = function(foundStyle, name) {
     });
   }
   var nameStyle = new ol.style.Style({
-    fill: undefined,
-    image: undefined,
-    text: textStyle,
-    stroke: undefined,
-    zIndex: undefined
+    text: textStyle
   });
   return nameStyle;
 };


### PR DESCRIPTION
This fixes the regression introduced with 15c1323ff95e058d7dfac930b6d42020449f2be7 which I reported in #4367.

Thanks for any review.

Fixes #4367