### PR TITLE
Use lowercase for all user agent checks

### DIFF
--- a/src/ol/has.js
+++ b/src/ol/has.js
@@ -24,7 +24,7 @@ ol.has.SAFARI = ua.indexOf('safari') !== -1 && ua.indexOf('chrom') === -1;
  * User agent string says we are dealing with a Mac as platform.
  * @type {boolean}
  */
-ol.has.MAC = ua.indexOf('Macintosh') !== -1;
+ol.has.MAC = ua.indexOf('macintosh') !== -1;
 
 
 /**


### PR DESCRIPTION
The box-selection example is currently broken, because the `ol.has.MAC` check is incorrect. This regression is fixed with the change here.