### PR TITLE
Mark olx.source.WMTSOptions#dimensions as not null

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -5537,7 +5537,7 @@ olx.source.VectorOptions.prototype.wrapX;
  *     version: (string|undefined),
  *     format: (string|undefined),
  *     matrixSet: string,
- *     dimensions: (Object|undefined),
+ *     dimensions: (!Object|undefined),
  *     url: (string|undefined),
  *     maxZoom: (number|undefined),
  *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
@@ -5676,7 +5676,7 @@ olx.source.WMTSOptions.prototype.matrixSet;
 /**
  * Additional "dimensions" for tile requests.  This is an object with properties
  * named like the advertised WMTS dimensions.
- * @type {Object|undefined}
+ * @type {!Object|undefined}
  * @api stable
  */
 olx.source.WMTSOptions.prototype.dimensions;

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -53,7 +53,7 @@ ol.source.WMTS = function(options) {
 
   /**
    * @private
-   * @type {Object}
+   * @type {!Object}
    */
   this.dimensions_ = options.dimensions !== undefined ? options.dimensions : {};
 
@@ -197,7 +197,7 @@ goog.inherits(ol.source.WMTS, ol.source.TileImage);
  * Get the dimensions, i.e. those passed to the constructor through the
  * "dimensions" option, and possibly updated using the updateDimensions
  * method.
- * @return {Object} Dimensions.
+ * @return {!Object} Dimensions.
  * @api
  */
 ol.source.WMTS.prototype.getDimensions = function() {


### PR DESCRIPTION
FYI: in a project I have:
```js
var dimensions = source.getDimensions();
var dimensionKeys = Object.keys(dimensions);
```
But the compiler complains that the Object may be null:
```
ERR! compile: ERROR - actual parameter 1 of Object.keys does not match formal parameter
ERR! compile found   : (Object|null)
ERR! compile required: Object
ERR! compile   var dimensionKeys = Object.keys(dimensions);
ERR! compile                                   ^
ERR! compile 
ERR! compile 
ERR! compile 1 error(s), 0 warning(s), 
ERR! compile 97.4% typed
ERR! compile 
ERR! compile
```