### PR TITLE
Register the change callback when the tile is enqueued

### DIFF
--- a/src/ol/structs/priorityqueue.js
+++ b/src/ol/structs/priorityqueue.js
@@ -122,6 +122,7 @@ ol.structs.PriorityQueue.prototype.dequeue = function() {
 /**
  * Enqueue an element. O(log N).
  * @param {T} element Element.
+ * @return {boolean} The element was added to the queue.
  */
 ol.structs.PriorityQueue.prototype.enqueue = function(element) {
   goog.asserts.assert(!(this.keyFunction_(element) in this.queuedElements_),
@@ -132,7 +133,9 @@ ol.structs.PriorityQueue.prototype.enqueue = function(element) {
     this.priorities_.push(priority);
     this.queuedElements_[this.keyFunction_(element)] = true;
     this.siftDown_(0, this.elements_.length - 1);
+    return true;
   }
+  return false;
 };
 
 

--- a/test/spec/ol/structs/priorityqueue.test.js
+++ b/test/spec/ol/structs/priorityqueue.test.js
@@ -28,12 +28,23 @@ describe('ol.structs.PriorityQueue', function() {
     });
 
     it('enqueue adds an element', function() {
-      pq.enqueue(0);
+      var added = pq.enqueue(0);
       expect(function() {
         pq.assertValid();
       }).not.to.throwException();
+      expect(added).to.be(true);
       expect(pq.elements_).to.eql([0]);
       expect(pq.priorities_).to.eql([0]);
+    });
+
+    it('do not enqueue element with DROP priority', function() {
+      var added = pq.enqueue(Infinity);
+      expect(function() {
+        pq.assertValid();
+      }).not.to.throwException();
+      expect(added).to.be(false);
+      expect(pq.elements_).to.eql([]);
+      expect(pq.priorities_).to.eql([]);
     });
 
     it('maintains the pq property while elements are enqueued', function() {


### PR DESCRIPTION
See #4452 

The `change` callback is registered as soon as the tile is queued; this allows to a tile to be queued in more than one queue and be notified when the tile loads.

A new Object has been added to hold the ids of the loading tiles; this is needed to only decrements the counter if the queue instance has loaded the tile.