### PR TITLE
Call the change callback when a non idle tile is removed from the queue

### DIFF
--- a/src/ol/tilequeue.js
+++ b/src/ol/tilequeue.js
@@ -100,6 +100,8 @@ ol.TileQueue.prototype.loadMoreTiles = function(maxTotalLoading, maxNewLoads) {
       tile.load();
       ++this.tilesLoading_;
       ++newLoads;
+    } else {
+      this.tileChangeCallback_();
     }
   }
 };


### PR DESCRIPTION
This PR fixes the side-by-side example (#4431), the regression was introduced in #3895 
