### PR TITLE
Fix rendering of transparent MapQuest layer type

### DIFF
--- a/src/ol/source/mapquestsource.js
+++ b/src/ol/source/mapquestsource.js
@@ -40,7 +40,7 @@ ol.source.MapQuest = function(opt_options) {
     logo: 'https://developer.mapquest.com/content/osm/mq_logo.png',
     maxZoom: layerConfig.maxZoom,
     reprojectionErrorThreshold: options.reprojectionErrorThreshold,
-    opaque: true,
+    opaque: layerConfig.opaque,
     tileLoadFunction: options.tileLoadFunction,
     url: url
   });
@@ -59,11 +59,12 @@ ol.source.MapQuest.TILE_ATTRIBUTION = new ol.Attribution({
 
 
 /**
- * @type {Object.<string, {maxZoom: number, attributions: (Array.<ol.Attribution>)}>}
+ * @type {Object.<string, {maxZoom: number, opaque: boolean, attributions: (Array.<ol.Attribution>)}>}
  */
 ol.source.MapQuestConfig = {
   'osm': {
     maxZoom: 19,
+    opaque: true,
     attributions: [
       ol.source.MapQuest.TILE_ATTRIBUTION,
       ol.source.OSM.ATTRIBUTION
@@ -71,6 +72,7 @@ ol.source.MapQuestConfig = {
   },
   'sat': {
     maxZoom: 18,
+    opaque: true,
     attributions: [
       ol.source.MapQuest.TILE_ATTRIBUTION,
       new ol.Attribution({
@@ -81,6 +83,7 @@ ol.source.MapQuestConfig = {
   },
   'hyb': {
     maxZoom: 18,
+    opaque: false,
     attributions: [
       ol.source.MapQuest.TILE_ATTRIBUTION,
       ol.source.OSM.ATTRIBUTION


### PR DESCRIPTION
This seems like an error exposed by https://github.com/openlayers/ol3/pull/4595 -- the `'hyb'` layer type is actually not opaque.

Fixes #4660.