### PR TITLE
Remove use of goog.math.isFiniteNumber()

### DIFF
--- a/src/ol/reproj/reproj.js
+++ b/src/ol/reproj/reproj.js
@@ -2,7 +2,6 @@ goog.provide('ol.reproj');
 
 goog.require('goog.labs.userAgent.browser');
 goog.require('goog.labs.userAgent.platform');
-goog.require('goog.math');
 goog.require('ol.dom');
 goog.require('ol.extent');
 goog.require('ol.math');
@@ -61,7 +60,7 @@ ol.reproj.calculateSourceResolution = function(sourceProj, targetProj,
       sourceProj.getPointResolution(sourceResolution, sourceCenter) /
       sourceResolution;
 
-  if (goog.math.isFiniteNumber(compensationFactor) && compensationFactor > 0) {
+  if (isFinite(compensationFactor) && compensationFactor > 0) {
     sourceResolution /= compensationFactor;
   }
 

--- a/src/ol/reproj/tile.js
+++ b/src/ol/reproj/tile.js
@@ -2,7 +2,6 @@ goog.provide('ol.reproj.Tile');
 goog.provide('ol.reproj.TileFunctionType');
 
 goog.require('goog.asserts');
-goog.require('goog.math');
 goog.require('ol.Tile');
 goog.require('ol.TileState');
 goog.require('ol.events');
@@ -145,7 +144,7 @@ ol.reproj.Tile = function(sourceProj, sourceTileGrid,
   var sourceResolution = ol.reproj.calculateSourceResolution(
       sourceProj, targetProj, targetCenter, targetResolution);
 
-  if (!goog.math.isFiniteNumber(sourceResolution) || sourceResolution <= 0) {
+  if (!isFinite(sourceResolution) || sourceResolution <= 0) {
     // invalid sourceResolution -> EMPTY
     // probably edges of the projections when no extent is defined
     this.state = ol.TileState.EMPTY;


### PR DESCRIPTION
This replaces `goog.math.isFiniteNumber()` with `isFinite()`.