### PR TITLE
Missing parameter description for ol.source.Tile#getOpaque

### DIFF
--- a/src/ol/source/tilesource.js
+++ b/src/ol/source/tilesource.js
@@ -176,7 +176,7 @@ ol.source.Tile.prototype.getKeyZXY = ol.tilecoord.getKeyZXY;
 
 
 /**
- * @param {ol.proj.Projection} projection
+ * @param {ol.proj.Projection} projection Projection.
  * @return {boolean} Opaque.
  */
 ol.source.Tile.prototype.getOpaque = function(projection) {


### PR DESCRIPTION
Minor jsdoc fix (error revealed by ESLint https://github.com/openlayers/ol3/pull/4602).