### PR TITLE
Use innerHTML instead of innerText to populate the status element

### DIFF
--- a/examples/select-features.js
+++ b/examples/select-features.js
@@ -71,7 +71,7 @@ var changeInteraction = function() {
   if (select !== null) {
     map.addInteraction(select);
     select.on('select', function(e) {
-      document.getElementById('status').innerText = '&nbsp;' +
+      document.getElementById('status').innerHTML = '&nbsp;' +
           e.target.getFeatures().getLength() +
           ' selected features (last operation selected ' + e.selected.length +
           ' and deselected ' + e.deselected.length + ' features)';


### PR DESCRIPTION
Removes the `&nbsp;` string in the status element