### PR TITLE
Remove use of goog.object

### DIFF
--- a/src/ol/control/attributioncontrol.js
+++ b/src/ol/control/attributioncontrol.js
@@ -7,12 +7,12 @@ goog.require('goog.dom');
 goog.require('goog.dom.classlist');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
-goog.require('goog.object');
 goog.require('goog.style');
 goog.require('ol');
 goog.require('ol.Attribution');
 goog.require('ol.control.Control');
 goog.require('ol.css');
+goog.require('ol.object');
 goog.require('ol.source.Tile');
 
 
@@ -152,7 +152,7 @@ ol.control.Attribution.prototype.getSourceAttributions = function(frameState) {
   var intersectsTileRange;
   var layerStatesArray = frameState.layerStatesArray;
   /** @type {Object.<string, ol.Attribution>} */
-  var attributions = goog.object.clone(frameState.attributions);
+  var attributions = ol.object.clone(frameState.attributions);
   /** @type {Object.<string, ol.Attribution>} */
   var hiddenAttributions = {};
   var projection = frameState.viewState.projection;
@@ -271,14 +271,14 @@ ol.control.Attribution.prototype.updateElement_ = function(frameState) {
   }
 
   var renderVisible =
-      !goog.object.isEmpty(this.attributionElementRenderedVisible_) ||
-      !goog.object.isEmpty(frameState.logos);
+      !ol.object.isEmpty(this.attributionElementRenderedVisible_) ||
+      !ol.object.isEmpty(frameState.logos);
   if (this.renderedVisible_ != renderVisible) {
     goog.style.setElementShown(this.element, renderVisible);
     this.renderedVisible_ = renderVisible;
   }
   if (renderVisible &&
-      goog.object.isEmpty(this.attributionElementRenderedVisible_)) {
+      ol.object.isEmpty(this.attributionElementRenderedVisible_)) {
     goog.dom.classlist.add(this.element, 'ol-logo-only');
   } else {
     goog.dom.classlist.remove(this.element, 'ol-logo-only');
@@ -325,7 +325,7 @@ ol.control.Attribution.prototype.insertLogos_ = function(frameState) {
     }
   }
 
-  goog.style.setElementShown(this.logoLi_, !goog.object.isEmpty(logos));
+  goog.style.setElementShown(this.logoLi_, !ol.object.isEmpty(logos));
 
 };
 

--- a/src/ol/format/esrijsonformat.js
+++ b/src/ol/format/esrijsonformat.js
@@ -2,7 +2,6 @@ goog.provide('ol.format.EsriJSON');
 
 goog.require('goog.array');
 goog.require('goog.asserts');
-goog.require('goog.object');
 goog.require('ol.Feature');
 goog.require('ol.extent');
 goog.require('ol.format.Feature');
@@ -17,6 +16,7 @@ goog.require('ol.geom.MultiPolygon');
 goog.require('ol.geom.Point');
 goog.require('ol.geom.Polygon');
 goog.require('ol.geom.flat.orient');
+goog.require('ol.object');
 goog.require('ol.proj');
 
 
