### PR TITLE
[WIP] New type inference

### DIFF
--- a/config/jsdoc/info/publish.js
+++ b/config/jsdoc/info/publish.js
@@ -69,12 +69,13 @@ exports.publish = function(data, opts) {
           types: ['{}']
         });
       } else {
-        var typedef = typedefs[typedefs.length - 1];
-        var type = typedef.types[0];
-        typedef.types[0] = type
-            .replace(/\}$/, ', ' + doc.longname.split('#')[1] +
-                ': (' + getTypes(doc.type.names).join('|') + ')}')
-            .replace('{, ', '{');
+// Nothing to do!
+//        var typedef = typedefs[typedefs.length - 1];
+//        var type = typedef.types[0];
+//        typedef.types[0] = type
+//            .replace(/\}$/, ', ' + doc.longname.split('#')[1] +
+//                ': (' + getTypes(doc.type.names).join('|') + ')}')
+//            .replace('{, ', '{');
       }
     } else if (doc.define) {
       defines.push({

--- a/config/ol.json
+++ b/config/ol.json
@@ -28,6 +28,7 @@
     "extra_annotation_name": [
       "api", "observable"
     ],
+    "new_type_inf": true,
     "compilation_level": "ADVANCED",
     "warning_level": "VERBOSE",
     "use_types_for_optimization": true,

--- a/externs/oli.js
+++ b/externs/oli.js
@@ -4,9 +4,9 @@
 
 
 /**
- * @type {Object}
+ * @const
  */
-var oli;
+var oli = {};
 
 
 
@@ -168,9 +168,9 @@ oli.SelectEvent.prototype.mapBrowserEvent;
 
 
 /**
- * @type {Object}
+ * @const
  */
-oli.control;
+oli.control = {};
 
 
 /**
@@ -188,9 +188,9 @@ oli.control.Control.prototype.setMap = function(map) {};
 
 
 /**
- * @type {Object}
+ * @const
  */
-oli.interaction;
+oli.interaction = {};
 
 
 /**
@@ -237,9 +237,9 @@ oli.interaction.TranslateEvent.prototype.coordinate;
 
 
 /**
- * @type {Object}
+ * @const
  */
-oli.render;
+oli.render = {};
 
 
 
@@ -274,9 +274,9 @@ oli.render.Event.prototype.vectorContext;
 
 
 /**
- * @type {Object}
+ * @const
  */
-oli.source;
+oli.source = {};
 
 
 /**

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -7138,30 +7138,11 @@ olx.view.FitOptions.prototype.maxZoom;
 
 
 /**
- * @typedef {{
- *     animate: boolean,
- *     attributions: Object.<string, ol.Attribution>,
- *     coordinateToPixelMatrix: ol.vec.Mat4.Number,
- *     extent: (null|ol.Extent),
- *     focus: ol.Coordinate,
- *     index: number,
- *     layerStates: Object.<number, ol.layer.LayerState>,
- *     layerStatesArray: Array.<ol.layer.LayerState>,
- *     logos: Object.<string, string>,
- *     pixelRatio: number,
- *     pixelToCoordinateMatrix: ol.vec.Mat4.Number,
- *     postRenderFunctions: Array.<ol.PostRenderFunction>,
- *     size: ol.Size,
- *     skippedFeatureUids: Object.<string, boolean>,
- *     tileQueue: ol.TileQueue,
- *     time: number,
- *     usedTiles: Object.<string, Object.<string, ol.TileRange>>,
- *     viewState: olx.ViewState,
- *     viewHints: Array.<number>,
- *     wantedTiles: !Object.<string, Object.<string, boolean>>}}
+ * @interface
+ * @struct
  * @api
  */
-olx.FrameState;
+olx.FrameState = function() {};
 
 
 /**

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -1720,10 +1720,8 @@ olx.format.EsriJSONOptions.prototype.geometryName;
 
 
 /**
- * @typedef {{featureClass: (function((ol.geom.Geometry|Object.<string, *>)=)|
- *         function(ol.geom.GeometryType,Array.<number>,
- *             (Array.<number>|Array.<Array.<number>>),Object.<string, *>)|
- *         undefined),
+ * @typedef {{
+ *     featureClass: (Function|undefined),
  *     geometryName: (string|undefined),
  *     layers: (Array.<string>|undefined),
  *     layerName: (string|undefined)}}

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -1,8 +1,8 @@
 
 /**
- * @type {Object}
+ * @const
  */
-var olx;
+var olx = {};
 
 
 /* typedefs for object literals provided by applications */
@@ -145,6 +145,13 @@ olx.GraticuleOptions.prototype.strokeStyle;
  * @api
  */
 olx.GraticuleOptions.prototype.targetSize;
+
+
+/**
+ * Namespace.
+ * @const
+ */
+olx.interaction = {};
 
 
 /**
@@ -671,9 +678,9 @@ olx.ViewOptions.prototype.zoomFactor;
 
 /**
  * Namespace.
- * @type {Object}
+ * @const
  */
-olx.animation;
+olx.animation = {};
 
 
 /**
@@ -863,9 +870,9 @@ olx.animation.ZoomOptions.prototype.easing;
 
 /**
  * Namespace.
- * @type {Object}
+ * @const
  */
-olx.control;
+olx.control = {};
 
 
 /**
@@ -1593,9 +1600,9 @@ olx.control.ZoomToExtentOptions.prototype.extent;
 
 /**
  * Namespace.
- * @type {Object}
+ * @const
  */
-olx.format;
+olx.format = {};
 
 
 /**
@@ -2240,13 +2247,6 @@ olx.format.WMSGetFeatureInfoOptions;
  * @api
  */
 olx.format.WMSGetFeatureInfoOptions.prototype.layers;
-
-
-/**
- * Namespace.
- * @type {Object}
- */
-olx.interaction;
 
 
 /**
@@ -3121,9 +3121,9 @@ olx.interaction.SnapOptions.prototype.source;
 
 /**
  * Namespace.
- * @type {Object}
+ * @const
  */
-olx.layer;
+olx.layer = {};
 
 
 /**
@@ -3864,9 +3864,9 @@ olx.layer.VectorTileOptions.prototype.visible;
 
 /**
  * Namespace.
- * @type {Object}
+ * @const
  */
-olx.render;
+olx.render = {};
 
 
 /**
@@ -3898,9 +3898,9 @@ olx.render.ToContextOptions.prototype.pixelRatio;
 
 /**
  * Namespace.
- * @type {Object}
+ * @const
  */
-olx.source;
+olx.source = {};
 
 
 /**
@@ -6230,9 +6230,9 @@ olx.source.ZoomifyOptions.prototype.size;
 
 /**
  * Namespace.
- * @type {Object}
+ * @const
  */
-olx.style;
+olx.style = {};
 
 
 /**
@@ -6834,9 +6834,9 @@ olx.style.StyleOptions.prototype.zIndex;
 
 /**
  * Namespace.
- * @type {Object}
+ * @const
  */
-olx.tilegrid;
+olx.tilegrid = {};
 
 
 /**
@@ -7078,9 +7078,9 @@ olx.tilegrid.XYZOptions.prototype.tileSize;
 
 /**
  * Namespace.
- * @type {Object}
+ * @const
  */
-olx.view;
+olx.view = {};
 
 
 /**
@@ -7140,7 +7140,8 @@ olx.view.FitOptions.prototype.maxZoom;
 
 
 /**
- * @typedef {{animate: boolean,
+ * @typedef {{
+ *     animate: boolean,
  *     attributions: Object.<string, ol.Attribution>,
  *     coordinateToPixelMatrix: ol.vec.Mat4.Number,
  *     extent: (null|ol.Extent),

--- a/src/ol/disposable.js
+++ b/src/ol/disposable.js
@@ -5,6 +5,7 @@ goog.require('ol');
 /**
  * Objects that need to clean up after themselves.
  * @constructor
+ * @struct
  */
 ol.Disposable = function() {};
 

--- a/src/ol/events/event.js
+++ b/src/ol/events/event.js
@@ -38,7 +38,11 @@ ol.events.Event = function(type, opt_target) {
 /**
  * Stop event propagation
  */
-ol.events.Event.prototype.preventDefault =
+ol.events.Event.prototype.preventDefault = function() {
+  this.stopPropagation();
+};
+
+
 ol.events.Event.prototype.stopPropagation = function() {
   this.propagationStopped = true;
 };

--- a/src/ol/events/eventtarget.js
+++ b/src/ol/events/eventtarget.js
@@ -20,6 +20,7 @@ goog.require('ol.events.Event');
  *    returns false.
  *
  * @constructor
+ * @struct
  * @extends {ol.Disposable}
  */
 ol.events.EventTarget = function() {

--- a/src/ol/format/gml/gml3format.js
+++ b/src/ol/format/gml/gml3format.js
@@ -1332,27 +1332,3 @@ ol.format.GML3.prototype.writeFeaturesNode = function(features, opt_options) {
  * @api stable
  */
 ol.format.GML = ol.format.GML3;
-
-
-/**
- * Encode an array of features in GML 3.1.1 Simple Features.
- *
- * @function
- * @param {Array.<ol.Feature>} features Features.
- * @param {olx.format.WriteOptions=} opt_options Options.
- * @return {string} Result.
- * @api stable
- */
-ol.format.GML.prototype.writeFeatures;
-
-
-/**
- * Encode an array of features in the GML 3.1.1 format as an XML node.
- *
- * @function
- * @param {Array.<ol.Feature>} features Features.
- * @param {olx.format.WriteOptions=} opt_options Options.
- * @return {Node} Node.
- * @api
- */
-ol.format.GML.prototype.writeFeaturesNode;

--- a/src/ol/format/mvtformat.js
+++ b/src/ol/format/mvtformat.js
@@ -47,9 +47,7 @@ ol.format.MVT = function(opt_options) {
 
   /**
    * @private
-   * @type {function((ol.geom.Geometry|Object.<string, *>)=)|
-   *     function(ol.geom.GeometryType,Array.<number>,
-   *         (Array.<number>|Array.<Array.<number>>),Object.<string, *>)}
+   * @type {Function}
    */
   this.featureClass_ = options.featureClass ?
       options.featureClass : ol.render.Feature;

--- a/src/ol/raster/operation.js
+++ b/src/ol/raster/operation.js
@@ -1,5 +1,6 @@
 goog.provide('ol.raster.Operation');
 goog.provide('ol.raster.OperationType');
+goog.require('ol.raster.Pixel');
 
 
 /**

--- a/src/ol/structs/lrucache.js
+++ b/src/ol/structs/lrucache.js
@@ -262,9 +262,31 @@ ol.structs.LRUCache.prototype.set = function(key, value) {
 
 
 /**
- * @typedef {{key_: string,
- *            newer: ol.structs.LRUCacheEntry,
- *            older: ol.structs.LRUCacheEntry,
- *            value_: *}}
+ * @interface
+ * @struct
  */
-ol.structs.LRUCacheEntry;
+ol.structs.LRUCacheEntry = function() {};
+
+
+/**
+ * @type {string}
+ */
+ol.structs.LRUCacheEntry.prototype.key_;
+
+
+/**
+ * @type {ol.structs.LRUCacheEntry}
+ */
+ol.structs.LRUCacheEntry.prototype.newer;
+
+
+/**
+ * @type {ol.structs.LRUCacheEntry}
+ */
+ol.structs.LRUCacheEntry.prototype.older;
+
+
+/**
+ * @type {*}
+ */
+ol.structs.LRUCacheEntry.prototype.value_;


### PR DESCRIPTION
Switch to the new type inference version of the compiler.
See https://github.com/google/closure-compiler/wiki/Using-NTI-%28new-type-inference%29

There are only 2 errors left:
```
ERR! compile /home/gberaudo/dev/ol3/src/ol/observable.js:22: ERROR - ol.Observable cannot extend this type; structs can only extend structs
ERR! compile ol.Observable = function() {
ERR! compile                 ^
ERR! compile 
ERR! compile 
ERR! compile /home/gberaudo/dev/ol3/src/ol/renderer/maprenderer.js:38: ERROR - ol.renderer.Map cannot extend this type; structs can only extend structs
ERR! compile ol.renderer.Map = function(container, map) {
ERR! compile                   ^
ERR! compile 
ERR! compile 
ERR! compile 2 error(s), 0
ERR! compile  warning(s)
ERR! compile 
ERR! Process exited with non-zero status, see log for more detail: 2 
```

TODO:
- [x] fix `structs can only extend structs` error;
- [ ] fix publish.js
