### PR TITLE
Add 'layers' option for WMSGetFeatureInfo format

### DIFF
--- a/examples/data/wmsgetfeatureinfo/osm-restaurant-hotel.xml
+++ b/examples/data/wmsgetfeatureinfo/osm-restaurant-hotel.xml
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<msGMLOutput 
+	 xmlns:gml="http://www.opengis.net/gml"
+	 xmlns:xlink="http://www.w3.org/1999/xlink"
+	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<restaurant_layer>
+	<gml:name>Restaurants</gml:name>
+		<restaurant_feature>
+			<gml:boundedBy>
+				<gml:Box srsName="EPSG:21781">
+					<gml:coordinates>537750.006175,150923.784252 537750.006175,150923.784252</gml:coordinates>
+				</gml:Box>
+			</gml:boundedBy>
+			<THE_GEOM>
+			<gml:Point srsName="EPSG:21781">
+			  <gml:coordinates>537750.006175,150923.784252</gml:coordinates>
+			</gml:Point>
+			</THE_GEOM>
+			<display_name>Château d&#39;Ouchy</display_name>
+			<name>Château d&#39;Ouchy</name>
+			<osm_id>1230808910</osm_id>
+			<access></access>
+			<aerialway></aerialway>
+			<amenity>restaurant</amenity>
+			<barrier></barrier>
+			<bicycle></bicycle>
+			<brand></brand>
+			<building></building>
+			<covered></covered>
+			<denomination></denomination>
+			<ele></ele>
+			<foot></foot>
+			<highway></highway>
+			<layer></layer>
+			<leisure></leisure>
+			<man_made></man_made>
+			<motorcar></motorcar>
+			<natural></natural>
+			<operator></operator>
+			<population></population>
+			<power></power>
+			<place></place>
+			<railway></railway>
+			<ref></ref>
+			<religion></religion>
+			<shop></shop>
+			<sport></sport>
+			<surface></surface>
+			<tourism></tourism>
+			<waterway></waterway>
+			<wood></wood>
+		</restaurant_feature>
+		<restaurant_feature>
+			<gml:boundedBy>
+				<gml:Box srsName="EPSG:21781">
+					<gml:coordinates>537770.247124,150975.613968 537770.247124,150975.613968</gml:coordinates>
+				</gml:Box>
+			</gml:boundedBy>
+			<THE_GEOM>
+			<gml:Point srsName="EPSG:21781">
+			  <gml:coordinates>537770.247124,150975.613968</gml:coordinates>
+			</gml:Point>
+			</THE_GEOM>
+			<display_name>Cafe du Vieil Ouchy</display_name>
+			<name>Cafe du Vieil Ouchy</name>
+			<osm_id>1433812389</osm_id>
+			<access></access>
+			<aerialway></aerialway>
+			<amenity>restaurant</amenity>
+			<barrier></barrier>
+			<bicycle></bicycle>
+			<brand></brand>
+			<building></building>
+			<covered></covered>
+			<denomination></denomination>
+			<ele></ele>
+			<foot></foot>
+			<highway></highway>
+			<layer></layer>
+			<leisure></leisure>
+			<man_made></man_made>
+			<motorcar></motorcar>
+			<natural></natural>
+			<operator>Carine Duca</operator>
+			<population></population>
+			<power></power>
+			<place></place>
+			<railway></railway>
+			<ref></ref>
+			<religion></religion>
+			<shop></shop>
+			<sport></sport>
+			<surface></surface>
+			<tourism></tourism>
+			<waterway></waterway>
+			<wood></wood>
+		</restaurant_feature>
+		<restaurant_feature>
+			<gml:boundedBy>
+				<gml:Box srsName="EPSG:21781">
+					<gml:coordinates>537789.197617,150976.218227 537789.197617,150976.218227</gml:coordinates>
+				</gml:Box>
+			</gml:boundedBy>
+			<THE_GEOM>
+			<gml:Point srsName="EPSG:21781">
+			  <gml:coordinates>537789.197617,150976.218227</gml:coordinates>
+			</gml:Point>
+			</THE_GEOM>
+			<display_name>Creperie</display_name>
+			<name>Creperie</name>
+			<osm_id>1433812391</osm_id>
+			<access></access>
+			<aerialway></aerialway>
+			<amenity>restaurant</amenity>
+			<barrier></barrier>
+			<bicycle></bicycle>
+			<brand></brand>
+			<building></building>
+			<covered></covered>
+			<denomination></denomination>
+			<ele></ele>
+			<foot></foot>
+			<highway></highway>
+			<layer></layer>
+			<leisure></leisure>
+			<man_made></man_made>
+			<motorcar></motorcar>
+			<natural></natural>
+			<operator></operator>
+			<population></population>
+			<power></power>
+			<place></place>
+			<railway></railway>
+			<ref></ref>
+			<religion></religion>
+			<shop></shop>
+			<sport></sport>
+			<surface></surface>
+			<tourism></tourism>
+			<waterway></waterway>
+			<wood></wood>
+		</restaurant_feature>
+		<restaurant_feature>
+			<gml:boundedBy>
+				<gml:Box srsName="EPSG:21781">
+					<gml:coordinates>537810.679909,150983.377694 537810.679909,150983.377694</gml:coordinates>
+				</gml:Box>
+			</gml:boundedBy>
+			<THE_GEOM>
+			<gml:Point srsName="EPSG:21781">
+			  <gml:coordinates>537810.679909,150983.377694</gml:coordinates>
+			</gml:Point>
+			</THE_GEOM>
+			<display_name>1433812390</display_name>
+			<name></name>
+			<osm_id>1433812390</osm_id>
+			<access></access>
+			<aerialway></aerialway>
+			<amenity>restaurant</amenity>
+			<barrier></barrier>
+			<bicycle></bicycle>
+			<brand></brand>
+			<building></building>
+			<covered></covered>
+			<denomination></denomination>
+			<ele></ele>
+			<foot></foot>
+			<highway></highway>
+			<layer></layer>
+			<leisure></leisure>
+			<man_made></man_made>
+			<motorcar></motorcar>
+			<natural></natural>
+			<operator></operator>
+			<population></population>
+			<power></power>
+			<place></place>
+			<railway></railway>
+			<ref></ref>
+			<religion></religion>
+			<shop></shop>
+			<sport></sport>
+			<surface></surface>
+			<tourism></tourism>
+			<waterway></waterway>
+			<wood></wood>
+		</restaurant_feature>
+	</restaurant_layer>
+	<hotel_layer>
+	<gml:name>Hôtels</gml:name>
+		<hotel_feature>
+			<gml:boundedBy>
+				<gml:Box srsName="EPSG:21781">
+					<gml:coordinates>537762.425297,150971.904013 537762.425297,150971.904013</gml:coordinates>
+				</gml:Box>
+			</gml:boundedBy>
+			<THE_GEOM>
+			<gml:Point srsName="EPSG:21781">
+			  <gml:coordinates>537762.425297,150971.904013</gml:coordinates>
+			</gml:Point>
+			</THE_GEOM>
+			<display_name>Hotel du port</display_name>
+			<name>Hotel du port</name>
+			<osm_id>2886793101</osm_id>
+			<access></access>
+			<aerialway></aerialway>
+			<amenity></amenity>
+			<barrier></barrier>
+			<bicycle></bicycle>
+			<brand></brand>
+			<building></building>
+			<covered></covered>
+			<denomination></denomination>
+			<ele></ele>
+			<foot></foot>
+			<highway></highway>
+			<layer></layer>
+			<leisure></leisure>
+			<man_made></man_made>
+			<motorcar></motorcar>
+			<natural></natural>
+			<operator></operator>
+			<population></population>
+			<power></power>
+			<place></place>
+			<railway></railway>
+			<ref></ref>
+			<religion></religion>
+			<shop></shop>
+			<sport></sport>
+			<surface></surface>
+			<tourism>hotel</tourism>
+			<waterway></waterway>
+			<wood></wood>
+		</hotel_feature>
+		<hotel_feature>
+			<gml:boundedBy>
+				<gml:Box srsName="EPSG:21781">
+					<gml:coordinates>537798.352160,150985.584164 537798.352160,150985.584164</gml:coordinates>
+				</gml:Box>
+			</gml:boundedBy>
+			<THE_GEOM>
+			<gml:Point srsName="EPSG:21781">
+			  <gml:coordinates>537798.352160,150985.584164</gml:coordinates>
+			</gml:Point>
+			</THE_GEOM>
+			<display_name>Angleterre</display_name>
+			<name>Angleterre</name>
+			<osm_id>1433812387</osm_id>
+			<access></access>
+			<aerialway></aerialway>
+			<amenity></amenity>
+			<barrier></barrier>
+			<bicycle></bicycle>
+			<brand></brand>
+			<building></building>
+			<covered></covered>
+			<denomination></denomination>
+			<ele></ele>
+			<foot></foot>
+			<highway></highway>
+			<layer></layer>
+			<leisure></leisure>
+			<man_made></man_made>
+			<motorcar></motorcar>
+			<natural></natural>
+			<operator></operator>
+			<population></population>
+			<power></power>
+			<place></place>
+			<railway></railway>
+			<ref></ref>
+			<religion></religion>
+			<shop></shop>
+			<sport></sport>
+			<surface></surface>
+			<tourism>hotel</tourism>
+			<waterway></waterway>
+			<wood></wood>
+		</hotel_feature>
+	</hotel_layer>
+</msGMLOutput>

