### PR TITLE
Flag ol.style.Text setOffsetX and Y as @api

### DIFF
--- a/src/ol/style/textstyle.js
+++ b/src/ol/style/textstyle.js
@@ -205,6 +205,7 @@ ol.style.Text.prototype.setFont = function(font) {
  * Set the x offset.
  *
  * @param {number} offsetX Horizontal text offset.
+ * @api
  */
 ol.style.Text.prototype.setOffsetX = function(offsetX) {
   this.offsetX_ = offsetX;
@@ -215,6 +216,7 @@ ol.style.Text.prototype.setOffsetX = function(offsetX) {
  * Set the y offset.
  *
  * @param {number} offsetY Vertical text offset.
+ * @api
  */
 ol.style.Text.prototype.setOffsetY = function(offsetY) {
   this.offsetY_ = offsetY;


### PR DESCRIPTION
This PR flags the `setOffsetX` and `setOffsetY` methods of the `ol.style.Text` as `@api`, thus allowing them to be used with the minimized version of the library.