### PR TITLE
Upgrade to eslint@2.0.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "clean-css": "3.4.9",
     "coveralls": "2.11.6",
     "debounce": "^1.0.0",
-    "eslint": "v2.0.0-beta.1",
+    "eslint": "v2.0.0-beta.2",
     "eslint-config-openlayers": "^3.0.0",
     "expect.js": "0.3.1",
     "gaze": "^0.5.1",


### PR DESCRIPTION
The changes in #4602 worked around two issues in ESLint that are now addressed.

Prior to https://github.com/eslint/eslint/commit/0f469b4, object properties would incorrectly be assigned comment blocks for parent statements.  And prior to https://github.com/eslint/eslint/commit/5cd5429, comment blocks for function expressions in call expressions would not be linted.
