### PR TITLE
Fix for TileQueue gradually choking up when using raster reprojection

### DIFF
--- a/src/ol/reproj/tile.js
+++ b/src/ol/reproj/tile.js
@@ -322,7 +322,7 @@ ol.reproj.Tile.prototype.load = function() {
     });
 
     if (leftToLoad === 0) {
-      this.reproject_();
+      goog.global.setTimeout(goog.bind(this.reproject_, this), 0);
     }
   }
 };

--- a/src/ol/tilequeue.js
+++ b/src/ol/tilequeue.js
@@ -119,10 +119,10 @@ ol.TileQueue.prototype.loadMoreTiles = function(maxTotalLoading, maxNewLoads) {
          this.getCount() > 0) {
     tile = /** @type {ol.Tile} */ (this.dequeue()[0]);
     if (tile.getState() === ol.TileState.IDLE) {
-      tile.load();
       this.tilesLoadingKeys_[tile.getKey()] = true;
       ++this.tilesLoading_;
       ++newLoads;
+      tile.load();
     }
   }
 };


### PR DESCRIPTION
In v3.12.1 release, the tile queue can occasionally get "full" (too many tiles are registered as currently loading) and no more tiles are loaded.
See http://openlayers.org/en/v3.12.1/examples/reprojection-wgs84.html (try zooming and panning the map for a while, until the loading stucks and no more tiles are loaded and reprojected).

This took me a while to notice and track down, but it is related to the changes introduced in https://github.com/openlayers/ol3/pull/4536.

When all the source tiles for the reprojection are already loaded, the reprojection (and state change) happens *synchronously* in `ol.reproj.Tile#load`. The tile is registered to `ol.TileQueue#tilesLoadingKeys_` *after* this call, but it is never removed since the `change` event is fired from inside the `load` method.

The fix for this is fairly straightforward.
Also, if anyone thinks it's a good idea, I can modify https://github.com/openlayers/ol3/blob/v3.12.1/src/ol/reproj/tile.js#L325 so that the `ol.reproj.Tile#load` is always async (`setTimeout(..., 0)` ?), but I don't think it's necessary.

