### PR TITLE
Fixed documentation typo (ol.source.ImageWMS)

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -4784,7 +4784,7 @@ olx.source.ImageWMSOptions.prototype.serverType;
 
 /**
  * Optional function to load an image given a URL.
- * @type {ol.TileLoadFunctionType|undefined}
+ * @type {ol.ImageLoadFunctionType|undefined}
  * @api
  */
 olx.source.ImageWMSOptions.prototype.imageLoadFunction;


### PR DESCRIPTION
the imageLoadFunction you can give the constructor of ol.source.ImageWMS is an ol.ImageLoadFunctionType not an ol.TileLoadFunctionType