### PR TITLE
Untangle vector tile feature reprojection

### DIFF
--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -12,7 +12,6 @@ goog.require('ol.VectorTile');
 goog.require('ol.format.FormatType');
 goog.require('ol.proj');
 goog.require('ol.proj.Projection');
-goog.require('ol.proj.Units');
 goog.require('ol.xml');
 
 
@@ -142,14 +141,7 @@ ol.featureloader.tile = function(url, format) {
        * @this {ol.VectorTile}
        */
       function(features, dataProjection) {
-        var dataUnits = dataProjection.getUnits();
-        if (dataUnits === ol.proj.Units.TILE_PIXELS) {
-          var projection = new ol.proj.Projection({
-            code: this.getProjection().getCode(),
-            units: dataUnits
-          });
-          this.setProjection(projection);
-        }
+        this.setProjection(dataProjection);
         this.setFeatures(features);
       },
       /**

--- a/src/ol/format/mvtformat.js
+++ b/src/ol/format/mvtformat.js
@@ -41,7 +41,7 @@ ol.format.MVT = function(opt_options) {
    * @type {ol.proj.Projection}
    */
   this.defaultDataProjection = new ol.proj.Projection({
-    code: 'EPSG:3857',
+    code: '',
     units: ol.proj.Units.TILE_PIXELS
   });
 

--- a/src/ol/source/vectortilesource.js
+++ b/src/ol/source/vectortilesource.js
@@ -1,6 +1,5 @@
 goog.provide('ol.source.VectorTile');
 
-goog.require('goog.asserts');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
 goog.require('ol.TileState');
@@ -54,7 +53,7 @@ ol.source.VectorTile = function(options) {
   /**
    * @protected
    * @type {function(new: ol.VectorTile, ol.TileCoord, ol.TileState, string,
-   *        ol.format.Feature, ol.TileLoadFunctionType, ol.proj.Projection)}
+   *        ol.format.Feature, ol.TileLoadFunctionType)}
    */
   this.tileClass = options.tileClass ? options.tileClass : ol.VectorTile;
 
@@ -70,7 +69,6 @@ ol.source.VectorTile.prototype.getTile = function(z, x, y, pixelRatio, projectio
   if (this.tileCache.containsKey(tileCoordKey)) {
     return /** @type {!ol.Tile} */ (this.tileCache.get(tileCoordKey));
   } else {
-    goog.asserts.assert(projection, 'argument projection is truthy');
     var tileCoord = [z, x, y];
     var urlTileCoord = this.getTileCoordForTileUrlFunction(
         tileCoord, projection);
@@ -80,7 +78,7 @@ ol.source.VectorTile.prototype.getTile = function(z, x, y, pixelRatio, projectio
         tileCoord,
         tileUrl !== undefined ? ol.TileState.IDLE : ol.TileState.EMPTY,
         tileUrl !== undefined ? tileUrl : '',
-        this.format_, this.tileLoadFunction, projection);
+        this.format_, this.tileLoadFunction);
     goog.events.listen(tile, goog.events.EventType.CHANGE,
         this.handleTileChange, false, this);
 

--- a/src/ol/vectortile.js
+++ b/src/ol/vectortile.js
@@ -26,9 +26,8 @@ ol.TileReplayState;
  * @param {string} src Data source url.
  * @param {ol.format.Feature} format Feature format.
  * @param {ol.TileLoadFunctionType} tileLoadFunction Tile load function.
- * @param {ol.proj.Projection} projection Feature projection.
  */
-ol.VectorTile = function(tileCoord, state, src, format, tileLoadFunction, projection) {
+ol.VectorTile = function(tileCoord, state, src, format, tileLoadFunction) {
 
   goog.base(this, tileCoord, state);
 
@@ -57,10 +56,11 @@ ol.VectorTile = function(tileCoord, state, src, format, tileLoadFunction, projec
   this.loader_;
 
   /**
+   * Data projection
    * @private
    * @type {ol.proj.Projection}
    */
-  this.projection_ = projection;
+  this.projection_;
 
   /**
    * @private
@@ -154,7 +154,7 @@ ol.VectorTile.prototype.load = function() {
   if (this.state == ol.TileState.IDLE) {
     this.setState(ol.TileState.LOADING);
     this.tileLoadFunction_(this, this.url_);
-    this.loader_(null, NaN, this.projection_);
+    this.loader_(null, NaN, null);
   }
 };
 

--- a/test/spec/ol/renderer/canvas/canvasvectortilelayerrenderer.test.js
+++ b/test/spec/ol/renderer/canvas/canvasvectortilelayerrenderer.test.js
@@ -4,20 +4,15 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
 
   describe('constructor', function() {
 
-    it('creates a new instance', function() {
-      var layer = new ol.layer.VectorTile({
-        source: new ol.source.VectorTile({})
-      });
-      var renderer = new ol.renderer.canvas.VectorTileLayer(layer);
-      expect(renderer).to.be.a(ol.renderer.canvas.VectorTileLayer);
-    });
+    var map, layer, feature1, feature2, target, tileCallback;
 
-    it('gives precedence to feature styles over layer styles', function() {
-      var target = document.createElement('div');
+    beforeEach(function() {
+      tileCallback = function() {};
+      target = document.createElement('div');
       target.style.width = '256px';
       target.style.height = '256px';
       document.body.appendChild(target);
-      var map = new ol.Map({
+      map = new ol.Map({
         view: new ol.View({
           center: [0, 0],
           zoom: 0
@@ -34,13 +29,15 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
           text: 'feature'
         })
       })];
-      var feature1 = new ol.Feature(new ol.geom.Point([0, 0]));
-      var feature2 = new ol.Feature(new ol.geom.Point([0, 0]));
+      feature1 = new ol.Feature(new ol.geom.Point([1, -1]));
+      feature2 = new ol.Feature(new ol.geom.Point([0, 0]));
       feature2.setStyle(featureStyle);
       var TileClass = function() {
         ol.VectorTile.apply(this, arguments);
         this.setState('loaded');
         this.setFeatures([feature1, feature2]);
+        this.setProjection(ol.proj.get('EPSG:4326'));
+        tileCallback(this);
       };
       ol.inherits(TileClass, ol.VectorTile);
       var source = new ol.source.VectorTile({
@@ -48,17 +45,52 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
         tileClass: TileClass,
         tileGrid: ol.tilegrid.createXYZ()
       });
-      var layer = new ol.layer.VectorTile({
+      layer = new ol.layer.VectorTile({
         source: source,
         style: layerStyle
       });
       map.addLayer(layer);
+    });
+
+    it('creates a new instance', function() {
+      var renderer = new ol.renderer.canvas.VectorTileLayer(layer);
+      expect(renderer).to.be.a(ol.renderer.canvas.VectorTileLayer);
+    });
+
+    afterEach(function() {
+      document.body.removeChild(target);
+      map.dispose();
+    });
+
+    it('gives precedence to feature styles over layer styles', function() {
       var spy = sinon.spy(map.getRenderer().getLayerRenderer(layer),
           'renderFeature');
       map.renderSync();
-      expect(spy.getCall(0).args[2]).to.be(layerStyle);
-      expect(spy.getCall(1).args[2]).to.be(featureStyle);
-      document.body.removeChild(target);
+      expect(spy.getCall(0).args[2]).to.be(layer.getStyle());
+      expect(spy.getCall(1).args[2]).to.be(feature2.getStyle());
+    });
+
+    it('transforms geometries when tile and view projection are different', function() {
+      var tile;
+      tileCallback = function(t) {
+        tile = t;
+      }
+      map.renderSync();
+      expect(tile.getProjection()).to.equal(ol.proj.get('EPSG:3857'));
+      expect(feature1.getGeometry().getCoordinates()).to.eql(
+          ol.proj.fromLonLat([1, -1]));
+    });
+
+    it('leaves geometries untouched when units are tile-pixels', function() {
+      var proj = new ol.proj.Projection({code: '', units: 'tile-pixels'});
+      var tile;
+      tileCallback = function(t) {
+        t.setProjection(proj);
+        tile = t;
+      }
+      map.renderSync();
+      expect(tile.getProjection()).to.equal(proj);
+      expect(feature1.getGeometry().getCoordinates()).to.eql([1, -1]);
     });
 
   });
@@ -121,6 +153,7 @@ goog.require('ol.format.MVT');
 goog.require('ol.geom.Point');
 goog.require('ol.layer.VectorTile');
 goog.require('ol.proj');
+goog.require('ol.proj.Projection');
 goog.require('ol.renderer.canvas.VectorTileLayer');
 goog.require('ol.source.VectorTile');
 goog.require('ol.style.Style');


### PR DESCRIPTION
When using an `ol.format.MVT` with `featureClass` set to `ol.Feature`, OpenLayers thinks it has to reproject features, even though they are drawn in the same projection ('EPSG:3857').

This change makes it so reprojection happens later in the renderer, where more information is available than in the feature format. In the future, this change here will also make it easier to transform features to a different projection, even if the data projection is in tile-pixels units.