### PR TITLE
Make tile loading count no longer depend on source count

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -7008,7 +7008,6 @@ olx.view.FitOptions.prototype.maxZoom;
  *     size: ol.Size,
  *     skippedFeatureUids: Object.<string, boolean>,
  *     tileQueue: ol.TileQueue,
- *     tileSourceCount: number,
  *     time: number,
  *     usedTiles: Object.<string, Object.<string, ol.TileRange>>,
  *     viewState: olx.ViewState,

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -1016,7 +1016,6 @@ ol.Map.prototype.handlePostRender = function() {
   if (!tileQueue.isEmpty()) {
     var maxTotalLoading = 16;
     var maxNewLoads = maxTotalLoading;
-    var tileSourceCount = 0;
     if (frameState) {
       var hints = frameState.viewHints;
       if (hints[ol.ViewHint.ANIMATING]) {
@@ -1027,10 +1026,7 @@ ol.Map.prototype.handlePostRender = function() {
         maxTotalLoading = this.loadTilesWhileInteracting_ ? 8 : 0;
         maxNewLoads = 2;
       }
-      tileSourceCount = frameState.tileSourceCount;
     }
-    maxTotalLoading *= tileSourceCount;
-    maxNewLoads *= tileSourceCount;
     if (tileQueue.getTilesLoading() < maxTotalLoading) {
       tileQueue.reprioritize(); // FIXME only call if view has changed
       tileQueue.loadMoreTiles(maxTotalLoading, maxNewLoads);
@@ -1332,7 +1328,6 @@ ol.Map.prototype.renderFrame_ = function(time) {
       size: size,
       skippedFeatureUids: this.skippedFeatureUids_,
       tileQueue: this.tileQueue_,
-      tileSourceCount: 0,
       time: time,
       usedTiles: {},
       viewState: viewState,

--- a/src/ol/renderer/layerrenderer.js
+++ b/src/ol/renderer/layerrenderer.js
@@ -298,7 +298,6 @@ ol.renderer.Layer.prototype.manageTilePyramid = function(
   var tileSourceKey = goog.getUid(tileSource).toString();
   if (!(tileSourceKey in frameState.wantedTiles)) {
     frameState.wantedTiles[tileSourceKey] = {};
-    ++frameState.tileSourceCount;
   }
   var wantedTiles = frameState.wantedTiles[tileSourceKey];
   var tileQueue = frameState.tileQueue;

--- a/src/ol/source/rastersource.js
+++ b/src/ol/source/rastersource.js
@@ -122,7 +122,6 @@ ol.source.Raster = function(options) {
     size: [0, 0],
     skippedFeatureUids: {},
     tileQueue: this.tileQueue_,
-    tileSourceCount: 0,
     time: Date.now(),
     usedTiles: {},
     viewState: /** @type {olx.ViewState} */ ({


### PR DESCRIPTION
This pull request changes the tile queue behaviour so the number of loading tiles is no longer influenced by the number of sources that request tiles. This should give better user experience in applications with many tile layers.

Fixes #4790.