### PR TITLE
Fix tests so they all pass in IE9

### DIFF
--- a/test/spec/ol/array.test.js
+++ b/test/spec/ol/array.test.js
@@ -386,7 +386,7 @@ describe('ol.array', function() {
     });
     it('extends an array in place with a big array', function() {
       var a = [];
-      var i = 500000; // original test has 1.000.000, but that was too slow
+      var i = 250000; // original test has 1.000.000, but that was too slow
       var bigArray = Array(i);
       while (i--) {
         bigArray[i] = i;

--- a/test/spec/ol/source/tileimagesource.test.js
+++ b/test/spec/ol/source/tileimagesource.test.js
@@ -8,7 +8,7 @@ describe('ol.source.TileImage', function() {
       tileGrid: opt_tileGrid ||
           ol.tilegrid.createForProjection(proj, undefined, [2, 2]),
       tileUrlFunction: ol.TileUrlFunction.createFromTemplate(
-          'data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA=')
+          'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=')
     });
   }
 


### PR DESCRIPTION
With this change, all tests pass in IE9. All it took was to test for less items in a big array, and an inline image that also works in IE9.