### PR TITLE
Add alpha default value to ol.Color array form

### DIFF
--- a/src/ol/color/color.js
+++ b/src/ol/color/color.js
@@ -17,7 +17,8 @@ goog.require('ol.math');
 /**
  * A color represented as a short array [red, green, blue, alpha].
  * red, green, and blue should be integers in the range 0..255 inclusive.
- * alpha should be a float in the range 0..1 inclusive.
+ * alpha should be a float in the range 0..1 inclusive. If no alpha value is
+ * given then `1` will be used.
  * @typedef {Array.<number>}
  * @api
  */
@@ -293,7 +294,7 @@ ol.color.toString = function(color) {
   if (b != (b | 0)) {
     b = (b + 0.5) | 0;
   }
-  var a = color[3];
+  var a = color[3] === undefined ? 1 : color[3];
   return 'rgba(' + r + ',' + g + ',' + b + ',' + a + ')';
 };
 

--- a/test/spec/ol/color.test.js
+++ b/test/spec/ol/color.test.js
@@ -129,6 +129,10 @@ describe('ol.color', function() {
       expect(ol.color.toString([1.2, 2.5, 3.7, 0.4])).to.be('rgba(1,3,4,0.4)');
     });
 
+    it('sets default alpha value if undefined', function() {
+      expect(ol.color.toString([0, 0, 0])).to.be('rgba(0,0,0,1)');
+    });
+
   });
 });
 


### PR DESCRIPTION
See #4993.

If `ol.Color` is informed like `[51, 51, 51]`, alpha value is default `1`.