### PR TITLE
Allow ol.Object property update without notification

### DIFF
--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -197,11 +197,11 @@ ol.Object.prototype.notify = function(key, oldValue) {
  * Sets a value.
  * @param {string} key Key name.
  * @param {*} value Value.
- * @param {boolean=} opt_silent Update property without triggering notification.
+ * @param {boolean=} opt_silent Update without triggering an event.
  * @api stable
  */
 ol.Object.prototype.set = function(key, value, opt_silent) {
-  if (opt_silent === true) {
+  if (opt_silent) {
     this.values_[key] = value;
   } else {
     var oldValue = this.values_[key];
@@ -215,7 +215,7 @@ ol.Object.prototype.set = function(key, value, opt_silent) {
  * Sets a collection of key-value pairs.  Note that this changes any existing
  * properties and adds new ones (it does not remove any existing properties).
  * @param {Object.<string, *>} values Values.
- * @param {boolean=} opt_silent update propertie silently
+ * @param {boolean=} opt_silent Update without triggering an event.
  * @api stable
  */
 ol.Object.prototype.setProperties = function(values, opt_silent) {
@@ -229,7 +229,7 @@ ol.Object.prototype.setProperties = function(values, opt_silent) {
 /**
  * Unsets a property.
  * @param {string} key Key name.
- * @param {boolean=} opt_silent update propertie silently
+ * @param {boolean=} opt_silent Unset without triggering an event.
  * @api stable
  */
 ol.Object.prototype.unset = function(key, opt_silent) {

--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -197,12 +197,17 @@ ol.Object.prototype.notify = function(key, oldValue) {
  * Sets a value.
  * @param {string} key Key name.
  * @param {*} value Value.
+ * @param {boolean=} opt_silent Update property without triggering notification.
  * @api stable
  */
-ol.Object.prototype.set = function(key, value) {
-  var oldValue = this.values_[key];
-  this.values_[key] = value;
-  this.notify(key, oldValue);
+ol.Object.prototype.set = function(key, value, opt_silent) {
+  if (opt_silent === true) {
+    this.values_[key] = value;
+  } else {
+    var oldValue = this.values_[key];
+    this.values_[key] = value;
+    this.notify(key, oldValue);
+  }
 };
 
 
@@ -210,12 +215,13 @@ ol.Object.prototype.set = function(key, value) {
  * Sets a collection of key-value pairs.  Note that this changes any existing
  * properties and adds new ones (it does not remove any existing properties).
  * @param {Object.<string, *>} values Values.
+ * @param {boolean=} opt_silent update propertie silently
  * @api stable
  */
-ol.Object.prototype.setProperties = function(values) {
+ol.Object.prototype.setProperties = function(values, opt_silent) {
   var key;
   for (key in values) {
-    this.set(key, values[key]);
+    this.set(key, values[key], opt_silent);
   }
 };
 
@@ -223,12 +229,15 @@ ol.Object.prototype.setProperties = function(values) {
 /**
  * Unsets a property.
  * @param {string} key Key name.
+ * @param {boolean=} opt_silent update propertie silently
  * @api stable
  */
-ol.Object.prototype.unset = function(key) {
+ol.Object.prototype.unset = function(key, opt_silent) {
   if (key in this.values_) {
     var oldValue = this.values_[key];
     delete this.values_[key];
-    this.notify(key, oldValue);
+    if (!opt_silent) {
+      this.notify(key, oldValue);
+    }
   }
 };


### PR DESCRIPTION
Add an optional notify argument to object set and setProperties methods.

If the argument is not provided, set and setProperties trigger an event.

If you update many objects or do so frequently and do not need notification, performance is improved by setting silent to true.

This is a squashed version of the commits in #4252.