### PR TITLE
Stricter check for ImageData constructor

### DIFF
--- a/test/spec/ol/source/rastersource.test.js
+++ b/test/spec/ol/source/rastersource.test.js
@@ -17,7 +17,14 @@ function itNoPhantom() {
   }
 }
 
-(typeof ImageData == 'function' ? describe : xdescribe)('ol.source.Raster',
+var hasImageDataConstructor = true;
+try {
+  new ImageData(1, 1);
+} catch (e) {
+  hasImageDataConstructor = false;
+}
+
+(hasImageDataConstructor ? describe : xdescribe)('ol.source.Raster',
     function() {
 
       var target, map, redSource, greenSource, blueSource, raster;


### PR DESCRIPTION
`ol.source.Raster` tests fail in Edge - Edge reports `typeof ImageData` to be a `function`, but throws an exception when it is used as constructor.