### PR TITLE
Add option to load TileJSON via XHR

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -5179,6 +5179,7 @@ olx.source.TileArcGISRestOptions.prototype.urls;
  *     reprojectionErrorThreshold: (number|undefined),
  *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
  *     url: string,
+ *     useXhr: (boolean|undefined),
  *     wrapX: (boolean|undefined)}}
  * @api
  */
@@ -5230,6 +5231,14 @@ olx.source.TileJSONOptions.prototype.tileLoadFunction;
  * @api stable
  */
 olx.source.TileJSONOptions.prototype.url;
+
+
+/**
+ * Use XmlHttpRequest to load the TileJSON. Default is `false`.
+ * @type {boolean|undefined}
+ * @api
+ */
+olx.source.TileJSONOptions.prototype.useXhr;
 
 
 /**

--- a/src/ol/source/tilejsonsource.js
+++ b/src/ol/source/tilejsonsource.js
@@ -9,6 +9,7 @@ goog.provide('ol.tilejson');
 
 goog.require('goog.asserts');
 goog.require('goog.net.Jsonp');
+goog.require('goog.net.XhrIo');
 goog.require('ol.Attribution');
 goog.require('ol.TileRange');
 goog.require('ol.TileUrlFunction');
@@ -40,9 +41,21 @@ ol.source.TileJSON = function(options) {
     wrapX: options.wrapX !== undefined ? options.wrapX : true
   });
 
-  var request = new goog.net.Jsonp(options.url);
-  request.send(undefined, goog.bind(this.handleTileJSONResponse, this),
-      goog.bind(this.handleTileJSONError, this));
+  if (options.useXhr) {
+    goog.net.XhrIo.send(options.url, goog.bind(function(e) {
+      var xhr = /** @type {goog.net.XhrIo} */(e.target);
+      if (xhr.isSuccess()) {
+        var response = /** @type {TileJSON} */(xhr.getResponseJson());
+        this.handleTileJSONResponse(response);
+      } else {
+        this.handleTileJSONError();
+      }
+    }, this));
+  } else {
+    var request = new goog.net.Jsonp(options.url);
+    request.send(undefined, goog.bind(this.handleTileJSONResponse, this),
+        goog.bind(this.handleTileJSONError, this));
+  }
 
 };
 goog.inherits(ol.source.TileJSON, ol.source.TileImage);


### PR DESCRIPTION
Some TileJSON sources (including Mapbox v4) do not allow to use JSONP (with `?callback=...`) to load the TileJSON.

This PR adds option to specify that XmlHttpRequest should be used instead.