--- a/examples/getfeatureinfo-layers.html
+++ b/examples/getfeatureinfo-layers.html
@@ -1,0 +1,28 @@
+---
+layout: example.html
+title: WMS GetFeatureInfo (Layers)
+shortdesc: >
+  Shows how to fetch features per layer name in a single WMS GetFeatureInfo
+  request
+docs: >
+  Demonstrates the use of the `layers` option in the
+  `ol.format.WMSGetFeatureInfo` format object, which allows features returned
+  by a single WMS GetFeatureInfo request that asks for more than one layer
+  to be read by layer name.
+resources:
+  - https://code.jquery.com/jquery-1.11.2.min.js
+---
+<table id="info">
+  <tr>
+    <td>All features:</td>
+    <td id="all"></td>
+  </tr>
+  <tr>
+    <td>Hotel features:</td>
+    <td id="hotel"></td>
+  </tr>
+  <tr>
+    <td>Restaurant features:</td>
+    <td id="restaurant"></td>
+  </tr>
+</table>

--- a/examples/getfeatureinfo-layers.js
+++ b/examples/getfeatureinfo-layers.js
@@ -1,0 +1,24 @@
+goog.require('ol.format.WMSGetFeatureInfo');
+
+$.ajax({
+  url: './data/wmsgetfeatureinfo/osm-restaurant-hotel.xml',
+  success: function(response) {
+
+    // this is the standard way to read the features
+    var allFeatures = new ol.format.WMSGetFeatureInfo().readFeatures(response);
+    $('#all').html(allFeatures.length.toString());
+
+    // when specifying the 'layers' options, only the features of those
+    // layers are returned by the format
+    var hotelFeatures = new ol.format.WMSGetFeatureInfo({
+      layers: ['hotel']
+    }).readFeatures(response);
+    $('#hotel').html(hotelFeatures.length.toString());
+
+    var restaurantFeatures = new ol.format.WMSGetFeatureInfo({
+      layers: ['restaurant']
+    }).readFeatures(response);
+    $('#restaurant').html(restaurantFeatures.length.toString());
+
+  }
+});

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -2218,6 +2218,24 @@ olx.format.WKTOptions.prototype.splitCollection;
 
 
 /**
+ * @typedef {{
+ *     layers: (Array.<string>|undefined)
+ * }}
+ * @api
+ */
+olx.format.WMSGetFeatureInfoOptions;
+
+
+/**
+ * If set, only features of the given layers will be returned by the format
+ * when read.
+ * @type {Array.<string>|undefined}
+ * @api
+ */
+olx.format.WMSGetFeatureInfoOptions.prototype.layers;
+
+
+/**
  * Namespace.
  * @type {Object}
  */

