### PR TITLE
Adding a check just in case the projection is not defined/supported

### DIFF
--- a/src/ol/format/gml/gml2format.js
+++ b/src/ol/format/gml/gml2format.js
@@ -64,7 +64,9 @@ ol.format.GML2.prototype.readFlatCoordinates_ = function(node, objectStack) {
   var axisOrientation = 'enu';
   if (containerSrs) {
     var proj = ol.proj.get(containerSrs);
-    axisOrientation = proj.getAxisOrientation();
+    if (proj) {
+      axisOrientation = proj.getAxisOrientation();
+    }
   }
   var coords = s.split(/[\s,]+/);
   // The "dimension" attribute is from the GML 3.0.1 spec.


### PR DESCRIPTION
Adding a check just in case the projection is not defined/supported on current app. It will just ignore it, as if there was no containerSrs defined.

On the current implementation, an exception is thrown, making it difficult, for example, to get a featureinfo request right.