### PR TITLE
Make ol.source.Cluster more flexible by adding a geometryFunction option

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -3984,6 +3984,7 @@ olx.source.BingMapsOptions.prototype.wrapX;
  *     distance: (number|undefined),
  *     extent: (ol.Extent|undefined),
  *     format: (ol.format.Feature|undefined),
+ *     geometryFunction: (undefined|function(ol.Feature):ol.geom.Point),
  *     logo: (string|undefined),
  *     projection: ol.proj.ProjectionLike,
  *     source: ol.source.Vector,
@@ -4015,6 +4016,25 @@ olx.source.ClusterOptions.prototype.distance;
  * @api
  */
 olx.source.ClusterOptions.prototype.extent;
+
+
+/**
+ * Function that takes an {@link ol.Feature} as argument and returns an
+ * {@link ol.geom.Point} as cluster calculation point for the feature. When a
+ * feature should not be considered for clustering, the function should return
+ * `null`. The default, which works when the underyling source contains point
+ * features only, is
+ * ```js
+ * function(feature) {
+ *   return feature.getGeometry();
+ * }
+ * ```
+ * See {@link ol.geom.Polygon#getInteriorPoint} for a way to get a cluster
+ * calculation point for polygons.
+ * @type {undefined|function(ol.Feature):ol.geom.Point}
+ * @api
+ */
+olx.source.ClusterOptions.prototype.geometryFunction;
 
 
 /**
@@ -6174,8 +6194,8 @@ olx.style.FillOptions;
 
 
 /**
- * A color, gradient or pattern. See {@link ol.color} 
- * and {@link ol.colorlike} for possible formats. Default null; 
+ * A color, gradient or pattern. See {@link ol.color}
+ * and {@link ol.colorlike} for possible formats. Default null;
  * if null, the Canvas/renderer default black will be used.
  * @type {ol.Color|ol.ColorLike|undefined}
  * @api

--- a/test/spec/ol/source/clustersource.test.js
+++ b/test/spec/ol/source/clustersource.test.js
@@ -14,8 +14,54 @@ describe('ol.source.Cluster', function() {
       expect(source).to.be.a(ol.source.Cluster);
     });
   });
+
+  describe('#loadFeatures', function() {
+    var extent = [-1, -1, 1, 1];
+    var projection = ol.proj.get('EPSG:3857');
+    it('clusters a source with point features', function() {
+      var source = new ol.source.Cluster({
+        source: new ol.source.Vector({
+          features: [
+            new ol.Feature(new ol.geom.Point([0, 0])),
+            new ol.Feature(new ol.geom.Point([0, 0]))
+          ]
+        })
+      });
+      source.loadFeatures(extent, 1, projection);
+      expect(source.getFeatures().length).to.be(1);
+      expect(source.getFeatures()[0].get('features').length).to.be(2);
+    });
+    it('clusters with a custom geometryFunction', function() {
+      var source = new ol.source.Cluster({
+        geometryFunction: function(feature) {
+          var geom = feature.getGeometry();
+          if (geom.getType() == 'Point') {
+            return geom;
+          } else if (geom.getType() == 'Polygon') {
+            return geom.getInteriorPoint();
+          }
+          return null;
+        },
+        source: new ol.source.Vector({
+          features: [
+            new ol.Feature(new ol.geom.Point([0, 0])),
+            new ol.Feature(new ol.geom.LineString([[0, 0], [1, 1]])),
+            new ol.Feature(new ol.geom.Polygon(
+                [[[-1, -1], [-1, 1], [1, 1], [1, -1], [-1, -1]]]))
+          ]
+        })
+      });
+      source.loadFeatures(extent, 1, projection);
+      expect(source.getFeatures().length).to.be(1);
+      expect(source.getFeatures()[0].get('features').length).to.be(2);
+    });
+  })
 });
 
+goog.require('ol.Feature');
+goog.require('ol.geom.LineString');
+goog.require('ol.geom.Point');
+goog.require('ol.geom.Polygon');
 goog.require('ol.proj');
 goog.require('ol.source.Cluster');
 goog.require('ol.source.Source');


### PR DESCRIPTION
Currently, `ol.source.Cluster` only works with sources that contain point features. With this change, applications get full flexibility of what and how to cluster. If you wanted to cluster points and polygons (using an interior point), but exclude linestrings, you could use the following configuration:
```js
  var source = new ol.source.Cluster({
    geometryFunction: function(feature) {
      var geom = feature.getGeometry();
      if (geom.getType() == 'Point') {
        return geom;
      } else if (geom.getType() == 'Polygon') {
        return geom.getInteriorPoint();
      }
      return null;
    },
    source: new ol.source.Vector({/*...*/})
  });
```

Fixes #3167.
Fixes #4814.