### PR TITLE
Do not rely on projection extent

### DIFF
--- a/src/ol/attribution.js
+++ b/src/ol/attribution.js
@@ -77,7 +77,7 @@ ol.Attribution.prototype.intersectsAnyTileRange =
         return true;
       }
       var extentTileRange = tileGrid.getTileRangeForExtentAndZ(
-          projection.getExtent(), parseInt(zKey, 10));
+          ol.tilegrid.extentFromProjection(projection), parseInt(zKey, 10));
       var width = extentTileRange.getWidth();
       if (tileRange.minX < extentTileRange.minX ||
           tileRange.maxX > extentTileRange.maxX) {


### PR DESCRIPTION
`ol.Attribution` should not require a projection with a configured extent.

Fixes #4634.