### PR TITLE
Remove use of goog.dom.createDom

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -260,7 +260,8 @@ ol.Map = function(options) {
    * @private
    * @type {Element}
    */
-  this.viewport_ = goog.dom.createDom('DIV', 'ol-viewport');
+  this.viewport_ = document.createElement('DIV');
+  this.viewport_.className = 'ol-viewport';
   this.viewport_.style.position = 'relative';
   this.viewport_.style.overflow = 'hidden';
   this.viewport_.style.width = '100%';
@@ -276,16 +277,16 @@ ol.Map = function(options) {
    * @private
    * @type {Element}
    */
-  this.overlayContainer_ = goog.dom.createDom('DIV',
-      'ol-overlaycontainer');
+  this.overlayContainer_ = document.createElement('DIV');
+  this.overlayContainer_.className = 'ol-overlaycontainer';
   this.viewport_.appendChild(this.overlayContainer_);
 
   /**
    * @private
    * @type {Element}
    */
-  this.overlayContainerStopEvent_ = goog.dom.createDom('DIV',
-      'ol-overlaycontainer-stopevent');
+  this.overlayContainerStopEvent_ = document.createElement('DIV');
+  this.overlayContainerStopEvent_.className = 'ol-overlaycontainer-stopevent';
   goog.events.listen(this.overlayContainerStopEvent_, [
     goog.events.EventType.CLICK,
     goog.events.EventType.DBLCLICK,

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -96,9 +96,8 @@ ol.Overlay = function(options) {
    * @private
    * @type {Element}
    */
-  this.element_ = goog.dom.createDom('DIV', {
-    'class': 'ol-overlay-container'
-  });
+  this.element_ = document.createElement('DIV');
+  this.element_.className = 'ol-overlay-container';
   this.element_.style.position = 'absolute';
 
   /**

--- a/test/spec/ol/map.test.js
+++ b/test/spec/ol/map.test.js
@@ -18,6 +18,23 @@ describe('ol.Map', function() {
         expect(interactions.item(i).getMap()).to.be(map);
       }
     });
+
+    it('creates the viewport', function() {
+      var map = new ol.Map({});
+      var viewport = map.getViewport();
+      var className = 'ol-viewport' + (ol.has.TOUCH ? ' ol-touch' : '');
+      expect(viewport.className).to.be(className);
+    });
+
+    it('creates the overlay containers', function() {
+      var map = new ol.Map({});
+      var container = map.getOverlayContainer();
+      expect(container.className).to.be('ol-overlaycontainer');
+
+      var containerStop = map.getOverlayContainerStopEvent();
+      expect(containerStop.className).to.be('ol-overlaycontainer-stopevent');
+    });
+
   });
 
   describe('#addInteraction()', function() {


### PR DESCRIPTION
Remove use of `goog.dom.createDom` when the function is only used to create an element and set its CSS class