### PR TITLE
Ignore XML sequence when comparing GML

### DIFF
--- a/test/spec/ol/format/gmlformat.test.js
+++ b/test/spec/ol/format/gmlformat.test.js
@@ -1034,7 +1034,7 @@ describe('ol.format.GML3', function() {
 
     it('writes back features as GML', function() {
       var serialized = gmlFormat.writeFeaturesNode(features);
-      expect(serialized).to.xmleql(ol.xml.parse(text));
+      expect(serialized).to.xmleql(ol.xml.parse(text), {ignoreElementOrder: true});
     });
 
   });

--- a/test/test-extensions.js
+++ b/test/test-extensions.js
@@ -125,6 +125,11 @@
           }
         }
       }
+      if (options && options.ignoreElementOrder) {
+        nodes.sort(function(a, b) {
+          return a.nodeName > b.nodeName ? 1 : a.nodeName < b.nodeName ? -1 : 0;
+        });
+      }
       return nodes;
     }
   }
@@ -275,7 +280,8 @@
   /**
    * Checks if the XML document sort of equals another XML document.
    * @param {Object} obj The other object.
-   * @param {Object} options The options.
+   * @param {{includeWhiteSpace: (boolean|undefined),
+   *     ignoreElementOrder: (boolean|undefined)}=} options The options.
    * @return {expect.Assertion} The assertion.
    */
   expect.Assertion.prototype.xmleql = function(obj, options) {


### PR DESCRIPTION
It may not be a good idea to do this - see https://github.com/openlayers/ol3/issues/4848#issuecomment-187940197. However, I think there is no practical use in enforcing the property sequence of a FeatureType. @bartvde, please correct me if I'm wrong, but I do not remember a single case where a WFS-T implementation complained on a WFS Insert because of a violated property sequence.

Fixes #4848.