### PR TITLE
Only run raster operations after image sources have loaded

### DIFF
--- a/src/ol/renderer/canvas/canvasimagelayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasimagelayerrenderer.js
@@ -202,5 +202,5 @@ ol.renderer.canvas.ImageLayer.prototype.prepareFrame = function(frameState, laye
     this.updateLogos(frameState, imageSource);
   }
 
-  return true;
+  return !!this.image_;
 };

--- a/src/ol/source/rastersource.js
+++ b/src/ol/source/rastersource.js
@@ -343,7 +343,9 @@ ol.source.Raster.prototype.onWorkerComplete_ = function(frameState, callback, er
  * @private
  */
 ol.source.Raster.getImageData_ = function(renderer, frameState, layerState) {
-  renderer.prepareFrame(frameState, layerState);
+  if (!renderer.prepareFrame(frameState, layerState)) {
+    return null;
+  }
   var width = frameState.size[0];
   var height = frameState.size[1];
   if (!ol.source.Raster.context_) {

--- a/test/spec/ol/source/rastersource.test.js
+++ b/test/spec/ol/source/rastersource.test.js
@@ -112,7 +112,7 @@ maybeDescribe('ol.source.Raster', function() {
         }
       });
 
-      source.on('afteroperations', function() {
+      source.once('afteroperations', function() {
         expect(log.length).to.equal(4);
         var inputs = log[0];
         var pixel = inputs[0];

--- a/test/spec/ol/source/rastersource.test.js
+++ b/test/spec/ol/source/rastersource.test.js
@@ -103,7 +103,7 @@ try {
 
           var log = [];
 
-          raster = new ol.source.Raster({
+          var source = new ol.source.Raster({
             threads: 0,
             sources: [redSource, greenSource, blueSource],
             operation: function(inputs) {
@@ -112,7 +112,7 @@ try {
             }
           });
 
-          raster.on('afteroperations', function() {
+          source.on('afteroperations', function() {
             expect(log.length).to.equal(4);
             var inputs = log[0];
             var pixel = inputs[0];
@@ -120,41 +120,39 @@ try {
             done();
           });
 
-          map.getLayers().item(0).setSource(raster);
+          map.getLayers().item(0).setSource(source);
           var view = map.getView();
           view.setCenter([0, 0]);
           view.setZoom(0);
 
         });
 
-        itNoPhantom('allows operation type to be set to "image"',
-            function(done) {
+        itNoPhantom('allows operation type to be set to "image"', function(done) {
+          var log = [];
 
-              var log = [];
+          var source = new ol.source.Raster({
+            operationType: ol.raster.OperationType.IMAGE,
+            threads: 0,
+            sources: [redSource, greenSource, blueSource],
+            operation: function(inputs) {
+              log.push(inputs);
+              return inputs[0];
+            }
+          });
 
-              raster = new ol.source.Raster({
-                operationType: ol.raster.OperationType.IMAGE,
-                threads: 0,
-                sources: [redSource, greenSource, blueSource],
-                operation: function(inputs) {
-                  log.push(inputs);
-                  return inputs[0];
-                }
-              });
+          source.on('afteroperations', function() {
+            expect(log.length).to.equal(1);
+            var inputs = log[0];
+            expect(inputs[0]).to.be.an(ImageData);
+            done();
+          });
 
-              raster.on('afteroperations', function() {
-                expect(log.length).to.equal(1);
-                var inputs = log[0];
-                expect(inputs[0]).to.be.an(ImageData);
-                done();
-              });
+          map.getLayers().item(0).setSource(source);
+          var view = map.getView();
+          view.setCenter([0, 0]);
+          view.setZoom(0);
 
-              map.getLayers().item(0).setSource(raster);
-              var view = map.getView();
-              view.setCenter([0, 0]);
-              view.setZoom(0);
-
-            });
+        });
 
       });
 

--- a/test/spec/ol/source/rastersource.test.js
+++ b/test/spec/ol/source/rastersource.test.js
@@ -140,7 +140,7 @@ maybeDescribe('ol.source.Raster', function() {
         }
       });
 
-      source.on('afteroperations', function() {
+      source.once('afteroperations', function() {
         expect(log.length).to.equal(1);
         var inputs = log[0];
         expect(inputs[0]).to.be.an(ImageData);
@@ -176,7 +176,7 @@ maybeDescribe('ol.source.Raster', function() {
       view.setCenter([0, 0]);
       view.setZoom(0);
 
-      raster.on('afteroperations', function(event) {
+      raster.once('afteroperations', function(event) {
         expect(count).to.equal(4);
         done();
       });
@@ -215,7 +215,7 @@ maybeDescribe('ol.source.Raster', function() {
         return inputs[0];
       });
 
-      raster.on('beforeoperations', function(event) {
+      raster.once('beforeoperations', function(event) {
         expect(count).to.equal(0);
         expect(!!event).to.be(true);
         expect(event.extent).to.be.an('array');
@@ -242,7 +242,7 @@ maybeDescribe('ol.source.Raster', function() {
         event.data.count = 0;
       });
 
-      raster.on('afteroperations', function(event) {
+      raster.once('afteroperations', function(event) {
         expect(event.data.count).to.equal(4);
         done();
       });
@@ -265,7 +265,7 @@ maybeDescribe('ol.source.Raster', function() {
         return inputs[0];
       });
 
-      raster.on('afteroperations', function(event) {
+      raster.once('afteroperations', function(event) {
         expect(count).to.equal(4);
         expect(!!event).to.be(true);
         expect(event.extent).to.be.an('array');
@@ -287,7 +287,7 @@ maybeDescribe('ol.source.Raster', function() {
         return inputs[0];
       });
 
-      raster.on('afteroperations', function(event) {
+      raster.once('afteroperations', function(event) {
         expect(event.data.message).to.equal('hello world');
         done();
       });

--- a/test/spec/ol/source/rastersource.test.js
+++ b/test/spec/ol/source/rastersource.test.js
@@ -9,13 +9,7 @@ var green = 'data:image/gif;base64,R0lGODlhAQABAPAAAAD/AP///yH5BAAAAAAALAAAA' +
 var blue = 'data:image/gif;base64,R0lGODlhAQABAPAAAAAA/////yH5BAAAAAAALAAAAA' +
     'ABAAEAAAICRAEAOw==';
 
-function itNoPhantom() {
-  if (window.checkForMocha) {
-    return xit.apply(this, arguments);
-  } else {
-    return it.apply(this, arguments);
-  }
-}
+var itNoPhantom = window.checkForMocha ? xit : it;
 
 var hasImageDataConstructor = true;
 try {

--- a/test/spec/ol/source/rastersource.test.js
+++ b/test/spec/ol/source/rastersource.test.js
@@ -85,7 +85,12 @@ maybeDescribe('ol.source.Raster', function() {
   });
 
   afterEach(function() {
-    goog.dispose(map);
+    map.setTarget(null);
+    map.dispose();
+    raster.dispose();
+    greenSource.dispose();
+    redSource.dispose();
+    blueSource.dispose();
     document.body.removeChild(target);
   });
 

--- a/test/spec/ol/source/rastersource.test.js
+++ b/test/spec/ol/source/rastersource.test.js
@@ -24,283 +24,284 @@ try {
   hasImageDataConstructor = false;
 }
 
-(hasImageDataConstructor ? describe : xdescribe)('ol.source.Raster',
-    function() {
+var maybeDescribe = hasImageDataConstructor ? describe : xdescribe;
 
-      var target, map, redSource, greenSource, blueSource, raster;
+maybeDescribe('ol.source.Raster', function() {
 
-      beforeEach(function() {
-        target = document.createElement('div');
+  var target, map, redSource, greenSource, blueSource, raster;
 
-        var style = target.style;
-        style.position = 'absolute';
-        style.left = '-1000px';
-        style.top = '-1000px';
-        style.width = '2px';
-        style.height = '2px';
-        document.body.appendChild(target);
+  beforeEach(function() {
+    target = document.createElement('div');
 
-        var extent = [-1, -1, 1, 1];
+    var style = target.style;
+    style.position = 'absolute';
+    style.left = '-1000px';
+    style.top = '-1000px';
+    style.width = '2px';
+    style.height = '2px';
+    document.body.appendChild(target);
 
-        redSource = new ol.source.ImageStatic({
-          url: red,
-          imageExtent: extent
-        });
+    var extent = [-1, -1, 1, 1];
 
-        greenSource = new ol.source.ImageStatic({
-          url: green,
-          imageExtent: extent
-        });
+    redSource = new ol.source.ImageStatic({
+      url: red,
+      imageExtent: extent
+    });
 
-        blueSource = new ol.source.ImageStatic({
-          url: blue,
-          imageExtent: extent
-        });
+    greenSource = new ol.source.ImageStatic({
+      url: green,
+      imageExtent: extent
+    });
 
-        raster = new ol.source.Raster({
-          threads: 0,
-          sources: [redSource, greenSource, blueSource],
-          operation: function(inputs) {
-            return inputs[0];
-          }
-        });
+    blueSource = new ol.source.ImageStatic({
+      url: blue,
+      imageExtent: extent
+    });
 
-        map = new ol.Map({
-          target: target,
-          view: new ol.View({
-            resolutions: [1],
-            projection: new ol.proj.Projection({
-              code: 'image',
-              units: 'pixels',
-              extent: extent
-            })
-          }),
-          layers: [
-            new ol.layer.Image({
-              source: raster
-            })
-          ]
-        });
+    raster = new ol.source.Raster({
+      threads: 0,
+      sources: [redSource, greenSource, blueSource],
+      operation: function(inputs) {
+        return inputs[0];
+      }
+    });
+
+    map = new ol.Map({
+      target: target,
+      view: new ol.View({
+        resolutions: [1],
+        projection: new ol.proj.Projection({
+          code: 'image',
+          units: 'pixels',
+          extent: extent
+        })
+      }),
+      layers: [
+        new ol.layer.Image({
+          source: raster
+        })
+      ]
+    });
+  });
+
+  afterEach(function() {
+    goog.dispose(map);
+    document.body.removeChild(target);
+  });
+
+  describe('constructor', function() {
+
+    it('returns a tile source', function() {
+      var source = new ol.source.Raster({
+        threads: 0,
+        sources: [new ol.source.Tile({})]
+      });
+      expect(source).to.be.a(ol.source.Source);
+      expect(source).to.be.a(ol.source.Raster);
+    });
+
+    itNoPhantom('defaults to "pixel" operation', function(done) {
+
+      var log = [];
+
+      var source = new ol.source.Raster({
+        threads: 0,
+        sources: [redSource, greenSource, blueSource],
+        operation: function(inputs) {
+          log.push(inputs);
+          return inputs[0];
+        }
       });
 
-      afterEach(function() {
-        goog.dispose(map);
-        document.body.removeChild(target);
+      source.on('afteroperations', function() {
+        expect(log.length).to.equal(4);
+        var inputs = log[0];
+        var pixel = inputs[0];
+        expect(pixel).to.be.an('array');
+        done();
       });
 
-      describe('constructor', function() {
+      map.getLayers().item(0).setSource(source);
+      var view = map.getView();
+      view.setCenter([0, 0]);
+      view.setZoom(0);
 
-        it('returns a tile source', function() {
-          var source = new ol.source.Raster({
-            threads: 0,
-            sources: [new ol.source.Tile({})]
-          });
-          expect(source).to.be.a(ol.source.Source);
-          expect(source).to.be.a(ol.source.Raster);
-        });
+    });
 
-        itNoPhantom('defaults to "pixel" operation', function(done) {
+    itNoPhantom('allows operation type to be set to "image"', function(done) {
+      var log = [];
 
-          var log = [];
-
-          var source = new ol.source.Raster({
-            threads: 0,
-            sources: [redSource, greenSource, blueSource],
-            operation: function(inputs) {
-              log.push(inputs);
-              return inputs[0];
-            }
-          });
-
-          source.on('afteroperations', function() {
-            expect(log.length).to.equal(4);
-            var inputs = log[0];
-            var pixel = inputs[0];
-            expect(pixel).to.be.an('array');
-            done();
-          });
-
-          map.getLayers().item(0).setSource(source);
-          var view = map.getView();
-          view.setCenter([0, 0]);
-          view.setZoom(0);
-
-        });
-
-        itNoPhantom('allows operation type to be set to "image"', function(done) {
-          var log = [];
-
-          var source = new ol.source.Raster({
-            operationType: ol.raster.OperationType.IMAGE,
-            threads: 0,
-            sources: [redSource, greenSource, blueSource],
-            operation: function(inputs) {
-              log.push(inputs);
-              return inputs[0];
-            }
-          });
-
-          source.on('afteroperations', function() {
-            expect(log.length).to.equal(1);
-            var inputs = log[0];
-            expect(inputs[0]).to.be.an(ImageData);
-            done();
-          });
-
-          map.getLayers().item(0).setSource(source);
-          var view = map.getView();
-          view.setCenter([0, 0]);
-          view.setZoom(0);
-
-        });
-
+      var source = new ol.source.Raster({
+        operationType: ol.raster.OperationType.IMAGE,
+        threads: 0,
+        sources: [redSource, greenSource, blueSource],
+        operation: function(inputs) {
+          log.push(inputs);
+          return inputs[0];
+        }
       });
 
-      describe('#setOperation()', function() {
-
-        itNoPhantom('allows operation to be set', function(done) {
-
-          var count = 0;
-          raster.setOperation(function(pixels) {
-            ++count;
-            var redPixel = pixels[0];
-            var greenPixel = pixels[1];
-            var bluePixel = pixels[2];
-            expect(redPixel).to.eql([255, 0, 0, 255]);
-            expect(greenPixel).to.eql([0, 255, 0, 255]);
-            expect(bluePixel).to.eql([0, 0, 255, 255]);
-            return pixels[0];
-          });
-
-          var view = map.getView();
-          view.setCenter([0, 0]);
-          view.setZoom(0);
-
-          raster.on('afteroperations', function(event) {
-            expect(count).to.equal(4);
-            done();
-          });
-
-        });
-
-        itNoPhantom('updates and re-runs the operation', function(done) {
-
-          var view = map.getView();
-          view.setCenter([0, 0]);
-          view.setZoom(0);
-
-          var count = 0;
-          raster.on('afteroperations', function(event) {
-            ++count;
-            if (count === 1) {
-              raster.setOperation(function(inputs) {
-                return inputs[0];
-              });
-            } else {
-              done();
-            }
-          });
-
-        });
-
+      source.on('afteroperations', function() {
+        expect(log.length).to.equal(1);
+        var inputs = log[0];
+        expect(inputs[0]).to.be.an(ImageData);
+        done();
       });
 
-      describe('beforeoperations', function() {
+      map.getLayers().item(0).setSource(source);
+      var view = map.getView();
+      view.setCenter([0, 0]);
+      view.setZoom(0);
 
-        itNoPhantom('gets called before operations are run', function(done) {
+    });
 
-          var count = 0;
-          raster.setOperation(function(inputs) {
-            ++count;
-            return inputs[0];
-          });
+  });
 
-          raster.on('beforeoperations', function(event) {
-            expect(count).to.equal(0);
-            expect(!!event).to.be(true);
-            expect(event.extent).to.be.an('array');
-            expect(event.resolution).to.be.a('number');
-            expect(event.data).to.be.an('object');
-            done();
-          });
+  describe('#setOperation()', function() {
 
-          var view = map.getView();
-          view.setCenter([0, 0]);
-          view.setZoom(0);
+    itNoPhantom('allows operation to be set', function(done) {
 
-        });
-
-
-        itNoPhantom('allows data to be set for the operation', function(done) {
-
-          raster.setOperation(function(inputs, data) {
-            ++data.count;
-            return inputs[0];
-          });
-
-          raster.on('beforeoperations', function(event) {
-            event.data.count = 0;
-          });
-
-          raster.on('afteroperations', function(event) {
-            expect(event.data.count).to.equal(4);
-            done();
-          });
-
-          var view = map.getView();
-          view.setCenter([0, 0]);
-          view.setZoom(0);
-
-        });
-
+      var count = 0;
+      raster.setOperation(function(pixels) {
+        ++count;
+        var redPixel = pixels[0];
+        var greenPixel = pixels[1];
+        var bluePixel = pixels[2];
+        expect(redPixel).to.eql([255, 0, 0, 255]);
+        expect(greenPixel).to.eql([0, 255, 0, 255]);
+        expect(bluePixel).to.eql([0, 0, 255, 255]);
+        return pixels[0];
       });
 
-      describe('afteroperations', function() {
+      var view = map.getView();
+      view.setCenter([0, 0]);
+      view.setZoom(0);
 
-        itNoPhantom('gets called after operations are run', function(done) {
-
-          var count = 0;
-          raster.setOperation(function(inputs) {
-            ++count;
-            return inputs[0];
-          });
-
-          raster.on('afteroperations', function(event) {
-            expect(count).to.equal(4);
-            expect(!!event).to.be(true);
-            expect(event.extent).to.be.an('array');
-            expect(event.resolution).to.be.a('number');
-            expect(event.data).to.be.an('object');
-            done();
-          });
-
-          var view = map.getView();
-          view.setCenter([0, 0]);
-          view.setZoom(0);
-
-        });
-
-        itNoPhantom('receives data set by the operation', function(done) {
-
-          raster.setOperation(function(inputs, data) {
-            data.message = 'hello world';
-            return inputs[0];
-          });
-
-          raster.on('afteroperations', function(event) {
-            expect(event.data.message).to.equal('hello world');
-            done();
-          });
-
-          var view = map.getView();
-          view.setCenter([0, 0]);
-          view.setZoom(0);
-
-        });
-
+      raster.on('afteroperations', function(event) {
+        expect(count).to.equal(4);
+        done();
       });
 
     });
+
+    itNoPhantom('updates and re-runs the operation', function(done) {
+
+      var view = map.getView();
+      view.setCenter([0, 0]);
+      view.setZoom(0);
+
+      var count = 0;
+      raster.on('afteroperations', function(event) {
+        ++count;
+        if (count === 1) {
+          raster.setOperation(function(inputs) {
+            return inputs[0];
+          });
+        } else {
+          done();
+        }
+      });
+
+    });
+
+  });
+
+  describe('beforeoperations', function() {
+
+    itNoPhantom('gets called before operations are run', function(done) {
+
+      var count = 0;
+      raster.setOperation(function(inputs) {
+        ++count;
+        return inputs[0];
+      });
+
+      raster.on('beforeoperations', function(event) {
+        expect(count).to.equal(0);
+        expect(!!event).to.be(true);
+        expect(event.extent).to.be.an('array');
+        expect(event.resolution).to.be.a('number');
+        expect(event.data).to.be.an('object');
+        done();
+      });
+
+      var view = map.getView();
+      view.setCenter([0, 0]);
+      view.setZoom(0);
+
+    });
+
+
+    itNoPhantom('allows data to be set for the operation', function(done) {
+
+      raster.setOperation(function(inputs, data) {
+        ++data.count;
+        return inputs[0];
+      });
+
+      raster.on('beforeoperations', function(event) {
+        event.data.count = 0;
+      });
+
+      raster.on('afteroperations', function(event) {
+        expect(event.data.count).to.equal(4);
+        done();
+      });
+
+      var view = map.getView();
+      view.setCenter([0, 0]);
+      view.setZoom(0);
+
+    });
+
+  });
+
+  describe('afteroperations', function() {
+
+    itNoPhantom('gets called after operations are run', function(done) {
+
+      var count = 0;
+      raster.setOperation(function(inputs) {
+        ++count;
+        return inputs[0];
+      });
+
+      raster.on('afteroperations', function(event) {
+        expect(count).to.equal(4);
+        expect(!!event).to.be(true);
+        expect(event.extent).to.be.an('array');
+        expect(event.resolution).to.be.a('number');
+        expect(event.data).to.be.an('object');
+        done();
+      });
+
+      var view = map.getView();
+      view.setCenter([0, 0]);
+      view.setZoom(0);
+
+    });
+
+    itNoPhantom('receives data set by the operation', function(done) {
+
+      raster.setOperation(function(inputs, data) {
+        data.message = 'hello world';
+        return inputs[0];
+      });
+
+      raster.on('afteroperations', function(event) {
+        expect(event.data.message).to.equal('hello world');
+        done();
+      });
+
+      var view = map.getView();
+      view.setCenter([0, 0]);
+      view.setZoom(0);
+
+    });
+
+  });
+
+});
 
 goog.require('ol.Map');
 goog.require('ol.View');


### PR DESCRIPTION
The raster tests were not properly cleaning up after themselves.  Listeners for `afteroperations` were getting called a second time after we had called `done()` in the tests.  This made it look like the wrong tests were failing.

This cleans up the raster tests by calling `obj.dispose()` on reused test objects and only listening for events once where we call `done()` in the listener.

There may still be an issue introduced in 98b823c5fcd2a9f9971b26490226f8f1da53ed2e with operations being run more often than expected.  But we should create a specific test that demonstrates the issue if one can be found.  The existing test failures were the result of sloppy test running.

**update** - this should now fix #4893.