### PR TITLE
Use requestAnimation polyfill for examples and update release notes

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,6 +2,10 @@
 
 ### v3.14.0
 
+#### Internet Explorer 9 support
+
+As of this release, OpenLayers requires a `requestAnimationFrame`/`cancelAnimationFrame` polyfill for IE 9 support. See http://cdn.polyfill.io/v2/docs/features/#requestAnimationFrame.
+
 #### Layer pre-/postcompose event changes
 
 It is the responsibility of the application to undo any canvas transform changes at the end of a layer 'precompose' or 'postcompose' handler. Previously, it was ok to set a null transform. The API now guarantees a device pixel coordinate system on the canvas with its origin in the top left corner of the map. However, applications should not rely on the underlying canvas being the same size as the visible viewport.

--- a/test/index.html
+++ b/test/index.html
@@ -15,6 +15,7 @@
   <script type="text/javascript" src="../node_modules/mocha/mocha.js"></script>
   <script type="text/javascript" src="../node_modules/proj4/dist/proj4.js"></script>
   <script type="text/javascript" src="test-extensions.js"></script>
+  <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=requestAnimationFrame"></script>
   <script>
     if (typeof initMochaPhantomJS === 'function') {
       initMochaPhantomJS()

--- a/test_rendering/index.html
+++ b/test_rendering/index.html
@@ -16,6 +16,7 @@
   <script type="text/javascript" src="../node_modules/proj4/dist/proj4.js"></script>
   <script type="text/javascript" src="../node_modules/resemblejs/resemble.js"></script>
   <script type="text/javascript" src="../test/test-extensions.js"></script>
+  <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=requestAnimationFrame"></script>
   <script>
     mocha.setup({
       ui: 'bdd',


### PR DESCRIPTION
For the tests to run in IE9, they need a polyfill for `requestAnimationFrame`.