### PR TITLE
Add missing setProjection function to ol.VectorTile API

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -4386,12 +4386,16 @@ olx.source.VectorTileOptions.prototype.tileGrid;
 
 
 /**
- * Optional function to load a tile given a URL. The default is
+ * Optional function to load a tile given a URL. Could look like this:
  * ```js
  * function(tile, url) {
- *   tile.setLoader(
- *       ol.featureloader.tile(url, tile.getFormat()));
- * };
+ *   tile.setLoader(function() {
+ *     var data = // ... fetch data
+ *     var format = tile.getFormat();
+ *     tile.setFeatures(format.readFeatures(data));
+ *     tile.setProjection(format.readProjection(data));
+ *   };
+ * });
  * ```
  * @type {ol.TileLoadFunctionType|undefined}
  * @api

--- a/src/ol/vectortile.js
+++ b/src/ol/vectortile.js
@@ -170,7 +170,9 @@ ol.VectorTile.prototype.setFeatures = function(features) {
 
 
 /**
+ * Set the projection of the features that were added with {@link #setFeatures}.
  * @param {ol.proj.Projection} projection Feature projection.
+ * @api
  */
 ol.VectorTile.prototype.setProjection = function(projection) {
   this.projection_ = projection;


### PR DESCRIPTION
Also adds an example snippet to give users an idea of how to use `tileLoadFunction` on an `ol.source.VectorTile`.

Fixes #4678.