### PR TITLE
Export ol.proj.equivalent

### DIFF
--- a/src/ol/proj/proj.js
+++ b/src/ol/proj/proj.js
@@ -706,6 +706,7 @@ ol.proj.get = function(projectionLike) {
  * @param {ol.proj.Projection} projection1 Projection 1.
  * @param {ol.proj.Projection} projection2 Projection 2.
  * @return {boolean} Equivalent.
+ * @api
  */
 ol.proj.equivalent = function(projection1, projection2) {
   if (projection1 === projection2) {


### PR DESCRIPTION
Export `ol.proj.equivalent`

The function `ol.proj.equivalent` is used for comparing two projections,
but not exposed publicly. It should be accessible using a public API to
be able to compare projections in the same way as OpenLayers does.

A test for the `ol.proj.equivalent` function itself already exists in
https://github.com/openlayers/ol3/blob/master/test/spec/ol/proj/proj.test.js

github issue #4913