### PR TITLE
Pass 'opaque' option on to superclass

### DIFF
--- a/src/ol/source/xyzsource.js
+++ b/src/ol/source/xyzsource.js
@@ -41,6 +41,7 @@ ol.source.XYZ = function(options) {
     attributions: options.attributions,
     crossOrigin: options.crossOrigin,
     logo: options.logo,
+    opaque: options.opaque,
     projection: projection,
     reprojectionErrorThreshold: options.reprojectionErrorThreshold,
     tileGrid: tileGrid,


### PR DESCRIPTION
The MapQuest sources do not benefit from the optimisations that are hinted by the `opaque` option. This pull request fixes that problem.