### PR TITLE
JSDoc fixes

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -1184,7 +1184,7 @@ olx.control.MousePositionOptions.prototype.undefinedHTML;
  *     collapseLabel: (string|Node|undefined),
  *     collapsible: (boolean|undefined),
  *     label: (string|Node|undefined),
- *     layers: (Array.<ol.layer.Layer>|ol.Collection|undefined),
+ *     layers: (Array.<ol.layer.Layer>|ol.Collection<ol.layer.Layer>|undefined),
  *     render: (function(ol.MapEvent)|undefined),
  *     target: (Element|undefined),
  *     tipLabel: (string|undefined),

--- a/src/ol/canvasfunction.js
+++ b/src/ol/canvasfunction.js
@@ -10,8 +10,12 @@ goog.provide('ol.CanvasFunctionType');
  * this function is cached by the source. The this keyword inside the function
  * references the {@link ol.source.ImageCanvas}.
  *
- * @typedef {function(this:ol.source.ImageCanvas, ol.Extent, number,
- *     number, ol.Size, ol.proj.Projection): HTMLCanvasElement}
+ * @callback ol.CanvasFunctionType
+ * @param {ol.Extent} extent The image extent
+ * @param {number} imgResolution The image resolution
+ * @param {number} pixelRatio The device pixel ratio
+ * @param {ol.Size} imgSize The image size
+ * @param {ol.proj.Projection} proj The image projection
  * @api
  */
 ol.CanvasFunctionType;

--- a/src/ol/centerconstraint.js
+++ b/src/ol/centerconstraint.js
@@ -5,7 +5,9 @@ goog.require('ol.math');
 
 
 /**
- * @typedef {function((ol.Coordinate|undefined)): (ol.Coordinate|undefined)}
+ * @callback ol.CenterConstraintType
+ * @param {(ol.Coordinate|undefined)} coord The coordinate
+ * @return {ol.Coordinate|undefined}
  */
 ol.CenterConstraintType;
 

--- a/src/ol/coordinate.js
+++ b/src/ol/coordinate.js
@@ -10,7 +10,9 @@ goog.require('goog.string');
  * A function that takes a {@link ol.Coordinate} and transforms it into a
  * `{string}`.
  *
- * @typedef {function((ol.Coordinate|undefined)): string}
+ * @callback ol.CoordinateFormatType
+ * @param {(ol.Coordinate|undefined)} coord The coordinate
+ * @return {string}
  * @api stable
  */
 ol.CoordinateFormatType;

--- a/src/ol/events.js
+++ b/src/ol/events.js
@@ -83,7 +83,9 @@ ol.events.Key;
  * Listener function. This function is called with an event object as argument.
  * When the function returns `false`, event propagation will stop.
  *
- * @typedef {function(ol.events.Event)|function(ol.events.Event): boolean}
+ * @callback ol.events.ListenerFunctionType
+ * @param {ol.events.Event} evt The event object
+ * @return {boolean} If false, event propagation will stop
  * @api
  */
 ol.events.ListenerFunctionType;

--- a/src/ol/events/condition.js
+++ b/src/ol/events/condition.js
@@ -11,7 +11,9 @@ goog.require('ol.MapBrowserPointerEvent');
  * A function that takes an {@link ol.MapBrowserEvent} and returns a
  * `{boolean}`. If the condition is met, true should be returned.
  *
- * @typedef {function(ol.MapBrowserEvent): boolean}
+ * @callback ol.events.ConditionType
+ * @param {ol.MapBrowserEvent} evt The map browser event
+ * @return {boolean} Returns true if the condition is met, otherwise false is returned
  * @api stable
  */
 ol.events.ConditionType;

