### PR TITLE
Set oli.source.VectorEvent#feature to ol.Feature|undefined

### DIFF
--- a/externs/oli.js
+++ b/externs/oli.js
@@ -328,6 +328,6 @@ oli.source.VectorEvent = function() {};
 
 
 /**
- * @type {ol.Feature}
+ * @type {ol.Feature|undefined}
  */
 oli.source.VectorEvent.prototype.feature;


### PR DESCRIPTION
This commit remove incoherency between the class and the interface.

See https://github.com/openlayers/ol3/blob/master/src/ol/source/vectorsource.js#L865