### PR TITLE
Don't use goog.isString()

### DIFF
--- a/src/ol/colorlike.js
+++ b/src/ol/colorlike.js
@@ -34,7 +34,7 @@ ol.colorlike.asColorLike = function(color) {
  */
 ol.colorlike.isColorLike = function(color) {
   return (
-      goog.isString(color) ||
+      typeof color === 'string' ||
       color instanceof CanvasPattern ||
       color instanceof CanvasGradient
   );


### PR DESCRIPTION
This removes a leftover of #4796 which was probably in development when that PR was merged.

Please review.