### PR TITLE
Fixed documentation error

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -4349,7 +4349,7 @@ olx.source.ImageMapGuideOptions.prototype.resolutions;
 
 /**
  * Optional function to load an image given a URL.
- * @type {ol.TileLoadFunctionType|undefined}
+ * @type {ol.ImageLoadFunctionType|undefined}
  * @api
  */
 olx.source.ImageMapGuideOptions.prototype.imageLoadFunction;
@@ -4965,7 +4965,7 @@ olx.source.ImageStaticOptions.prototype.imageSize;
 
 /**
  * Optional function to load an image given a URL.
- * @type {ol.TileLoadFunctionType|undefined}
+ * @type {ol.ImageLoadFunctionType|undefined}
  * @api
  */
 olx.source.ImageStaticOptions.prototype.imageLoadFunction;


### PR DESCRIPTION
The imageLoad function option of all ol.source.Image subclasses are not of type ol.TileLoadFunctionType but of type ol.ImageLoadFunctionType.