### PR TITLE
IE support for ol.source.Raster

### DIFF
--- a/examples/region-growing.js
+++ b/examples/region-growing.js
@@ -59,7 +59,7 @@ function growRegion(inputs, data) {
     }
     edge = newedge;
   }
-  return new ImageData(outputData, width, height);
+  return {data: outputData, width: width, height: height};
 }
 
 function next4Edges(edge) {

--- a/examples/shaded-relief.js
+++ b/examples/shaded-relief.js
@@ -99,7 +99,7 @@ function shade(inputs, data) {
     }
   }
 
-  return new ImageData(shadeData, width, height);
+  return {data: shadeData, width: width, height: height};
 }
 
 var elevation = new ol.source.XYZ({

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "metalsmith-layouts": "1.6.4",
     "nomnom": "1.8.1",
     "pbf": "1.3.5",
-    "pixelworks": "1.0.0",
+    "pixelworks": "1.1.0",
     "rbush": "1.4.2",
     "temp": "0.8.3",
     "vector-tile": "1.2.0",

--- a/test/spec/ol/source/rastersource.test.js
+++ b/test/spec/ol/source/rastersource.test.js
@@ -11,16 +11,7 @@ var blue = 'data:image/gif;base64,R0lGODlhAQABAPAAAAAA/////yH5BAAAAAAALAAAAA' +
 
 var itNoPhantom = window.checkForMocha ? xit : it;
 
-var hasImageDataConstructor = true;
-try {
-  new ImageData(1, 1);
-} catch (e) {
-  hasImageDataConstructor = false;
-}
-
-var maybeDescribe = hasImageDataConstructor ? describe : xdescribe;
-
-maybeDescribe('ol.source.Raster', function() {
+describe('ol.source.Raster', function() {
 
   var target, map, redSource, greenSource, blueSource, raster;
 

--- a/test/spec/ol/source/rastersource.test.js
+++ b/test/spec/ol/source/rastersource.test.js
@@ -9,8 +9,6 @@ var green = 'data:image/gif;base64,R0lGODlhAQABAPAAAAD/AP///yH5BAAAAAAALAAAA' +
 var blue = 'data:image/gif;base64,R0lGODlhAQABAPAAAAAA/////yH5BAAAAAAALAAAAA' +
     'ABAAEAAAICRAEAOw==';
 
-var itNoPhantom = window.checkForMocha ? xit : it;
-
 describe('ol.source.Raster', function() {
 
   var target, map, redSource, greenSource, blueSource, raster;
@@ -90,7 +88,7 @@ describe('ol.source.Raster', function() {
       expect(source).to.be.a(ol.source.Raster);
     });
 
-    itNoPhantom('defaults to "pixel" operation', function(done) {
+    it('defaults to "pixel" operation', function(done) {
 
       var log = [];
 
@@ -118,7 +116,7 @@ describe('ol.source.Raster', function() {
 
     });
 
-    itNoPhantom('allows operation type to be set to "image"', function(done) {
+    it('allows operation type to be set to "image"', function(done) {
       var log = [];
 
       var source = new ol.source.Raster({
@@ -134,7 +132,10 @@ describe('ol.source.Raster', function() {
       source.once('afteroperations', function() {
         expect(log.length).to.equal(1);
         var inputs = log[0];
-        expect(inputs[0]).to.be.an(ImageData);
+        var imageData = inputs[0];
+        expect(imageData.data).to.be.a(Uint8ClampedArray);
+        expect(imageData.width).to.be(2);
+        expect(imageData.height).to.be(2);
         done();
       });
 
@@ -149,7 +150,7 @@ describe('ol.source.Raster', function() {
 
   describe('#setOperation()', function() {
 
-    itNoPhantom('allows operation to be set', function(done) {
+    it('allows operation to be set', function(done) {
 
       var count = 0;
       raster.setOperation(function(pixels) {
@@ -174,7 +175,7 @@ describe('ol.source.Raster', function() {
 
     });
 
-    itNoPhantom('updates and re-runs the operation', function(done) {
+    it('updates and re-runs the operation', function(done) {
 
       var view = map.getView();
       view.setCenter([0, 0]);
@@ -198,7 +199,7 @@ describe('ol.source.Raster', function() {
 
   describe('beforeoperations', function() {
 
-    itNoPhantom('gets called before operations are run', function(done) {
+    it('gets called before operations are run', function(done) {
 
       var count = 0;
       raster.setOperation(function(inputs) {
@@ -222,7 +223,7 @@ describe('ol.source.Raster', function() {
     });
 
 
-    itNoPhantom('allows data to be set for the operation', function(done) {
+    it('allows data to be set for the operation', function(done) {
 
       raster.setOperation(function(inputs, data) {
         ++data.count;
@@ -248,7 +249,7 @@ describe('ol.source.Raster', function() {
 
   describe('afteroperations', function() {
 
-    itNoPhantom('gets called after operations are run', function(done) {
+    it('gets called after operations are run', function(done) {
 
       var count = 0;
       raster.setOperation(function(inputs) {
@@ -271,7 +272,7 @@ describe('ol.source.Raster', function() {
 
     });
 
-    itNoPhantom('receives data set by the operation', function(done) {
+    it('receives data set by the operation', function(done) {
 
       raster.setOperation(function(inputs, data) {
         data.message = 'hello world';


### PR DESCRIPTION
This brings in `pixelworks@1.1.0` which has a workaround for the lack of an `ImageData` constructor in IE (add your votes here to support its addition: https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/8804656-support-for-the-imagedata-constructor).

For `image` type operations, workers can return `ImageData`-like objects (with `data`, `width`, and `height` properties).  On IE, they will be called with the same.  No changes should be required for `pixel` type operations.
