### PR TITLE
Fix Examples layout page

### DIFF
--- a/config/examples/example.html
+++ b/config/examples/example.html
@@ -18,8 +18,10 @@
   <body>
 
     <header class="navbar" role="navigation">
-      <div class="container" id="navbar-inner-container">
-        <a class="navbar-brand" href="./"><img src="./resources/logo-70x70.png">&nbsp;OpenLayers 3 Examples</a>
+      <div class="container">
+        <div class="display-table pull-left" id="navbar-logo-container">
+          <a class="navbar-brand" href="./"><img src="./resources/logo-70x70.png">&nbsp;OpenLayers 3 Examples</a>
+        </div>
         <ul class="nav navbar-nav pull-right">
           <li><a href="../doc">Docs</a></li>
           <li><a class="active" href="index.html">Examples</a></li>

--- a/examples/index.html
+++ b/examples/index.html
@@ -11,9 +11,6 @@
       body {
         padding-top: 70px;
       }
-      .navbar-form {
-        margin-top: 12px;
-      }
       input.search-query {
         color: #333;
       }
@@ -186,11 +183,13 @@
 
     <header class="navbar navbar-fixed-top" role="navigation">
       <div class="container">
-        <a class="navbar-brand" href="./"><img src="./resources/logo-70x70.png">&nbsp;OpenLayers 3 Examples</a>
-        <form class="navbar-form navbar-left search-form" role="search">
-          <input name="q" type="text" id="keywords" class="search-query" placeholder="Search" autofocus>
-          <span id="count"></span>
-        </form>
+        <div class="display-table pull-left">
+          <a class="navbar-brand" href="./"><img src="./resources/logo-70x70.png">&nbsp;OpenLayers 3 Examples</a>
+          <form class="navbar-form" role="search">
+            <input name="q" type="text" id="keywords" class="search-query" placeholder="Search" autofocus>
+            <span id="count"></span>
+          </form>
+        </div>
         <ul class="nav navbar-nav pull-right">
           <li><a href="../doc">Docs</a></li>
           <li><a class="active" href="index.html">Examples</a></li>

--- a/examples/resources/common.js
+++ b/examples/resources/common.js
@@ -22,7 +22,7 @@
     return;
   }
 
-  var container = document.getElementById('navbar-inner-container');
+  var container = document.getElementById('navbar-logo-container');
   if (!container) {
     return;
   }
@@ -74,7 +74,7 @@
 
   select.className = 'input-medium';
 
-  form.className = 'navbar-form pull-right version-form';
+  form.className = 'navbar-form version-form';
   form.appendChild(select);
 
   container.appendChild(form);

--- a/examples/resources/layout.css
+++ b/examples/resources/layout.css
@@ -32,12 +32,15 @@ body {
 .navbar-nav>li>a {
   color: white;
 }
-.search-form, .version-form {
-  position: absolute;
-  left: 450px;
+.display-table {
+  display: table;
+}
+.version-form, .navbar-form {
+  display: table-cell;
+  vertical-align: middle;
 }
 .version-form {
-  top: 5px;
+  color: #333;
 }
 
 #title {


### PR DESCRIPTION
Let's give a more solid approach to the Examples page.

This PR fixes #4888 and remove the `position:absolute` made by #4831.

Now there's a `div` tying up the Logo `a#href` and the Search `form` (or Version `select`) together.