### PR TITLE
Make sure compiled code calls ol.VectorTile#setProjection

### DIFF
--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -108,7 +108,7 @@ ol.featureloader.loadFeaturesXhr = function(url, format, success, failure) {
                     var dataUnits = format.readProjection(source).getUnits();
                     if (dataUnits === ol.proj.Units.TILE_PIXELS) {
                       projection = new ol.proj.Projection({
-                        code: projection.getCode(),
+                        code: this.getProjection().getCode(),
                         units: dataUnits
                       });
                       this.setProjection(projection);


### PR DESCRIPTION
This pull request fixes an issue which can be observed when looking at http://openlayers.org/en/master/examples/mapbox-vector-tiles.html: the tiles are reprojected, because the compiler strips out the code that sets the tile projection with the correct `tile-pixels` units in `ol.featureloader.xhr` (for whatever reason).