### PR TITLE
Fix geolocation error cast

### DIFF
--- a/src/ol/geolocation.js
+++ b/src/ol/geolocation.js
@@ -191,7 +191,7 @@ ol.Geolocation.prototype.positionChange_ = function(position) {
 ol.Geolocation.prototype.positionError_ = function(error) {
   error.type = ol.events.EventType.ERROR;
   this.setTracking(false);
-  this.dispatchEvent(/** @type {{type: string}} */ (error));
+  this.dispatchEvent(/** @type {{type: string, target: undefined}} */ (error));
 };
 
 


### PR DESCRIPTION
Despite the dispatchEvent method accepting a hash with a `target` property of `undefined`, closure may still require the `target` property to be explicit.