### PR TITLE
Allow configuration of the test reporter

### DIFF
--- a/tasks/test-coverage.js
+++ b/tasks/test-coverage.js
@@ -164,7 +164,7 @@ var foundAllJavaScriptSourceFiles = function(err, files) {
   wrench.copyDirSyncRecursive(instrumentedDir, dir, copyOpts);
 
   log('• run test suite on instrumented code');
-  runTestsuite(true, collectAndWriteCoverageData);
+  runTestsuite({coverage: true, reporter: 'dot'}, collectAndWriteCoverageData);
 };
 
 /**

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -40,7 +40,9 @@ function listen(min, max, server, callback) {
 }
 
 
-function runTests(includeCoverage, callback) {
+function runTests(conf, callback) {
+  var coverage = 'coverage' in conf ? conf.coverage : false;
+  var reporter = 'reporter' in conf ? conf.reporter : 'spec';
   /**
    * Create the debug server and run tests.
    */
@@ -60,14 +62,14 @@ function runTests(includeCoverage, callback) {
       var args = [
         require.resolve('mocha-phantomjs-core'),
         url + '/test/index.html',
-        'spec'
+        reporter
       ];
       var config = {
         ignoreResourceErrors: true,
         useColors: true
       };
 
-      if (includeCoverage) {
+      if (coverage) {
         config.hooks = path.join(__dirname, '../test/phantom_hooks.js');
       }
 
@@ -82,7 +84,7 @@ function runTests(includeCoverage, callback) {
 }
 
 if (require.main === module) {
-  runTests(false, function(code) {
+  runTests({coverage: false, reporter: 'spec'}, function(code) {
     process.exit(code);
   });
 }


### PR DESCRIPTION
The reporter for the standard tests is still `spec`; the one for the
gathering of code coverage is set to `dot` to not clutter the output
of the logfile on travis.