### PR TITLE
Fix rendering of mocha's special characters on travis

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "jquery": "2.1.4",
     "jshint": "2.8.0",
     "mocha": "2.3.3",
-    "mocha-phantomjs-core": "^1.2.1",
+    "mocha-phantomjs": "4.0.1",
     "mustache": "2.2.0",
     "phantomjs": "1.9.18",
     "proj4": "2.3.12",

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -57,17 +57,25 @@ function runTests(includeCoverage, callback) {
       }
       var address = server.address();
       var url = 'http://' + address.address + ':' + address.port;
+
       var args = [
-        require.resolve('mocha-phantomjs-core'),
-        url + '/test/index.html'
+        '--ssl-protocol', 'any',
+        '--ignore-ssl-errors', 'true'
       ];
 
       if (includeCoverage) {
-        args.push('spec', '{"hooks": "' +
-          path.join(__dirname, '../test/phantom_hooks.js') + '"}');
+        args.push(
+          '--hooks', path.join(__dirname, '../test/phantom_hooks.js'),
+          '--reporter', 'dot',
+          '--ignore-resource-errors'
+        );
       }
 
-      var child = spawn(phantomjs.path, args, {stdio: 'inherit'});
+      args.push(url + '/test/index.html');
+
+      var mochaPhantom = require.resolve('mocha-phantomjs');
+
+      var child = spawn(mochaPhantom, args, {stdio: 'inherit'});
       child.on('exit', function(code) {
         callback(code);
       });


### PR DESCRIPTION
This PR suggests to use a recent version of [`mocha-phantomjs`](https://www.npmjs.com/package/mocha-phantomjs) which fixes the output of the testsuite on travis.

The `tasks/test.js` had to be adjusted to directly use the `mocha-phantomjs` binary.

**Before:**

![ol3-tests-on-travis-before](https://cloud.githubusercontent.com/assets/227934/10964603/728c468e-83a8-11e5-855c-14ee6a85df36.png)

**After:**

![ol3-tests-on-travis-after](https://cloud.githubusercontent.com/assets/227934/10964604/7601368a-83a8-11e5-9961-92a605498ecb.png)

Please review.