### PR TITLE
Add new cacheSize option to ol.source

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -1,5 +1,19 @@
 ## Upgrade notes
 
+### v3.15.0
+
+#### Removal of `ol.DEFAULT_TILE_CACHE_HIGH_WATER_MARK`
+
+The `ol.DEFAULT_TILE_CACHE_HIGH_WATER_MARK` define has been removed. The size of the cache can now be defined on every tile based `ol.source`:
+```js
+new ol.layer.Tile({
+  source: new ol.source.OSM({
+    cacheSize: 128
+  })
+})
+```
+The default cache size is `2048`.
+
 ### v3.14.0
 
 #### Internet Explorer 9 support

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -3904,7 +3904,8 @@ olx.source;
 
 
 /**
- * @typedef {{culture: (string|undefined),
+ * @typedef {{cacheSize: (number|undefined),
+ *     culture: (string|undefined),
  *     key: string,
  *     imagerySet: string,
  *     maxZoom: (number|undefined),
@@ -3914,6 +3915,14 @@ olx.source;
  * @api
  */
 olx.source.BingMapsOptions;
+
+
+/**
+ * Cache size. Default is `2048`.
+ * @type {number|undefined}
+ * @api
+ */
+olx.source.BingMapsOptions.prototype.cacheSize;
 
 
 /**
@@ -4107,6 +4116,7 @@ olx.source.TileUTFGridOptions.prototype.url;
 
 /**
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ *            cacheSize: (number|undefined),
  *            crossOrigin: (null|string|undefined),
  *            logo: (string|olx.LogoOptions|undefined),
  *            opaque: (boolean|undefined),
@@ -4134,6 +4144,14 @@ olx.source.TileImageOptions;
  * @api
  */
 olx.source.TileImageOptions.prototype.attributions;
+
+
+/**
+ * Cache size. Default is `2048`.
+ * @type {number|undefined}
+ * @api
+ */
+olx.source.TileImageOptions.prototype.cacheSize;
 
 
 /**
@@ -4270,6 +4288,7 @@ olx.source.TileImageOptions.prototype.wrapX;
 
 /**
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ *            cacheSize: (number|undefined),
  *            format: (ol.format.Feature|undefined),
  *            logo: (string|olx.LogoOptions|undefined),
  *            opaque: (boolean|undefined),
@@ -4296,6 +4315,15 @@ olx.source.VectorTileOptions;
  * @api
  */
 olx.source.VectorTileOptions.prototype.attributions;
+
+
+
+/**
+ * Cache size. Default is `128`.
+ * @type {number|undefined}
+ * @api
+ */
+olx.source.VectorTileOptions.prototype.cacheSize;
 
 
 /**
@@ -4518,13 +4546,22 @@ olx.source.ImageMapGuideOptions.prototype.params;
 
 
 /**
- * @typedef {{layer: string,
+ * @typedef {{cacheSize: (number|undefined),
+ *     layer: string,
  *     reprojectionErrorThreshold: (number|undefined),
  *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
  *     url: (string|undefined)}}
  * @api
  */
 olx.source.MapQuestOptions;
+
+
+/**
+ * Cache size. Default is `2048`.
+ * @type {number|undefined}
+ * @api
+ */
+olx.source.MapQuestOptions.prototype.cacheSize;
 
 
 /**
@@ -4600,6 +4637,7 @@ olx.source.TileDebugOptions.prototype.wrapX;
 
 /**
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ *     cacheSize: (number|undefined),
  *     crossOrigin: (null|string|undefined),
  *     maxZoom: (number|undefined),
  *     opaque: (boolean|undefined),
@@ -4618,6 +4656,14 @@ olx.source.OSMOptions;
  * @api stable
  */
 olx.source.OSMOptions.prototype.attributions;
+
+
+/**
+ * Cache size. Default is `2048`.
+ * @type {number|undefined}
+ * @api
+ */
+olx.source.OSMOptions.prototype.cacheSize;
 
 
 /**
@@ -5016,7 +5062,8 @@ olx.source.ImageWMSOptions.prototype.url;
 
 
 /**
- * @typedef {{layer: string,
+ * @typedef {{cacheSize: (number|undefined),
+ *     layer: string,
  *     minZoom: (number|undefined),
  *     maxZoom: (number|undefined),
  *     opaque: (boolean|undefined),
@@ -5027,6 +5074,13 @@ olx.source.ImageWMSOptions.prototype.url;
  */
 olx.source.StamenOptions;
 
