### PR TITLE
Fix checkbox display in geolocation example

### DIFF
--- a/examples/geolocation.html
+++ b/examples/geolocation.html
@@ -12,9 +12,11 @@ tags: "geolocation, openstreetmap"
     <div class="span4 pull-right">
       <div id="info" class="alert alert-danger" style="display: none;"></div>
     </div>
-    <label class="checkbox" for="track">
-      <input id="track" type="checkbox"/>track position
-    </label>
+    <div class="checkbox">
+      <label class="checkbox">
+        <input id="track" type="checkbox"/>track position
+      </label>
+    </div>
     <p>position accuracy : <code id="accuracy"></code></p>
     <p>altitude : <code id="altitude"></code></p>
     <p>altitude accuracy : <code id="altitudeAccuracy"></code></p>


### PR DESCRIPTION
Currently, in the geolocation example, the checkbox is almost off-screen.
This pull request fixes the display of the checkbox.
![screenshot from 2015-11-17 11 16 48](https://cloud.githubusercontent.com/assets/319774/11208682/d9a780ea-8d1c-11e5-80b0-27074098bc36.png)
