### PR TITLE
Respect fixed tile url functions when setting url(s)

### DIFF
--- a/src/ol/source/tilearcgisrestsource.js
+++ b/src/ol/source/tilearcgisrestsource.js
@@ -42,7 +42,6 @@ ol.source.TileArcGISRest = function(opt_options) {
     reprojectionErrorThreshold: options.reprojectionErrorThreshold,
     tileGrid: options.tileGrid,
     tileLoadFunction: options.tileLoadFunction,
-    tileUrlFunction: this.tileUrlFunction_.bind(this),
     url: options.url,
     urls: options.urls,
     wrapX: options.wrapX !== undefined ? options.wrapX : true
@@ -138,13 +137,9 @@ ol.source.TileArcGISRest.prototype.getTilePixelRatio = function(pixelRatio) {
 
 
 /**
- * @param {ol.TileCoord} tileCoord Tile coordinate.
- * @param {number} pixelRatio Pixel ratio.
- * @param {ol.proj.Projection} projection Projection.
- * @return {string|undefined} Tile URL.
- * @private
+ * @inheritDoc
  */
-ol.source.TileArcGISRest.prototype.tileUrlFunction_ = function(tileCoord, pixelRatio, projection) {
+ol.source.TileArcGISRest.prototype.fixedTileUrlFunction = function(tileCoord, pixelRatio, projection) {
 
   var tileGrid = this.getTileGrid();
   if (!tileGrid) {

--- a/src/ol/source/tilewmssource.js
+++ b/src/ol/source/tilewmssource.js
@@ -46,7 +46,6 @@ ol.source.TileWMS = function(opt_options) {
     reprojectionErrorThreshold: options.reprojectionErrorThreshold,
     tileGrid: options.tileGrid,
     tileLoadFunction: options.tileLoadFunction,
-    tileUrlFunction: this.tileUrlFunction_.bind(this),
     url: options.url,
     urls: options.urls,
     wrapX: options.wrapX !== undefined ? options.wrapX : true
@@ -301,13 +300,9 @@ ol.source.TileWMS.prototype.resetCoordKeyPrefix_ = function() {
 
 
 /**
- * @param {ol.TileCoord} tileCoord Tile coordinate.
- * @param {number} pixelRatio Pixel ratio.
- * @param {ol.proj.Projection} projection Projection.
- * @return {string|undefined} Tile URL.
- * @private
+ * @inheritDoc
  */
-ol.source.TileWMS.prototype.tileUrlFunction_ = function(tileCoord, pixelRatio, projection) {
+ol.source.TileWMS.prototype.fixedTileUrlFunction = function(tileCoord, pixelRatio, projection) {
 
   var tileGrid = this.getTileGrid();
   if (!tileGrid) {

--- a/src/ol/source/urltilesource.js
+++ b/src/ol/source/urltilesource.js
@@ -63,9 +63,8 @@ ol.source.UrlTile = function(options) {
    * @protected
    * @type {ol.TileUrlFunctionType}
    */
-  this.tileUrlFunction = options.tileUrlFunction ?
-      options.tileUrlFunction :
-      ol.TileUrlFunction.nullTileUrlFunction;
+  this.tileUrlFunction =
+      this.fixedTileUrlFunction || ol.TileUrlFunction.nullTileUrlFunction;
 
   /**
    * @protected
@@ -74,11 +73,7 @@ ol.source.UrlTile = function(options) {
   this.urls = null;
 
   if (options.urls) {
-    if (options.tileUrlFunction) {
-      this.urls = options.urls;
-    } else {
-      this.setUrls(options.urls);
-    }
+    this.setUrls(options.urls);
   } else if (options.url) {
     this.setUrl(options.url);
   }
@@ -89,6 +84,12 @@ ol.source.UrlTile = function(options) {
 };
 goog.inherits(ol.source.UrlTile, ol.source.Tile);
 
+
+/**
+ * @type {ol.TileUrlFunctionType|undefined}
+ * @protected
+ */
+ol.source.UrlTile.prototype.fixedTileUrlFunction;
 
 /**
  * Return the tile load function of the source.
@@ -181,9 +182,10 @@ ol.source.UrlTile.prototype.setTileUrlFunction = function(tileUrlFunction) {
  * @api stable
  */
 ol.source.UrlTile.prototype.setUrl = function(url) {
-  this.setTileUrlFunction(ol.TileUrlFunction.createFromTemplates(
-      ol.TileUrlFunction.expandUrl(url), this.tileGrid));
   this.urls = [url];
+  var urls = ol.TileUrlFunction.expandUrl(url);
+  this.setTileUrlFunction(this.fixedTileUrlFunction ||
+      ol.TileUrlFunction.createFromTemplates(urls, this.tileGrid));
 };
 
 
@@ -193,9 +195,9 @@ ol.source.UrlTile.prototype.setUrl = function(url) {
  * @api stable
  */
 ol.source.UrlTile.prototype.setUrls = function(urls) {
-  this.setTileUrlFunction(ol.TileUrlFunction.createFromTemplates(
-      urls, this.tileGrid));
   this.urls = urls;
+  this.setTileUrlFunction(this.fixedTileUrlFunction ||
+      ol.TileUrlFunction.createFromTemplates(urls, this.tileGrid));
 };
 
 

--- a/test/spec/ol/source/tilearcgisrestsource.test.js
+++ b/test/spec/ol/source/tilearcgisrestsource.test.js
@@ -253,6 +253,9 @@ describe('ol.source.TileArcGISRest', function() {
       var urls = source.getUrls();
 
       expect(urls).to.eql(['http://test3.com/MapServer']);
+
+      var tileUrl = source.tileUrlFunction([0, 0, 0], 1, ol.proj.get('EPSG:4326'));
+      expect(tileUrl.indexOf(urls[0])).to.be(0);
     });
 
 

--- a/test/spec/ol/source/tilewmssource.test.js
+++ b/test/spec/ol/source/tilewmssource.test.js
@@ -258,6 +258,14 @@ describe('ol.source.TileWMS', function() {
       expect(uri.getFragment()).to.be.empty();
     });
   });
+
+  describe('#setUrl()', function() {
+    var source = new ol.source.TileWMS(options);
+    var url = 'http://foo/';
+    source.setUrl(url);
+    var tileUrl = source.tileUrlFunction([0, 0, 0], 1, ol.proj.get('EPSG:4326'));
+    expect(tileUrl.indexOf(url)).to.be(0);
+  });
 });
 
 


### PR DESCRIPTION
Using `setUrl()` or `setUrls()` on a tiled WMS or ArcGISRest source currently overwrites the builtin tile url function. These methods need to be modified to respect the fixed tile url function that is set on these sources.

Fixes #4670.