+
+/**
+ * Cache size. Default is `2048`.
+ * @type {number|undefined}
+ * @api
+ */
+olx.source.StamenOptions.prototype.cacheSize;
 
 /**
  * Layer.
@@ -5176,6 +5230,7 @@ olx.source.ImageStaticOptions.prototype.url;
 
 /**
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ *     cacheSize: (number|undefined),
  *     crossOrigin: (null|string|undefined),
  *     params: (Object.<string, *>|undefined),
  *     logo: (string|olx.LogoOptions|undefined),
@@ -5197,6 +5252,14 @@ olx.source.TileArcGISRestOptions;
  * @api
  */
 olx.source.TileArcGISRestOptions.prototype.attributions;
+
+
+/**
+ * Cache size. Default is `2048`.
+ * @type {number|undefined}
+ * @api
+ */
+olx.source.TileArcGISRestOptions.prototype.cacheSize;
 
 
 /**
@@ -5303,6 +5366,7 @@ olx.source.TileArcGISRestOptions.prototype.urls;
 
 /**
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ *     cacheSize: (number|undefined),
  *     crossOrigin: (null|string|undefined),
  *     jsonp: (boolean|undefined),
  *     reprojectionErrorThreshold: (number|undefined),
@@ -5322,6 +5386,14 @@ olx.source.TileJSONOptions;
  * @api stable
  */
 olx.source.TileJSONOptions.prototype.attributions;
+
+
+/**
+ * Cache size. Default is `2048`.
+ * @type {number|undefined}
+ * @api
+ */
+olx.source.TileJSONOptions.prototype.cacheSize;
 
 
 /**
@@ -5385,6 +5457,7 @@ olx.source.TileJSONOptions.prototype.wrapX;
 
 /**
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ *     cacheSize: (number|undefined),
  *     params: Object.<string,*>,
  *     crossOrigin: (null|string|undefined),
  *     gutter: (number|undefined),
@@ -5410,6 +5483,14 @@ olx.source.TileWMSOptions;
  * @api stable
  */
 olx.source.TileWMSOptions.prototype.attributions;
+
+
+/**
+ * Cache size. Default is `2048`.
+ * @type {number|undefined}
+ * @api
+ */
+olx.source.TileWMSOptions.prototype.cacheSize;
 
 
 /**
@@ -5675,6 +5756,7 @@ olx.source.VectorOptions.prototype.wrapX;
 
 /**
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ *     cacheSize: (number|undefined),
  *     crossOrigin: (string|null|undefined),
  *     logo: (string|olx.LogoOptions|undefined),
  *     tileGrid: ol.tilegrid.WMTS,
@@ -5707,6 +5789,14 @@ olx.source.WMTSOptions;
  * @api
  */
 olx.source.WMTSOptions.prototype.attributions;
+
+
+/**
+ * Cache size. Default is `2048`.
+ * @type {number|undefined}
+ * @api
+ */
+olx.source.WMTSOptions.prototype.cacheSize;
 
 
 /**
@@ -5882,6 +5972,7 @@ olx.source.WMTSOptions.prototype.wrapX;
 
 /**
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ *     cacheSize: (number|undefined),
  *     crossOrigin: (null|string|undefined),
  *     logo: (string|olx.LogoOptions|undefined),
  *     opaque: (boolean|undefined),
@@ -5908,6 +5999,14 @@ olx.source.XYZOptions;
  * @api stable
  */
 olx.source.XYZOptions.prototype.attributions;
+
+
+/**
+ * Cache size. Default is `2048`.
+ * @type {number|undefined}
+ * @api
+ */
+olx.source.XYZOptions.prototype.cacheSize;
 
 
 /**
@@ -6048,6 +6147,7 @@ olx.source.XYZOptions.prototype.wrapX;
 
 /**
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ *     cacheSize: (number|undefined),
  *     crossOrigin: (null|string|undefined),
  *     logo: (string|olx.LogoOptions|undefined),
  *     reprojectionErrorThreshold: (number|undefined),
@@ -6065,6 +6165,14 @@ olx.source.ZoomifyOptions;
  * @api stable
  */
 olx.source.ZoomifyOptions.prototype.attributions;
