### PR TITLE
Remove extra options from icon example

### DIFF
--- a/examples/icon.js
+++ b/examples/icon.js
@@ -23,8 +23,6 @@ var iconStyle = new ol.style.Style({
     anchor: [0.5, 46],
     anchorXUnits: 'fraction',
     anchorYUnits: 'pixels',
-    color: '#8959A8',
-    opacity: 0.75,
     src: 'data/icon.png'
   }))
 });


### PR DESCRIPTION
Before:

![image](https://cloud.githubusercontent.com/assets/41094/12224968/fef70432-b7bb-11e5-9f49-5c63c1dafeb8.png)

After:

![image](https://cloud.githubusercontent.com/assets/41094/12224972/1030b414-b7bc-11e5-9c2a-094ffb95b663.png)

I'd rather see us add dedicated examples that showcase specific options where they are useful.  In this case, I think `color` and `opacity` make for an uglier example.
