### PR TITLE
Support for multi-line labels (improved)

### DIFF
--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -398,12 +398,34 @@ ol.render.canvas.Replay.prototype.replay_ = function(
                 goog.vec.Mat4.getElement(localTransform, 0, 3),
                 goog.vec.Mat4.getElement(localTransform, 1, 3));
           }
-          if (stroke) {
-            context.strokeText(text, x, y);
+
+          // Support multiple lines separated by \n
+          var lines = text.split('\n');
+          var numLines = lines.length;
+          var fontSize, lineY;
+          if (numLines > 1) {
+            // Estimate line height using width of capital M, and add padding
+            fontSize = Math.round(context.measureText('M').width * 1.5);
+            lineY = y - (((numLines - 1) / 2) * fontSize);
+          } else {
+            // No need to calculate line height/offset for a single line
+            fontSize = 0;
+            lineY = y;
           }
-          if (fill) {
-            context.fillText(text, x, y);
+
+          for (var lineIndex = 0; lineIndex < numLines; lineIndex++) {
+            var line = lines[lineIndex];
+            if (stroke) {
+              context.strokeText(line, x, lineY);
+            }
+            if (fill) {
+              context.fillText(line, x, lineY);
+            }
+
+            // Move next line down by fontSize px
+            lineY = lineY + fontSize;
           }
+
           if (scale != 1 || rotation !== 0) {
             context.setTransform(1, 0, 0, 1, 0, 0);
           }


### PR DESCRIPTION
This is an improved version of https://github.com/openlayers/ol3/pull/3797, which was in turn a cleanup of https://github.com/openlayers/ol3/pull/3538. Improvements are as follows:

* Use context.measureText instead of parseFloat to estimate text height
* Skip text height estimation if there are no newlines in the text
* Reset context transform after drawing the text (not sure if this is necessary, but maintains consistency with other canvas instructions)

Using measureText solves several of the issues with https://github.com/openlayers/ol3/pull/3797:

* Font sizes no longer have to be in px to function correctly
* Padding between lines is a fraction of the line height instead of an arbitrary 5px
* Bold font definitions work. This was the reason for the examples breaking in the previous PR; parseFloat can't get the font size value from "bold 12px Arial".