### PR TITLE
Upgrade to JSTS 1.0.2 in example

### DIFF
--- a/examples/jsts.html
+++ b/examples/jsts.html
@@ -7,6 +7,6 @@ docs: >
   with OpenLayers 3.
 tags: "vector, jsts, buffer"
 resources:
-  - https://cdn.rawgit.com/bjornharrtell/jsts/gh-pages/1.0.1/jsts.min.js
+  - https://cdn.rawgit.com/bjornharrtell/jsts/gh-pages/1.0.2/jsts.min.js
 ---
 <div id="map" class="map"></div>


### PR DESCRIPTION
JSTS 1.0.2 resolves polyfill issues in the previous version that caused build troubles in #4927.