### PR TITLE
Downgrade to mocha@2.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "gaze": "^0.5.1",
     "istanbul": "0.4.2",
     "jquery": "2.2.0",
-    "mocha": "2.4.2",
+    "mocha": "2.3.4",
     "mocha-phantomjs-core": "^1.3.0",
     "mustache": "2.2.1",
     "phantomjs": "2.1.2",


### PR DESCRIPTION
See https://github.com/openlayers/ol3/pull/4726#issuecomment-175750681.

Also related:
 * mochajs/mocha#2060
 * mochajs/mocha#2060

And more upgrade hazards:
 * mochajs/mocha#2080 (see also the hanging tests on #243)

Before upgrading mocha, let's confirm `npm test` works locally and that the output is readable on Travis.