### PR TITLE
Do not render in handleDownEvent

### DIFF
--- a/src/ol/interaction/dragpaninteraction.js
+++ b/src/ol/interaction/dragpaninteraction.js
@@ -88,7 +88,6 @@ ol.interaction.DragPan.handleDragEvent_ = function(mapBrowserEvent) {
     ol.coordinate.rotate(center, viewState.rotation);
     ol.coordinate.add(center, viewState.center);
     center = view.constrainCenter(center);
-    map.render();
     view.setCenter(center);
   }
   this.lastCentroid = centroid;
@@ -121,7 +120,6 @@ ol.interaction.DragPan.handleUpEvent_ = function(mapBrowserEvent) {
       view.setCenter(dest);
     }
     view.setHint(ol.ViewHint.INTERACTING, -1);
-    map.render();
     return false;
   } else {
     this.lastCentroid = null;
@@ -144,7 +142,6 @@ ol.interaction.DragPan.handleDownEvent_ = function(mapBrowserEvent) {
     if (!this.handlingDownUpSequence) {
       view.setHint(ol.ViewHint.INTERACTING, 1);
     }
-    map.render();
     if (this.kineticPreRenderFn_ &&
         map.removePreRenderFunction(this.kineticPreRenderFn_)) {
       view.setCenter(mapBrowserEvent.frameState.viewState.center);

--- a/src/ol/interaction/dragrotateandzoominteraction.js
+++ b/src/ol/interaction/dragrotateandzoominteraction.js
@@ -89,7 +89,6 @@ ol.interaction.DragRotateAndZoom.handleDragEvent_ = function(mapBrowserEvent) {
   var theta = Math.atan2(delta.y, delta.x);
   var magnitude = delta.magnitude();
   var view = map.getView();
-  map.render();
   if (this.lastAngle_ !== undefined) {
     var angleDelta = theta - this.lastAngle_;
     ol.interaction.Interaction.rotateWithoutConstraints(

--- a/src/ol/interaction/dragrotateinteraction.js
+++ b/src/ol/interaction/dragrotateinteraction.js
@@ -73,7 +73,6 @@ ol.interaction.DragRotate.handleDragEvent_ = function(mapBrowserEvent) {
     var delta = theta - this.lastAngle_;
     var view = map.getView();
     var rotation = view.getRotation();
-    map.render();
     ol.interaction.Interaction.rotateWithoutConstraints(
         map, view, rotation - delta);
   }
@@ -117,7 +116,6 @@ ol.interaction.DragRotate.handleDownEvent_ = function(mapBrowserEvent) {
   if (browserEvent.isMouseActionButton() && this.condition_(mapBrowserEvent)) {
     var map = mapBrowserEvent.map;
     map.getView().setHint(ol.ViewHint.INTERACTING, 1);
-    map.render();
     this.lastAngle_ = undefined;
     return true;
   } else {

--- a/src/ol/interaction/keyboardzoominteraction.js
+++ b/src/ol/interaction/keyboardzoominteraction.js
@@ -75,7 +75,6 @@ ol.interaction.KeyboardZoom.handleEvent = function(mapBrowserEvent) {
         (charCode == '+'.charCodeAt(0) || charCode == '-'.charCodeAt(0))) {
       var map = mapBrowserEvent.map;
       var delta = (charCode == '+'.charCodeAt(0)) ? this.delta_ : -this.delta_;
-      map.render();
       var view = map.getView();
       goog.asserts.assert(view, 'map must have view');
       ol.interaction.Interaction.zoomByDelta(

--- a/src/ol/interaction/mousewheelzoominteraction.js
+++ b/src/ol/interaction/mousewheelzoominteraction.js
@@ -119,7 +119,6 @@ ol.interaction.MouseWheelZoom.prototype.doZoom_ = function(map) {
   var view = map.getView();
   goog.asserts.assert(view, 'map must have view');
 
-  map.render();
   ol.interaction.Interaction.zoomByDelta(map, view, -delta, this.lastAnchor_,
       this.duration_);
 

--- a/src/ol/interaction/pinchrotateinteraction.js
+++ b/src/ol/interaction/pinchrotateinteraction.js
@@ -116,7 +116,6 @@ ol.interaction.PinchRotate.handleDragEvent_ = function(mapBrowserEvent) {
   if (this.rotating_) {
     var view = map.getView();
     var rotation = view.getRotation();
-    map.render();
     ol.interaction.Interaction.rotateWithoutConstraints(map, view,
         rotation + rotationDelta, this.anchor_);
   }
@@ -162,7 +161,6 @@ ol.interaction.PinchRotate.handleDownEvent_ = function(mapBrowserEvent) {
     if (!this.handlingDownUpSequence) {
       map.getView().setHint(ol.ViewHint.INTERACTING, 1);
     }
-    map.render();
     return true;
   } else {
     return false;

--- a/src/ol/interaction/pinchzoominteraction.js
+++ b/src/ol/interaction/pinchzoominteraction.js
@@ -98,7 +98,6 @@ ol.interaction.PinchZoom.handleDragEvent_ = function(mapBrowserEvent) {
   this.anchor_ = map.getCoordinateFromPixel(centroid);
 
   // scale, bypass the resolution constraint
-  map.render();
   ol.interaction.Interaction.zoomWithoutConstraints(
       map, view, resolution * scaleDelta, this.anchor_);
 
@@ -145,7 +144,6 @@ ol.interaction.PinchZoom.handleDownEvent_ = function(mapBrowserEvent) {
     if (!this.handlingDownUpSequence) {
       map.getView().setHint(ol.ViewHint.INTERACTING, 1);
     }
-    map.render();
     return true;
   } else {
     return false;


### PR DESCRIPTION
Does anybody know why we call `map.render()` in `handleDownEvent_` in our interactions? To me, this does not make much sense, because nothing has happened yet at this point, so rendering should be pretty useless. Any other opinions? Or am I missing something? If not, we might consider merging this.