### PR TITLE
Fix select interaction regression caused by #4391

### DIFF
--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -283,7 +283,7 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
          * @param {ol.layer.Layer} layer Layer.
          */
         function(feature, layer) {
-          if (layer && this.filter_(feature, layer)) {
+          if (!layer || this.filter_(feature, layer)) {
             selected.push(feature);
             this.addFeatureLayerAssociation_(feature, layer);
             return !this.multi_;

--- a/test/spec/ol/interaction/selectinteraction.test.js
+++ b/test/spec/ol/interaction/selectinteraction.test.js
@@ -179,7 +179,7 @@ describe('ol.interaction.Select', function() {
         unmanaged.setMap(map);
         map.renderSync();
         simulateEvent(ol.MapBrowserEvent.EventType.SINGLECLICK, 10, -20);
-        expect(spy.firstCall.args[0]).to.not.equal(feature);
+        expect(spy.getCalls().length).to.be(0);
         unmanaged.setMap(null);
       });
     });


### PR DESCRIPTION
The select interaction determines selection candidate features by using `ol.Map#forEachFeatureAtPixel`. It uses an internal unmanaged layer that selected features are added to, and adds selected features to the skippedFeatures hash on the map. Before the change made with this pull request, a selected feature was immediately removed from the selection as soon as it was added to the unmanaged layer, because the unmanaged layer was ignored in forEachFeatureAtPixel (`null` as layer arg and `if (layer && filter())`). Now already selected features remain in the selection, because a `null` layer is accpted in the forEachFeatureAtPixel handler (`if (!layer || filter())`).

Fixes #4441.