+
+
+/**
+ * Cache size. Default is `2048`.
+ * @type {number|undefined}
+ * @api
+ */
+olx.source.ZoomifyOptions.prototype.cacheSize;
 
 
 /**

--- a/src/ol/ol.js
+++ b/src/ol/ol.js
@@ -36,12 +36,6 @@ ol.DEFAULT_RASTER_REPROJECTION_ERROR_THRESHOLD = 0.5;
 
 
 /**
- * @define {number} Default high water mark.
- */
-ol.DEFAULT_TILE_CACHE_HIGH_WATER_MARK = 2048;
-
-
-/**
  * @define {number} Default tile size.
  */
 ol.DEFAULT_TILE_SIZE = 256;

--- a/src/ol/source/bingmapssource.js
+++ b/src/ol/source/bingmapssource.js
@@ -24,6 +24,7 @@ goog.require('ol.tilecoord');
 ol.source.BingMaps = function(options) {
 
   goog.base(this, {
+    cacheSize: options.cacheSize,
     crossOrigin: 'anonymous',
     opaque: true,
     projection: ol.proj.get('EPSG:3857'),

--- a/src/ol/source/mapquestsource.js
+++ b/src/ol/source/mapquestsource.js
@@ -36,6 +36,7 @@ ol.source.MapQuest = function(opt_options) {
 
   goog.base(this, {
     attributions: layerConfig.attributions,
+    cacheSize: options.cacheSize,
     crossOrigin: 'anonymous',
     logo: 'https://developer.mapquest.com/content/osm/mq_logo.png',
     maxZoom: layerConfig.maxZoom,

--- a/src/ol/source/osmsource.js
+++ b/src/ol/source/osmsource.js
@@ -32,6 +32,7 @@ ol.source.OSM = function(opt_options) {
 
   goog.base(this, {
     attributions: attributions,
+    cacheSize: options.cacheSize,
     crossOrigin: crossOrigin,
     opaque: options.opaque !== undefined ? options.opaque : true,
     maxZoom: options.maxZoom !== undefined ? options.maxZoom : 19,

--- a/src/ol/source/stamensource.js
+++ b/src/ol/source/stamensource.js
@@ -103,6 +103,7 @@ ol.source.Stamen = function(options) {
 
   goog.base(this, {
     attributions: ol.source.Stamen.ATTRIBUTIONS,
+    cacheSize: options.cacheSize,
     crossOrigin: 'anonymous',
     maxZoom: providerConfig.maxZoom,
     // FIXME uncomment the following when tilegrid supports minZoom

--- a/src/ol/source/tilearcgisrestsource.js
+++ b/src/ol/source/tilearcgisrestsource.js
@@ -33,6 +33,7 @@ ol.source.TileArcGISRest = function(opt_options) {
 
   goog.base(this, {
     attributions: options.attributions,
+    cacheSize: options.cacheSize,
     crossOrigin: options.crossOrigin,
     logo: options.logo,
     projection: options.projection,

--- a/src/ol/source/tileimagesource.js
+++ b/src/ol/source/tileimagesource.js
@@ -25,6 +25,7 @@ ol.source.TileImage = function(options) {
 
   goog.base(this, {
     attributions: options.attributions,
+    cacheSize: options.cacheSize,
     extent: options.extent,
     logo: options.logo,
     opaque: options.opaque,

--- a/src/ol/source/tilejsonsource.js
+++ b/src/ol/source/tilejsonsource.js
@@ -31,6 +31,7 @@ ol.source.TileJSON = function(options) {
 
   goog.base(this, {
     attributions: options.attributions,
+    cacheSize: options.cacheSize,
     crossOrigin: options.crossOrigin,
     projection: ol.proj.get('EPSG:3857'),
     reprojectionErrorThreshold: options.reprojectionErrorThreshold,

--- a/src/ol/source/tilewmssource.js
+++ b/src/ol/source/tilewmssource.js
@@ -39,6 +39,7 @@ ol.source.TileWMS = function(opt_options) {
 
   goog.base(this, {
     attributions: options.attributions,
+    cacheSize: options.cacheSize,
     crossOrigin: options.crossOrigin,
     logo: options.logo,
     opaque: !transparent,

--- a/src/ol/source/vectortilesource.js
+++ b/src/ol/source/vectortilesource.js
@@ -26,12 +26,9 @@ goog.require('ol.source.UrlTile');
  */
 ol.source.VectorTile = function(options) {
 
-  var cacheSize = options.cacheSize !== undefined ?
-      options.cacheSize : ol.DEFAULT_TILE_CACHE_HIGH_WATER_MARK / 16;
-
   goog.base(this, {
     attributions: options.attributions,
-    cacheSize: cacheSize,
+    cacheSize: options.cacheSize !== undefined ? options.cacheSize : 128,
     extent: options.extent,
     logo: options.logo,
     opaque: options.opaque,

--- a/src/ol/source/vectortilesource.js
+++ b/src/ol/source/vectortilesource.js
@@ -26,9 +26,12 @@ goog.require('ol.source.UrlTile');
  */
 ol.source.VectorTile = function(options) {
 
+  var cacheSize = options.cacheSize !== undefined ?
+      options.cacheSize : ol.DEFAULT_TILE_CACHE_HIGH_WATER_MARK / 16;
+
   goog.base(this, {
     attributions: options.attributions,
-    cacheSize: ol.DEFAULT_TILE_CACHE_HIGH_WATER_MARK / 16,
+    cacheSize: cacheSize,
     extent: options.extent,
     logo: options.logo,
     opaque: options.opaque,

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -174,6 +174,7 @@ ol.source.WMTS = function(options) {
 
   goog.base(this, {
     attributions: options.attributions,
+    cacheSize: options.cacheSize,
     crossOrigin: options.crossOrigin,
     logo: options.logo,
     projection: options.projection,

--- a/src/ol/source/xyzsource.js
+++ b/src/ol/source/xyzsource.js
@@ -38,6 +38,7 @@ ol.source.XYZ = function(options) {
 
   goog.base(this, {
     attributions: options.attributions,
+    cacheSize: options.cacheSize,
     crossOrigin: options.crossOrigin,
     logo: options.logo,
     opaque: options.opaque,

--- a/src/ol/source/zoomifysource.js
+++ b/src/ol/source/zoomifysource.js
@@ -121,6 +121,7 @@ ol.source.Zoomify = function(opt_options) {
 
   goog.base(this, {
     attributions: options.attributions,
+    cacheSize: options.cacheSize,
     crossOrigin: options.crossOrigin,
     logo: options.logo,
     reprojectionErrorThreshold: options.reprojectionErrorThreshold,

--- a/src/ol/tilecache.js
+++ b/src/ol/tilecache.js
@@ -1,6 +1,5 @@
 goog.provide('ol.TileCache');
 
-goog.require('ol');
 goog.require('ol.TileRange');
 goog.require('ol.structs.LRUCache');
 goog.require('ol.tilecoord');
@@ -20,8 +19,7 @@ ol.TileCache = function(opt_highWaterMark) {
    * @private
    * @type {number}
    */
-  this.highWaterMark_ = opt_highWaterMark !== undefined ?
-      opt_highWaterMark : ol.DEFAULT_TILE_CACHE_HIGH_WATER_MARK;
+  this.highWaterMark_ = opt_highWaterMark !== undefined ? opt_highWaterMark : 2048;
 
 };
 goog.inherits(ol.TileCache, ol.structs.LRUCache);


### PR DESCRIPTION
Fixes #4702 

Option added to:
 - olx.source.BingMapsOptions
 - olx.source.MapQuestOptions
 - olx.source.OSMOptions
 - olx.source.StamenOptions
 - olx.source.TileArcGISRestOptions
 - olx.source.TileImageOptions
 - olx.source.TileJSONOptions
 - olx.source.TileWMSOptions
 - olx.source.XYZOptions
 - olx.source.ZoomifyOptions


All sources except vector, static image and single image
