### PR TITLE
Fix imagestyle docs

### DIFF
--- a/src/ol/style/imagestyle.js
+++ b/src/ol/style/imagestyle.js
@@ -27,7 +27,8 @@ ol.style.ImageOptions;
 /**
  * @classdesc
  * A base class used for creating subclasses and not instantiated in
- * apps. Base class for {@link ol.style.Icon} and {@link ol.style.Circle}.
+ * apps. Base class for {@link ol.style.Icon}, {@link ol.style.Circle} and
+ * {@link ol.style.RegularShape}.
  *
  * @constructor
  * @param {ol.style.ImageOptions} options Options.


### PR DESCRIPTION
The constructor docs of `ol.style.Image` are outdated. This pull request fixes that.