### PR TITLE
Fix type in vector source

### DIFF
--- a/src/ol/source/vectorsource.js
+++ b/src/ol/source/vectorsource.js
@@ -157,7 +157,11 @@ ol.source.Vector = function(opt_options) {
    */
   this.featuresCollection_ = null;
 
-  var collection, features;
+  /**
+   * @type {!ol.Collection.<ol.Feature>}
+   */
+  var collection;
+  var features;
   if (options.features instanceof ol.Collection) {
     collection = options.features;
     features = collection.getArray();


### PR DESCRIPTION
The closure compiler requires the type of the collection to be declared.
Otherwise this compilation error occurs:

```
ERR! compile
node_modules/openlayers/src/ol/source/vectorsource.js:174:
ERROR - actual parameter 1 of
ol.source.Vector.prototype.bindFeaturesCollection_ does not match formal
parameter
ERR! compile found   : (ol.Collection|undefined)
ERR! compile required: ol.Collection<(null|ol.Feature)>
ERR! compile     this.bindFeaturesCollection_(collection)
```