### PR TITLE
Use WHEEL instead of legacy DOMMouseScroll event

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -291,7 +291,8 @@ ol.Map = function(options) {
     ol.events.EventType.TOUCHSTART,
     ol.events.EventType.MSPOINTERDOWN,
     ol.MapBrowserEvent.EventType.POINTERDOWN,
-    goog.userAgent.GECKO ? 'DOMMouseScroll' : ol.events.EventType.MOUSEWHEEL
+    ol.events.EventType.WHEEL,
+    ol.events.EventType.MOUSEWHEEL
   ];
   for (var i = 0, ii = overlayEvents.length; i < ii; ++i) {
     ol.events.listen(this.overlayContainerStopEvent_, overlayEvents[i],


### PR DESCRIPTION
We use the same event combination (WHEEL and MOUSEWHEEL) everywhere else in the library.

Fixes #4957