### PR TITLE
Use XHR by default to load TileJSON in ol.source.TileJSON

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -12,6 +12,18 @@ import proj4 from 'proj4';
 ol.proj.setProj4(proj4);
 ```
 
+#### `ol.source.TileJSON` changes
+
+The `ol.source.TileJSON` now uses `XmlHttpRequest` to load the TileJSON instead of JSONP with callback.
+When using server without proper CORS support, `jsonp: true` option can be passed to the constructor to get the same behavior as before:
+```js
+new ol.source.TileJSON({
+  url: 'http://serverwithoutcors.com/tilejson.json',
+  jsonp: true
+})
+```
+Also for Mapbox v3, make sure you use urls ending with `.json` (which are able to handle both `XmlHttpRequest` and JSONP) instead of `.jsonp`.
+
 ### v3.12.0
 
 #### `ol.Map#forEachFeatureAtPixel` changes

--- a/examples/custom-interactions.js
+++ b/examples/custom-interactions.js
@@ -158,7 +158,7 @@ var map = new ol.Map({
   layers: [
     new ol.layer.Tile({
       source: new ol.source.TileJSON({
-        url: 'http://api.tiles.mapbox.com/v3/mapbox.geography-class.jsonp'
+        url: 'http://api.tiles.mapbox.com/v3/mapbox.geography-class.json'
       })
     }),
     new ol.layer.Vector({

--- a/examples/icon.js
+++ b/examples/icon.js
@@ -40,7 +40,7 @@ var vectorLayer = new ol.layer.Vector({
 
 var rasterLayer = new ol.layer.Tile({
   source: new ol.source.TileJSON({
-    url: 'http://api.tiles.mapbox.com/v3/mapbox.geography-class.jsonp',
+    url: 'http://api.tiles.mapbox.com/v3/mapbox.geography-class.json',
     crossOrigin: ''
   })
 });

--- a/examples/layer-extent.js
+++ b/examples/layer-extent.js
@@ -19,7 +19,7 @@ var extents = {
 var base = new ol.layer.Tile({
   source: new ol.source.TileJSON({
     url: 'http://api.tiles.mapbox.com/v3/' +
-        'mapbox.world-black.jsonp',
+        'mapbox.world-black.json',
     crossOrigin: 'anonymous'
   })
 });
@@ -28,7 +28,7 @@ var overlay = new ol.layer.Tile({
   extent: extents.northwest,
   source: new ol.source.TileJSON({
     url: 'http://api.tiles.mapbox.com/v3/' +
-        'mapbox.world-glass.jsonp',
+        'mapbox.world-glass.json',
     crossOrigin: 'anonymous'
   })
 });

--- a/examples/layer-group.js
+++ b/examples/layer-group.js
@@ -15,14 +15,14 @@ var map = new ol.Map({
         new ol.layer.Tile({
           source: new ol.source.TileJSON({
             url: 'http://api.tiles.mapbox.com/v3/' +
-                'mapbox.20110804-hoa-foodinsecurity-3month.jsonp',
+                'mapbox.20110804-hoa-foodinsecurity-3month.json',
             crossOrigin: 'anonymous'
           })
         }),
         new ol.layer.Tile({
           source: new ol.source.TileJSON({
             url: 'http://api.tiles.mapbox.com/v3/' +
-                'mapbox.world-borders-light.jsonp',
+                'mapbox.world-borders-light.json',
             crossOrigin: 'anonymous'
           })
         })

--- a/examples/min-max-resolution.js
+++ b/examples/min-max-resolution.js
@@ -19,7 +19,7 @@ var map = new ol.Map({
     new ol.layer.Tile({
       source: new ol.source.TileJSON({
         url: 'http://api.tiles.mapbox.com/v3/' +
-            'mapbox.natural-earth-hypso-bathy.jsonp',
+            'mapbox.natural-earth-hypso-bathy.json',
         crossOrigin: 'anonymous'
       }),
       minResolution: 2000,

--- a/examples/popup.js
+++ b/examples/popup.js
@@ -46,7 +46,7 @@ var map = new ol.Map({
     new ol.layer.Tile({
       source: new ol.source.TileJSON({
         url: 'http://api.tiles.mapbox.com/v3/' +
-            'mapbox.natural-earth-hypso-bathy.jsonp',
+            'mapbox.natural-earth-hypso-bathy.json',
         crossOrigin: 'anonymous'
       })
     })

--- a/examples/semi-transparent-layer.js
+++ b/examples/semi-transparent-layer.js
@@ -13,7 +13,7 @@ var map = new ol.Map({
     }),
     new ol.layer.Tile({
       source: new ol.source.TileJSON({
-        url: 'http://api.tiles.mapbox.com/v3/mapbox.va-quake-aug.jsonp',
+        url: 'http://api.tiles.mapbox.com/v3/mapbox.va-quake-aug.json',
         crossOrigin: 'anonymous'
       })
     })

--- a/examples/tile-load-events.js
+++ b/examples/tile-load-events.js
@@ -79,7 +79,7 @@ Progress.prototype.hide = function() {
 var progress = new Progress(document.getElementById('progress'));
 
 var source = new ol.source.TileJSON({
-  url: 'http://api.tiles.mapbox.com/v3/mapbox.world-bright.jsonp',
+  url: 'http://api.tiles.mapbox.com/v3/mapbox.world-bright.json',
   crossOrigin: 'anonymous'
 });
 

--- a/examples/tilejson.js
+++ b/examples/tilejson.js
@@ -8,7 +8,7 @@ var map = new ol.Map({
   layers: [
     new ol.layer.Tile({
       source: new ol.source.TileJSON({
-        url: 'http://api.tiles.mapbox.com/v3/mapbox.geography-class.jsonp',
+        url: 'http://api.tiles.mapbox.com/v3/mapbox.geography-class.json',
         crossOrigin: 'anonymous'
       })
     })

--- a/examples/topojson.js
+++ b/examples/topojson.js
@@ -12,7 +12,7 @@ goog.require('ol.style.Style');
 
 var raster = new ol.layer.Tile({
   source: new ol.source.TileJSON({
-    url: 'http://api.tiles.mapbox.com/v3/mapbox.world-dark.jsonp'
+    url: 'http://api.tiles.mapbox.com/v3/mapbox.world-dark.json'
   })
 });
 

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -5206,10 +5206,10 @@ olx.source.TileArcGISRestOptions.prototype.urls;
 /**
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
  *     crossOrigin: (null|string|undefined),
+ *     jsonp: (boolean|undefined),
  *     reprojectionErrorThreshold: (number|undefined),
  *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
  *     url: string,
- *     useXhr: (boolean|undefined),
  *     wrapX: (boolean|undefined)}}
  * @api
  */
@@ -5239,6 +5239,15 @@ olx.source.TileJSONOptions.prototype.crossOrigin;
 
 
 /**
+ * Use JSONP with callback to load the TileJSON. Useful when the server
+ * does not support CORS. Default is `false`.
+ * @type {boolean|undefined}
+ * @api
+ */
+olx.source.TileJSONOptions.prototype.jsonp;
+
+
+/**
  * Maximum allowed reprojection error (in pixels). Default is `0.5`.
  * Higher values can increase reprojection performance, but decrease precision.
  * @type {number|undefined}
@@ -5261,14 +5270,6 @@ olx.source.TileJSONOptions.prototype.tileLoadFunction;
  * @api stable
  */
 olx.source.TileJSONOptions.prototype.url;
-
-
-/**
- * Use XmlHttpRequest to load the TileJSON. Default is `false`.
- * @type {boolean|undefined}
- * @api
- */
-olx.source.TileJSONOptions.prototype.useXhr;
 
 
 /**

--- a/test/spec/ol/source/tilejsonsource.test.js
+++ b/test/spec/ol/source/tilejsonsource.test.js
@@ -21,23 +21,9 @@ describe('ol.source.TileJSON', function() {
     var source, tileGrid;
 
     beforeEach(function(done) {
-      var googNetJsonp = goog.net.Jsonp;
-      // mock goog.net.Jsonp (used in the ol.source.TileJSON constructor)
-      goog.net.Jsonp = function() {
-        this.send = function() {
-          var callback = arguments[1];
-          var client = new XMLHttpRequest();
-          client.open('GET', 'spec/ol/data/tilejson.json', true);
-          client.onload = function() {
-            callback(JSON.parse(client.responseText));
-          };
-          client.send();
-        };
-      };
       source = new ol.source.TileJSON({
-        url: 'http://api.tiles.mapbox.com/v3/mapbox.geography-class.jsonp'
+        url: 'spec/ol/data/tilejson.json'
       });
-      goog.net.Jsonp = googNetJsonp;
       var key = source.on('change', function() {
         if (source.getState() === 'ready') {
           ol.Observable.unByKey(key);
@@ -88,7 +74,6 @@ describe('ol.source.TileJSON', function() {
 });
 
 goog.require('goog.events');
-goog.require('goog.net.Jsonp');
 goog.require('ol.source.State');
 goog.require('ol.source.TileJSON');
 goog.require('ol.Observable');


### PR DESCRIPTION
Based on comments in #4619 this PR makes XHR the default method of loading TileJSONs in `ol.source.TileJSON`. This ensures better future compatibility (especially with Mapbox API v4), although it might require changes to some existing applications when upgrading (see upgrade notes).

Some Mapbox v3 urls had to be changed from `.jsonp` (these actually does not seem to be mentioned anywhere in to documentation https://www.mapbox.com/developers/api/v3/#cors-and-jsonp) to `.json`.

This adds new closure dependency `goog.net.CorsXmlHttpFactory`, which internally uses `XDomainRequest` to ensure IE9 compatibility. This can be safely dropped in the future when we no longer support IE9 (possibly soon? https://www.microsoft.com/en-us/WindowsForBusiness/End-of-IE-support).