### PR TITLE
Unlisten before calling listener and bind to target by default

### DIFF
--- a/src/ol/events.js
+++ b/src/ol/events.js
@@ -107,11 +107,12 @@ ol.events.ListenerObjType;
  */
 ol.events.bindListener_ = function(listenerObj) {
   var boundListener = function(evt) {
-    var rv = listenerObj.listener.call(listenerObj.bindTo, evt);
+    var listener = listenerObj.listener;
+    var bindTo = listenerObj.bindTo || listenerObj.target;
     if (listenerObj.callOnce) {
       ol.events.unlistenByKey(listenerObj);
     }
-    return rv;
+    return listener.call(bindTo, evt);
   }
   listenerObj.boundListener = boundListener;
   return boundListener;

--- a/test/spec/ol/events.test.js
+++ b/test/spec/ol/events.test.js
@@ -24,23 +24,32 @@ describe('ol.events', function() {
       boundListener();
       expect(listenerObj.listener.thisValues[0]).to.equal(listenerObj.bindTo);
     });
-    it('binds a self-unregistering listener when callOnce is true', function() {
-      var bindTo = {id: 1};
-      var listener = sinon.spy();
-      target.removeEventListener = function() {};
+    it('binds to the target when bindTo is not provided', function() {
       var listenerObj = {
-        type: 'foo',
-        target: target,
-        listener: listener,
-        bindTo: bindTo,
-        callOnce: true
+        listener: sinon.spy(),
+        target: {id: 1}
       };
       var boundListener = ol.events.bindListener_(listenerObj);
       expect(listenerObj.boundListener).to.equal(boundListener);
-      var spy = sinon.spy(ol.events, 'unlistenByKey');
       boundListener();
-      expect(listener.thisValues[0]).to.equal(bindTo);
-      expect(spy.firstCall.args[0]).to.eql(listenerObj);
+      expect(listenerObj.listener.thisValues[0]).to.equal(listenerObj.target);
+    });
+    it('binds a self-unregistering listener when callOnce is true', function() {
+      var bindTo = {id: 1};
+      var listenerObj = {
+        type: 'foo',
+        target: target,
+        bindTo: bindTo,
+        callOnce: true
+      };
+      var unlistenSpy = sinon.spy(ol.events, 'unlistenByKey');
+      listenerObj.listener = function() {
+        expect(this).to.equal(bindTo);
+        expect(unlistenSpy.firstCall.args[0]).to.eql(listenerObj);
+      }
+      var boundListener = ol.events.bindListener_(listenerObj);
+      expect(listenerObj.boundListener).to.equal(boundListener);
+      boundListener();
       ol.events.unlistenByKey.restore();
     });
   });


### PR DESCRIPTION
The problem reported in #4919 is a regression caused by the `goog.events.*` removal. Listeners were always called synchronously, but the difference with the new implementation is that a `once` listener is unregistered *after* calling the listener, whereas it was unregistered *before* previously. The second problem is that when `opt_this` is not provided, we no longer bind to the event target by default.

Fixes #4919.