### PR TITLE
Check SVG icon size returns 0 to show SVG icon on IE 11

### DIFF
--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -348,8 +348,8 @@ ol.render.canvas.Replay.prototype.replay_ = function(
             context.globalAlpha = alpha * opacity;
           }
 
-          var w = (width + originX > image.width) ? image.width - originX : width;
-          var h = (height + originY > image.height) ? image.height - originY : height;
+          var w = (image.width > 0 && width + originX > image.width) ? image.width - originX : width;
+          var h = (image.height > 0 && height + originY > image.height) ? image.height - originY : height;
 
           context.drawImage(image, originX, originY, w, h,
               x, y, w * pixelRatio, h * pixelRatio);


### PR DESCRIPTION
I can reproduce the problem using an SVG icon on Internet Explorer 11 as described in #3220.  

The solution from @ahocevar (add 'size' to the icon configuration) works until the calculation for the safari was added (936cd6a). On the IE 11 image.height and image.width returns 0  based on the bug mentioned in the ticket.

With the patch on the IE 11 the svg-icon use the size from the configuration.