### PR TITLE
Don't use goog.string.newlines.*

### DIFF
--- a/src/ol/format/igcformat.js
+++ b/src/ol/format/igcformat.js
@@ -2,7 +2,6 @@ goog.provide('ol.format.IGC');
 goog.provide('ol.format.IGCZ');
 
 goog.require('goog.asserts');
-goog.require('goog.string.newlines');
 goog.require('ol.Feature');
 goog.require('ol.format.Feature');
 goog.require('ol.format.TextFeature');
@@ -88,6 +87,16 @@ ol.format.IGC.HFDTE_RECORD_RE_ = /^HFDTE(\d{2})(\d{2})(\d{2})/;
 
 
 /**
+ * A regular expression matching the newline characters `\r\n`, `\r` and `\n`.
+ *
+ * @const
+ * @type {RegExp}
+ * @private
+ */
+ol.format.IGC.NEWLINE_RE_ = /\r\n|\r|\n/;
+
+
+/**
  * @inheritDoc
  */
 ol.format.IGC.prototype.getExtensions = function() {
@@ -112,7 +121,7 @@ ol.format.IGC.prototype.readFeature;
  */
 ol.format.IGC.prototype.readFeatureFromText = function(text, opt_options) {
   var altitudeMode = this.altitudeMode_;
-  var lines = goog.string.newlines.splitLines(text);
+  var lines = text.split(ol.format.IGC.NEWLINE_RE_);
   /** @type {Object.<string, string>} */
   var properties = {};
   var flatCoordinates = [];


### PR DESCRIPTION
…instead simply use `String.prototype.split` with a regular expression.

I was also thinking of inlining the regular expression, so if everybody likes that better, I can update this PR.

Please review.