### PR TITLE
Correct typedef of selectinteraction options obj

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -2995,7 +2995,7 @@ olx.interaction.SelectOptions.prototype.multi;
  * not set the interaction will create a collection. In any case the collection
  * used by the interaction is returned by
  * {@link ol.interaction.Select#getFeatures}.
- * @type {ol.Collection.<ol.Feature>}
+ * @type {ol.Collection.<ol.Feature>|undefined}
  * @api
  */
 olx.interaction.SelectOptions.prototype.features;


### PR DESCRIPTION
The key `features` of the constructor options that can be passed to
`ol.interaction.Select` can also be `undefined`.

Rendered API docs before: ![before](https://cloud.githubusercontent.com/assets/227934/11841451/acc38e3c-a3fd-11e5-996e-f92df4423baf.png)

… and after: ![after](https://cloud.githubusercontent.com/assets/227934/11841463/bcc7f8ea-a3fd-11e5-83ab-90d13e61cb43.png)
 
Please review.