### PR TITLE
Fix for reprojecting opaque tile sources

### DIFF
--- a/src/ol/renderer/canvas/canvastilelayerrenderer.js
+++ b/src/ol/renderer/canvas/canvastilelayerrenderer.js
@@ -365,7 +365,7 @@ ol.renderer.canvas.TileLayer.prototype.prepareFrame =
   /** @type {Array.<number>} */
   var zs = Object.keys(tilesToDrawByZ).map(Number);
   zs.sort(ol.array.numberSafeCompareFunction);
-  var opaque = tileSource.getOpaque();
+  var opaque = tileSource.getOpaque(projection);
   var origin = ol.extent.getTopLeft(tileGrid.getTileCoordExtent(
       [z, canvasTileRange.minX, canvasTileRange.maxY],
       tmpExtent));

--- a/src/ol/source/tileimagesource.js
+++ b/src/ol/source/tileimagesource.js
@@ -123,6 +123,20 @@ ol.source.TileImage.prototype.expireCache = function(projection, usedTiles) {
 /**
  * @inheritDoc
  */
+ol.source.TileImage.prototype.getOpaque = function(projection) {
+  if (ol.ENABLE_RASTER_REPROJECTION &&
+      this.getProjection() && projection &&
+      !ol.proj.equivalent(this.getProjection(), projection)) {
+    return false;
+  } else {
+    return goog.base(this, 'getOpaque', projection);
+  }
+};
+
+
+/**
+ * @inheritDoc
+ */
 ol.source.TileImage.prototype.getTileGridForProjection = function(projection) {
   if (!ol.ENABLE_RASTER_REPROJECTION) {
     return goog.base(this, 'getTileGridForProjection', projection);

--- a/src/ol/source/tilesource.js
+++ b/src/ol/source/tilesource.js
@@ -178,9 +178,10 @@ ol.source.Tile.prototype.getKeyZXY = ol.tilecoord.getKeyZXY;
 
 
 /**
+ * @param {ol.proj.Projection} projection
  * @return {boolean} Opaque.
  */
-ol.source.Tile.prototype.getOpaque = function() {
+ol.source.Tile.prototype.getOpaque = function(projection) {
   return this.opaque_;
 };
 


### PR DESCRIPTION
The tile sources that are marked as 'opaque'  (to benefit from rendering optimizations) are sometimes rendered incorrectly when reprojected -- the resulting reprojected tiles are not always opaque (e.g. projection boundaries, deformations, ...) and tiles from other zoom levels "bleed-through".

This PR changes `getOpaque` to return `false` when reprojecting.