--- a/src/ol/feature.js
+++ b/src/ol/feature.js
@@ -289,8 +289,9 @@ ol.Feature.prototype.setGeometryName = function(name) {
  * resolution. The `this` keyword inside the function references the
  * {@link ol.Feature} to be styled.
  *
- * @typedef {function(this: ol.Feature, number):
- *     (ol.style.Style|Array.<ol.style.Style>)}
+ * @callback ol.FeatureStyleFunction
+ * @param {number} resolution The resolution
+ * @return {ol.style.Style|Array.<ol.style.Style>} The styles for the given resolution
  * @api stable
  */
 ol.FeatureStyleFunction;

--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -23,8 +23,10 @@ goog.require('ol.xml');
  * The function is responsible for loading the features and adding them to the
  * source.
  * @api
- * @typedef {function(this:ol.source.Vector, ol.Extent, number,
- *                    ol.proj.Projection)}
+ * @callback ol.FeatureLoader
+ * @param {ol.Extent} extent The area to be loaded
+ * @param {number} resolution The resolution (map units per pixel)
+ * @param {ol.proj.Projection} projection The projection
  */
 ol.FeatureLoader;
 
@@ -38,7 +40,11 @@ ol.FeatureLoader;
  * {@link ol.proj.Projection} for the projection  as arguments and returns a
  * `{string}` representing the URL.
  * @api
- * @typedef {function(ol.Extent, number, ol.proj.Projection) : string}
+ * @callback ol.FeatureUrlFunction
+ * @param {ol.Extent} extent The area to be loaded
+ * @param {number} resolution The resolution (map units per pixel)
+ * @param {ol.proj.Projection} projection The projection
+ * @return {string} The URL
  */
 ol.FeatureUrlFunction;
 

--- a/src/ol/framestate.js
+++ b/src/ol/framestate.js
@@ -5,7 +5,10 @@ goog.provide('ol.PreRenderFunction');
 
 
 /**
- * @typedef {function(ol.Map, ?olx.FrameState): boolean}
+ * @callback ol.PostRenderFunction
+ * @param {ol.Map} map The map
+ * @param {olx.FrameState} [frameState] The frame state
+ * @return {boolean}
  */
 ol.PostRenderFunction;
 
@@ -15,7 +18,10 @@ ol.PostRenderFunction;
  * with the {@link ol.Map} as first and an optional {@link olx.FrameState} as
  * second argument. Return `true` to keep this function for the next frame,
  * `false` to remove it.
- * @typedef {function(ol.Map, ?olx.FrameState): boolean}
  * @api
+ * @callback ol.PreRenderFunction
+ * @param {ol.Map} map The map
+ * @param {olx.FrameState} [frameState] The frame state
+ * @return {boolean} Returns true to keep this function for the next frame, returns false to remove it
  */
 ol.PreRenderFunction;

--- a/src/ol/imagecanvas.js
+++ b/src/ol/imagecanvas.js
@@ -99,6 +99,7 @@ ol.ImageCanvas.prototype.getImage = function(opt_context) {
  * If any error occurs during drawing, the "done" callback should be called with
  * that error.
  *
- * @typedef {function(function(Error))}
+ * @callback ol.ImageCanvasLoader
+ * @param {Error} error The error
  */
 ol.ImageCanvasLoader;

--- a/src/ol/imageloadfunction.js
+++ b/src/ol/imageloadfunction.js
@@ -15,7 +15,9 @@ goog.provide('ol.ImageLoadFunctionType');
  * post requests or - in general - through XHR requests, where the src of the
  * image element would be set to a data URI when the content is loaded.
  *
- * @typedef {function(ol.Image, string)}
  * @api
+ * @callback ol.ImageLoadFunctionType
+ * @param {ol.Image} img The image
+ * @param {string} src The source
  */
 ol.ImageLoadFunctionType;

--- a/src/ol/interaction/dragboxinteraction.js
+++ b/src/ol/interaction/dragboxinteraction.js
@@ -84,8 +84,12 @@ goog.inherits(ol.DragBoxEvent, ol.events.Event);
  * A function that takes a {@link ol.MapBrowserEvent} and two
  * {@link ol.Pixel}s and returns a `{boolean}`. If the condition is met,
  * true should be returned.
- * @typedef {function(ol.MapBrowserEvent, ol.Pixel, ol.Pixel):boolean}
  * @api
+ * @callback ol.interaction.DragBoxEndConditionType
+ * @param {ol.MapBrowserEvent} evt The map browser event
+ * @param {ol.Pixel} firstPixel The first pixel
+ * @param {ol.Pixel} secondPixel The second pixel
+ * @return {boolean} Returns true if the condition is met. Returns false if it is not.
  */
 ol.interaction.DragBoxEndConditionType;
 

--- a/src/ol/interaction/drawinteraction.js
+++ b/src/ol/interaction/drawinteraction.js
@@ -845,10 +845,12 @@ ol.interaction.Draw.getMode_ = function(type) {
  * arguments, and returns a geometry. The optional existing geometry is the
  * geometry that is returned when the function is called without a second
  * argument.
- * @typedef {function(!(ol.Coordinate|Array.<ol.Coordinate>|
- *     Array.<Array.<ol.Coordinate>>), ol.geom.SimpleGeometry=):
- *     ol.geom.SimpleGeometry}
+ *
  * @api
+ * @callback ol.interaction.DrawGeometryFunctionType
+ * @param {(ol.Coordinate|Array.<ol.Coordinate>|Array.<Array.<ol.Coordinate>>)} coords Coordinates
+ * @param {ol.geom.SimpleGeometry} [geom] The existing geometry
+ * @return {ol.geom.SimpleGeometry}
  */
 ol.interaction.DrawGeometryFunctionType;
 

--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -35,9 +35,12 @@ ol.interaction.SelectEventType = {
  * A function that takes an {@link ol.Feature} or {@link ol.render.Feature} and
  * an {@link ol.layer.Layer} and returns `true` if the feature may be selected
  * or `false` otherwise.
- * @typedef {function((ol.Feature|ol.render.Feature), ol.layer.Layer):
- *     boolean}
+ *
  * @api
+ * @callback ol.interaction.SelectFilterFunction
+ * @param {(ol.Feature|ol.render.Feature)} feature The feature
+ * @param {ol.layer.Layer} layer The layer
+ * @return {boolean} Returns true if the feature may be selected. Returns false otherwise
  */
 ol.interaction.SelectFilterFunction;
 

--- a/src/ol/loadingstrategy.js
+++ b/src/ol/loadingstrategy.js
@@ -5,8 +5,11 @@ goog.require('ol.TileCoord');
 
 
 /**
- * @typedef {function(ol.Extent, number): Array.<ol.Extent>}
  * @api
+ * @callback ol.LoadingStrategy
+ * @param {ol.Extent} extent The extent
+ * @param {number} resolution The resolution
+ * @return {Array.<ol.Extent>}
  */
 ol.LoadingStrategy;
 

--- a/src/ol/raster/operation.js
+++ b/src/ol/raster/operation.js
@@ -15,7 +15,7 @@ ol.raster.OperationType = {
 
 /**
  * A function that takes an array of input data, performs some operation, and
- * returns an array of ouput data.  For `'pixel'` type operations, functions
+ * returns an array of output data.  For `'pixel'` type operations, functions
  * will be called with an array of {@link ol.raster.Pixel} data and should
  * return an array of the same.  For `'image'` type operations, functions will
  * be called with an array of {@link ImageData
@@ -25,8 +25,10 @@ ol.raster.OperationType = {
  * from raster events, where it can be initialized in "beforeoperations" and
  * accessed again in "afteroperations".
  *
- * @typedef {function((Array.<ol.raster.Pixel>|Array.<ImageData>), Object):
- *     (Array.<ol.raster.Pixel>|Array.<ImageData>)}
  * @api
+ * @callback ol.raster.Operation
+ * @param {(Array.<ol.raster.Pixel>|Array.<ImageData>)} input An aray of input data
+ * @param {Object} data The data object
+ * @returns {Array.<ol.raster.Pixel>|Array.<ImageData>} An array of output data
  */
 ol.raster.Operation;

--- a/src/ol/reproj/image.js
+++ b/src/ol/reproj/image.js
@@ -13,7 +13,11 @@ goog.require('ol.reproj.Triangulation');
 
 
 /**
- * @typedef {function(ol.Extent, number, number) : ol.ImageBase}
+ * @callback ol.reproj.ImageFunctionType
+ * @param {ol.Extent} extent The extent
+ * @param {number} resolution The resolution
+ * @param {number} pixelRatio The pixel ratio
+ * @return {ol.ImageBase}
  */
 ol.reproj.ImageFunctionType;
 

--- a/src/ol/reproj/tile.js
+++ b/src/ol/reproj/tile.js
@@ -16,7 +16,12 @@ goog.require('ol.reproj.Triangulation');
 
 
 /**
- * @typedef {function(number, number, number, number) : ol.Tile}
+ * @callback ol.reproj.TileFunctionType
+ * @param {number} srcZ Z
+ * @param {number} srcX X
+ * @param {number} srcY Y
+ * @param {number} pixelRatio Pixel ratio
+ * @return {ol.Tile}
  */
 ol.reproj.TileFunctionType;
 

--- a/src/ol/resolutionconstraint.js
+++ b/src/ol/resolutionconstraint.js
@@ -6,7 +6,11 @@ goog.require('ol.math');
 
 
 /**
- * @typedef {function((number|undefined), number, number): (number|undefined)}
+ * @callback ol.ResolutionConstraintType
+ * @param {(number|undefined)} resolution The resolution
+ * @param {number} delta The delta
+ * @param {number} direction The direction
+ * @return {number|undefined}
  */
 ol.ResolutionConstraintType;
 

--- a/src/ol/rotationconstraint.js
+++ b/src/ol/rotationconstraint.js
@@ -5,7 +5,10 @@ goog.require('ol.math');
 
 
 /**
- * @typedef {function((number|undefined), number): (number|undefined)}
+ * @callback ol.RotationConstraintType
+ * @param {(number|undefined)} rotation The rotation
+ * @param {number} delta The delta
+ * @return {number|undefined}
  */
 ol.RotationConstraintType;
 

--- a/src/ol/style/style.js
+++ b/src/ol/style/style.js
@@ -198,9 +198,11 @@ ol.style.Style.prototype.setZIndex = function(zIndex) {
  * the view's resolution. The function should return an array of
  * {@link ol.style.Style}. This way e.g. a vector layer can be styled.
  *
- * @typedef {function((ol.Feature|ol.render.Feature), number):
- *     (ol.style.Style|Array.<ol.style.Style>)}
  * @api
+ * @callback ol.style.StyleFunction
+ * @param {(ol.Feature|ol.render.Feature)} feature The feature
+ * @param {number} resolution The view's resolution
+ * @return {ol.style.Style|Array.<ol.style.Style>} The style(s) for the feature
  */
 ol.style.StyleFunction;
 
@@ -355,9 +357,10 @@ ol.style.createDefaultEditingStyles = function() {
  * A function that takes an {@link ol.Feature} as argument and returns an
  * {@link ol.geom.Geometry} that will be rendered and styled for the feature.
  *
- * @typedef {function((ol.Feature|ol.render.Feature)):
- *     (ol.geom.Geometry|ol.render.Feature|undefined)}
  * @api
+ * @callback ol.style.GeometryFunction
+ * @param {ol.Feature|ol.render.Feature} feature The feature
+ * @return {ol.geom.Geometry|ol.render.Feature|undefined} The geometry of feature that will be rendered and styled for the feature
  */
 ol.style.GeometryFunction;
 

--- a/src/ol/tileloadfunction.js
+++ b/src/ol/tileloadfunction.js
@@ -5,7 +5,9 @@ goog.provide('ol.TileLoadFunctionType');
  * A function that takes an {@link ol.Tile} for the tile and a `{string}` for
  * the url as arguments.
  *
- * @typedef {function(ol.Tile, string)}
  * @api
+ * @callback ol.TileLoadFunctionType
+ * @param {ol.Tile} tile The tile
+ * @param {string} url The URL
  */
 ol.TileLoadFunctionType;

--- a/src/ol/tilequeue.js
+++ b/src/ol/tilequeue.js
@@ -3,13 +3,14 @@ goog.provide('ol.TileQueue');
 
 goog.require('ol.events');
 goog.require('ol.events.EventType');
-goog.require('ol.Coordinate');
 goog.require('ol.TileState');
 goog.require('ol.structs.PriorityQueue');
 
 
 /**
- * @typedef {function(ol.Tile, string, ol.Coordinate, number): number}
+ * @callback ol.TilePriorityFunction
+ * @param {Array} element Element
+ * @return {number}
  */
 ol.TilePriorityFunction;
 

--- a/src/ol/tileurlfunction.js
+++ b/src/ol/tileurlfunction.js
@@ -17,16 +17,22 @@ goog.require('ol.tilecoord');
  * URL, or undefined if no tile should be requested for the passed tile
  * coordinate.
  *
- * @typedef {function(ol.TileCoord, number,
- *           ol.proj.Projection): (string|undefined)}
  * @api
+ * @callback ol.TileUrlFunctionType
+ * @param {ol.TileCoord} coord The tile coordinate
+ * @param {number} pixelRatio The pixel ratio
+ * @param {ol.proj.Projection} proj The projection
+ * @return {string|undefined}
  */
 ol.TileUrlFunctionType;
 
 
 /**
- * @typedef {function(ol.TileCoord, ol.proj.Projection, ol.TileCoord=):
- *     ol.TileCoord}
+ * @callback ol.TileCoordTransformType
+ * @param {ol.TileCoord} tileCoord The tile coordinate
+ * @param {ol.proj.Projection} proj The projection
+ * @param {ol.TileCoord} [opt_tileCoord] An optional tile coordinate
+ * @return {ol.TileCoord}
  */
 ol.TileCoordTransformType;
 

--- a/src/ol/transformfunction.js
+++ b/src/ol/transformfunction.js
@@ -7,7 +7,11 @@ goog.provide('ol.TransformFunction');
  * transforms the input coordinate values, populates the output array, and
  * returns the output array.
  *
- * @typedef {function(Array.<number>, Array.<number>=, number=): Array.<number>}
  * @api stable
+ * @callback ol.TransformFunction
+ * @param {Array.<number>} input The array of input coordinate values
+ * @param {Array.<number>} [output] The output array
+ * @param {number} [dimension] The dimension
+ * @return {Array.<number>} The output array
  */
 ol.TransformFunction;

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -17,13 +17,18 @@ ol.xml.NodeStackItem;
 
 
 /**
- * @typedef {function(Node, Array.<*>)}
+ * @callback ol.xml.Parser
+ * @param {Node} node The node
+ * @param {Array.<*>} objStack The object stack
  */
 ol.xml.Parser;
 
 
 /**
- * @typedef {function(Node, *, Array.<*>)}
+ * @callback ol.xml.Serializer
+ * @param {Node} node The node
+ * @param {*} value The value
+ * @param {Array.<*>} objStack The object stack
  */
 ol.xml.Serializer;
 


### PR DESCRIPTION
This pull request contains various fixes to JSDoc comments to not only improve the API docs of function types, but also to make the ol3 source more amenable to be able to generate a TypeScript definition from (which I am currently working on through my JSDoc plugin: https://github.com/jumpinjackie/jsdoc-typescript-plugin)

 * Use `@callback` with `@param` and `@return` (where appropriate) to document function types instead of `@typedef`
 * `olx.control.OverviewMapOptions#layers` should have `ol.Collection<ol.layer.Layer>` instead of `ol.Collection`
 * Remove an unused `goog.require` from `src/ol/tilequeue.js` as a result of the wholesale change to `@callback`

The change to `@callback` results in documentation that currently looks like this (v3.13.1)

![ol3_typedefs_before](https://cloud.githubusercontent.com/assets/563860/13009750/507e0f3a-d1f2-11e5-9e1d-45a9a9c715b7.PNG)

To this

![ol3_typedefs_after](https://cloud.githubusercontent.com/assets/563860/13009754/56536126-d1f2-11e5-829b-42601d7c4dae.PNG)