### PR TITLE
Fix usage of mocha-phantomjs-core after update

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "jquery": "2.1.4",
     "jshint": "2.8.0",
     "mocha": "2.3.3",
-    "mocha-phantomjs-core": "1.2.1",
+    "mocha-phantomjs-core": "^1.3.0",
     "mustache": "2.2.0",
     "phantomjs": "1.9.18",
     "proj4": "2.3.12",

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -59,13 +59,19 @@ function runTests(includeCoverage, callback) {
       var url = 'http://' + address.address + ':' + address.port;
       var args = [
         require.resolve('mocha-phantomjs-core'),
-        url + '/test/index.html'
+        url + '/test/index.html',
+        'spec'
       ];
+      var config = {
+        ignoreResourceErrors: true,
+        useColors: true,
+      };
 
       if (includeCoverage) {
-        args.push('spec', '{"hooks": "' +
-          path.join(__dirname, '../test/phantom_hooks.js') + '"}');
+        config.hooks = path.join(__dirname, '../test/phantom_hooks.js');
       }
+
+      args.push(JSON.stringify(config));
 
       var child = spawn(phantomjs.path, args, {stdio: 'inherit'});
       child.on('exit', function(code) {

--- a/test/spec/ol/source/rastersource.test.js
+++ b/test/spec/ol/source/rastersource.test.js
@@ -10,7 +10,7 @@ var blue = 'data:image/gif;base64,R0lGODlhAQABAPAAAAAA/////yH5BAAAAAAALAAAAA' +
     'ABAAEAAAICRAEAOw==';
 
 function itNoPhantom() {
-  if (window.initMochaPhantomJS) {
+  if (window.checkForMocha) {
     return xit.apply(this, arguments);
   } else {
     return it.apply(this, arguments);


### PR DESCRIPTION
Fixes #4377.

At least that's my opinion. Let's see if Travis agrees.

If nothing else, it at least is a true fix that replaces the quick fix from #4388.