@@ -71,7 +71,7 @@ ol.format.EsriJSON.readGeometry_ = function(object, opt_options) {
   } else if (object.rings) {
     var layout = ol.format.EsriJSON.getGeometryLayout_(object);
     var rings = ol.format.EsriJSON.convertRings_(object.rings, layout);
-    object = /** @type {EsriJSONGeometry} */(goog.object.clone(object));
+    object = /** @type {EsriJSONGeometry} */(ol.object.clone(object));
     if (rings.length === 1) {
       type = ol.geom.GeometryType.POLYGON;
       object.rings = rings[0];
@@ -653,7 +653,7 @@ ol.format.EsriJSON.prototype.writeFeatureObject = function(
   }
   var properties = feature.getProperties();
   delete properties[feature.getGeometryName()];
-  if (!goog.object.isEmpty(properties)) {
+  if (!ol.object.isEmpty(properties)) {
     object['attributes'] = properties;
   } else {
     object['attributes'] = {};

--- a/src/ol/format/geojsonformat.js
+++ b/src/ol/format/geojsonformat.js
@@ -4,7 +4,6 @@
 goog.provide('ol.format.GeoJSON');
 
 goog.require('goog.asserts');
-goog.require('goog.object');
 goog.require('ol.Feature');
 goog.require('ol.format.Feature');
 goog.require('ol.format.JSONFeature');
@@ -15,6 +14,7 @@ goog.require('ol.geom.MultiPoint');
 goog.require('ol.geom.MultiPolygon');
 goog.require('ol.geom.Point');
 goog.require('ol.geom.Polygon');
+goog.require('ol.object');
 goog.require('ol.proj');
 
 
@@ -542,7 +542,7 @@ ol.format.GeoJSON.prototype.writeFeatureObject = function(
   }
   var properties = feature.getProperties();
   delete properties[feature.getGeometryName()];
-  if (!goog.object.isEmpty(properties)) {
+  if (!ol.object.isEmpty(properties)) {
     object['properties'] = properties;
   } else {
     object['properties'] = null;

--- a/src/ol/format/gml/gml3format.js
+++ b/src/ol/format/gml/gml3format.js
@@ -4,7 +4,6 @@ goog.provide('ol.format.GML3');
 goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.dom.NodeType');
-goog.require('goog.object');
 goog.require('ol');
 goog.require('ol.Feature');
 goog.require('ol.extent');
@@ -19,6 +18,7 @@ goog.require('ol.geom.MultiLineString');
 goog.require('ol.geom.MultiPolygon');
 goog.require('ol.geom.Point');
 goog.require('ol.geom.Polygon');
+goog.require('ol.object');
 goog.require('ol.proj');
 goog.require('ol.xml');
 
@@ -1021,7 +1021,7 @@ ol.format.GML3.prototype.writeGeometryElement =
     function(node, geometry, objectStack) {
   var context = objectStack[objectStack.length - 1];
   goog.asserts.assert(goog.isObject(context), 'context should be an Object');
-  var item = goog.object.clone(context);
+  var item = ol.object.clone(context);
   item.node = node;
   var value;
   if (goog.isArray(geometry)) {
@@ -1083,7 +1083,7 @@ ol.format.GML3.prototype.writeFeatureElement =
       }
     }
   }
-  var item = goog.object.clone(context);
+  var item = ol.object.clone(context);
   item.node = node;
   ol.xml.pushSerializeAndPop(/** @type {ol.xml.NodeStackItem} */
       (item), context.serializers,
@@ -1109,7 +1109,7 @@ ol.format.GML3.prototype.writeFeatureMembers_ =
   serializers[featureNS] = {};
   serializers[featureNS][featureType] = ol.xml.makeChildAppender(
       this.writeFeatureElement, this);
-  var item = goog.object.clone(context);
+  var item = ol.object.clone(context);
   item.node = node;
   ol.xml.pushSerializeAndPop(/** @type {ol.xml.NodeStackItem} */
       (item),
@@ -1291,7 +1291,7 @@ ol.format.GML3.prototype.writeGeometryNode = function(geometry, opt_options) {
     curve: this.curve_, surface: this.surface_,
     multiSurface: this.multiSurface_, multiCurve: this.multiCurve_};
   if (opt_options) {
-    goog.object.extend(context, opt_options);
+    ol.object.extend(context, opt_options);
   }
   this.writeGeometryElement(geom, geometry, [context]);
   return geom;
@@ -1334,7 +1334,7 @@ ol.format.GML3.prototype.writeFeaturesNode = function(features, opt_options) {
     featureType: this.featureType
   };
   if (opt_options) {
-    goog.object.extend(context, opt_options);
+    ol.object.extend(context, opt_options);
   }
   this.writeFeatureMembers_(node, features, [context]);
   return node;

--- a/src/ol/format/gml/gmlbaseformat.js
+++ b/src/ol/format/gml/gmlbaseformat.js
@@ -6,7 +6,6 @@ goog.provide('ol.format.GMLBase');
 goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.dom.NodeType');
-goog.require('goog.object');
 goog.require('goog.string');
 goog.require('ol.Feature');
 goog.require('ol.format.Feature');
@@ -20,6 +19,7 @@ goog.require('ol.geom.MultiPoint');
 goog.require('ol.geom.MultiPolygon');
 goog.require('ol.geom.Point');
 goog.require('ol.geom.Polygon');
+goog.require('ol.object');
 goog.require('ol.proj');
 goog.require('ol.xml');
 
@@ -124,11 +124,11 @@ ol.format.GMLBase.prototype.readFeaturesInternal = function(node, objectStack) {
           var ft = child.nodeName.split(':').pop();
           if (featureType.indexOf(ft) === -1) {
             var key;
-            if (!goog.object.contains(featureNS, child.namespaceURI)) {
-              key = prefix + goog.object.getCount(featureNS);
+            if (!ol.object.contains(featureNS, child.namespaceURI)) {
+              key = prefix + ol.object.getCount(featureNS);
               featureNS[key] = child.namespaceURI;
             } else {
-              key = goog.object.findKey(featureNS, function(value) {
+              key = ol.object.findKey(featureNS, function(value) {
                 return value === child.namespaceURI;
               });
             }
@@ -613,7 +613,7 @@ ol.format.GMLBase.prototype.readFeaturesFromNode =
     featureNS: this.featureNS
   };
   if (opt_options) {
-    goog.object.extend(options, this.getReadOptions(node, opt_options));
+    ol.object.extend(options, this.getReadOptions(node, opt_options));
   }
   return this.readFeaturesInternal(node, [options]);
 };

--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -10,7 +10,6 @@ goog.require('goog.Uri');
 goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.dom.NodeType');
-goog.require('goog.object');
 goog.require('ol');
 goog.require('ol.Feature');
 goog.require('ol.FeatureStyleFunction');
@@ -31,6 +30,7 @@ goog.require('ol.geom.MultiPolygon');
 goog.require('ol.geom.Point');
 goog.require('ol.geom.Polygon');
 goog.require('ol.math');
+goog.require('ol.object');
 goog.require('ol.proj');
 goog.require('ol.style.Fill');
 goog.require('ol.style.Icon');
@@ -333,9 +333,9 @@ ol.format.KML.createNameStyleFunction_ = function(foundStyle, name) {
       textAlign = 'left';
     }
   }
-  if (!goog.object.isEmpty(foundStyle.getText())) {
+  if (!ol.object.isEmpty(foundStyle.getText())) {
     textStyle = /** @type {ol.style.Text} */
-        (goog.object.clone(foundStyle.getText()));
+        (ol.object.clone(foundStyle.getText()));
     textStyle.setText(name);
     textStyle.setTextAlign(textAlign);
     textStyle.setOffsetX(textOffset[0]);

--- a/src/ol/format/osmxmlformat.js
+++ b/src/ol/format/osmxmlformat.js
@@ -4,7 +4,6 @@ goog.provide('ol.format.OSMXML');
 goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.dom.NodeType');
-goog.require('goog.object');
 goog.require('ol.Feature');
 goog.require('ol.format.Feature');
 goog.require('ol.format.XMLFeature');
@@ -12,6 +11,7 @@ goog.require('ol.geom.GeometryLayout');
 goog.require('ol.geom.LineString');
 goog.require('ol.geom.Point');
 goog.require('ol.geom.Polygon');
+goog.require('ol.object');
 goog.require('ol.proj');
 goog.require('ol.xml');
 
@@ -74,7 +74,7 @@ ol.format.OSMXML.readNode_ = function(node, objectStack) {
   var values = ol.xml.pushParseAndPop({
     tags: {}
   }, ol.format.OSMXML.NODE_PARSERS_, node, objectStack);
-  if (!goog.object.isEmpty(values.tags)) {
+  if (!ol.object.isEmpty(values.tags)) {
     var geometry = new ol.geom.Point(coordinates);
     ol.format.Feature.transformWithOptions(geometry, false, options);
     var feature = new ol.Feature(geometry);

--- a/src/ol/format/topojsonformat.js
+++ b/src/ol/format/topojsonformat.js
@@ -1,7 +1,6 @@
 goog.provide('ol.format.TopoJSON');
 
 goog.require('goog.asserts');
-goog.require('goog.object');
 goog.require('ol.Feature');
 goog.require('ol.format.Feature');
 goog.require('ol.format.JSONFeature');
@@ -11,6 +10,7 @@ goog.require('ol.geom.MultiPoint');
 goog.require('ol.geom.MultiPolygon');
 goog.require('ol.geom.Point');
 goog.require('ol.geom.Polygon');
+goog.require('ol.object');
 goog.require('ol.proj');
 
 
@@ -300,7 +300,7 @@ ol.format.TopoJSON.prototype.readFeaturesFromObject = function(
     }
     /** @type {Array.<ol.Feature>} */
     var features = [];
-    var topoJSONFeatures = goog.object.getValues(topoJSONTopology.objects);
+    var topoJSONFeatures = ol.object.getValues(topoJSONTopology.objects);
     var i, ii;
     var feature;
     for (i = 0, ii = topoJSONFeatures.length; i < ii; ++i) {

--- a/src/ol/format/wfsformat.js
+++ b/src/ol/format/wfsformat.js
@@ -2,13 +2,13 @@ goog.provide('ol.format.WFS');
 
 goog.require('goog.asserts');
 goog.require('goog.dom.NodeType');
-goog.require('goog.object');
 goog.require('ol');
 goog.require('ol.format.GML3');
 goog.require('ol.format.GMLBase');
 goog.require('ol.format.XMLFeature');
 goog.require('ol.format.XSD');
 goog.require('ol.geom.Geometry');
+goog.require('ol.object');
 goog.require('ol.proj');
 goog.require('ol.xml');
 
@@ -123,7 +123,7 @@ ol.format.WFS.prototype.readFeaturesFromNode = function(node, opt_options) {
     'featureType': this.featureType_,
     'featureNS': this.featureNS_
   };
-  goog.object.extend(context, this.getReadOptions(node,
+  ol.object.extend(context, this.getReadOptions(node,
       opt_options ? opt_options : {}));
   var objectStack = [context];
   this.gmlFormat_.FEATURE_COLLECTION_PARSERS[ol.format.GMLBase.GMLNS][
@@ -545,7 +545,7 @@ ol.format.WFS.writeQuery_ = function(node, featureType, objectStack) {
     ol.xml.setAttributeNS(node, ol.format.WFS.XMLNS, 'xmlns:' + featurePrefix,
         featureNS);
   }
-  var item = goog.object.clone(context);
+  var item = ol.object.clone(context);
   item.node = node;
   ol.xml.pushSerializeAndPop(item,
       ol.format.WFS.QUERY_SERIALIZERS_,
@@ -612,7 +612,7 @@ ol.format.WFS.GETFEATURE_SERIALIZERS_ = {
 ol.format.WFS.writeGetFeature_ = function(node, featureTypes, objectStack) {
   var context = objectStack[objectStack.length - 1];
   goog.asserts.assert(goog.isObject(context), 'context should be an Object');
-  var item = goog.object.clone(context);
+  var item = ol.object.clone(context);
   item.node = node;
   ol.xml.pushSerializeAndPop(item,
       ol.format.WFS.GETFEATURE_SERIALIZERS_,
@@ -700,7 +700,7 @@ ol.format.WFS.prototype.writeTransaction = function(inserts, updates, deletes,
   if (inserts) {
     obj = {node: node, featureNS: options.featureNS,
       featureType: options.featureType, featurePrefix: options.featurePrefix};
-    goog.object.extend(obj, baseObj);
+    ol.object.extend(obj, baseObj);
     ol.xml.pushSerializeAndPop(obj,
         ol.format.WFS.TRANSACTION_SERIALIZERS_,
         ol.xml.makeSimpleNodeFactory('Insert'), inserts,
@@ -709,7 +709,7 @@ ol.format.WFS.prototype.writeTransaction = function(inserts, updates, deletes,
   if (updates) {
     obj = {node: node, featureNS: options.featureNS,
       featureType: options.featureType, featurePrefix: options.featurePrefix};
-    goog.object.extend(obj, baseObj);
+    ol.object.extend(obj, baseObj);
     ol.xml.pushSerializeAndPop(obj,
         ol.format.WFS.TRANSACTION_SERIALIZERS_,
         ol.xml.makeSimpleNodeFactory('Update'), updates,

--- a/src/ol/format/wmscapabilitiesformat.js
+++ b/src/ol/format/wmscapabilitiesformat.js
@@ -2,11 +2,11 @@ goog.provide('ol.format.WMSCapabilities');
 
 goog.require('goog.asserts');
 goog.require('goog.dom.NodeType');
-goog.require('goog.object');
 goog.require('ol');
 goog.require('ol.format.XLink');
 goog.require('ol.format.XML');
 goog.require('ol.format.XSD');
+goog.require('ol.object');
 goog.require('ol.xml');
 
 
@@ -344,7 +344,7 @@ ol.format.WMSCapabilities.readLayer_ = function(node, objectStack) {
   var addKeys = ['Style', 'CRS', 'AuthorityURL'];
   addKeys.forEach(function(key) {
     if (key in parentLayerObject) {
-      var childValue = goog.object.setIfUndefined(layerObject, key, []);
+      var childValue = ol.object.setIfUndefined(layerObject, key, []);
       childValue = childValue.concat(parentLayerObject[key]);
       layerObject[key] = childValue;
     }

--- a/src/ol/format/wmsgetfeatureinfoformat.js
+++ b/src/ol/format/wmsgetfeatureinfoformat.js
@@ -3,9 +3,9 @@ goog.provide('ol.format.WMSGetFeatureInfo');
 goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.dom.NodeType');
-goog.require('goog.object');
 goog.require('ol.format.GML2');
 goog.require('ol.format.XMLFeature');
+goog.require('ol.object');
 goog.require('ol.xml');
 
 
@@ -141,7 +141,7 @@ ol.format.WMSGetFeatureInfo.prototype.readFeaturesFromNode =
     'featureNS': this.featureNS
   };
   if (opt_options) {
-    goog.object.extend(options, this.getReadOptions(node, opt_options));
+    ol.object.extend(options, this.getReadOptions(node, opt_options));
   }
   return this.readFeatures_(node, [options]);
 };

--- a/src/ol/geom/geometrycollection.js
+++ b/src/ol/geom/geometrycollection.js
@@ -2,10 +2,10 @@ goog.provide('ol.geom.GeometryCollection');
 
 goog.require('goog.events');
 goog.require('goog.events.EventType');
-goog.require('goog.object');
 goog.require('ol.extent');
 goog.require('ol.geom.Geometry');
 goog.require('ol.geom.GeometryType');
+goog.require('ol.object');
 
 
 
@@ -163,7 +163,7 @@ ol.geom.GeometryCollection.prototype.getGeometriesArray = function() {
 ol.geom.GeometryCollection.prototype.getSimplifiedGeometry =
     function(squaredTolerance) {
   if (this.simplifiedGeometryRevision != this.getRevision()) {
-    goog.object.clear(this.simplifiedGeometryCache);
+    ol.object.clear(this.simplifiedGeometryCache);
     this.simplifiedGeometryMaxMinSquaredTolerance = 0;
     this.simplifiedGeometryRevision = this.getRevision();
   }

--- a/src/ol/geom/multipolygon.js
+++ b/src/ol/geom/multipolygon.js
@@ -2,7 +2,6 @@ goog.provide('ol.geom.MultiPolygon');
 
 goog.require('goog.array');
 goog.require('goog.asserts');
-goog.require('goog.object');
 goog.require('ol');
 goog.require('ol.extent');
 goog.require('ol.geom.GeometryLayout');
@@ -20,6 +19,7 @@ goog.require('ol.geom.flat.interiorpoint');
 goog.require('ol.geom.flat.intersectsextent');
 goog.require('ol.geom.flat.orient');
 goog.require('ol.geom.flat.simplify');
+goog.require('ol.object');
 
 
 
@@ -121,7 +121,7 @@ ol.geom.MultiPolygon.prototype.appendPolygon = function(polygon) {
 ol.geom.MultiPolygon.prototype.clone = function() {
   var multiPolygon = new ol.geom.MultiPolygon(null);
   var newEndss = /** @type {Array.<Array.<number>>} */
-      (goog.object.unsafeClone(this.endss_));
+      (ol.object.unsafeClone(this.endss_));
   multiPolygon.setFlatCoordinates(
       this.layout, this.flatCoordinates.slice(), newEndss);
   return multiPolygon;

--- a/src/ol/geom/simplegeometry.js
+++ b/src/ol/geom/simplegeometry.js
@@ -2,11 +2,11 @@ goog.provide('ol.geom.SimpleGeometry');
 
 goog.require('goog.asserts');
 goog.require('goog.functions');
-goog.require('goog.object');
 goog.require('ol.extent');
 goog.require('ol.geom.Geometry');
 goog.require('ol.geom.GeometryLayout');
 goog.require('ol.geom.flat.transform');
+goog.require('ol.object');
 
 
 
@@ -148,7 +148,7 @@ ol.geom.SimpleGeometry.prototype.getLayout = function() {
 ol.geom.SimpleGeometry.prototype.getSimplifiedGeometry =
     function(squaredTolerance) {
   if (this.simplifiedGeometryRevision != this.getRevision()) {
-    goog.object.clear(this.simplifiedGeometryCache);
+    ol.object.clear(this.simplifiedGeometryCache);
     this.simplifiedGeometryMaxMinSquaredTolerance = 0;
     this.simplifiedGeometryRevision = this.getRevision();
   }

--- a/src/ol/image.js
+++ b/src/ol/image.js
@@ -3,10 +3,10 @@ goog.provide('ol.Image');
 goog.require('goog.asserts');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
-goog.require('goog.object');
 goog.require('ol.ImageBase');
 goog.require('ol.ImageState');
 goog.require('ol.extent');
+goog.require('ol.object');
 
 
 
@@ -82,7 +82,7 @@ ol.Image.prototype.getImage = function(opt_context) {
     var key = goog.getUid(opt_context);
     if (key in this.imageByContext_) {
       return this.imageByContext_[key];
-    } else if (goog.object.isEmpty(this.imageByContext_)) {
+    } else if (ol.object.isEmpty(this.imageByContext_)) {
       image = this.image_;
     } else {
       image = /** @type {Image} */ (this.image_.cloneNode(false));

--- a/src/ol/imagetile.js
+++ b/src/ol/imagetile.js
@@ -3,11 +3,11 @@ goog.provide('ol.ImageTile');
 goog.require('goog.asserts');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
-goog.require('goog.object');
 goog.require('ol.Tile');
 goog.require('ol.TileCoord');
 goog.require('ol.TileLoadFunctionType');
 goog.require('ol.TileState');
+goog.require('ol.object');
 
 
 
@@ -88,7 +88,7 @@ ol.ImageTile.prototype.getImage = function(opt_context) {
     var key = goog.getUid(opt_context);
     if (key in this.imageByContext_) {
       return this.imageByContext_[key];
-    } else if (goog.object.isEmpty(this.imageByContext_)) {
+    } else if (ol.object.isEmpty(this.imageByContext_)) {
       image = this.image_;
     } else {
       image = /** @type {Image} */ (this.image_.cloneNode(false));

--- a/src/ol/interaction/pointerinteraction.js
+++ b/src/ol/interaction/pointerinteraction.js
@@ -1,12 +1,12 @@
 goog.provide('ol.interaction.Pointer');
 
 goog.require('goog.functions');
-goog.require('goog.object');
 goog.require('ol');
 goog.require('ol.MapBrowserEvent.EventType');
 goog.require('ol.MapBrowserPointerEvent');
 goog.require('ol.Pixel');
 goog.require('ol.interaction.Interaction');
+goog.require('ol.object');
 
 
 
@@ -136,7 +136,7 @@ ol.interaction.Pointer.prototype.updateTrackedPointers_ =
       // update only when there was a pointerdown event for this pointer
       this.trackedPointers_[event.pointerId] = event;
     }
-    this.targetPointers = goog.object.getValues(this.trackedPointers_);
+    this.targetPointers = ol.object.getValues(this.trackedPointers_);
   }
 };
 

--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -8,7 +8,6 @@ goog.require('goog.asserts');
 goog.require('goog.events');
 goog.require('goog.events.Event');
 goog.require('goog.functions');
-goog.require('goog.object');
 goog.require('ol.CollectionEventType');
 goog.require('ol.Feature');
 goog.require('ol.array');
@@ -16,6 +15,7 @@ goog.require('ol.events.condition');
 goog.require('ol.geom.GeometryType');
 goog.require('ol.interaction.Interaction');
 goog.require('ol.layer.Vector');
+goog.require('ol.object');
 goog.require('ol.source.Vector');
 
 
@@ -301,7 +301,7 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
       features.extend(selected);
       // Modify object this.featureLayerAssociation_
       if (selected.length === 0) {
-        goog.object.clear(this.featureLayerAssociation_);
+        ol.object.clear(this.featureLayerAssociation_);
       } else {
         if (deselected.length > 0) {
           deselected.forEach(function(feature) {

--- a/src/ol/interaction/snapinteraction.js
+++ b/src/ol/interaction/snapinteraction.js
@@ -4,7 +4,6 @@ goog.provide('ol.interaction.SnapProperty');
 goog.require('goog.asserts');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
-goog.require('goog.object');
 goog.require('ol');
 goog.require('ol.Collection');
 goog.require('ol.CollectionEvent');
@@ -17,6 +16,7 @@ goog.require('ol.coordinate');
 goog.require('ol.extent');
 goog.require('ol.geom.Geometry');
 goog.require('ol.interaction.Pointer');
+goog.require('ol.object');
 goog.require('ol.source.Vector');
 goog.require('ol.source.VectorEvent');
 goog.require('ol.source.VectorEventType');
@@ -597,7 +597,7 @@ ol.interaction.Snap.handleEvent_ = function(evt) {
  * @private
  */
 ol.interaction.Snap.handleUpEvent_ = function(evt) {
-  var featuresToUpdate = goog.object.getValues(this.pendingFeatures_);
+  var featuresToUpdate = ol.object.getValues(this.pendingFeatures_);
   if (featuresToUpdate.length) {
     featuresToUpdate.forEach(this.updateFeature_, this);
     this.pendingFeatures_ = {};

--- a/src/ol/layer/heatmaplayer.js
+++ b/src/ol/layer/heatmaplayer.js
@@ -2,12 +2,12 @@ goog.provide('ol.layer.Heatmap');
 
 goog.require('goog.asserts');
 goog.require('goog.events');
-goog.require('goog.object');
 goog.require('ol');
 goog.require('ol.Object');
 goog.require('ol.dom');
 goog.require('ol.layer.Vector');
 goog.require('ol.math');
+goog.require('ol.object');
 goog.require('ol.render.EventType');
 goog.require('ol.style.Icon');
 goog.require('ol.style.Style');
@@ -40,7 +40,7 @@ ol.layer.HeatmapLayerProperty = {
 ol.layer.Heatmap = function(opt_options) {
   var options = opt_options ? opt_options : {};
 
-  var baseOptions = goog.object.clone(options);
+  var baseOptions = ol.object.clone(options);
 
   delete baseOptions.gradient;
   delete baseOptions.radius;

--- a/src/ol/layer/layer.js
+++ b/src/ol/layer/layer.js
@@ -2,11 +2,11 @@ goog.provide('ol.layer.Layer');
 
 goog.require('goog.events');
 goog.require('goog.events.EventType');
-goog.require('goog.object');
 goog.require('ol');
 goog.require('ol.Object');
 goog.require('ol.layer.Base');
 goog.require('ol.layer.LayerProperty');
+goog.require('ol.object');
 goog.require('ol.render.EventType');
 goog.require('ol.source.State');
 
@@ -35,7 +35,7 @@ goog.require('ol.source.State');
  */
 ol.layer.Layer = function(options) {
 
-  var baseOptions = goog.object.clone(options);
+  var baseOptions = ol.object.clone(options);
   delete baseOptions.source;
 
   goog.base(this, /** @type {olx.layer.LayerOptions} */ (baseOptions));

--- a/src/ol/layer/layerbase.js
+++ b/src/ol/layer/layerbase.js
@@ -2,10 +2,10 @@ goog.provide('ol.layer.Base');
 goog.provide('ol.layer.LayerProperty');
 goog.provide('ol.layer.LayerState');
 
-goog.require('goog.object');
 goog.require('ol');
 goog.require('ol.Object');
 goog.require('ol.math');
+goog.require('ol.object');
 goog.require('ol.source.State');
 
 
@@ -58,7 +58,7 @@ ol.layer.Base = function(options) {
   /**
    * @type {Object.<string, *>}
    */
-  var properties = goog.object.clone(options);
+  var properties = ol.object.clone(options);
   properties[ol.layer.LayerProperty.OPACITY] =
       options.opacity !== undefined ? options.opacity : 1;
   properties[ol.layer.LayerProperty.VISIBLE] =

--- a/src/ol/layer/layergroup.js
+++ b/src/ol/layer/layergroup.js
@@ -3,7 +3,6 @@ goog.provide('ol.layer.Group');
 goog.require('goog.asserts');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
-goog.require('goog.object');
 goog.require('ol.Collection');
 goog.require('ol.CollectionEvent');
 goog.require('ol.CollectionEventType');
@@ -11,6 +10,7 @@ goog.require('ol.Object');
 goog.require('ol.ObjectEventType');
 goog.require('ol.extent');
 goog.require('ol.layer.Base');
+goog.require('ol.object');
 goog.require('ol.source.State');
 
 
@@ -38,7 +38,7 @@ ol.layer.Group = function(opt_options) {
 
   var options = opt_options || {};
   var baseOptions = /** @type {olx.layer.GroupOptions} */
-      (goog.object.clone(options));
+      (ol.object.clone(options));
   delete baseOptions.layers;
 
   var layers = options.layers;
@@ -104,10 +104,10 @@ ol.layer.Group.prototype.handleLayersChanged_ = function(event) {
       goog.events.listen(layers, ol.CollectionEventType.REMOVE,
           this.handleLayersRemove_, false, this));
 
-  goog.object.forEach(this.listenerKeys_, function(keys) {
+  ol.object.forEach(this.listenerKeys_, function(keys) {
     keys.forEach(goog.events.unlistenByKey);
   });
-  goog.object.clear(this.listenerKeys_);
+  ol.object.clear(this.listenerKeys_);
 
   var layersArray = layers.getArray();
   var i, ii, layer;

--- a/src/ol/layer/tilelayer.js
+++ b/src/ol/layer/tilelayer.js
@@ -1,8 +1,8 @@
 goog.provide('ol.layer.Tile');
 
-goog.require('goog.object');
 goog.require('ol');
 goog.require('ol.layer.Layer');
+goog.require('ol.object');
 
 
 /**
@@ -32,7 +32,7 @@ ol.layer.TileProperty = {
 ol.layer.Tile = function(opt_options) {
   var options = opt_options ? opt_options : {};
 
-  var baseOptions = goog.object.clone(options);
+  var baseOptions = ol.object.clone(options);
 
   delete baseOptions.preload;
   delete baseOptions.useInterimTilesOnError;

--- a/src/ol/layer/vectorlayer.js
+++ b/src/ol/layer/vectorlayer.js
@@ -1,9 +1,9 @@
 goog.provide('ol.layer.Vector');
 
 goog.require('goog.asserts');
-goog.require('goog.object');
 goog.require('ol');
 goog.require('ol.layer.Layer');
+goog.require('ol.object');
 goog.require('ol.style.Style');
 
 
@@ -39,7 +39,7 @@ ol.layer.Vector = function(opt_options) {
       goog.isFunction(options.renderOrder),
       'renderOrder must be a comparator function');
 
-  var baseOptions = goog.object.clone(options);
+  var baseOptions = ol.object.clone(options);
 
   delete baseOptions.style;
   delete baseOptions.renderBuffer;

--- a/src/ol/layer/vectortilelayer.js
+++ b/src/ol/layer/vectortilelayer.js
@@ -1,7 +1,7 @@
 goog.provide('ol.layer.VectorTile');
 
-goog.require('goog.object');
 goog.require('ol.layer.Vector');
+goog.require('ol.object');
 
 
 /**
@@ -29,7 +29,7 @@ ol.layer.VectorTileProperty = {
 ol.layer.VectorTile = function(opt_options) {
   var options = opt_options ? opt_options : {};
 
-  var baseOptions = goog.object.clone(options);
+  var baseOptions = ol.object.clone(options);
 
   delete baseOptions.preload;
   delete baseOptions.useInterimTilesOnError;

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -24,7 +24,6 @@ goog.require('goog.events.MouseWheelHandler.EventType');
 goog.require('goog.functions');
 goog.require('goog.log');
 goog.require('goog.log.Level');
-goog.require('goog.object');
 goog.require('goog.style');
 goog.require('goog.vec.Mat4');
 goog.require('ol.Collection');
@@ -51,6 +50,7 @@ goog.require('ol.has');
 goog.require('ol.interaction');
 goog.require('ol.layer.Base');
 goog.require('ol.layer.Group');
+goog.require('ol.object');
 goog.require('ol.proj');
 goog.require('ol.proj.common');
 goog.require('ol.renderer.Map');
@@ -300,7 +300,7 @@ ol.Map = function(options) {
 
   var mapBrowserEventHandler = new ol.MapBrowserEventHandler(this);
   goog.events.listen(mapBrowserEventHandler,
-      goog.object.getValues(ol.MapBrowserEvent.EventType),
+      ol.object.getValues(ol.MapBrowserEvent.EventType),
       this.handleMapBrowserEvent, false, this);
   this.registerDisposable(mapBrowserEventHandler);
 
@@ -1027,7 +1027,7 @@ ol.Map.prototype.handlePostRender = function() {
         maxTotalLoading = this.loadTilesWhileInteracting_ ? 8 : 0;
         maxNewLoads = 2;
       }
-      tileSourceCount = goog.object.getCount(frameState.wantedTiles);
+      tileSourceCount = ol.object.getCount(frameState.wantedTiles);
     }
     maxTotalLoading *= tileSourceCount;
     maxNewLoads *= tileSourceCount;
@@ -1311,7 +1311,7 @@ ol.Map.prototype.renderFrame_ = function(time) {
       index: this.frameIndex_++,
       layerStates: layerStates,
       layerStatesArray: layerStatesArray,
-      logos: goog.object.clone(this.logos_),
+      logos: ol.object.clone(this.logos_),
       pixelRatio: this.pixelRatio_,
       pixelToCoordinateMatrix: this.pixelToCoordinateMatrix_,
       postRenderFunctions: [],

--- a/src/ol/mapbrowserevent.js
+++ b/src/ol/mapbrowserevent.js
@@ -8,11 +8,11 @@ goog.require('goog.events');
 goog.require('goog.events.BrowserEvent');
 goog.require('goog.events.EventTarget');
 goog.require('goog.events.EventType');
-goog.require('goog.object');
 goog.require('ol');
 goog.require('ol.Coordinate');
 goog.require('ol.MapEvent');
 goog.require('ol.Pixel');
+goog.require('ol.object');
 goog.require('ol.pointer.PointerEvent');
 goog.require('ol.pointer.PointerEventHandler');
 
@@ -265,7 +265,7 @@ ol.MapBrowserEventHandler.prototype.updateActivePointers_ =
   } else if (event.type == ol.MapBrowserEvent.EventType.POINTERDOWN) {
     this.trackedTouches_[event.pointerId] = true;
   }
-  this.activePointers_ = goog.object.getCount(this.trackedTouches_);
+  this.activePointers_ = ol.object.getCount(this.trackedTouches_);
 };
 
 

--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -1,10 +1,280 @@
 goog.provide('ol.Object');
 goog.provide('ol.ObjectEvent');
 goog.provide('ol.ObjectEventType');
+goog.provide('ol.object');
 
 goog.require('goog.events');
 goog.require('goog.events.Event');
 goog.require('ol.Observable');
+
+
+/**
+ * Calls a function for each element in an object/map/hash. If any
+ * call returns true, returns true (without checking the rest). If
+ * all calls return false, returns false.
+ *
+ * @param {Object.<K,V>} obj The object to check.
+ * @param {function(this:T,V,?,Object.<K,V>):boolean} f The function to
+ *     call for every element. This function
+ *     takes 3 arguments (the element, the index and the object) and should
+ *     return a boolean.
+ * @param {T=} opt_obj This is used as the 'this' object within f.
+ * @return {boolean} true if any element passes the test.
+ * @template T,K,V
+ */
+ol.object.some = function(obj, f, opt_obj) {
+  for (var key in obj) {
+    if (f.call(opt_obj, obj[key], key, obj)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+
+/**
+ * Searches an object for an element that satisfies the given condition and
+ * returns its key.
+ * @param {Object.<K,V>} obj The object to search in.
+ * @param {function(this:T,V,string,Object.<K,V>):boolean} f The
+ *      function to call for every element. Takes 3 arguments (the value,
+ *     the key and the object) and should return a boolean.
+ * @param {T=} opt_this An optional "this" context for the function.
+ * @return {string|undefined} The key of an element for which the function
+ *     returns true or undefined if no such element is found.
+ * @template T,K,V
+ */
+ol.object.findKey = function(obj, f, opt_this) {
+  for (var key in obj) {
+    if (f.call(opt_this, obj[key], key, obj)) {
+      return key;
+    }
+  }
+  return undefined;
+};
+
+
+/**
+ * Whether the object/hash/map contains the given object as a value.
+ * An alias for ol.object.containsValue(obj, val).
+ *
+ * @param {Object.<K,V>} obj The object in which to look for val.
+ * @param {V} val The object for which to check.
+ * @return {boolean} true if val is present.
+ * @template K,V
+ */
+ol.object.contains = function(obj, val) {
+  return ol.object.containsValue(obj, val);
+};
+
+
+/**
+ * Whether the object/map/hash contains the given value. This is O(n).
+ *
+ * @param {Object.<K,V>} obj The object in which to look for val.
+ * @param {V} val The value for which to check.
+ * @return {boolean} true If the map contains the value.
+ * @template K,V
+ */
+ol.object.containsValue = function(obj, val) {
+  for (var key in obj) {
+    if (obj[key] == val) {
+      return true;
+    }
+  }
+  return false;
+};
+
+
+/**
+ * Returns the value for the given key.
+ *
+ * @param {Object.<K,V>} obj The object from which to get the value.
+ * @param {string} key The key for which to get the value.
+ * @param {R=} opt_val The value to return if no item is found for the given
+ *     key (default is undefined).
+ * @return {V|R|undefined} The value for the given key.
+ * @template K,V,R
+ */
+ol.object.get = function(obj, key, opt_val) {
+  if (key in obj) {
+    return obj[key];
+  }
+  return opt_val;
+};
+
+
+/**
+ * Calls a function for each element in an object/map/hash.
+ *
+ * @param {Object.<K,V>} obj The object over which to iterate.
+ * @param {function(this:T,V,?,Object.<K,V>):?} f The function to call
+ *     for every element. This function takes 3 arguments (the element, the
+ *     index and the object) and the return value is ignored.
+ * @param {T=} opt_obj This is used as the 'this' object within f.
+ * @template T,K,V
+ */
+ol.object.forEach = function(obj, f, opt_obj) {
+  for (var key in obj) {
+    f.call(opt_obj, obj[key], key, obj);
+  }
+};
+
+
+/**
+ * Returns the number of key-value pairs in the object map.
+ *
+ * @param {Object} obj The object for which to get the number of key-value
+ *     pairs.
+ * @return {number} The number of key-value pairs in the object map.
+ */
+ol.object.getCount = function(obj) {
+  return obj === null ? 0 : Object.keys(obj).length;
+};
+
+
+/**
+ * Does a flat clone of the object.
+ *
+ * @param {Object.<K,V>} obj Object to clone.
+ * @return {!Object.<K,V>} Clone of the input object.
+ * @template K,V
+ */
+ol.object.clone = function(obj) {
+  var res = {};
+  for (var key in obj) {
+    res[key] = obj[key];
+  }
+  return res;
+};
+
+
+/**
+ * Clones a value. The input may be an Object, Array, or basic type. Objects and
+ * arrays will be cloned recursively.
+ *
+ * WARNINGS:
+ * <code>ol.object.unsafeClone</code> does not detect reference loops. Objects
+ * that refer to themselves will cause infinite recursion.
+ *
+ * <code>ol.object.unsafeClone</code> is unaware of unique identifiers, and
+ * copies UIDs created by <code>getUid</code> into cloned results.
+ *
+ * @param {*} obj The value to clone.
+ * @return {*} A clone of the input value.
+ */
+ol.object.unsafeClone = function(obj) {
+  var type = goog.typeOf(obj);
+  if (type == 'object' || type == 'array') {
+    if (obj.clone) {
+      return obj.clone();
+    }
+    var clone = type == 'array' ? [] : {};
+    for (var key in obj) {
+      clone[key] = ol.object.unsafeClone(obj[key]);
+    }
+    return clone;
+  }
+
+  return obj;
+};
+
+
+/**
+ * Removes all key value pairs from the object/map/hash.
+ *
+ * @param {Object} obj The object to clear.
+ */
+ol.object.clear = function(obj) {
+  for (var i in obj) {
+    delete obj[i];
+  }
+};
+
+
+/**
+ * Adds a key-value pair to the object/map/hash if it doesn't exist yet.
+ *
+ * @param {Object.<K,V>} obj The object to which to add the key-value pair.
+ * @param {string} key The key to add.
+ * @param {V} value The value to add if the key wasn't present.
+ * @return {V} The value of the entry at the end of the function.
+ * @template K,V
+ */
+ol.object.setIfUndefined = function(obj, key, value) {
+  return key in obj ? obj[key] : (obj[key] = value);
+};
+
+
+/**
+ * Returns the keys of the object/map/hash.
+ *
+ * @param {Object} obj The object from which to get the keys.
+ * @return {!Array.<string>} Array of property keys.
+ */
+ol.object.getKeys = function(obj) {
+  var res = [];
+  var i = 0;
+  for (var key in obj) {
+    res[i++] = key;
+  }
+  return res;
+};
+
+
+/**
+ * Returns the values of the object/map/hash.
+ *
+ * @param {Object.<K,V>} obj The object from which to get the values.
+ * @return {!Array.<V>} The values in the object/map/hash.
+ * @template K,V
+ */
+ol.object.getValues = function(obj) {
+  var res = [];
+  var i = 0;
+  for (var key in obj) {
+    res[i++] = obj[key];
+  }
+  return res;
+};
+
+
+/**
+ * Extends an object with another object.
+ * This operates 'in-place'; it does not create a new Object.
+ *
+ * Example:
+ * var o = {};
+ * ol.object.extend(o, {a: 0, b: 1});
+ * o; // {a: 0, b: 1}
+ * ol.object.extend(o, {b: 2, c: 3});
+ * o; // {a: 0, b: 2, c: 3}
+ *
+ * @param {Object} target The object to modify. Existing properties will be
+ *     overwritten if they are also present in one of the objects in
+ *     {@code var_args}.
+ * @param {...Object} var_args The objects from which values will be copied.
+ */
+ol.object.extend = function(target, var_args) {
+  var key, source;
+  for (var i = 1; i < arguments.length; i++) {
+    source = arguments[i];
+    for (key in source) {
+      target[key] = source[key];
+    }
+  }
+};
+
+
+/**
+ * Whether the object/map/hash is empty.
+ *
+ * @param {Object} obj The object to test.
+ * @return {boolean} true if obj is empty.
+ */
+ol.object.isEmpty = function(obj) {
+  return obj === null ? true : Object.keys(obj).length === 0;
+};
 
 
 /**

--- a/src/ol/pointer/touchsource.js
+++ b/src/ol/pointer/touchsource.js
@@ -31,8 +31,8 @@
 goog.provide('ol.pointer.TouchSource');
 
 goog.require('goog.array');
-goog.require('goog.object');
 goog.require('ol');
+goog.require('ol.object');
 goog.require('ol.pointer.EventSource');
 goog.require('ol.pointer.MouseSource');
 
@@ -125,7 +125,7 @@ ol.pointer.TouchSource.prototype.isPrimaryTouch_ = function(inTouch) {
  * @private
  */
 ol.pointer.TouchSource.prototype.setPrimaryTouch_ = function(inTouch) {
-  var count = goog.object.getCount(this.pointerMap);
+  var count = ol.object.getCount(this.pointerMap);
   if (count === 0 || (count === 1 &&
       ol.pointer.MouseSource.POINTER_ID.toString() in this.pointerMap)) {
     this.firstTouchId_ = inTouch.identifier;
@@ -269,7 +269,7 @@ ol.pointer.TouchSource.prototype.vacuumTouches_ = function(inEvent) {
   var touchList = inEvent.getBrowserEvent().touches;
   // pointerMap.getCount() should be < touchList.length here,
   // as the touchstart has not been processed yet.
-  var keys = goog.object.getKeys(this.pointerMap);
+  var keys = ol.object.getKeys(this.pointerMap);
   var count = keys.length;
   if (count >= touchList.length) {
     var d = [];

--- a/src/ol/proj/proj.js
+++ b/src/ol/proj/proj.js
@@ -5,11 +5,11 @@ goog.provide('ol.proj.ProjectionLike');
 goog.provide('ol.proj.Units');
 
 goog.require('goog.asserts');
-goog.require('goog.object');
 goog.require('ol');
 goog.require('ol.Extent');
 goog.require('ol.TransformFunction');
 goog.require('ol.extent');
+goog.require('ol.object');
 goog.require('ol.sphere.NORMAL');
 
 
@@ -600,7 +600,7 @@ ol.proj.removeTransform = function(source, destination) {
       'destinationCode should be in transforms of sourceCode');
   var transform = transforms[sourceCode][destinationCode];
   delete transforms[sourceCode][destinationCode];
-  if (goog.object.isEmpty(transforms[sourceCode])) {
+  if (ol.object.isEmpty(transforms[sourceCode])) {
     delete transforms[sourceCode];
   }
   return transform;

--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -10,7 +10,6 @@ goog.provide('ol.render.canvas.TextReplay');
 
 goog.require('goog.array');
 goog.require('goog.asserts');
-goog.require('goog.object');
 goog.require('goog.vec.Mat4');
 goog.require('ol');
 goog.require('ol.array');
@@ -21,6 +20,7 @@ goog.require('ol.extent.Relationship');
 goog.require('ol.geom.flat.simplify');
 goog.require('ol.geom.flat.transform');
 goog.require('ol.has');
+goog.require('ol.object');
 goog.require('ol.render.IReplayGroup');
 goog.require('ol.render.VectorContext');
 goog.require('ol.render.canvas');
@@ -246,7 +246,7 @@ ol.render.canvas.Replay.prototype.replay_ = function(
     goog.asserts.assert(pixelCoordinates === this.pixelCoordinates_,
         'pixelCoordinates should be the same as this.pixelCoordinates_');
   }
-  var skipFeatures = !goog.object.isEmpty(skippedFeaturesHash);
+  var skipFeatures = !ol.object.isEmpty(skippedFeaturesHash);
   var i = 0; // instruction index
   var ii = instructions.length; // end of instructions
   var d = 0; // data index
@@ -1962,7 +1962,7 @@ ol.render.canvas.ReplayGroup.prototype.getReplay =
  * @inheritDoc
  */
 ol.render.canvas.ReplayGroup.prototype.isEmpty = function() {
-  return goog.object.isEmpty(this.replaysByZIndex_);
+  return ol.object.isEmpty(this.replaysByZIndex_);
 };
 
 

--- a/src/ol/render/webgl/webglreplay.js
+++ b/src/ol/render/webgl/webglreplay.js
@@ -3,9 +3,9 @@ goog.provide('ol.render.webgl.ReplayGroup');
 
 goog.require('goog.asserts');
 goog.require('goog.functions');
-goog.require('goog.object');
 goog.require('goog.vec.Mat4');
 goog.require('ol.extent');
+goog.require('ol.object');
 goog.require('ol.render.IReplayGroup');
 goog.require('ol.render.VectorContext');
 goog.require('ol.render.webgl.imagereplay.shader.Default');
@@ -627,7 +627,7 @@ ol.render.webgl.ImageReplay.prototype.drawReplay_ =
       goog.webgl.UNSIGNED_INT : goog.webgl.UNSIGNED_SHORT;
   var elementSize = context.hasOESElementIndexUint ? 4 : 2;
 
-  if (!goog.object.isEmpty(skippedFeaturesHash)) {
+  if (!ol.object.isEmpty(skippedFeaturesHash)) {
     this.drawReplaySkipping_(
         gl, skippedFeaturesHash, textures, groupIndices,
         elementType, elementSize);
@@ -1010,7 +1010,7 @@ ol.render.webgl.ReplayGroup.prototype.getReplay =
  * @inheritDoc
  */
 ol.render.webgl.ReplayGroup.prototype.isEmpty = function() {
-  return goog.object.isEmpty(this.replays_);
+  return ol.object.isEmpty(this.replays_);
 };
 
 

--- a/src/ol/renderer/maprenderer.js
+++ b/src/ol/renderer/maprenderer.js
@@ -7,11 +7,11 @@ goog.require('goog.dispose');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
 goog.require('goog.functions');
-goog.require('goog.object');
 goog.require('goog.vec.Mat4');
 goog.require('ol');
 goog.require('ol.extent');
 goog.require('ol.layer.Layer');
+goog.require('ol.object');
 goog.require('ol.renderer.Layer');
 goog.require('ol.style.IconImageCache');
 goog.require('ol.vec.Mat4');
@@ -96,7 +96,7 @@ ol.renderer.Map.prototype.createLayerRenderer = goog.abstractMethod;
  * @inheritDoc
  */
 ol.renderer.Map.prototype.disposeInternal = function() {
-  goog.object.forEach(this.layerRenderers_, goog.dispose);
+  ol.object.forEach(this.layerRenderers_, goog.dispose);
   goog.base(this, 'disposeInternal');
 };
 

--- a/src/ol/renderer/webgl/webglmaprenderer.js
+++ b/src/ol/renderer/webgl/webglmaprenderer.js
@@ -9,7 +9,6 @@ goog.require('goog.events');
 goog.require('goog.events.Event');
 goog.require('goog.log');
 goog.require('goog.log.Logger');
-goog.require('goog.object');
 goog.require('goog.style');
 goog.require('goog.webgl');
 goog.require('ol');
@@ -20,6 +19,7 @@ goog.require('ol.layer.Image');
 goog.require('ol.layer.Layer');
 goog.require('ol.layer.Tile');
 goog.require('ol.layer.Vector');
+goog.require('ol.object');
 goog.require('ol.render.Event');
 goog.require('ol.render.EventType');
 goog.require('ol.render.webgl.Immediate');
@@ -383,7 +383,7 @@ ol.renderer.webgl.Map.prototype.handleWebGLContextLost = function(event) {
   event.preventDefault();
   this.textureCache_.clear();
   this.textureCacheFrameMarkerCount_ = 0;
-  goog.object.forEach(this.getLayerRenderers(),
+  ol.object.forEach(this.getLayerRenderers(),
       /**
        * @param {ol.renderer.Layer} layerRenderer Layer renderer.
        * @param {string} key Key.

--- a/src/ol/reproj/tile.js
+++ b/src/ol/reproj/tile.js
@@ -5,11 +5,11 @@ goog.require('goog.asserts');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
 goog.require('goog.math');
-goog.require('goog.object');
 goog.require('ol.Tile');
 goog.require('ol.TileState');
 goog.require('ol.extent');
 goog.require('ol.math');
+goog.require('ol.object');
 goog.require('ol.proj');
 goog.require('ol.reproj');
 goog.require('ol.reproj.Triangulation');
@@ -220,7 +220,7 @@ ol.reproj.Tile.prototype.getImage = function(opt_context) {
     var key = goog.getUid(opt_context);
     if (key in this.canvasByContext_) {
       return this.canvasByContext_[key];
-    } else if (goog.object.isEmpty(this.canvasByContext_)) {
+    } else if (ol.object.isEmpty(this.canvasByContext_)) {
       image = this.canvas_;
     } else {
       image = /** @type {HTMLCanvasElement} */ (this.canvas_.cloneNode(false));

--- a/src/ol/source/clustersource.js
+++ b/src/ol/source/clustersource.js
@@ -5,11 +5,11 @@ goog.provide('ol.source.Cluster');
 
 goog.require('goog.asserts');
 goog.require('goog.events.EventType');
-goog.require('goog.object');
 goog.require('ol.Feature');
 goog.require('ol.coordinate');
 goog.require('ol.extent');
 goog.require('ol.geom.Point');
+goog.require('ol.object');
 goog.require('ol.source.Vector');
 
 
@@ -141,7 +141,7 @@ ol.source.Cluster.prototype.cluster_ = function() {
     }
   }
   goog.asserts.assert(
-      goog.object.getCount(clustered) == this.source_.getFeatures().length,
+      ol.object.getCount(clustered) == this.source_.getFeatures().length,
       'number of clustered equals number of features in the source');
 };
 

--- a/src/ol/source/imagemapguidesource.js
+++ b/src/ol/source/imagemapguidesource.js
@@ -2,11 +2,11 @@ goog.provide('ol.source.ImageMapGuide');
 
 goog.require('goog.events');
 goog.require('goog.events.EventType');
-goog.require('goog.object');
 goog.require('goog.uri.utils');
 goog.require('ol.Image');
 goog.require('ol.ImageLoadFunctionType');
 goog.require('ol.extent');
+goog.require('ol.object');
 goog.require('ol.source.Image');
 
 
@@ -194,7 +194,7 @@ ol.source.ImageMapGuide.getScale = function(extent, size, metersPerUnit, dpi) {
  * @api stable
  */
 ol.source.ImageMapGuide.prototype.updateParams = function(params) {
-  goog.object.extend(this.params_, params);
+  ol.object.extend(this.params_, params);
   this.changed();
 };
 
@@ -225,7 +225,7 @@ ol.source.ImageMapGuide.prototype.getUrl =
     'SETVIEWCENTERX': center[0],
     'SETVIEWCENTERY': center[1]
   };
-  goog.object.extend(baseParams, params);
+  ol.object.extend(baseParams, params);
   return goog.uri.utils.appendParamsFromMap(baseUrl, baseParams);
 };
 

--- a/src/ol/source/imagewmssource.js
+++ b/src/ol/source/imagewmssource.js
@@ -5,13 +5,13 @@ goog.provide('ol.source.ImageWMS');
 goog.require('goog.asserts');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
-goog.require('goog.object');
 goog.require('goog.string');
 goog.require('goog.uri.utils');
 goog.require('ol');
 goog.require('ol.Image');
 goog.require('ol.ImageLoadFunctionType');
 goog.require('ol.extent');
+goog.require('ol.object');
 goog.require('ol.proj');
 goog.require('ol.source.Image');
 goog.require('ol.source.wms');
@@ -158,7 +158,7 @@ ol.source.ImageWMS.prototype.getGetFeatureInfoUrl =
     'TRANSPARENT': true,
     'QUERY_LAYERS': this.params_['LAYERS']
   };
-  goog.object.extend(baseParams, this.params_, params);
+  ol.object.extend(baseParams, this.params_, params);
 
   var x = Math.floor((coordinate[0] - extent[0]) / resolution);
   var y = Math.floor((extent[3] - coordinate[1]) / resolution);
@@ -231,7 +231,7 @@ ol.source.ImageWMS.prototype.getImageInternal =
     'FORMAT': 'image/png',
     'TRANSPARENT': true
   };
-  goog.object.extend(params, this.params_);
+  ol.object.extend(params, this.params_);
 
   this.imageSize_[0] = Math.ceil(imageWidth * this.ratio_);
   this.imageSize_[1] = Math.ceil(imageHeight * this.ratio_);
@@ -366,7 +366,7 @@ ol.source.ImageWMS.prototype.setUrl = function(url) {
  * @api stable
  */
 ol.source.ImageWMS.prototype.updateParams = function(params) {
-  goog.object.extend(this.params_, params);
+  ol.object.extend(this.params_, params);
   this.updateV13_();
   this.image_ = null;
   this.changed();
@@ -378,6 +378,6 @@ ol.source.ImageWMS.prototype.updateParams = function(params) {
  */
 ol.source.ImageWMS.prototype.updateV13_ = function() {
   var version =
-      goog.object.get(this.params_, 'VERSION', ol.DEFAULT_WMS_VERSION);
+      ol.object.get(this.params_, 'VERSION', ol.DEFAULT_WMS_VERSION);
   this.v13_ = goog.string.compareVersions(version, '1.3') >= 0;
 };

--- a/src/ol/source/rastersource.js
+++ b/src/ol/source/rastersource.js
@@ -6,7 +6,6 @@ goog.require('goog.asserts');
 goog.require('goog.events');
 goog.require('goog.events.Event');
 goog.require('goog.events.EventType');
-goog.require('goog.object');
 goog.require('goog.vec.Mat4');
 goog.require('ol.ImageCanvas');
 goog.require('ol.TileQueue');
@@ -15,6 +14,7 @@ goog.require('ol.ext.pixelworks');
 goog.require('ol.extent');
 goog.require('ol.layer.Image');
 goog.require('ol.layer.Tile');
+goog.require('ol.object');
 goog.require('ol.raster.OperationType');
 goog.require('ol.renderer.canvas.ImageLayer');
 goog.require('ol.renderer.canvas.TileLayer');
@@ -171,10 +171,10 @@ ol.source.Raster.prototype.updateFrameState_ =
     function(extent, resolution, projection) {
 
   var frameState = /** @type {olx.FrameState} */ (
-      goog.object.clone(this.frameState_));
+      ol.object.clone(this.frameState_));
 
   frameState.viewState = /** @type {olx.ViewState} */ (
-      goog.object.clone(frameState.viewState));
+      ol.object.clone(frameState.viewState));
 
   var center = ol.extent.getCenter(extent);
   var width = Math.round(ol.extent.getWidth(extent) / resolution);

--- a/src/ol/source/tilearcgisrestsource.js
+++ b/src/ol/source/tilearcgisrestsource.js
@@ -2,12 +2,12 @@ goog.provide('ol.source.TileArcGISRest');
 
 goog.require('goog.asserts');
 goog.require('goog.math');
-goog.require('goog.object');
 goog.require('goog.string');
 goog.require('goog.uri.utils');
 goog.require('ol');
 goog.require('ol.TileCoord');
 goog.require('ol.extent');
+goog.require('ol.object');
 goog.require('ol.proj');
 goog.require('ol.size');
 goog.require('ol.source.TileImage');
@@ -182,7 +182,7 @@ ol.source.TileArcGISRest.prototype.tileUrlFunction_ =
     'FORMAT': 'PNG32',
     'TRANSPARENT': true
   };
-  goog.object.extend(baseParams, this.params_);
+  ol.object.extend(baseParams, this.params_);
 
   return this.getRequestUrl_(tileCoord, tileSize, tileExtent,
       pixelRatio, projection, baseParams);
@@ -195,6 +195,6 @@ ol.source.TileArcGISRest.prototype.tileUrlFunction_ =
  * @api stable
  */
 ol.source.TileArcGISRest.prototype.updateParams = function(params) {
-  goog.object.extend(this.params_, params);
+  ol.object.extend(this.params_, params);
   this.changed();
 };

--- a/src/ol/source/tileimagesource.js
+++ b/src/ol/source/tileimagesource.js
@@ -3,10 +3,10 @@ goog.provide('ol.source.TileImage');
 goog.require('goog.asserts');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
-goog.require('goog.object');
 goog.require('ol.ImageTile');
 goog.require('ol.TileCache');
 goog.require('ol.TileState');
+goog.require('ol.object');
 goog.require('ol.proj');
 goog.require('ol.reproj.Tile');
 goog.require('ol.source.UrlTile');
@@ -96,7 +96,7 @@ ol.source.TileImage.prototype.canExpireCache = function() {
   if (canExpire) {
     return true;
   } else {
-    return goog.object.some(this.tileCacheForProjection, function(tileCache) {
+    return ol.object.some(this.tileCacheForProjection, function(tileCache) {
       return tileCache.canExpireCache();
     });
   }
@@ -114,7 +114,7 @@ ol.source.TileImage.prototype.expireCache = function(projection, usedTiles) {
   var usedTileCache = this.getTileCacheForProjection(projection);
 
   this.tileCache.expireCache(this.tileCache == usedTileCache ? usedTiles : {});
-  goog.object.forEach(this.tileCacheForProjection, function(tileCache) {
+  ol.object.forEach(this.tileCacheForProjection, function(tileCache) {
     tileCache.expireCache(tileCache == usedTileCache ? usedTiles : {});
   });
 };
@@ -291,7 +291,7 @@ ol.source.TileImage.prototype.setRenderReprojectionEdges = function(render) {
     return;
   }
   this.renderReprojectionEdges_ = render;
-  goog.object.forEach(this.tileCacheForProjection, function(tileCache) {
+  ol.object.forEach(this.tileCacheForProjection, function(tileCache) {
     tileCache.clear();
   });
   this.changed();

--- a/src/ol/source/tilewmssource.js
+++ b/src/ol/source/tilewmssource.js
@@ -6,12 +6,12 @@ goog.provide('ol.source.TileWMS');
 
 goog.require('goog.asserts');
 goog.require('goog.math');
-goog.require('goog.object');
 goog.require('goog.string');
 goog.require('goog.uri.utils');
 goog.require('ol');
 goog.require('ol.TileCoord');
 goog.require('ol.extent');
+goog.require('ol.object');
 goog.require('ol.proj');
 goog.require('ol.size');
 goog.require('ol.source.TileImage');
@@ -36,7 +36,7 @@ ol.source.TileWMS = function(opt_options) {
 
   var params = options.params !== undefined ? options.params : {};
 
-  var transparent = goog.object.get(params, 'TRANSPARENT', true);
+  var transparent = ol.object.get(params, 'TRANSPARENT', true);
 
   goog.base(this, {
     attributions: options.attributions,
@@ -157,7 +157,7 @@ ol.source.TileWMS.prototype.getGetFeatureInfoUrl =
     'TRANSPARENT': true,
     'QUERY_LAYERS': this.params_['LAYERS']
   };
-  goog.object.extend(baseParams, this.params_, params);
+  ol.object.extend(baseParams, this.params_, params);
 
   var x = Math.floor((coordinate[0] - tileExtent[0]) / tileResolution);
   var y = Math.floor((tileExtent[3] - coordinate[1]) / tileResolution);
@@ -360,7 +360,7 @@ ol.source.TileWMS.prototype.tileUrlFunction_ =
     'FORMAT': 'image/png',
     'TRANSPARENT': true
   };
-  goog.object.extend(baseParams, this.params_);
+  ol.object.extend(baseParams, this.params_);
 
   return this.getRequestUrl_(tileCoord, tileSize, tileExtent,
       pixelRatio, projection, baseParams);
@@ -373,7 +373,7 @@ ol.source.TileWMS.prototype.tileUrlFunction_ =
  * @api stable
  */
 ol.source.TileWMS.prototype.updateParams = function(params) {
-  goog.object.extend(this.params_, params);
+  ol.object.extend(this.params_, params);
   this.resetCoordKeyPrefix_();
   this.updateV13_();
   this.changed();
@@ -385,6 +385,6 @@ ol.source.TileWMS.prototype.updateParams = function(params) {
  */
 ol.source.TileWMS.prototype.updateV13_ = function() {
   var version =
-      goog.object.get(this.params_, 'VERSION', ol.DEFAULT_WMS_VERSION);
+      ol.object.get(this.params_, 'VERSION', ol.DEFAULT_WMS_VERSION);
   this.v13_ = goog.string.compareVersions(version, '1.3') >= 0;
 };

--- a/src/ol/source/vectorsource.js
+++ b/src/ol/source/vectorsource.js
@@ -10,7 +10,6 @@ goog.require('goog.asserts');
 goog.require('goog.events');
 goog.require('goog.events.Event');
 goog.require('goog.events.EventType');
-goog.require('goog.object');
 goog.require('ol');
 goog.require('ol.Collection');
 goog.require('ol.CollectionEventType');
@@ -22,6 +21,7 @@ goog.require('ol.ObjectEventType');
 goog.require('ol.extent');
 goog.require('ol.featureloader');
 goog.require('ol.loadingstrategy');
+goog.require('ol.object');
 goog.require('ol.proj');
 goog.require('ol.source.Source');
 goog.require('ol.source.State');
@@ -388,17 +388,17 @@ ol.source.Vector.prototype.clear = function(opt_fast) {
     var rmFeatureInternal = this.removeFeatureInternal;
     if (this.featuresRtree_) {
       this.featuresRtree_.forEach(rmFeatureInternal, this);
-      goog.object.forEach(this.nullGeometryFeatures_, rmFeatureInternal, this);
+      ol.object.forEach(this.nullGeometryFeatures_, rmFeatureInternal, this);
     }
   }
   if (this.featuresCollection_) {
     this.featuresCollection_.clear();
   }
-  goog.asserts.assert(goog.object.isEmpty(this.featureChangeKeys_),
+  goog.asserts.assert(ol.object.isEmpty(this.featureChangeKeys_),
       'featureChangeKeys is an empty object now');
-  goog.asserts.assert(goog.object.isEmpty(this.idIndex_),
+  goog.asserts.assert(ol.object.isEmpty(this.idIndex_),
       'idIndex is an empty object now');
-  goog.asserts.assert(goog.object.isEmpty(this.undefIdIndex_),
+  goog.asserts.assert(ol.object.isEmpty(this.undefIdIndex_),
       'undefIdIndex is an empty object now');
 
   if (this.featuresRtree_) {
@@ -555,9 +555,9 @@ ol.source.Vector.prototype.getFeatures = function() {
     features = this.featuresCollection_.getArray();
   } else if (this.featuresRtree_) {
     features = this.featuresRtree_.getAll();
-    if (!goog.object.isEmpty(this.nullGeometryFeatures_)) {
+    if (!ol.object.isEmpty(this.nullGeometryFeatures_)) {
       goog.array.extend(
-          features, goog.object.getValues(this.nullGeometryFeatures_));
+          features, ol.object.getValues(this.nullGeometryFeatures_));
     }
   }
   goog.asserts.assert(features !== undefined,
@@ -749,7 +749,7 @@ ol.source.Vector.prototype.handleFeatureChange_ = function(event) {
  */
 ol.source.Vector.prototype.isEmpty = function() {
   return this.featuresRtree_.isEmpty() &&
-      goog.object.isEmpty(this.nullGeometryFeatures_);
+      ol.object.isEmpty(this.nullGeometryFeatures_);
 };
 
 

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -3,12 +3,12 @@ goog.provide('ol.source.WMTSRequestEncoding');
 
 goog.require('goog.array');
 goog.require('goog.asserts');
-goog.require('goog.object');
 goog.require('goog.uri.utils');
 goog.require('ol.TileUrlFunction');
 goog.require('ol.TileUrlFunctionType');
 goog.require('ol.array');
 goog.require('ol.extent');
+goog.require('ol.object');
 goog.require('ol.proj');
 goog.require('ol.source.TileImage');
 goog.require('ol.tilegrid.WMTS');
@@ -113,7 +113,7 @@ ol.source.WMTS = function(options) {
   };
 
   if (requestEncoding == ol.source.WMTSRequestEncoding.KVP) {
-    goog.object.extend(context, {
+    ol.object.extend(context, {
       'Service': 'WMTS',
       'Request': 'GetTile',
       'Version': this.version_,
@@ -155,7 +155,7 @@ ol.source.WMTS = function(options) {
               'TileCol': tileCoord[1],
               'TileRow': -tileCoord[2] - 1
             };
-            goog.object.extend(localContext, dimensions);
+            ol.object.extend(localContext, dimensions);
             var url = template;
             if (requestEncoding == ol.source.WMTSRequestEncoding.KVP) {
               url = goog.uri.utils.appendParamsFromMap(url, localContext);
@@ -292,7 +292,7 @@ ol.source.WMTS.prototype.resetDimensionsKey_ = function() {
  * @api
  */
 ol.source.WMTS.prototype.updateDimensions = function(dimensions) {
-  goog.object.extend(this.dimensions_, dimensions);
+  ol.object.extend(this.dimensions_, dimensions);
   this.resetDimensionsKey_();
   this.changed();
 };

--- a/src/ol/structs/lrucache.js
+++ b/src/ol/structs/lrucache.js
@@ -1,7 +1,7 @@
 goog.provide('ol.structs.LRUCache');
 
 goog.require('goog.asserts');
-goog.require('goog.object');
+goog.require('ol.object');
 
 
 
@@ -47,14 +47,14 @@ ol.structs.LRUCache = function() {
  */
 ol.structs.LRUCache.prototype.assertValid = function() {
   if (this.count_ === 0) {
-    goog.asserts.assert(goog.object.isEmpty(this.entries_),
+    goog.asserts.assert(ol.object.isEmpty(this.entries_),
         'entries must be an empty object (count = 0)');
     goog.asserts.assert(!this.oldest_,
         'oldest must be null (count = 0)');
     goog.asserts.assert(!this.newest_,
         'newest must be null (count = 0)');
   } else {
-    goog.asserts.assert(goog.object.getCount(this.entries_) == this.count_,
+    goog.asserts.assert(ol.object.getCount(this.entries_) == this.count_,
         'number of entries matches count');
     goog.asserts.assert(this.oldest_,
         'we have an oldest entry');

--- a/src/ol/structs/priorityqueue.js
+++ b/src/ol/structs/priorityqueue.js
@@ -1,7 +1,7 @@
 goog.provide('ol.structs.PriorityQueue');
 
 goog.require('goog.asserts');
-goog.require('goog.object');
+goog.require('ol.object');
 
 
 
@@ -89,7 +89,7 @@ ol.structs.PriorityQueue.prototype.assertValid = function() {
 ol.structs.PriorityQueue.prototype.clear = function() {
   this.elements_.length = 0;
   this.priorities_.length = 0;
-  goog.object.clear(this.queuedElements_);
+  ol.object.clear(this.queuedElements_);
 };
 
 

--- a/src/ol/structs/rbush.js
+++ b/src/ol/structs/rbush.js
@@ -1,9 +1,9 @@
 goog.provide('ol.structs.RBush');
 
 goog.require('goog.asserts');
-goog.require('goog.object');
 goog.require('ol.ext.rbush');
 goog.require('ol.extent');
+goog.require('ol.object');
 
 
 
@@ -236,7 +236,7 @@ ol.structs.RBush.prototype.forEach_ = function(values, callback, opt_this) {
  * @return {boolean} Is empty.
  */
 ol.structs.RBush.prototype.isEmpty = function() {
-  return goog.object.isEmpty(this.items_);
+  return ol.object.isEmpty(this.items_);
 };
 
 

--- a/src/ol/style/atlasmanager.js
+++ b/src/ol/style/atlasmanager.js
@@ -3,8 +3,8 @@ goog.provide('ol.style.AtlasManager');
 
 goog.require('goog.asserts');
 goog.require('goog.functions');
-goog.require('goog.object');
 goog.require('ol');
+goog.require('ol.object');
 
 
 /**
@@ -315,7 +315,7 @@ ol.style.Atlas = function(size, space) {
  */
 ol.style.Atlas.prototype.get = function(id) {
   return /** @type {?ol.style.AtlasInfo} */ (
-      goog.object.get(this.entries_, id, null));
+      ol.object.get(this.entries_, id, null));
 };
 
 

--- a/src/ol/tilegrid/tilegrid.js
+++ b/src/ol/tilegrid/tilegrid.js
@@ -2,7 +2,6 @@ goog.provide('ol.tilegrid.TileGrid');
 
 goog.require('goog.array');
 goog.require('goog.asserts');
-goog.require('goog.object');
 goog.require('ol');
 goog.require('ol.Coordinate');
 goog.require('ol.TileCoord');
@@ -11,6 +10,7 @@ goog.require('ol.array');
 goog.require('ol.extent');
 goog.require('ol.extent.Corner');
 goog.require('ol.math');
+goog.require('ol.object');
 goog.require('ol.proj');
 goog.require('ol.proj.METERS_PER_UNIT');
 goog.require('ol.proj.Projection');
@@ -553,7 +553,7 @@ ol.tilegrid.createForExtent =
  */
 ol.tilegrid.createXYZ = function(opt_options) {
   var options = /** @type {olx.tilegrid.TileGridOptions} */ ({});
-  goog.object.extend(options, opt_options !== undefined ?
+  ol.object.extend(options, opt_options !== undefined ?
       opt_options : /** @type {olx.tilegrid.XYZOptions} */ ({}));
   if (options.extent === undefined) {
     options.extent = ol.proj.get('EPSG:3857').getExtent();

--- a/src/ol/webgl/context.js
+++ b/src/ol/webgl/context.js
@@ -3,9 +3,9 @@ goog.provide('ol.webgl.Context');
 goog.require('goog.asserts');
 goog.require('goog.events');
 goog.require('goog.log');
-goog.require('goog.object');
 goog.require('ol');
 goog.require('ol.array');
+goog.require('ol.object');
 goog.require('ol.webgl.Buffer');
 goog.require('ol.webgl.WebGLContextEventType');
 
@@ -164,13 +164,13 @@ ol.webgl.Context.prototype.deleteBuffer = function(buf) {
 ol.webgl.Context.prototype.disposeInternal = function() {
   var gl = this.getGL();
   if (!gl.isContextLost()) {
-    goog.object.forEach(this.bufferCache_, function(bufferCacheEntry) {
+    ol.object.forEach(this.bufferCache_, function(bufferCacheEntry) {
       gl.deleteBuffer(bufferCacheEntry.buffer);
     });
-    goog.object.forEach(this.programCache_, function(program) {
+    ol.object.forEach(this.programCache_, function(program) {
       gl.deleteProgram(program);
     });
-    goog.object.forEach(this.shaderCache_, function(shader) {
+    ol.object.forEach(this.shaderCache_, function(shader) {
       gl.deleteShader(shader);
     });
     // delete objects for hit-detection
@@ -282,9 +282,9 @@ ol.webgl.Context.prototype.getProgram = function(
  * FIXME empy description for jsdoc
  */
 ol.webgl.Context.prototype.handleWebGLContextLost = function() {
-  goog.object.clear(this.bufferCache_);
-  goog.object.clear(this.shaderCache_);
-  goog.object.clear(this.programCache_);
+  ol.object.clear(this.bufferCache_);
+  ol.object.clear(this.shaderCache_);
+  ol.object.clear(this.programCache_);
   this.currentProgram_ = null;
   this.hitDetectionFramebuffer_ = null;
   this.hitDetectionTexture_ = null;

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -4,8 +4,8 @@ goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.dom.NodeType');
 goog.require('goog.dom.xml');
-goog.require('goog.object');
 goog.require('goog.userAgent');
+goog.require('ol.object');
 
 
 /**
@@ -455,7 +455,7 @@ ol.xml.makeObjectPropertyPusher =
               opt_property : node.localName;
           goog.asserts.assert(goog.isObject(object),
               'entity from stack was not an object');
-          var array = goog.object.setIfUndefined(object, property, []);
+          var array = ol.object.setIfUndefined(object, property, []);
           array.push(value);
         }
       });

--- a/test/spec/ol/feature.test.js
+++ b/test/spec/ol/feature.test.js
@@ -81,7 +81,7 @@ describe('ol.Feature', function() {
     it('is empty by default', function() {
       var feature = new ol.Feature();
       var properties = feature.getProperties();
-      expect(goog.object.isEmpty(properties)).to.be(true);
+      expect(ol.object.isEmpty(properties)).to.be(true);
     });
 
   });
@@ -463,7 +463,7 @@ describe('ol.Feature.createStyleFunction()', function() {
 
 
 goog.require('goog.events');
-goog.require('goog.object');
+goog.require('ol.object');
 goog.require('ol.Feature');
 goog.require('ol.geom.Point');
 goog.require('ol.style.Style');

--- a/test/spec/ol/layer/layergroup.test.js
+++ b/test/spec/ol/layer/layergroup.test.js
@@ -279,10 +279,10 @@ describe('ol.layer.Group', function() {
       var layerGroup = new ol.layer.Group({
         layers: layers
       });
-      expect(goog.object.getCount(layerGroup.listenerKeys_)).to.eql(0);
+      expect(ol.object.getCount(layerGroup.listenerKeys_)).to.eql(0);
       var layer = new ol.layer.Layer({});
       layers.push(layer);
-      expect(goog.object.getCount(layerGroup.listenerKeys_)).to.eql(1);
+      expect(ol.object.getCount(layerGroup.listenerKeys_)).to.eql(1);
 
       var listeners = layerGroup.listenerKeys_[goog.getUid(layer)];
       expect(listeners.length).to.eql(2);
@@ -291,7 +291,7 @@ describe('ol.layer.Group', function() {
 
       // remove the layer from the group
       layers.pop();
-      expect(goog.object.getCount(layerGroup.listenerKeys_)).to.eql(0);
+      expect(ol.object.getCount(layerGroup.listenerKeys_)).to.eql(0);
       expect(listeners[0].removed).to.eql(true);
       expect(listeners[1].removed).to.eql(true);
     });
@@ -364,9 +364,9 @@ describe('ol.layer.Group', function() {
       expect(layerStatesArray[0]).to.eql(layer1.getLayerState());
 
       // layer state should match except for layer reference
-      var layerState = goog.object.clone(layerStatesArray[0]);
+      var layerState = ol.object.clone(layerStatesArray[0]);
       delete layerState.layer;
-      var groupState = goog.object.clone(layerGroup.getLayerState());
+      var groupState = ol.object.clone(layerGroup.getLayerState());
       delete groupState.layer;
       expect(layerState).to.eql(groupState);
 
@@ -413,14 +413,14 @@ describe('ol.layer.Group', function() {
       var groupState, layerState;
 
       // layer state should match except for layer reference
-      layerState = goog.object.clone(layerStatesArray[0]);
+      layerState = ol.object.clone(layerStatesArray[0]);
       delete layerState.layer;
-      groupState = goog.object.clone(layerGroup.getLayerState());
+      groupState = ol.object.clone(layerGroup.getLayerState());
       delete groupState.layer;
       expect(layerState).to.eql(groupState);
 
       // layer state should be transformed (and we ignore layer reference)
-      layerState = goog.object.clone(layerStatesArray[1]);
+      layerState = ol.object.clone(layerStatesArray[1]);
       delete layerState.layer;
       expect(layerState).to.eql({
         opacity: 0.25,
@@ -493,11 +493,12 @@ goog.require('goog.array');
 goog.require('goog.dispose');
 goog.require('goog.events.EventType');
 goog.require('goog.events.Listener');
-goog.require('goog.object');
+goog.require('ol.object');
 goog.require('ol.ObjectEventType');
 goog.require('ol.extent');
 goog.require('ol.layer.Layer');
 goog.require('ol.layer.Group');
+goog.require('ol.object');
 goog.require('ol.renderer.Map');
 goog.require('ol.source.Source');
 goog.require('ol.source.State');

--- a/test/spec/ol/pointer/touchsource.test.js
+++ b/test/spec/ol/pointer/touchsource.test.js
@@ -1,6 +1,6 @@
 goog.provide('ol.test.pointer.TouchSource');
 
-goog.require('goog.object');
+goog.require('ol.object');
 
 describe('ol.pointer.TouchSource', function() {
   var handler;
@@ -48,7 +48,7 @@ describe('ol.pointer.TouchSource', function() {
       expect(pointerEvent2.clientX).to.be(30);
       expect(pointerEvent2.clientY).to.be(45);
 
-      expect(goog.object.getCount(handler.pointerMap)).to.be(2);
+      expect(ol.object.getCount(handler.pointerMap)).to.be(2);
     });
 
     it('creates the right pointer events', function() {
@@ -59,7 +59,7 @@ describe('ol.pointer.TouchSource', function() {
         {identifier: 3, clientX: 10, clientY: 11}
       ]);
       expect(eventSpy.calledOnce).to.be.ok();
-      expect(goog.object.getCount(handler.pointerMap)).to.be(1);
+      expect(ol.object.getCount(handler.pointerMap)).to.be(1);
 
       // second touch (first touch still down)
       simulateTouchEvent('touchstart', [
@@ -67,7 +67,7 @@ describe('ol.pointer.TouchSource', function() {
       ], [{identifier: 3}, {identifier: 4}]
       );
       expect(eventSpy.calledTwice).to.be.ok();
-      expect(goog.object.getCount(handler.pointerMap)).to.be(2);
+      expect(ol.object.getCount(handler.pointerMap)).to.be(2);
 
       // first touch moves
       var moveEventSpy = sinon.spy();
@@ -89,7 +89,7 @@ describe('ol.pointer.TouchSource', function() {
       ], [{identifier: 3}, {identifier: 4}]
       );
       expect(upEventSpy.calledTwice).to.be.ok();
-      expect(goog.object.getCount(handler.pointerMap)).to.be(0);
+      expect(ol.object.getCount(handler.pointerMap)).to.be(0);
     });
 
     it('handles flawed touches', function() {
@@ -100,7 +100,7 @@ describe('ol.pointer.TouchSource', function() {
         {identifier: 3, clientX: 10, clientY: 11}
       ]);
       expect(eventSpy.calledOnce).to.be.ok();
-      expect(goog.object.getCount(handler.pointerMap)).to.be(1);
+      expect(ol.object.getCount(handler.pointerMap)).to.be(1);
 
       // second touch, but the first touch has disappeared
       var cancelEventSpy = sinon.spy();
@@ -113,7 +113,7 @@ describe('ol.pointer.TouchSource', function() {
 
       // the first (broken) touch is canceled
       expect(cancelEventSpy.calledOnce).to.be.ok();
-      expect(goog.object.getCount(handler.pointerMap)).to.be(1);
+      expect(ol.object.getCount(handler.pointerMap)).to.be(1);
     });
   });
 

--- a/test/spec/ol/source/tilesource.test.js
+++ b/test/spec/ol/source/tilesource.test.js
@@ -253,7 +253,7 @@ describe('ol.test.source.TileMock', function() {
 
 });
 
-goog.require('goog.object');
+goog.require('ol.object');
 goog.require('ol.Tile');
 goog.require('ol.TileRange');
 goog.require('ol.TileState');


### PR DESCRIPTION
This PR removes the remaining use of `goog.object` in source and tests by moving the original implementation of the functions that are still used to `ol.object`. I did some minor refactoring to some of the functions, i.e I make use of `Object.keys` where possible.