### PR TITLE
Performance management when rendering vector tiles

### DIFF
--- a/src/ol/ol.js
+++ b/src/ol/ol.js
@@ -223,6 +223,16 @@ ol.SIMPLIFY_TOLERANCE = 0.5;
 
 
 /**
+ * @define {number} Maximum time in millsieconds spent for accurate rendering of
+ * a vector tile layer during interactions and animations. When exceeded,
+ * existing tiles will be scaled / rotated to fit the current view. When
+ * `updateWhileAnimating` or `updateWhileInteracting` is set to `true` on the
+ * layer, accurate rendering will always be used. Default is `50` milliseconds.
+ */
+ol.VECTOR_TILE_MAX_RENDER_TIME = 50;
+
+
+/**
  * @define {number} Texture cache high water mark.
  */
 ol.WEBGL_TEXTURE_CACHE_HIGH_WATER_MARK = 1024;

--- a/src/ol/vectortile.js
+++ b/src/ol/vectortile.js
@@ -13,7 +13,10 @@ goog.require('ol.proj.Projection');
  *     dirty: boolean,
  *     renderedRenderOrder: (null|function(ol.Feature, ol.Feature):number),
  *     renderedRevision: number,
- *     replayGroup: ol.render.IReplayGroup}}
+ *     renderTime: number,
+ *     replayGroup: ol.render.IReplayGroup,
+ *     resolution: number,
+ *     rotation: number}}
  */
 ol.TileReplayState;
 
@@ -72,7 +75,10 @@ ol.VectorTile =
     dirty: false,
     renderedRenderOrder: null,
     renderedRevision: -1,
-    replayGroup: null
+    renderTime: NaN,
+    replayGroup: null,
+    resolution: NaN,
+    rotation: NaN
   };
 
   /**


### PR DESCRIPTION
To improve the user experience when zooming and rotating vector tile layers, this pull request suggests the introduction of a "fast lane" for rendering vector tiles that take longer than a certain threshold to render. When the fast lane is entered, existing pre-rendered tiles will be scaled to match the current view, without replaying the replay group.

When the layer is configured with `updateWhileAnimating` or `updateWhileInteracting`, the fast lane will be avoided. The threshold for the maximum rendering is defined in the new compiler define `ol.MAX_VECTOR_TILE_RENDER_TIME`.