### PR TITLE
Update vector label example

### DIFF
--- a/examples/vector-labels.css
+++ b/examples/vector-labels.css
@@ -35,3 +35,11 @@ h2 {
 .edit-form-elem select {
   width: 130px;
 }
+
+.edit-form br {
+  clear: left;
+}
+
+.clearall {
+  clear: both;
+}

--- a/examples/vector-labels.html
+++ b/examples/vector-labels.html
@@ -3,7 +3,10 @@ layout: example.html
 title: Vector Labels
 shortdesc: Example of GeoJSON features with labels.
 docs: >
-  **Note:** The 'Text/Wrap' option is currently not working properly. This is because ol3 uses Canvas's strokeText and fillText functions that do not support text wrapping.
+  This example showcases a number of options that can be set on text styles.
+  When "Text/Wrap" is chosen (for example for the line features), the label is
+  wrapped by inserting the character `\n`, which will create a multi-line
+  label.
 tags: "geojson, vector, openstreetmap, label"
 ---
 <div id="map" class="map"></div>
@@ -274,3 +277,4 @@ tags: "geojson, vector, openstreetmap, label"
     <input type="text" value="3" id="polygons-outline-width" />
   </div>
 </div>
+<div class="clearall"></div>


### PR DESCRIPTION
Mention that multi-line labels are now supported and fix the layout.

![ol3-example](https://cloud.githubusercontent.com/assets/266474/11740040/287173f8-9ff0-11e5-85e3-0e87e7482917.png)