--- a/src/ol/format/wmsgetfeatureinfoformat.js
+++ b/src/ol/format/wmsgetfeatureinfoformat.js
@@ -4,6 +4,7 @@ goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.dom.NodeType');
 goog.require('goog.object');
+goog.require('ol.array');
 goog.require('ol.format.GML2');
 goog.require('ol.format.XMLFeature');
 goog.require('ol.xml');
@@ -16,9 +17,12 @@ goog.require('ol.xml');
  *
  * @constructor
  * @extends {ol.format.XMLFeature}
+ * @param {olx.format.WMSGetFeatureInfoOptions=} opt_options Options.
  * @api
  */
-ol.format.WMSGetFeatureInfo = function() {
+ol.format.WMSGetFeatureInfo = function(opt_options) {
+
+  var options = opt_options ? opt_options : {};
 
   /**
    * @private
@@ -32,6 +36,13 @@ ol.format.WMSGetFeatureInfo = function() {
    * @type {ol.format.GML2}
    */
   this.gmlFormat_ = new ol.format.GML2();
+
+
+  /**
+   * @private
+   * @type {Array.<string>}
+   */
+  this.layers_ = options.layers ? options.layers : null;
 
   goog.base(this);
 };
@@ -86,7 +97,13 @@ ol.format.WMSGetFeatureInfo.prototype.readFeatures_ = function(node, objectStack
           'localName of layer node should match layerIdentifier');
 
       var toRemove = ol.format.WMSGetFeatureInfo.layerIdentifier_;
-      var featureType = layer.localName.replace(toRemove, '') +
+      var layerName = layer.localName.replace(toRemove, '');
+
+      if (this.layers_ && !ol.array.includes(this.layers_, layerName)) {
+        continue;
+      }
+
+      var featureType = layerName +
           ol.format.WMSGetFeatureInfo.featureIdentifier_;
 
       context['featureType'] = featureType;

--- a/test/spec/ol/format/wmsgetfeatureinfoformat.test.js
+++ b/test/spec/ol/format/wmsgetfeatureinfoformat.test.js
@@ -140,6 +140,18 @@ describe('ol.format.WMSGetFeatureInfo', function() {
         expect(features.length).to.be(2);
         expect(features[0].get('OBJECTID')).to.be('287');
         expect(features[1].get('OBJECTID')).to.be('1251');
+        var aaa64Features = new ol.format.WMSGetFeatureInfo({
+          layers: ['AAA64']
+        }).readFeatures(text);
+        expect(aaa64Features.length).to.be(1);
+        var allFeatures = new ol.format.WMSGetFeatureInfo({
+          layers: ['AAA64', 'AAA62']
+        }).readFeatures(text);
+        expect(allFeatures.length).to.be(2);
+        var dummyFeatures = new ol.format.WMSGetFeatureInfo({
+          layers: ['foo', 'bar']
+        }).readFeatures(text);
+        expect(dummyFeatures.length).to.be(0);
       });
 
       it('read geoserver’s response', function() {


### PR DESCRIPTION
This option allows the format to read only features from
the given layers. This is useful if you wish to make a
single query to a WMS server with multiple layers in it
and classify the result per layer name.

 - [x] write some tests
 - [x] use `layers` as option to be more consistent with MVT
 - [x] validate the comparison of the layer name, @bartvde ?
 - [x] travis
 - [x] complete the review