### PR TITLE
Improve vector tile related docs

### DIFF
--- a/config/jsdoc/api/index.md
+++ b/config/jsdoc/api/index.md
@@ -11,6 +11,7 @@
 [ol.layer.Tile](ol.layer.Tile.html)<br>
 [ol.layer.Image](ol.layer.Image.html)<br>
 [ol.layer.Vector](ol.layer.Vector.html)</td>
+[ol.layer.VectorTile](ol.layer.VectorTile.html)</td>
 </tr><tr>
 <th>Controls</th><th>Interactions</th><th>Sources and formats</th>
 </tr><tr>
@@ -27,6 +28,7 @@ Interactions for [vector features](ol.Feature.html)
 <td>[Tile sources](ol.source.Tile.html) for [ol.layer.Tile](ol.layer.Tile.html)
 <br>[Image sources](ol.source.Image.html) for [ol.layer.Image](ol.layer.Image.html)
 <br>[Vector sources](ol.source.Vector.html) for [ol.layer.Vector](ol.layer.Vector.html)
+<br>[Vector tile sources](ol.source.VectorTile.html) for [ol.layer.VectorTile](ol.layer.VectorTile.html)
 <br>[Formats](ol.format.Feature.html) for reading/writing vector data
 <br>[ol.format.WMSCapabilities](ol.format.WMSCapabilities.html)</td></tr>
 <tr><th>Projections</th><th>Observable objects</th><th>Other components</th></tr>

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -3688,9 +3688,11 @@ olx.layer.VectorTileOptions;
 
 
 /**
- * The buffer around the viewport extent used by the renderer when getting
- * features from the vector source for the rendering or hit-detection.
- * Recommended value: the size of the largest symbol, line width or label.
+ * The buffer around the tile extent used by the renderer when getting features
+ * from the vector tile for the rendering or hit-detection.
+ * Recommended value: Vector tiles are usually generated with a buffer, so this
+ * value should match the largest possible buffer of the used tiles. It should
+ * be at least the size of the largest point symbol or line width.
  * Default is 100 pixels.
  * @type {number|undefined}
  * @api


### PR DESCRIPTION
The documentation of the `renderBuffer` option for `ol.layer.VectorTile` was misleading, and vector tile related information was missing in the API doc landing page.

Fixes #4538.