### PR TITLE
Use console.error instead of goog.log.error

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
       "proj4": false
     },
     "rules": {
+      "no-console": 0,
       "no-constant-condition": 0
     }
   },

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -7,12 +7,9 @@ goog.provide('ol.MapProperty');
 
 goog.require('goog.asserts');
 goog.require('goog.async.nextTick');
-goog.require('goog.debug.Console');
 goog.require('goog.dom');
 goog.require('goog.dom.classlist');
 goog.require('goog.functions');
-goog.require('goog.log');
-goog.require('goog.log.Level');
 goog.require('goog.style');
 goog.require('goog.vec.Mat4');
 goog.require('ol.Collection');
@@ -1620,12 +1617,3 @@ ol.Map.createOptionsInternal = function(options) {
 
 
 ol.proj.common.add();
-
-
-if (goog.DEBUG) {
-  (function() {
-    goog.debug.Console.autoInstall();
-    var logger = goog.log.getLogger('ol');
-    logger.setLevel(goog.log.Level.FINEST);
-  })();
-}

--- a/src/ol/webgl/context.js
+++ b/src/ol/webgl/context.js
@@ -1,7 +1,6 @@
 goog.provide('ol.webgl.Context');
 
 goog.require('goog.asserts');
-goog.require('goog.log');
 goog.require('ol');
 goog.require('ol.array');
 goog.require('ol.events');
@@ -229,7 +228,7 @@ ol.webgl.Context.prototype.getShader = function(shaderObject) {
     if (goog.DEBUG) {
       if (!gl.getShaderParameter(shader, goog.webgl.COMPILE_STATUS) &&
           !gl.isContextLost()) {
-        goog.log.error(this.logger_, gl.getShaderInfoLog(shader));
+        console.error('ol.webgl.Context', gl.getShaderInfoLog(shader));
       }
     }
     goog.asserts.assert(
@@ -265,7 +264,7 @@ ol.webgl.Context.prototype.getProgram = function(
     if (goog.DEBUG) {
       if (!gl.getProgramParameter(program, goog.webgl.LINK_STATUS) &&
           !gl.isContextLost()) {
-        goog.log.error(this.logger_, gl.getProgramInfoLog(program));
+        console.error('ol.webgl.Context', gl.getProgramInfoLog(program));
       }
     }
     goog.asserts.assert(
@@ -343,13 +342,6 @@ ol.webgl.Context.prototype.useProgram = function(program) {
     return true;
   }
 };
-
-
-/**
- * @private
- * @type {goog.log.Logger}
- */
-ol.webgl.Context.prototype.logger_ = goog.log.getLogger('ol.webgl.Context');
 
 
 /**


### PR DESCRIPTION
`goog.log.error` was only used in `src/ol/webgl/context.js` and only in debug mode.
