### PR TITLE
Fixes #4654 Developer Documentation Updated

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -25,7 +25,7 @@ The minimum requirements are:
 
 * GNU Make
 * Git
-* [Node.js](http://nodejs.org/) (0.10.x or higher)
+* [Node.js](http://nodejs.org/) (higher than 0.12.x)
 * Python 2.6 or 2.7
 * Java 7 (JRE and JDK)
 


### PR DESCRIPTION
Metalsmith v2.0 and above uses generators which are not supported out of the box by node.js 0.12.x and below.