### PR TITLE
Cleanup after goog.array, goog.object and goog.isDef removal

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,20 +101,6 @@ style of the existing OpenLayers 3 code, which includes:
 
  * Do not use assignments inside expressions.
 
- * Avoid the use of `goog.array.clone` with arrays (use slice instead).
-
- * Use `array.length = 0` instead of `goog.array.clear`.
-
- * Use `v !== undefined` instead of `goog.isDef(v)` and `v === null` instead of
-   `goog.isNull(v)`.
-
- * Use ECMAScript 5.1 functions instead of the `goog` equivalents. For example,
-   use `Object.keys(obj)` instead of `goog.object.getKeys(obj)`, `arr.forEach(f)`
-   instead of `goog.array.forEach(arr, f)`, etc ...
-
- * Use bracket notation instead of `goog.object.set` and `goog.object.get` (with
-   two arguments).
-
  * Use uppercase for `@const` variables.
 
 ### Configure your editor

--- a/test/spec/ol/tilegrid/wmtstilegrid.test.js
+++ b/test/spec/ol/tilegrid/wmtstilegrid.test.js
@@ -42,17 +42,17 @@ describe('ol.tilegrid.WMTS', function() {
           expect(tileGrid.origins_).to.be.an('array');
           expect(tileGrid.origins_).to.have.length(20);
           expect(tileGrid.origins_).to.eql(
-              goog.array.repeat([-20037508.3428, 20037508.3428], 20));
+              Array.apply(null, Array(20)).map(Array.prototype.valueOf,
+                  [-20037508.3428, 20037508.3428]));
 
           expect(tileGrid.tileSizes_).to.be.an('array');
           expect(tileGrid.tileSizes_).to.have.length(20);
           expect(tileGrid.tileSizes_).to.eql(
-              goog.array.repeat(256, 20));
+              Array.apply(null, Array(20)).map(Number.prototype.valueOf, 256));
 
         });
   });
 });
 
-goog.require('goog.array');
 goog.require('ol.format.WMTSCapabilities');
 goog.require('ol.tilegrid.WMTS');

--- a/test/test-extensions.js
+++ b/test/test-extensions.js
@@ -311,7 +311,7 @@
    */
   expect.Assertion.prototype.arreql = function(obj) {
     this.assert(
-        goog.array.equals(this.obj, obj),
+        ol.array.equals(this.obj, obj),
         function() {
           return 'expected ' + expect.stringify(this.obj) +
               ' to sort of equal ' + expect.stringify(obj);
@@ -330,12 +330,13 @@
    * @return {expect.Assertion} The assertion.
    */
   expect.Assertion.prototype.arreqlNaN = function(obj) {
-    function compare(a, b) {
+    function compare(a, i) {
+      var b = obj[i];
       return a === b || (typeof a === 'number' && typeof b === 'number' &&
           isNaN(a) && isNaN(b));
     }
     this.assert(
-        goog.array.equals(this.obj, obj, compare),
+        this.obj.length === obj.length && this.obj.every(compare),
         function() {
           return 'expected ' + expect.stringify(this.obj) +
               ' to sort of equal ' + expect.stringify(obj);


### PR DESCRIPTION
This pull request removes `goog.array` calls from tests, and cleans up `CONTRIBUTING.md`.