### PR TITLE
Allow '' for crossOrigin (as Anonymous alias)

### DIFF
--- a/src/ol/image.js
+++ b/src/ol/image.js
@@ -38,7 +38,7 @@ ol.Image = function(extent, resolution, pixelRatio, attributions, src,
    * @type {HTMLCanvasElement|Image|HTMLVideoElement}
    */
   this.image_ = new Image();
-  if (crossOrigin) {
+  if (crossOrigin !== null) {
     this.image_.crossOrigin = crossOrigin;
   }
 

--- a/src/ol/imagetile.js
+++ b/src/ol/imagetile.js
@@ -37,7 +37,7 @@ ol.ImageTile = function(tileCoord, state, src, crossOrigin, tileLoadFunction) {
    * @type {Image}
    */
   this.image_ = new Image();
-  if (crossOrigin) {
+  if (crossOrigin !== null) {
     this.image_.crossOrigin = crossOrigin;
   }
 

--- a/src/ol/style/iconstyle.js
+++ b/src/ol/style/iconstyle.js
@@ -392,7 +392,7 @@ ol.style.IconImage_ = function(image, src, size, crossOrigin, imageState) {
    */
   this.image_ = !image ? new Image() : image;
 
-  if (crossOrigin) {
+  if (crossOrigin !== null) {
     this.image_.crossOrigin = crossOrigin;
   }
 


### PR DESCRIPTION
This fixes a regression introduced by the goog.isDef removal.

From the HTML 5 spec: "The empty string is also a valid keyword, and maps to the Anonymous state"