### PR TITLE
Make render tests work on more devices

### DIFF
--- a/test_rendering/slimerjs-profile/prefs.js
+++ b/test_rendering/slimerjs-profile/prefs.js
@@ -1,3 +1,4 @@
 user_pref("webgl.force-enabled", true);
 user_pref("webgl.disabled", false);
 user_pref("webgl.msaa-force", true);
+user_pref("layout.css.devPixelsPerPx", "1.0");

--- a/test_rendering/spec/ol/reproj/tile.test.js
+++ b/test_rendering/spec/ol/reproj/tile.test.js
@@ -18,8 +18,7 @@ describe('ol.rendering.reproj.Tile', function() {
       tile.listen('change', function(e) {
         if (tile.getState() == ol.TileState.LOADED) {
           expect(tilesRequested).to.be(expectedRequests);
-          resembleCanvas(tile.getImage(), expectedUrl,
-              IMAGE_TOLERANCE, done);
+          resembleCanvas(tile.getImage(), expectedUrl, 7.5, done);
         }
       });
       tile.load();


### PR DESCRIPTION
By setting a device pixel ratio of 1.0 and increasing the tolerance for raster reprojection tests, the render tests now also run from the console on OSX devices with retina display.