### PR TITLE
[wip] Blur the zoom buttons after click

### DIFF
--- a/src/ol/control/zoomcontrol.js
+++ b/src/ol/control/zoomcontrol.js
@@ -85,6 +85,7 @@ goog.inherits(ol.control.Zoom, ol.control.Control);
 ol.control.Zoom.prototype.handleClick_ = function(delta, event) {
   event.preventDefault();
   this.zoomByDelta_(delta);
+  event.target.blur();
 };
 
 


### PR DESCRIPTION
Fixes #3500 

It will probably break the keyboard navigation
EDIT: yes, keyboard navigation is broken (as broken as Leaflet)