### PR TITLE
Improve ol.source.StaticImage

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -4936,6 +4936,7 @@ olx.source.StamenOptions.prototype.url;
  *     crossOrigin: (null|string|undefined),
  *     imageExtent: (ol.Extent),
  *     imageLoadFunction: (ol.ImageLoadFunctionType|undefined),
+ *     imageSize: (ol.Size|undefined),
  *     logo: (string|olx.LogoOptions|undefined),
  *     projection: ol.proj.ProjectionLike,
  *     url: string}}
@@ -4995,6 +4996,15 @@ olx.source.ImageStaticOptions.prototype.logo;
  * @api
  */
 olx.source.ImageStaticOptions.prototype.projection;
+
+
+/**
+ * Size of the image in pixels. Usually the image size is auto-detected, so this
+ * only needs to be set if auto-detection fails for some reason.
+ * @type {ol.Size|undefined}
+ * @api stable
+ */
+olx.source.ImageStaticOptions.prototype.imageSize;
 
 
 /**

--- a/test/spec/ol/source/imagestaticsource.test.js
+++ b/test/spec/ol/source/imagestaticsource.test.js
@@ -33,6 +33,26 @@ describe('ol.source.ImageStatic', function() {
       image.load();
     });
 
+    it('respects imageSize', function(done) {
+      var source = new ol.source.ImageStatic({
+        url: 'spec/ol/source/images/12-655-1583.png',
+        imageExtent: [
+          -13629027.891360067, 4539747.983913189,
+          -13619243.951739565, 4559315.863154193],
+        imageSize: [254, 254],
+        projection: projection
+      });
+
+      source.on('imageloadend', function(event) {
+        expect(image.getImage().width).to.be(127);
+        expect(image.getImage().height).to.be(254);
+        done();
+      });
+
+      var image = source.getImage(extent, resolution, pixelRatio, projection);
+      image.load();
+    });
+
     it('triggers image load events', function(done) {
       var source = new ol.source.ImageStatic({
         url: 'spec/ol/source/images/12-655-1583.png',


### PR DESCRIPTION
Brings back the imgSize property, and puts all image load handler code in a single listener.