### PR TITLE
Remove VectorTile getSource re-definition of return value

### DIFF
--- a/src/ol/layer/vectortilelayer.js
+++ b/src/ol/layer/vectortilelayer.js
@@ -54,15 +54,6 @@ ol.layer.VectorTile.prototype.getPreload = function() {
 
 
 /**
- * Return the associated {@link ol.source.VectorTile source} of the layer.
- * @function
- * @return {ol.source.VectorTile} Source.
- * @api
- */
-ol.layer.VectorTile.prototype.getSource;
-
-
-/**
  * Whether we use interim tiles on error.
  * @return {boolean} Use interim tiles on error.
  * @observable


### PR DESCRIPTION
This PR removes the re-definition of the value returned by `ol.layer.VectorTile#getSource`, which was `ol.source.VectorTile`.  This re-definition causes issues when using the `ol-externs.js` file:

```
ERR! compile ol3/build/ol-externs.js:3743: ERROR - mismatch of the getSource property type and the type of the property it overrides from superclass ol.layer.Layer
ERR! compile original: function (this:ol.layer.Vector): (null|ol.source.Vector)
ERR! compile override: function (this:ol.layer.VectorTile): (null|ol.source.VectorTile)
ERR! compile ol.layer.VectorTile.prototype.getSource = function() {};
```

Doing an assertion instead in the renderer should be enough.  In fact, where this method was used, assertions were already made.  See : https://github.com/openlayers/ol3/blob/master/src/ol/renderer/canvas/canvasvectortilelayerrenderer.js#L93

That method is marked as `@api`.  The without this fix, the documentation returns the correct type: http://openlayers.org/en/v3.13.0/apidoc/ol.layer.VectorTile.html#getSource.  With this fix, it would no longer be the case.

Should `ol.layer.Vector#getSource` return both types and should assertions added if that brings errors ?