### PR TITLE
Add 'function' jsdoc tag to ol.geom.Geometry#rotate

### DIFF
--- a/src/ol/geom/geometry.js
+++ b/src/ol/geom/geometry.js
@@ -175,6 +175,7 @@ ol.geom.Geometry.prototype.getExtent = function(opt_extent) {
  * @param {number} angle Rotation angle in radians.
  * @param {ol.Coordinate} anchor The rotation center.
  * @api
+ * @function
  */
 ol.geom.Geometry.prototype.rotate = goog.abstractMethod;
 


### PR DESCRIPTION
Otherwise the function is in the 'Members' section of the API documentation.