### PR TITLE
Improve precision of ol.reproj.render

### DIFF
--- a/src/ol/reproj/reproj.js
+++ b/src/ol/reproj/reproj.js
@@ -128,17 +128,17 @@ ol.reproj.render = function(width, height, pixelRatio,
       Math.round(pixelRatio * canvasWidthInUnits / sourceResolution),
       Math.round(pixelRatio * canvasHeightInUnits / sourceResolution));
 
-  stitchContext.scale(pixelRatio / sourceResolution,
-                      pixelRatio / sourceResolution);
-  stitchContext.translate(-sourceDataExtent[0], sourceDataExtent[3]);
+  var stitchScale = pixelRatio / sourceResolution;
 
   sources.forEach(function(src, i, arr) {
-    var xPos = src.extent[0];
-    var yPos = -src.extent[3];
+    var xPos = src.extent[0] - sourceDataExtent[0];
+    var yPos = -(src.extent[3] - sourceDataExtent[3]);
     var srcWidth = ol.extent.getWidth(src.extent);
     var srcHeight = ol.extent.getHeight(src.extent);
 
-    stitchContext.drawImage(src.image, xPos, yPos, srcWidth, srcHeight);
+    stitchContext.drawImage(src.image,
+                            xPos * stitchScale, yPos * stitchScale,
+                            srcWidth * stitchScale, srcHeight * stitchScale);
   });
 
   var targetTopLeft = ol.extent.getTopLeft(targetExtent);


### PR DESCRIPTION
There are sometimes visible gaps inside reprojected raster tiles (see https://github.com/openlayers/ol3/issues/4681#issuecomment-185331288).

It turns out to be a problem with precision of operations inside canvas 2d context and this issue can be fixed by doing the scaling multiplication in javascript instead of the canvas.