### PR TITLE
Use jsdoc@3.4.0

### DIFF
--- a/config/jsdoc/api/conf.json
+++ b/config/jsdoc/api/conf.json
@@ -16,7 +16,7 @@
         ]
     },
     "plugins": [
-        "node_modules/jsdoc-fork/plugins/markdown",
+        "node_modules/jsdoc/plugins/markdown",
         "config/jsdoc/api/plugins/inheritdoc",
         "config/jsdoc/api/plugins/typedefs",
         "config/jsdoc/api/plugins/events",

--- a/config/jsdoc/api/plugins/api.js
+++ b/config/jsdoc/api/plugins/api.js
@@ -16,7 +16,7 @@ exports.defineTags = function(dictionary) {
         doclet.stability = level;
       } else {
         var errorText = util.format('Invalid stability level (%s) in %s line %s', tag.text, doclet.meta.filename, doclet.meta.lineno);
-        require('jsdoc-fork/lib/jsdoc/util/error').handle( new Error(errorText) );
+        require('jsdoc/lib/jsdoc/util/error').handle( new Error(errorText) );
       }
     }
   });

--- a/config/jsdoc/api/template/publish.js
+++ b/config/jsdoc/api/template/publish.js
@@ -1,10 +1,10 @@
 /*global env: true */
-var template = require('jsdoc-fork/lib/jsdoc/template'),
-    fs = require('jsdoc-fork/lib/jsdoc/fs'),
-    path = require('jsdoc-fork/lib/jsdoc/path'),
+var template = require('jsdoc/lib/jsdoc/template'),
+    fs = require('jsdoc/lib/jsdoc/fs'),
+    path = require('jsdoc/lib/jsdoc/path'),
     taffy = require('taffydb').taffy,
-    handle = require('jsdoc-fork/lib/jsdoc/util/error').handle,
-    helper = require('jsdoc-fork/lib/jsdoc/util/templateHelper'),
+    handle = require('jsdoc/lib/jsdoc/util/error').handle,
+    helper = require('jsdoc/lib/jsdoc/util/templateHelper'),
     _ = require('underscore'),
     htmlsafe = helper.htmlsafe,
     linkto = helper.linkto,
@@ -350,8 +350,8 @@ exports.publish = function(taffyData, opts, tutorials) {
     var staticFileScanner;
     if (conf['default'].staticFiles) {
         staticFilePaths = conf['default'].staticFiles.paths || [];
-        staticFileFilter = new (require('jsdoc-fork/lib/jsdoc/src/filter')).Filter(conf['default'].staticFiles);
-        staticFileScanner = new (require('jsdoc-fork/lib/jsdoc/src/scanner')).Scanner();
+        staticFileFilter = new (require('jsdoc/lib/jsdoc/src/filter')).Filter(conf['default'].staticFiles);
+        staticFileScanner = new (require('jsdoc/lib/jsdoc/src/scanner')).Scanner();
 
         staticFilePaths.forEach(function(filePath) {
             var extraStaticFiles = staticFileScanner.scan([filePath], 10, staticFileFilter);

--- a/config/jsdoc/info/publish.js
+++ b/config/jsdoc/info/publish.js
@@ -6,8 +6,6 @@ var assert = require('assert');
 var fs = require('fs');
 var path = require('path');
 
-var Promise = require('bluebird');
-
 
 /**
  * Publish hook for the JSDoc template.  Writes to JSON stdout.
@@ -171,17 +169,13 @@ exports.publish = function(data, opts) {
     return (symbol.name in augments || symbol.virtual);
   });
 
-  return new Promise(function(resolve, reject) {
-
-    process.stdout.write(
-        JSON.stringify({
-          symbols: symbols,
-          defines: defines,
-          typedefs: typedefs,
-          externs: externs,
-          base: base
-        }, null, 2), resolve);
-
-  });
+  process.stdout.write(
+      JSON.stringify({
+        symbols: symbols,
+        defines: defines,
+        typedefs: typedefs,
+        externs: externs,
+        base: base
+      }, null, 2));
 
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   ],
   "dependencies": {
     "async": "1.5.0",
-    "bluebird": "^3.0.5",
     "browserify": "12.0.1",
     "closure-util": "1.9.0",
     "derequire": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "glob": "6.0.1",
     "graceful-fs": "4.1.2",
     "handlebars": "4.0.4",
-    "jsdoc-fork": "^4.0.0-beta.1",
+    "jsdoc": "3.4.0",
     "marked": "0.3.5",
     "metalsmith": "2.1.0",
     "metalsmith-layouts": "1.4.2",

--- a/tasks/generate-info.js
+++ b/tasks/generate-info.js
@@ -15,7 +15,7 @@ var externsPaths = [
 ];
 var infoPath = path.join(__dirname, '..', 'build', 'info.json');
 
-var jsdocResolved = require.resolve('jsdoc-fork/jsdoc.js');
+var jsdocResolved = require.resolve('jsdoc/jsdoc.js');
 var jsdoc = path.resolve(path.dirname(jsdocResolved), '../.bin/jsdoc');
 
 // on Windows, use jsdoc.cmd


### PR DESCRIPTION
This removes our dependency on the temporary fork.  The latest JSDoc release works on Node 4, and we no longer need to return a promise from our template's publish script.