### PR TITLE
Do not remove listeners while dispatching event

### DIFF
--- a/src/ol/events/eventtarget.js
+++ b/src/ol/events/eventtarget.js
@@ -70,11 +70,13 @@ ol.events.EventTarget.prototype.dispatchEvent = function(event) {
   var type = evt.type;
   evt.target = this;
   var listeners = this.listeners_[type];
+  var propagate;
   if (listeners) {
     this.pendingRemovals_[type] = 0;
     for (var i = 0, ii = listeners.length; i < ii; ++i) {
       if (listeners[i].call(this, evt) === false || evt.propagationStopped) {
-        return false;
+        propagate = false;
+        break;
       }
     }
     var pendingRemovals = this.pendingRemovals_[type];
@@ -82,6 +84,7 @@ ol.events.EventTarget.prototype.dispatchEvent = function(event) {
     while (pendingRemovals--) {
       this.removeEventListener(type, ol.nullFunction);
     }
+    return propagate;
   }
 };
 

--- a/src/ol/events/eventtarget.js
+++ b/src/ol/events/eventtarget.js
@@ -72,7 +72,9 @@ ol.events.EventTarget.prototype.dispatchEvent = function(event) {
   var listeners = this.listeners_[type];
   var propagate;
   if (listeners) {
-    this.pendingRemovals_[type] = 0;
+    if (!(type in this.pendingRemovals_)) {
+      this.pendingRemovals_[type] = 0;
+    }
     for (var i = 0, ii = listeners.length; i < ii; ++i) {
       if (listeners[i].call(this, evt) === false || evt.propagationStopped) {
         propagate = false;

--- a/src/ol/events/eventtarget.js
+++ b/src/ol/events/eventtarget.js
@@ -1,5 +1,6 @@
 goog.provide('ol.events.EventTarget');
 
+goog.require('goog.asserts');
 goog.require('ol.Disposable');
 goog.require('ol.events');
 goog.require('ol.events.Event');
@@ -28,6 +29,12 @@ ol.events.EventTarget = function() {
 
   /**
    * @private
+   * @type {!Object.<string, number>}
+   */
+  this.pendingRemovals_ = {};
+
+  /**
+   * @private
    * @type {!Object.<string, Array.<ol.events.ListenerFunctionType>>}
    */
   this.listeners_ = {};
@@ -46,7 +53,7 @@ ol.events.EventTarget.prototype.addEventListener = function(type, listener) {
     listeners = this.listeners_[type] = [];
   }
   if (listeners.indexOf(listener) === -1) {
-    listeners.unshift(listener);
+    listeners.push(listener);
   }
 };
 
@@ -64,11 +71,16 @@ ol.events.EventTarget.prototype.dispatchEvent = function(event) {
   evt.target = this;
   var listeners = this.listeners_[type];
   if (listeners) {
-    for (var i = listeners.length - 1; i >= 0; --i) {
-      if (listeners[i].call(this, evt) === false ||
-          evt.propagationStopped) {
+    this.pendingRemovals_[type] = 0;
+    for (var i = 0, ii = listeners.length; i < ii; ++i) {
+      if (listeners[i].call(this, evt) === false || evt.propagationStopped) {
         return false;
       }
+    }
+    var pendingRemovals = this.pendingRemovals_[type];
+    delete this.pendingRemovals_[type];
+    while (pendingRemovals--) {
+      this.removeEventListener(type, ol.nullFunction);
     }
   }
 };
@@ -84,7 +96,7 @@ ol.events.EventTarget.prototype.disposeInternal = function() {
 
 /**
  * Get the listeners for a specified event type. Listeners are returned in the
- * opposite order that they will be called in.
+ * order that they will be called in.
  *
  * @param {string} type Type.
  * @return {Array.<ol.events.ListenerFunctionType>} Listeners.
@@ -114,9 +126,16 @@ ol.events.EventTarget.prototype.removeEventListener = function(type, listener) {
   var listeners = this.listeners_[type];
   if (listeners) {
     var index = listeners.indexOf(listener);
-    listeners.splice(index, 1);
-    if (listeners.length === 0) {
-      delete this.listeners_[type];
+    goog.asserts.assert(index != -1, 'listener not found');
+    if (type in this.pendingRemovals_) {
+      // make listener a no-op, and remove later in #dispatchEvent()
+      listeners[index] = ol.nullFunction;
+      ++this.pendingRemovals_[type];
+    } else {
+      listeners.splice(index, 1);
+      if (listeners.length === 0) {
+        delete this.listeners_[type];
+      }
     }
   }
 };

--- a/test/spec/ol/events.test.js
+++ b/test/spec/ol/events.test.js
@@ -214,7 +214,7 @@ describe('ol.events', function() {
       var key2 = ol.events.listen(target, 'foo', listener, {});
       expect(key1.boundListener).to.not.equal(key2.boundListener);
       expect(target.getListeners('foo')).to.eql(
-          [key2.boundListener, key1.boundListener]);
+          [key1.boundListener, key2.boundListener]);
     });
   });
 

--- a/test/spec/ol/events/eventtarget.test.js
+++ b/test/spec/ol/events/eventtarget.test.js
@@ -115,6 +115,21 @@ describe('ol.events.EventTarget', function() {
       expect(events[0]).to.equal(event);
       expect(events[0].target).to.equal(eventTarget);
     });
+    it('is safe to remove listeners in listeners', function() {
+      eventTarget.addEventListener('foo', spy3);
+      eventTarget.addEventListener('foo', function() {
+        eventTarget.removeEventListener('foo', spy1);
+        eventTarget.removeEventListener('foo', spy2);
+        eventTarget.removeEventListener('foo', spy3);
+      });
+      eventTarget.addEventListener('foo', spy1);
+      eventTarget.addEventListener('foo', spy2);
+      expect(function() {
+        eventTarget.dispatchEvent('foo');
+      }).not.to.throwException();
+      expect(called).to.eql([3]);
+      expect(eventTarget.getListeners('foo')).to.have.length(1);
+    });
   });
 
   describe('#dispose()', function() {

--- a/test/spec/ol/events/eventtarget.test.js
+++ b/test/spec/ol/events/eventtarget.test.js
@@ -130,6 +130,23 @@ describe('ol.events.EventTarget', function() {
       expect(called).to.eql([3]);
       expect(eventTarget.getListeners('foo')).to.have.length(1);
     });
+    it('is safe to do weird things in listeners', function() {
+      eventTarget.addEventListener('foo', spy2);
+      eventTarget.addEventListener('foo', function weird(evt) {
+        eventTarget.removeEventListener('foo', weird);
+        eventTarget.removeEventListener('foo', spy1);
+        eventTarget.dispatchEvent('foo');
+        eventTarget.removeEventListener('foo', spy2);
+        eventTarget.dispatchEvent('foo');
+        evt.preventDefault();
+      });
+      eventTarget.addEventListener('foo', spy1);
+      expect(function() {
+        eventTarget.dispatchEvent('foo');
+      }).not.to.throwException();
+      expect(called).to.eql([2, 2]);
+      expect(eventTarget.getListeners('foo')).to.be(undefined);
+    });
   });
 
   describe('#dispose()', function() {


### PR DESCRIPTION
When listeners are removed in listeners for the same event type, unexpected behaviour can be observed (exceptions thrown, listeners called more than once). To fix this, we can defer listener removal until all listeners have been called.

Fixes #4986.