### PR TITLE
Skip tests where features are not available

### DIFF
--- a/test/spec/.eslintrc
+++ b/test/spec/.eslintrc
@@ -6,6 +6,7 @@
     "afterLoadText": false,
     "expect": false,
     "proj4": false,
-    "sinon": false
+    "sinon": false,
+    "where": false
   }
 }

--- a/test/spec/ol/format/mvtformat.test.js
+++ b/test/spec/ol/format/mvtformat.test.js
@@ -1,74 +1,73 @@
 goog.provide('ol.test.format.MVT');
 
-(typeof ArrayBuffer == 'function' ? describe : xdescribe)('ol.format.MVT',
-    function() {
+where('ArrayBuffer').describe('ol.format.MVT', function() {
 
-      var data;
-      beforeEach(function(done) {
-        var xhr = new XMLHttpRequest();
-        xhr.open('GET', 'spec/ol/data/14-8938-5680.vector.pbf');
-        xhr.responseType = 'arraybuffer';
-        xhr.onload = function() {
-          data = xhr.response;
-          done();
-        };
-        xhr.send();
-      });
+  var data;
+  beforeEach(function(done) {
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', 'spec/ol/data/14-8938-5680.vector.pbf');
+    xhr.responseType = 'arraybuffer';
+    xhr.onload = function() {
+      data = xhr.response;
+      done();
+    };
+    xhr.send();
+  });
 
-      describe('#readFeatures', function() {
+  describe('#readFeatures', function() {
 
-        it('uses ol.render.Feature as feature class by default', function() {
-          var format = new ol.format.MVT({layers: ['water']});
-          var features = format.readFeatures(data);
-          expect(features[0]).to.be.a(ol.render.Feature);
-        });
-
-        it('parses only specified layers', function() {
-          var format = new ol.format.MVT({layers: ['water']});
-          var features = format.readFeatures(data);
-          expect(features.length).to.be(10);
-        });
-
-        it('parses geometries correctly', function() {
-          var format = new ol.format.MVT({
-            featureClass: ol.Feature,
-            layers: ['poi_label']
-          });
-          var pbf = new ol.ext.pbf(data);
-          var tile = new ol.ext.vectortile.VectorTile(pbf);
-          var geometry, rawGeometry;
-
-          rawGeometry = tile.layers['poi_label'].feature(0).loadGeometry();
-          geometry = format.readFeatures(data)[0]
-              .getGeometry();
-          expect(geometry.getType()).to.be('Point');
-          expect(geometry.getCoordinates())
-              .to.eql([rawGeometry[0][0].x, rawGeometry[0][0].y]);
-
-          rawGeometry = tile.layers['water'].feature(0).loadGeometry();
-          format.setLayers(['water']);
-          geometry = format.readFeatures(data)[0]
-              .getGeometry();
-          expect(geometry.getType()).to.be('Polygon');
-          expect(rawGeometry[0].length)
-              .to.equal(geometry.getCoordinates()[0].length);
-          expect(geometry.getCoordinates()[0][0])
-              .to.eql([rawGeometry[0][0].x, rawGeometry[0][0].y]);
-
-          rawGeometry = tile.layers['barrier_line'].feature(0).loadGeometry();
-          format.setLayers(['barrier_line']);
-          geometry = format.readFeatures(data)[0]
-              .getGeometry();
-          expect(geometry.getType()).to.be('MultiLineString');
-          expect(rawGeometry[1].length)
-              .to.equal(geometry.getCoordinates()[1].length);
-          expect(geometry.getCoordinates()[1][0])
-              .to.eql([rawGeometry[1][0].x, rawGeometry[1][0].y]);
-        });
-
-      });
-
+    it('uses ol.render.Feature as feature class by default', function() {
+      var format = new ol.format.MVT({layers: ['water']});
+      var features = format.readFeatures(data);
+      expect(features[0]).to.be.a(ol.render.Feature);
     });
+
+    it('parses only specified layers', function() {
+      var format = new ol.format.MVT({layers: ['water']});
+      var features = format.readFeatures(data);
+      expect(features.length).to.be(10);
+    });
+
+    it('parses geometries correctly', function() {
+      var format = new ol.format.MVT({
+        featureClass: ol.Feature,
+        layers: ['poi_label']
+      });
+      var pbf = new ol.ext.pbf(data);
+      var tile = new ol.ext.vectortile.VectorTile(pbf);
+      var geometry, rawGeometry;
+
+      rawGeometry = tile.layers['poi_label'].feature(0).loadGeometry();
+      geometry = format.readFeatures(data)[0]
+          .getGeometry();
+      expect(geometry.getType()).to.be('Point');
+      expect(geometry.getCoordinates())
+          .to.eql([rawGeometry[0][0].x, rawGeometry[0][0].y]);
+
+      rawGeometry = tile.layers['water'].feature(0).loadGeometry();
+      format.setLayers(['water']);
+      geometry = format.readFeatures(data)[0]
+          .getGeometry();
+      expect(geometry.getType()).to.be('Polygon');
+      expect(rawGeometry[0].length)
+          .to.equal(geometry.getCoordinates()[0].length);
+      expect(geometry.getCoordinates()[0][0])
+          .to.eql([rawGeometry[0][0].x, rawGeometry[0][0].y]);
+
+      rawGeometry = tile.layers['barrier_line'].feature(0).loadGeometry();
+      format.setLayers(['barrier_line']);
+      geometry = format.readFeatures(data)[0]
+          .getGeometry();
+      expect(geometry.getType()).to.be('MultiLineString');
+      expect(rawGeometry[1].length)
+          .to.equal(geometry.getCoordinates()[1].length);
+      expect(geometry.getCoordinates()[1][0])
+          .to.eql([rawGeometry[1][0].x, rawGeometry[1][0].y]);
+    });
+
+  });
+
+});
 
 
 goog.require('ol.Feature');

--- a/test/spec/ol/source/rastersource.test.js
+++ b/test/spec/ol/source/rastersource.test.js
@@ -9,7 +9,7 @@ var green = 'data:image/gif;base64,R0lGODlhAQABAPAAAAD/AP///yH5BAAAAAAALAAAA' +
 var blue = 'data:image/gif;base64,R0lGODlhAQABAPAAAAAA/////yH5BAAAAAAALAAAAA' +
     'ABAAEAAAICRAEAOw==';
 
-describe('ol.source.Raster', function() {
+where('Uint8ClampedArray').describe('ol.source.Raster', function() {
 
   var target, map, redSource, greenSource, blueSource, raster;
 

--- a/test/test-extensions.js
+++ b/test/test-extensions.js
@@ -458,4 +458,25 @@
     }
   };
 
+  var features = {
+    Uint8ClampedArray: ('Uint8ClampedArray' in global)
+  };
+
+  /**
+   * Allow tests to be skipped where certain features are not available.  The
+   * provided key must be in the above `features` lookup.  Keys should
+   * correspond to the feature that is required, but can be any string.
+   * @param {string} key The required feature name.
+   * @return {Object} An object with a `describe` function that will run tests
+   *     if the required feature is available and skip them otherwise.
+   */
+  global.where = function(key) {
+    if (!(key in features)) {
+      throw new Error('where() called with unknown key: ' + key);
+    }
+    return {
+      describe: features[key] ? global.describe : global.xdescribe
+    };
+  };
+
 })(this);

--- a/test/test-extensions.js
+++ b/test/test-extensions.js
@@ -459,6 +459,7 @@
   };
 
   var features = {
+    ArrayBuffer: typeof ArrayBuffer === 'function',
     Uint8ClampedArray: ('Uint8ClampedArray' in global)
   };
 


### PR DESCRIPTION
This adds a global `where` function that can be used to selectively ignore tests where features are not available.

Ideally, this makes tests pass in IE < 11 (where `Uint8ClampedArray` and `ol.source.Raster` do not work).