### PR TITLE
Fix gaps between vector tiles on Firefox

### DIFF
--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -1993,10 +1993,14 @@ ol.render.canvas.ReplayGroup.prototype.replay = function(
       flatClipCoords, 0, 8, 2, transform, flatClipCoords);
   context.save();
   context.beginPath();
-  context.moveTo(flatClipCoords[0], flatClipCoords[1]);
-  context.lineTo(flatClipCoords[2], flatClipCoords[3]);
-  context.lineTo(flatClipCoords[4], flatClipCoords[5]);
-  context.lineTo(flatClipCoords[6], flatClipCoords[7]);
+  context.moveTo(
+      Math.floor(flatClipCoords[0]), Math.floor(flatClipCoords[1]));
+  context.lineTo(
+      Math.floor(flatClipCoords[2]), Math.ceil(flatClipCoords[3]));
+  context.lineTo(
+      Math.ceil(flatClipCoords[4]), Math.ceil(flatClipCoords[5]));
+  context.lineTo(
+      Math.ceil(flatClipCoords[6]), Math.floor(flatClipCoords[7]));
   context.closePath();
   context.clip();
 


### PR DESCRIPTION
I was looking at this [nice demo](http://stvno.github.io/page/cbsexplorerol/) by @stvno and noticed that the tile borders were clearly visible on Firefox (or resizing the browser window made them appear).

The problem was that the coordinates used to clip the tiles were floating point numbers. Apparently this is no problem on Chrome but Firefox requires rounded integer values. My first attempt was to use `Math.round` for all coordinates of the clipping rectangle, but the gaps still showed up. So, now I am using `Math.floor` for the min. coordinates and `Math.ceil` for the max. coordinates.

@tonio Could you please test if this also fixes the problem on your system?

Closes #4329