### PR TITLE
Give map a focus-outline in accessible-example

### DIFF
--- a/examples/accessible.css
+++ b/examples/accessible.css
@@ -14,3 +14,6 @@ a.skiplink:focus {
   background-color: #fff;
   padding: 0.3em;
 }
+#map:focus {
+  outline: #4A74A8 solid 0.15em;
+}


### PR DESCRIPTION
This makes it easier to see if the map-element currently has the focus:

![outline](https://cloud.githubusercontent.com/assets/227934/12415911/9e053830-be9e-11e5-9f3c-c818b15ab60e.png)
