### PR TITLE
Suppress the use of colors with mocha

### DIFF
--- a/tasks/test.js
+++ b/tasks/test.js
@@ -64,7 +64,7 @@ function runTests(includeCoverage, callback) {
       ];
       var config = {
         ignoreResourceErrors: true,
-        useColors: true
+        useColors: false
       };
 
       if (includeCoverage) {


### PR DESCRIPTION
With the upgrade to `mocha@2.4.2`, the test output on Travis is mangled (see https://github.com/openlayers/ol3/pull/4726#issuecomment-175750681).

I'm not seeing colored output on my terminal locally, so I'm going to see if this `useColors` option has any effect on Travis.

See also mochajs/mocha#2064.  There could also be an incompatibility in our version of `mocha-phantomjs-core`.

Update: it looks like mochajs/mocha#2060 describes a similar issue.