### PR TITLE
Use node.setAttribute to set namespaceURI of a node

### DIFF
--- a/src/ol/format/wmsgetfeatureinfoformat.js
+++ b/src/ol/format/wmsgetfeatureinfoformat.js
@@ -73,7 +73,7 @@ ol.format.WMSGetFeatureInfo.layerIdentifier_ = '_layer';
  */
 ol.format.WMSGetFeatureInfo.prototype.readFeatures_ = function(node, objectStack) {
 
-  node.namespaceURI = this.featureNS_;
+  node.setAttribute('namespaceURI', this.featureNS_);
   goog.asserts.assert(node.nodeType == goog.dom.NodeType.ELEMENT,
       'node.nodeType should be ELEMENT');
   var localName = ol.xml.getLocalName(node);
@@ -114,7 +114,7 @@ ol.format.WMSGetFeatureInfo.prototype.readFeatures_ = function(node, objectStack
           this.gmlFormat_.readFeatureElement, this.gmlFormat_);
       var parsersNS = ol.xml.makeStructureNS(
           [context['featureNS'], null], parsers);
-      layer.namespaceURI = this.featureNS_;
+      layer.setAttribute('namespaceURI', this.featureNS_);
       var layerFeatures = ol.xml.pushParseAndPop(
           [], parsersNS, layer, objectStack, this.gmlFormat_);
       if (layerFeatures) {


### PR DESCRIPTION
I faced an issue today while using the `ol.format.WMSGetFeatureInfo` format in an environment where ol3 is compiled along with the lib that uses it.  I have no idea why, but the following line failed under the compiled mode:

    node.namespaceURI = "some text"

I got an error like this:

> TypeError: Cannot set property namespaceURI of #<Element> which has only a getter

After reading what I found about this in the following [article on StackOverflow](http://stackoverflow.com/questions/32468352/uncaught-typeerror-cannot-set-property-style-of-htmlelement-which-has-only-a), I tried using the `Node#setAttribute` method instead and it worked.

This PR is the result of that.