### PR TITLE
Use a subpixel overlap for render regions

### DIFF
--- a/examples/mapbox-vector-tiles-advanced.js
+++ b/examples/mapbox-vector-tiles-advanced.js
@@ -45,6 +45,7 @@ var map = new ol.Map({
     new ol.layer.VectorTile({
       preload: Infinity,
       source: new ol.source.VectorTile({
+        opaque: true,
         attributions: [new ol.Attribution({
           html: '© <a href="https://www.mapbox.com/map-feedback/">Mapbox</a> ' +
               '© <a href="http://www.openstreetmap.org/copyright">' +

--- a/examples/mapbox-vector-tiles.js
+++ b/examples/mapbox-vector-tiles.js
@@ -17,6 +17,7 @@ var map = new ol.Map({
   layers: [
     new ol.layer.VectorTile({
       source: new ol.source.VectorTile({
+        opaque: true,
         attributions: [new ol.Attribution({
           html: '© <a href="https://www.mapbox.com/map-feedback/">Mapbox</a> ' +
               '© <a href="http://www.openstreetmap.org/copyright">' +

--- a/examples/osm-vector-tiles.js
+++ b/examples/osm-vector-tiles.js
@@ -35,6 +35,7 @@ var map = new ol.Map({
   layers: [
     new ol.layer.VectorTile({
       source: new ol.source.VectorTile({
+        opaque: true,
         format: format,
         tileGrid: tileGrid,
         url: 'http://{a-c}.tile.openstreetmap.us/' +
@@ -48,6 +49,7 @@ var map = new ol.Map({
     }),
     new ol.layer.VectorTile({
       source: new ol.source.VectorTile({
+        opaque: true,
         format: format,
         tileGrid: tileGrid,
         url: 'http://{a-c}.tile.openstreetmap.us/' +
@@ -82,6 +84,7 @@ var map = new ol.Map({
     }),
     new ol.layer.VectorTile({
       source: new ol.source.VectorTile({
+        opaque: true,
         format: format,
         tileGrid: tileGrid,
         url: 'http://{a-c}.tile.openstreetmap.us/' +
@@ -93,6 +96,7 @@ var map = new ol.Map({
     }),
     new ol.layer.VectorTile({
       source: new ol.source.VectorTile({
+        opaque: true,
         format: format,
         tileGrid: tileGrid,
         url: 'http://{a-c}.tile.openstreetmap.us/' +

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -4221,7 +4221,11 @@ olx.source.VectorTileOptions.prototype.logo;
 
 
 /**
- * Whether the layer is opaque.
+ * Whether the layer is opaque. Set to true when the layer is at the bottom of
+ * the layer stack, and both the layer and all of its feature styles have an
+ * opacity of 1 or no opacity set. This setting avoids potential gaps at tile
+ * borders in
+ * the rendered map. Default is false.
  * @type {boolean|undefined}
  * @api
  */

--- a/src/ol/renderer/canvas/canvasvectortilelayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectortilelayerrenderer.js
@@ -178,16 +178,18 @@ ol.renderer.canvas.VectorTileLayer.prototype.createReplayGroup = function(tile,
       'Source is an ol.source.VectorTile');
   var tileGrid = source.getTileGrid();
   var tileCoord = tile.getTileCoord();
+  var buffer = source.getOpaque() ? 0.25 * pixelRatio : 0;
+  var resolution = tileGrid.getResolution(tileCoord[0]);
   var pixelSpace = tile.getProjection().getUnits() == ol.proj.Units.TILE_PIXELS;
   var extent;
   if (pixelSpace) {
     var tilePixelSize = source.getTilePixelSize(tileCoord[0], pixelRatio,
         tile.getProjection());
-    extent = [0, 0, tilePixelSize[0], tilePixelSize[1]];
+    extent = [-0.25, -0.25, tilePixelSize[0] + 0.25, tilePixelSize[1] + 0.25];
   } else {
-    extent = tileGrid.getTileCoordExtent(tileCoord);
+    extent = ol.extent.buffer(tileGrid.getTileCoordExtent(tileCoord),
+        buffer * resolution);
   }
-  var resolution = tileGrid.getResolution(tileCoord[0]);
   var tileResolution = pixelSpace ? source.getTilePixelRatio() : resolution;
   replayState.dirty = false;
   var replayGroup = new ol.render.canvas.ReplayGroup(0, extent,


### PR DESCRIPTION
When rendering vector tiles, the clip lines may cause small gaps between neighbouring tiles. By introducing a 0.5 pixel overlap (0.25 pixels for each tile), this effect can be avoided.

This is an alternative to #4499, which also works for transparent layers/geometries.

Fixes #4329.