### PR TITLE
Bind tileUrlFunction to the source

### DIFF
--- a/src/ol/source/urltilesource.js
+++ b/src/ol/source/urltilesource.js
@@ -63,8 +63,9 @@ ol.source.UrlTile = function(options) {
    * @protected
    * @type {ol.TileUrlFunctionType}
    */
-  this.tileUrlFunction =
-      this.fixedTileUrlFunction || ol.TileUrlFunction.nullTileUrlFunction;
+  this.tileUrlFunction = this.fixedTileUrlFunction ?
+      this.fixedTileUrlFunction.bind(this) :
+      ol.TileUrlFunction.nullTileUrlFunction;
 
   /**
    * @protected
@@ -184,7 +185,8 @@ ol.source.UrlTile.prototype.setTileUrlFunction = function(tileUrlFunction) {
 ol.source.UrlTile.prototype.setUrl = function(url) {
   this.urls = [url];
   var urls = ol.TileUrlFunction.expandUrl(url);
-  this.setTileUrlFunction(this.fixedTileUrlFunction ||
+  this.setTileUrlFunction(this.fixedTileUrlFunction ?
+      this.fixedTileUrlFunction.bind(this) :
       ol.TileUrlFunction.createFromTemplates(urls, this.tileGrid));
 };
 
@@ -196,7 +198,8 @@ ol.source.UrlTile.prototype.setUrl = function(url) {
  */
 ol.source.UrlTile.prototype.setUrls = function(urls) {
   this.urls = urls;
-  this.setTileUrlFunction(this.fixedTileUrlFunction ||
+  this.setTileUrlFunction(this.fixedTileUrlFunction ?
+      this.fixedTileUrlFunction.bind(this) :
       ol.TileUrlFunction.createFromTemplates(urls, this.tileGrid));
 };
 


### PR DESCRIPTION
In order to have the function returned by ol.source.UrlTile#getTileUrlFunction()
to return a url even when executed outside the context of the source, then it
should be bound to the source.

This closes https://github.com/openlayers/ol3/issues/4695.