### PR TITLE
Accept simpler forms of specifying attribution(s) for sources.

### DIFF
--- a/examples/flight-animation.js
+++ b/examples/flight-animation.js
@@ -76,10 +76,8 @@ var animateFlights = function(event) {
 
 flightsSource = new ol.source.Vector({
   wrapX: false,
-  attributions: [new ol.Attribution({
-    html: 'Flight data by ' +
-        '<a href="http://openflights.org/data.html">OpenFlights</a>,'
-  })],
+  attributions: 'Flight data by ' +
+        '<a href="http://openflights.org/data.html">OpenFlights</a>,',
   loader: function() {
     var url = 'data/openflights/flights.json';
     fetch(url).then(function(response) {

--- a/examples/igc.js
+++ b/examples/igc.js
@@ -86,10 +86,7 @@ var map = new ol.Map({
     new ol.layer.Tile({
       source: new ol.source.OSM({
         attributions: [
-          new ol.Attribution({
-            html: 'All maps &copy; ' +
-                '<a href="http://www.opencyclemap.org/">OpenCycleMap</a>'
-          }),
+          'All maps © <a href="http://www.opencyclemap.org/">OpenCycleMap</a>',
           ol.source.OSM.ATTRIBUTION
         ],
         url: 'http://{a-c}.tile.opencyclemap.org/cycle/{z}/{x}/{y}.png'

--- a/examples/localized-openstreetmap.js
+++ b/examples/localized-openstreetmap.js
@@ -9,10 +9,7 @@ goog.require('ol.source.OSM');
 var openCycleMapLayer = new ol.layer.Tile({
   source: new ol.source.OSM({
     attributions: [
-      new ol.Attribution({
-        html: 'All maps &copy; ' +
-            '<a href="http://www.opencyclemap.org/">OpenCycleMap</a>'
-      }),
+      'All maps © <a href="http://www.opencyclemap.org/">OpenCycleMap</a>',
       ol.source.OSM.ATTRIBUTION
     ],
     url: 'http://{a-c}.tile.opencyclemap.org/cycle/{z}/{x}/{y}.png'
@@ -22,10 +19,7 @@ var openCycleMapLayer = new ol.layer.Tile({
 var openSeaMapLayer = new ol.layer.Tile({
   source: new ol.source.OSM({
     attributions: [
-      new ol.Attribution({
-        html: 'All maps &copy; ' +
-            '<a href="http://www.openseamap.org/">OpenSeaMap</a>'
-      }),
+      'All maps © <a href="http://www.openseamap.org/">OpenSeaMap</a>',
       ol.source.OSM.ATTRIBUTION
     ],
     opaque: false,

--- a/examples/mapbox-vector-tiles-advanced.js
+++ b/examples/mapbox-vector-tiles-advanced.js
@@ -45,11 +45,9 @@ var map = new ol.Map({
     new ol.layer.VectorTile({
       preload: Infinity,
       source: new ol.source.VectorTile({
-        attributions: [new ol.Attribution({
-          html: '© <a href="https://www.mapbox.com/map-feedback/">Mapbox</a> ' +
-              '© <a href="http://www.openstreetmap.org/copyright">' +
-              'OpenStreetMap contributors</a>'
-        })],
+        attributions: '© <a href="https://www.mapbox.com/map-feedback/">Mapbox</a> ' +
+          '© <a href="http://www.openstreetmap.org/copyright">' +
+          'OpenStreetMap contributors</a>',
         format: new ol.format.MVT(),
         tileGrid: new ol.tilegrid.TileGrid({
           extent: ol.proj.get('EPSG:3857').getExtent(),

--- a/examples/mapbox-vector-tiles.js
+++ b/examples/mapbox-vector-tiles.js
@@ -17,11 +17,9 @@ var map = new ol.Map({
   layers: [
     new ol.layer.VectorTile({
       source: new ol.source.VectorTile({
-        attributions: [new ol.Attribution({
-          html: '© <a href="https://www.mapbox.com/map-feedback/">Mapbox</a> ' +
-              '© <a href="http://www.openstreetmap.org/copyright">' +
-              'OpenStreetMap contributors</a>'
-        })],
+        attributions: '© <a href="https://www.mapbox.com/map-feedback/">Mapbox</a> ' +
+          '© <a href="http://www.openstreetmap.org/copyright">' +
+          'OpenStreetMap contributors</a>',
         format: new ol.format.MVT(),
         tileGrid: ol.tilegrid.createXYZ({maxZoom: 22}),
         tilePixelRatio: 16,

--- a/examples/reprojection.js
+++ b/examples/reprojection.js
@@ -81,12 +81,8 @@ layers['wms4326'] = new ol.layer.Tile({
 
 layers['wms21781'] = new ol.layer.Tile({
   source: new ol.source.TileWMS({
-    attributions: [new ol.Attribution({
-      html: '&copy; ' +
-          '<a href="http://www.geo.admin.ch/internet/geoportal/' +
-          'en/home.html">' +
-          'Pixelmap 1:1000000 / geo.admin.ch</a>'
-    })],
+    attributions: '© <a href="http://www.geo.admin.ch/internet/geoportal/' +
+      'en/home.html">Pixelmap 1:1000000 / geo.admin.ch</a>',
     crossOrigin: 'anonymous',
     params: {
       'LAYERS': 'ch.swisstopo.pixelkarte-farbe-pk1000.noscale',
@@ -120,10 +116,8 @@ layers['grandcanyon'] = new ol.layer.Tile({
     crossOrigin: '',
     tilePixelRatio: 2,
     maxZoom: 15,
-    attributions: [new ol.Attribution({
-      html: 'Tiles &copy; USGS, rendered with ' +
-          '<a href="http://www.maptiler.com/">MapTiler</a>'
-    })]
+    attributions: 'Tiles © USGS, rendered with ' +
+      '<a href="http://www.maptiler.com/">MapTiler</a>'
   })
 });
 

--- a/examples/static-image.js
+++ b/examples/static-image.js
@@ -21,11 +21,7 @@ var map = new ol.Map({
   layers: [
     new ol.layer.Image({
       source: new ol.source.ImageStatic({
-        attributions: [
-          new ol.Attribution({
-            html: '&copy; <a href="http://xkcd.com/license.html">xkcd</a>'
-          })
-        ],
+        attributions: '© <a href="http://xkcd.com/license.html">xkcd</a>',
         url: 'http://imgs.xkcd.com/comics/online_communities.png',
         projection: projection,
         imageExtent: extent

--- a/examples/vector-esri-edit.js
+++ b/examples/vector-esri-edit.js
@@ -53,14 +53,10 @@ var vector = new ol.layer.Vector({
   source: vectorSource
 });
 
-var attribution = new ol.Attribution({
-  html: 'Tiles &copy; <a href="http://services.arcgisonline.com/ArcGIS/' +
-      'rest/services/World_Topo_Map/MapServer">ArcGIS</a>'
-});
-
 var raster = new ol.layer.Tile({
   source: new ol.source.XYZ({
-    attributions: [attribution],
+    attributions: 'Tiles © <a href="http://services.arcgisonline.com/ArcGIS/' +
+        'rest/services/World_Topo_Map/MapServer">ArcGIS</a>',
     url: 'http://server.arcgisonline.com/ArcGIS/rest/services/' +
         'World_Topo_Map/MapServer/tile/{z}/{y}/{x}'
   })

--- a/examples/vector-esri.js
+++ b/examples/vector-esri.js
@@ -95,15 +95,10 @@ var vector = new ol.layer.Vector({
   }
 });
 
-
-var attribution = new ol.Attribution({
-  html: 'Tiles &copy; <a href="http://services.arcgisonline.com/ArcGIS/' +
-      'rest/services/World_Topo_Map/MapServer">ArcGIS</a>'
-});
-
 var raster = new ol.layer.Tile({
   source: new ol.source.XYZ({
-    attributions: [attribution],
+    attributions: 'Tiles © <a href="http://services.arcgisonline.com/ArcGIS/' +
+        'rest/services/World_Topo_Map/MapServer">ArcGIS</a>',
     url: 'http://server.arcgisonline.com/ArcGIS/rest/services/' +
         'World_Topo_Map/MapServer/tile/{z}/{y}/{x}'
   })

--- a/examples/wms-custom-proj.js
+++ b/examples/wms-custom-proj.js
@@ -48,12 +48,8 @@ var layers = [
     source: new ol.source.TileWMS({
       url: 'http://wms.geo.admin.ch/',
       crossOrigin: 'anonymous',
-      attributions: [new ol.Attribution({
-        html: '&copy; ' +
-            '<a href="http://www.geo.admin.ch/internet/geoportal/' +
-            'en/home.html">' +
-            'Pixelmap 1:1000000 / geo.admin.ch</a>'
-      })],
+      attributions: '© <a href="http://www.geo.admin.ch/internet/geoportal/' +
+          'en/home.html">Pixelmap 1:1000000 / geo.admin.ch</a>',
       params: {
         'LAYERS': 'ch.swisstopo.pixelkarte-farbe-pk1000.noscale',
         'FORMAT': 'image/jpeg'
@@ -66,12 +62,8 @@ var layers = [
     source: new ol.source.TileWMS({
       url: 'http://wms.geo.admin.ch/',
       crossOrigin: 'anonymous',
-      attributions: [new ol.Attribution({
-        html: '&copy; ' +
-            '<a href="http://www.geo.admin.ch/internet/geoportal/' +
-            'en/home.html">' +
-            'National parks / geo.admin.ch</a>'
-      })],
+      attributions: '© <a href="http://www.geo.admin.ch/internet/geoportal/' +
+          'en/home.html">National parks / geo.admin.ch</a>',
       params: {'LAYERS': 'ch.bafu.schutzgebiete-paerke_nationaler_bedeutung'},
       serverType: 'mapserver'
     })

--- a/examples/wms-image-custom-proj.js
+++ b/examples/wms-image-custom-proj.js
@@ -36,12 +36,8 @@ var layers = [
     source: new ol.source.ImageWMS({
       url: 'http://wms.geo.admin.ch/',
       crossOrigin: 'anonymous',
-      attributions: [new ol.Attribution({
-        html: '&copy; ' +
-            '<a href="http://www.geo.admin.ch/internet/geoportal/' +
-            'en/home.html">' +
-            'Pixelmap 1:1000000 / geo.admin.ch</a>'
-      })],
+      attributions: '© <a href="http://www.geo.admin.ch/internet/geoportal/' +
+          'en/home.html">Pixelmap 1:1000000 / geo.admin.ch</a>',
       params: {
         'LAYERS': 'ch.swisstopo.pixelkarte-farbe-pk1000.noscale',
         'FORMAT': 'image/jpeg'
@@ -54,12 +50,8 @@ var layers = [
     source: new ol.source.ImageWMS({
       url: 'http://wms.geo.admin.ch/',
       crossOrigin: 'anonymous',
-      attributions: [new ol.Attribution({
-        html: '&copy; ' +
-            '<a href="http://www.geo.admin.ch/internet/geoportal/' +
-            'en/home.html">' +
-            'National parks / geo.admin.ch</a>'
-      })],
+      attributions: '© <a href="http://www.geo.admin.ch/internet/geoportal/' +
+          'en/home.html">National parks / geo.admin.ch</a>',
       params: {'LAYERS': 'ch.bafu.schutzgebiete-paerke_nationaler_bedeutung'},
       serverType: /** @type {ol.source.wms.ServerType} */ ('mapserver')
     })

--- a/examples/wms-no-proj.js
+++ b/examples/wms-no-proj.js
@@ -11,12 +11,8 @@ goog.require('ol.source.TileWMS');
 var layers = [
   new ol.layer.Tile({
     source: new ol.source.TileWMS({
-      attributions: [new ol.Attribution({
-        html: '&copy; ' +
-            '<a href="http://www.geo.admin.ch/internet/geoportal/' +
-            'en/home.html">' +
-            'Pixelmap 1:1000000 / geo.admin.ch</a>'
-      })],
+      attributions: '© <a href="http://www.geo.admin.ch/internet/geoportal/' +
+          'en/home.html">Pixelmap 1:1000000 / geo.admin.ch</a>',
       crossOrigin: 'anonymous',
       params: {
         'LAYERS': 'ch.swisstopo.pixelkarte-farbe-pk1000.noscale',
@@ -27,12 +23,8 @@ var layers = [
   }),
   new ol.layer.Image({
     source: new ol.source.ImageWMS({
-      attributions: [new ol.Attribution({
-        html: '&copy; ' +
-            '<a href="http://www.geo.admin.ch/internet/geoportal/' +
-            'en/home.html">' +
-            'National parks / geo.admin.ch</a>'
-      })],
+      attributions: '© <a href="http://www.geo.admin.ch/internet/geoportal/' +
+          'en/home.html">National parks / geo.admin.ch</a>',
       crossOrigin: 'anonymous',
       params: {'LAYERS': 'ch.bafu.schutzgebiete-paerke_nationaler_bedeutung'},
       serverType: 'mapserver',

--- a/examples/wmts-dimensions.js
+++ b/examples/wmts-dimensions.js
@@ -33,13 +33,9 @@ var wmtsSource = new ol.source.WMTS({
   format: 'image/png',
   matrixSet: 'EPSG:3857',
   attributions: [
-    new ol.Attribution({
-      html: '<a href="http://scalgo.com">SCALGO</a>'
-    }),
-    new ol.Attribution({
-      html: '<a href="http://www.cgiar-csi.org/data/' +
-          'srtm-90m-digital-elevation-database-v4-1">CGIAR-CSI SRTM</a>'
-    })
+    '<a href="http://scalgo.com">SCALGO</a>',
+    '<a href="http://www.cgiar-csi.org/data/' +
+        'srtm-90m-digital-elevation-database-v4-1">CGIAR-CSI SRTM</a>'
   ],
   tileGrid: tileGrid,
   style: 'default',

--- a/examples/wmts.js
+++ b/examples/wmts.js
@@ -21,12 +21,6 @@ for (var z = 0; z < 14; ++z) {
   matrixIds[z] = z;
 }
 
-var attribution = new ol.Attribution({
-  html: 'Tiles &copy; <a href="http://services.arcgisonline.com/arcgis/rest/' +
-      'services/Demographics/USA_Population_Density/MapServer/">ArcGIS</a>'
-});
-
-
 var map = new ol.Map({
   layers: [
     new ol.layer.Tile({
@@ -36,7 +30,8 @@ var map = new ol.Map({
     new ol.layer.Tile({
       opacity: 0.7,
       source: new ol.source.WMTS({
-        attributions: [attribution],
+        attributions: 'Tiles © <a href="http://services.arcgisonline.com/arcgis/rest/' +
+            'services/Demographics/USA_Population_Density/MapServer/">ArcGIS</a>',
         url: 'http://services.arcgisonline.com/arcgis/rest/' +
             'services/Demographics/USA_Population_Density/MapServer/WMTS/',
         layer: '0',

--- a/examples/xyz-esri-4326-512.js
+++ b/examples/xyz-esri-4326-512.js
@@ -6,7 +6,7 @@ goog.require('ol.proj');
 goog.require('ol.source.XYZ');
 
 var attribution = new ol.Attribution({
-  html: 'Copyright:&copy; 2013 ESRI, i-cubed, GeoEye'
+  html: 'Copyright:© 2013 ESRI, i-cubed, GeoEye'
 });
 
 var projection = ol.proj.get('EPSG:4326');

--- a/examples/xyz-esri.js
+++ b/examples/xyz-esri.js
@@ -7,7 +7,7 @@ goog.require('ol.source.XYZ');
 
 
 var attribution = new ol.Attribution({
-  html: 'Tiles &copy; <a href="http://services.arcgisonline.com/ArcGIS/' +
+  html: 'Tiles © <a href="http://services.arcgisonline.com/ArcGIS/' +
       'rest/services/World_Topo_Map/MapServer">ArcGIS</a>'
 });
 

--- a/examples/xyz-retina.js
+++ b/examples/xyz-retina.js
@@ -6,12 +6,6 @@ goog.require('ol.proj');
 goog.require('ol.source.OSM');
 goog.require('ol.source.XYZ');
 
-
-var attribution = new ol.Attribution({
-  html: 'Tiles &copy; USGS, rendered with ' +
-      '<a href="http://www.maptiler.com/">MapTiler</a>'
-});
-
 var mapMinZoom = 1;
 var mapMaxZoom = 15;
 var mapExtent = [-112.261791, 35.983744, -112.113981, 36.132062];
@@ -25,7 +19,8 @@ var map = new ol.Map({
     new ol.layer.Tile({
       extent: ol.proj.transformExtent(mapExtent, 'EPSG:4326', 'EPSG:3857'),
       source: new ol.source.XYZ({
-        attributions: [attribution],
+        attributions: 'Tiles © USGS, rendered with ' +
+            '<a href="http://www.maptiler.com/">MapTiler</a>',
         url: 'http://tileserver.maptiler.com/grandcanyon@2x/{z}/{x}/{y}.png',
         tilePixelRatio: 2, // THIS IS IMPORTANT
         minZoom: mapMinZoom,

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -3904,6 +3904,13 @@ olx.source;
 
 
 /**
+ * @typedef {string|Array.<string>|ol.Attribution|Array.<ol.Attribution>}
+ * @api
+ */
+olx.source.AttributionOption;
+
+
+/**
  * @typedef {{cacheSize: (number|undefined),
  *     culture: (string|undefined),
  *     key: string,
@@ -3989,7 +3996,7 @@ olx.source.BingMapsOptions.prototype.wrapX;
 
 
 /**
- * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ * @typedef {{attributions: (olx.source.AttributionOption|undefined),
  *     distance: (number|undefined),
  *     extent: (ol.Extent|undefined),
  *     format: (ol.format.Feature|undefined),
@@ -4005,7 +4012,7 @@ olx.source.ClusterOptions;
 
 /**
  * Attributions.
- * @type {Array.<ol.Attribution>|undefined}
+ * @type {olx.source.AttributionOption|undefined}
  * @api
  */
 olx.source.ClusterOptions.prototype.attributions;
@@ -4115,7 +4122,7 @@ olx.source.TileUTFGridOptions.prototype.url;
 
 
 /**
- * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ * @typedef {{attributions: (olx.source.AttributionOption|undefined),
  *            cacheSize: (number|undefined),
  *            crossOrigin: (null|string|undefined),
  *            logo: (string|olx.LogoOptions|undefined),
@@ -4140,7 +4147,7 @@ olx.source.TileImageOptions;
 
 /**
  * Attributions.
- * @type {Array.<ol.Attribution>|undefined}
+ * @type {olx.source.AttributionOption|undefined}
  * @api
  */
 olx.source.TileImageOptions.prototype.attributions;
@@ -4287,7 +4294,7 @@ olx.source.TileImageOptions.prototype.wrapX;
 
 
 /**
- * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ * @typedef {{attributions: (olx.source.AttributionOption|undefined),
  *            cacheSize: (number|undefined),
  *            format: (ol.format.Feature|undefined),
  *            logo: (string|olx.LogoOptions|undefined),
@@ -4311,11 +4318,10 @@ olx.source.VectorTileOptions;
 
 /**
  * Attributions.
- * @type {Array.<ol.Attribution>|undefined}
+ * @type {olx.source.AttributionOption|undefined}
  * @api
  */
 olx.source.VectorTileOptions.prototype.attributions;
-
 
 
 /**
@@ -4640,7 +4646,7 @@ olx.source.TileDebugOptions.prototype.wrapX;
 
 
 /**
- * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ * @typedef {{attributions: (olx.source.AttributionOption|undefined),
  *     cacheSize: (number|undefined),
  *     crossOrigin: (null|string|undefined),
  *     maxZoom: (number|undefined),
@@ -4656,7 +4662,7 @@ olx.source.OSMOptions;
 
 /**
  * Attributions.
- * @type {Array.<ol.Attribution>|undefined}
+ * @type {olx.source.AttributionOption|undefined}
  * @api stable
  */
 olx.source.OSMOptions.prototype.attributions;
@@ -4740,7 +4746,7 @@ olx.source.OSMOptions.prototype.wrapX;
 
 
 /**
- * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ * @typedef {{attributions: (olx.source.AttributionOption|undefined),
  *     canvasFunction: ol.CanvasFunctionType,
  *     logo: (string|olx.LogoOptions|undefined),
  *     projection: ol.proj.ProjectionLike,
@@ -4754,7 +4760,7 @@ olx.source.ImageCanvasOptions;
 
 /**
  * Attributions.
- * @type {Array.<ol.Attribution>|undefined}
+ * @type {olx.source.AttributionOption|undefined}
  * @api
  */
 olx.source.ImageCanvasOptions.prototype.attributions;
@@ -4819,7 +4825,7 @@ olx.source.ImageCanvasOptions.prototype.state;
 
 
 /**
- * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ * @typedef {{attributions: (olx.source.AttributionOption|undefined),
  *     logo: (string|olx.LogoOptions|undefined),
  *     projection: ol.proj.ProjectionLike,
  *     ratio: (number|undefined),
@@ -4833,7 +4839,7 @@ olx.source.ImageVectorOptions;
 
 /**
  * Attributions.
- * @type {Array.<ol.Attribution>|undefined}
+ * @type {olx.source.AttributionOption|undefined}
  * @api
  */
 olx.source.ImageVectorOptions.prototype.attributions;
@@ -4951,7 +4957,7 @@ olx.source.RasterOptions.prototype.operationType;
 
 
 /**
- * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ * @typedef {{attributions: (olx.source.AttributionOption|undefined),
  *     crossOrigin: (null|string|undefined),
  *     hidpi: (boolean|undefined),
  *     serverType: (ol.source.wms.ServerType|string|undefined),
@@ -4969,7 +4975,7 @@ olx.source.ImageWMSOptions;
 
 /**
  * Attributions.
- * @type {Array.<ol.Attribution>|undefined}
+ * @type {olx.source.AttributionOption|undefined}
  * @api stable
  */
 olx.source.ImageWMSOptions.prototype.attributions;
@@ -5149,7 +5155,7 @@ olx.source.StamenOptions.prototype.url;
 
 
 /**
- * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ * @typedef {{attributions: (olx.source.AttributionOption|undefined),
  *     crossOrigin: (null|string|undefined),
  *     imageExtent: (ol.Extent),
  *     imageLoadFunction: (ol.ImageLoadFunctionType|undefined),
@@ -5164,7 +5170,7 @@ olx.source.ImageStaticOptions;
 
 /**
  * Attributions.
- * @type {Array.<ol.Attribution>|undefined}
+ * @type {olx.source.AttributionOption|undefined}
  * @api stable
  */
 olx.source.ImageStaticOptions.prototype.attributions;
@@ -5233,7 +5239,7 @@ olx.source.ImageStaticOptions.prototype.url;
 
 
 /**
- * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ * @typedef {{attributions: (olx.source.AttributionOption|undefined),
  *     cacheSize: (number|undefined),
  *     crossOrigin: (null|string|undefined),
  *     params: (Object.<string, *>|undefined),
@@ -5252,7 +5258,7 @@ olx.source.TileArcGISRestOptions;
 
 /**
  * Attributions.
- * @type {Array.<ol.Attribution>|undefined}
+ * @type {olx.source.AttributionOption|undefined}
  * @api
  */
 olx.source.TileArcGISRestOptions.prototype.attributions;
@@ -5369,7 +5375,7 @@ olx.source.TileArcGISRestOptions.prototype.urls;
 
 
 /**
- * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ * @typedef {{attributions: (olx.source.AttributionOption|undefined),
  *     cacheSize: (number|undefined),
  *     crossOrigin: (null|string|undefined),
  *     jsonp: (boolean|undefined),
@@ -5386,7 +5392,7 @@ olx.source.TileJSONOptions;
  * Optional attributions for the source.  If provided, these will be used
  * instead of any attribution data advertised by the server.  If not provided,
  * any attributions advertised by the server will be used.
- * @type {Array.<ol.Attribution>|undefined}
+ * @type {olx.source.AttributionOption|undefined}
  * @api stable
  */
 olx.source.TileJSONOptions.prototype.attributions;
@@ -5460,7 +5466,7 @@ olx.source.TileJSONOptions.prototype.wrapX;
 
 
 /**
- * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ * @typedef {{attributions: (olx.source.AttributionOption|undefined),
  *     cacheSize: (number|undefined),
  *     params: Object.<string,*>,
  *     crossOrigin: (null|string|undefined),
@@ -5483,7 +5489,7 @@ olx.source.TileWMSOptions;
 
 /**
  * Attributions.
- * @type {Array.<ol.Attribution>|undefined}
+ * @type {olx.source.AttributionOption|undefined}
  * @api stable
  */
 olx.source.TileWMSOptions.prototype.attributions;
@@ -5639,7 +5645,7 @@ olx.source.TileWMSOptions.prototype.wrapX;
 
 
 /**
- * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ * @typedef {{attributions: (olx.source.AttributionOption|undefined),
  *     features: (Array.<ol.Feature>|ol.Collection.<ol.Feature>|undefined),
  *     format: (ol.format.Feature|undefined),
  *     loader: (ol.FeatureLoader|undefined),
@@ -5655,7 +5661,7 @@ olx.source.VectorOptions;
 
 /**
  * Attributions.
- * @type {Array.<ol.Attribution>|undefined}
+ * @type {olx.source.AttributionOption|undefined}
  * @api stable
  */
 olx.source.VectorOptions.prototype.attributions;
@@ -5759,7 +5765,7 @@ olx.source.VectorOptions.prototype.wrapX;
 
 
 /**
- * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ * @typedef {{attributions: (olx.source.AttributionOption|undefined),
  *     cacheSize: (number|undefined),
  *     crossOrigin: (string|null|undefined),
  *     logo: (string|olx.LogoOptions|undefined),
@@ -5789,7 +5795,7 @@ olx.source.WMTSOptions;
 
 /**
  * Attributions.
- * @type {Array.<ol.Attribution>|undefined}
+ * @type {olx.source.AttributionOption|undefined}
  * @api
  */
 olx.source.WMTSOptions.prototype.attributions;
@@ -5975,7 +5981,7 @@ olx.source.WMTSOptions.prototype.wrapX;
 
 
 /**
- * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ * @typedef {{attributions: (olx.source.AttributionOption|undefined),
  *     cacheSize: (number|undefined),
  *     crossOrigin: (null|string|undefined),
  *     logo: (string|olx.LogoOptions|undefined),
@@ -5999,7 +6005,7 @@ olx.source.XYZOptions;
 
 /**
  * Attributions.
- * @type {Array.<ol.Attribution>|undefined}
+ * @type {olx.source.AttributionOption|undefined}
  * @api stable
  */
 olx.source.XYZOptions.prototype.attributions;
@@ -6150,7 +6156,7 @@ olx.source.XYZOptions.prototype.wrapX;
 
 
 /**
- * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ * @typedef {{attributions: (olx.source.AttributionOption|undefined),
  *     cacheSize: (number|undefined),
  *     crossOrigin: (null|string|undefined),
  *     logo: (string|olx.LogoOptions|undefined),
@@ -6165,7 +6171,7 @@ olx.source.ZoomifyOptions;
 
 /**
  * Attributions.
- * @type {Array.<ol.Attribution>|undefined}
+ * @type {olx.source.AttributionOption|undefined}
  * @api stable
  */
 olx.source.ZoomifyOptions.prototype.attributions;

--- a/src/ol/source/imagesource.js
+++ b/src/ol/source/imagesource.js
@@ -3,7 +3,6 @@ goog.provide('ol.source.ImageEvent');
 
 goog.require('goog.asserts');
 goog.require('ol.events.Event');
-goog.require('ol.Attribution');
 goog.require('ol.ImageState');
 goog.require('ol.array');
 goog.require('ol.extent');
@@ -13,7 +12,7 @@ goog.require('ol.source.Source');
 
 
 /**
- * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ * @typedef {{attributions: (olx.source.AttributionOption|undefined),
  *            extent: (null|ol.Extent|undefined),
  *            logo: (string|olx.LogoOptions|undefined),
  *            projection: ol.proj.ProjectionLike,

--- a/src/ol/source/imagestaticsource.js
+++ b/src/ol/source/imagestaticsource.js
@@ -20,10 +20,6 @@ goog.require('ol.source.Image');
  * @api stable
  */
 ol.source.ImageStatic = function(options) {
-
-  var attributions = options.attributions !== undefined ?
-      options.attributions : null;
-
   var imageExtent = options.imageExtent;
 
   var crossOrigin = options.crossOrigin !== undefined ?
@@ -34,7 +30,7 @@ ol.source.ImageStatic = function(options) {
       options.imageLoadFunction : ol.source.Image.defaultImageLoadFunction;
 
   goog.base(this, {
-    attributions: attributions,
+    attributions: options.attributions,
     logo: options.logo,
     projection: ol.proj.get(options.projection)
   });
@@ -43,7 +39,7 @@ ol.source.ImageStatic = function(options) {
    * @private
    * @type {ol.Image}
    */
-  this.image_ = new ol.Image(imageExtent, undefined, 1, attributions,
+  this.image_ = new ol.Image(imageExtent, undefined, 1, this.getAttributions(),
       options.url, crossOrigin, imageLoadFunction);
 
   /**

--- a/src/ol/source/source.js
+++ b/src/ol/source/source.js
@@ -21,7 +21,7 @@ ol.source.State = {
 
 
 /**
- * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ * @typedef {{attributions: (olx.source.AttributionOption|undefined),
  *            logo: (string|olx.LogoOptions|undefined),
  *            projection: ol.proj.ProjectionLike,
  *            state: (ol.source.State|undefined),
@@ -57,8 +57,7 @@ ol.source.Source = function(options) {
    * @private
    * @type {Array.<ol.Attribution>}
    */
-  this.attributions_ = options.attributions !== undefined ?
-      options.attributions : null;
+  this.attributions_ = ol.source.Source.toAttributionsArray_(options.attributions);
 
   /**
    * @private
@@ -81,6 +80,37 @@ ol.source.Source = function(options) {
 
 };
 goog.inherits(ol.source.Source, ol.Object);
+
+/**
+ * Turns various ways of defining an attribution to an array of `ol.Attributions`.
+ *
+ * @param {olx.source.AttributionOption|undefined}
+ *     attributionLike The attributions as string, array of strings,
+ *     `ol.Attribution`, array of `ol.Attribution` or undefined.
+ * @return {Array.<ol.Attribution>} The array of `ol.Attribution` or null if
+ *     `undefined` was given.
+ */
+ol.source.Source.toAttributionsArray_ = function(attributionLike) {
+  if (typeof attributionLike === 'string') {
+    return [new ol.Attribution({html: attributionLike})];
+  } else if (attributionLike instanceof ol.Attribution) {
+    return [attributionLike];
+  } else if (Array.isArray(attributionLike)) {
+    var len = attributionLike.length;
+    var attributions = new Array(len);
+    for (var i = 0; i < len; i++) {
+      var item = attributionLike[i];
+      if (typeof item === 'string') {
+        attributions[i] = new ol.Attribution({html: item});
+      } else {
+        attributions[i] = item;
+      }
+    }
+    return attributions;
+  } else {
+    return null;
+  }
+}
 
 
 /**
@@ -161,11 +191,13 @@ ol.source.Source.prototype.refresh = function() {
 
 /**
  * Set the attributions of the source.
- * @param {Array.<ol.Attribution>} attributions Attributions.
+ * @param {olx.source.AttributionOption|undefined} attributions Attributions.
+ *     Can be passed as `string`, `Array<string>`, `{@link ol.Attribution}`,
+ *     `Array<{@link ol.Attribution}>` or `undefined`.
  * @api
  */
 ol.source.Source.prototype.setAttributions = function(attributions) {
-  this.attributions_ = attributions;
+  this.attributions_ = ol.source.Source.toAttributionsArray_(attributions);
   this.changed();
 };
 

--- a/src/ol/source/tilesource.js
+++ b/src/ol/source/tilesource.js
@@ -5,7 +5,6 @@ goog.provide('ol.source.TileOptions');
 goog.require('goog.asserts');
 goog.require('ol.events.Event');
 goog.require('ol');
-goog.require('ol.Attribution');
 goog.require('ol.Extent');
 goog.require('ol.TileCache');
 goog.require('ol.TileRange');
@@ -18,7 +17,7 @@ goog.require('ol.tilegrid.TileGrid');
 
 
 /**
- * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ * @typedef {{attributions: (olx.source.AttributionOption|undefined),
  *            cacheSize: (number|undefined),
  *            extent: (ol.Extent|undefined),
  *            logo: (string|olx.LogoOptions|undefined),

--- a/src/ol/source/urltilesource.js
+++ b/src/ol/source/urltilesource.js
@@ -11,7 +11,7 @@ goog.require('ol.source.TileEvent');
 
 
 /**
- * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ * @typedef {{attributions: (olx.source.AttributionOption|undefined),
  *            cacheSize: (number|undefined),
  *            extent: (ol.Extent|undefined),
  *            logo: (string|olx.LogoOptions|undefined),

--- a/test/spec/ol/source/source.test.js
+++ b/test/spec/ol/source/source.test.js
@@ -11,6 +11,74 @@ describe('ol.source.Source', function() {
     });
   });
 
+  describe('config option `attributions`', function() {
+    it('accepts undefined', function() {
+      var source = new ol.source.Source({});
+      var attributions = source.getAttributions();
+      expect(attributions).to.be(null);
+    });
+    it('accepts a single string', function() {
+      var source = new ol.source.Source({
+        attributions: 'Humpty'
+      });
+      var attributions = source.getAttributions();
+      expect(attributions).to.not.be(null);
+      expect(attributions).to.have.length(1);
+      expect(attributions[0]).to.be.an(ol.Attribution);
+      expect(attributions[0].getHTML()).to.be('Humpty');
+    });
+    it('accepts an array of strings', function() {
+      var source = new ol.source.Source({
+        attributions: ['Humpty', 'Dumpty']
+      });
+      var attributions = source.getAttributions();
+      expect(attributions).to.not.be(null);
+      expect(attributions).to.have.length(2);
+      expect(attributions[0]).to.be.an(ol.Attribution);
+      expect(attributions[0].getHTML()).to.be('Humpty');
+      expect(attributions[1]).to.be.an(ol.Attribution);
+      expect(attributions[1].getHTML()).to.be('Dumpty');
+    });
+    it('accepts a single ol.Attribution', function() {
+      var passedAttribution = new ol.Attribution({html: 'Humpty'});
+      var source = new ol.source.Source({
+        attributions: passedAttribution
+      });
+      var attributions = source.getAttributions();
+      expect(attributions).to.not.be(null);
+      expect(attributions).to.have.length(1);
+      expect(attributions[0]).to.be.an(ol.Attribution);
+      expect(attributions[0]).to.be(passedAttribution);
+    });
+    it('accepts an array of ol.Attribution', function() {
+      var firstAttribution = new ol.Attribution({html: 'Humpty'});
+      var secondAttribution = new ol.Attribution({html: 'Dumpty'});
+      var source = new ol.source.Source({
+        attributions: [firstAttribution, secondAttribution]
+      });
+      var attributions = source.getAttributions();
+      expect(attributions).to.not.be(null);
+      expect(attributions).to.have.length(2);
+      expect(attributions[0]).to.be.an(ol.Attribution);
+      expect(attributions[0]).to.be(firstAttribution);
+      expect(attributions[1]).to.be.an(ol.Attribution);
+      expect(attributions[1]).to.be(secondAttribution);
+    });
+    it('accepts an array with a string and an ol.Attribution', function() {
+      var attribution = new ol.Attribution({html: 'Dumpty'});
+      var source = new ol.source.Source({
+        attributions: ['Humpty', attribution]
+      });
+      var attributions = source.getAttributions();
+      expect(attributions).to.not.be(null);
+      expect(attributions).to.have.length(2);
+      expect(attributions[0]).to.be.an(ol.Attribution);
+      expect(attributions[0].getHTML()).to.be('Humpty');
+      expect(attributions[1]).to.be.an(ol.Attribution);
+      expect(attributions[1]).to.be(attribution);
+    });
+  });
+
   describe('#refresh()', function() {
     it('dispatches the change event', function() {
       var source = new ol.source.Source({
@@ -23,7 +91,77 @@ describe('ol.source.Source', function() {
     });
   });
 
+  describe('#setAttributions`', function() {
+    var source = null;
+
+    beforeEach(function() {
+      source = new ol.source.Source({
+        attributions: 'before'
+      });
+    });
+    afterEach(function() {
+      source = null;
+    });
+
+    it('accepts undefined', function() {
+      source.setAttributions();
+      var attributions = source.getAttributions();
+      expect(attributions).to.be(null);
+    });
+    it('accepts a single string', function() {
+      source.setAttributions('Humpty');
+      var attributions = source.getAttributions();
+      expect(attributions).to.not.be(null);
+      expect(attributions).to.have.length(1);
+      expect(attributions[0]).to.be.an(ol.Attribution);
+      expect(attributions[0].getHTML()).to.be('Humpty');
+    });
+    it('accepts an array of strings', function() {
+      source.setAttributions(['Humpty', 'Dumpty']);
+      var attributions = source.getAttributions();
+      expect(attributions).to.not.be(null);
+      expect(attributions).to.have.length(2);
+      expect(attributions[0]).to.be.an(ol.Attribution);
+      expect(attributions[0].getHTML()).to.be('Humpty');
+      expect(attributions[1]).to.be.an(ol.Attribution);
+      expect(attributions[1].getHTML()).to.be('Dumpty');
+    });
+    it('accepts a single ol.Attribution', function() {
+      var passedAttribution = new ol.Attribution({html: 'Humpty'});
+      source.setAttributions(passedAttribution);
+      var attributions = source.getAttributions();
+      expect(attributions).to.not.be(null);
+      expect(attributions).to.have.length(1);
+      expect(attributions[0]).to.be.an(ol.Attribution);
+      expect(attributions[0]).to.be(passedAttribution);
+    });
+    it('accepts an array of ol.Attribution', function() {
+      var firstAttribution = new ol.Attribution({html: 'Humpty'});
+      var secondAttribution = new ol.Attribution({html: 'Dumpty'});
+      source.setAttributions([firstAttribution, secondAttribution]);
+      var attributions = source.getAttributions();
+      expect(attributions).to.not.be(null);
+      expect(attributions).to.have.length(2);
+      expect(attributions[0]).to.be.an(ol.Attribution);
+      expect(attributions[0]).to.be(firstAttribution);
+      expect(attributions[1]).to.be.an(ol.Attribution);
+      expect(attributions[1]).to.be(secondAttribution);
+    });
+    it('accepts an array with a string and an ol.Attribution', function() {
+      var attribution = new ol.Attribution({html: 'Dumpty'});
+      source.setAttributions(['Humpty', attribution])
+      var attributions = source.getAttributions();
+      expect(attributions).to.not.be(null);
+      expect(attributions).to.have.length(2);
+      expect(attributions[0]).to.be.an(ol.Attribution);
+      expect(attributions[0].getHTML()).to.be('Humpty');
+      expect(attributions[1]).to.be.an(ol.Attribution);
+      expect(attributions[1]).to.be(attribution);
+    });
+  });
+
 });
 
+goog.require('ol.Attribution');
 goog.require('ol.proj');
 goog.require('ol.source.Source');


### PR DESCRIPTION
The way we can specify attributions for `ol.source.Source` and subclasses is quite verbose for the most common use case: on simple string attribution.

This PR suggests to accept a 

* `string`
* `Array<string>`
* `ol.Attribution`
* `Array<ol.Attribution>`
* `undefined`

as configuration value for the `attributions` key in the constructor options of `ol.source.Source`.

This API is fully backwards compatible. 

I also updated our examples to make use of the simpler way of specifying attributions.

Please review.

/cc @tschaub, I know you wanted less awkwardness here, so I'd value your feedback here. Other may of course also chime in.

Fixes #4100