### PR TITLE
WMS_MS_Capabilities 1.1.1 supports SRS instead of CRS

### DIFF
--- a/src/ol/format/wmscapabilitiesformat.js
+++ b/src/ol/format/wmscapabilitiesformat.js
@@ -116,7 +116,7 @@ ol.format.WMSCapabilities.readBoundingBox_ = function(node, objectStack) {
   ];
 
   return {
-    'crs': node.getAttribute('CRS'),
+    'crs': node.getAttribute('CRS') || node.getAttribute('SRS'),
     'extent': extent,
     'res': resolutions
   };
@@ -701,6 +701,7 @@ ol.format.WMSCapabilities.LAYER_PARSERS_ = ol.xml.makeStructureNS(
       'KeywordList': ol.xml.makeObjectPropertySetter(
           ol.format.WMSCapabilities.readKeywordList_),
       'CRS': ol.xml.makeObjectPropertyPusher(ol.format.XSD.readString),
+      'SRS': ol.xml.makeObjectPropertyPusher(ol.format.XSD.readString),
       'EX_GeographicBoundingBox': ol.xml.makeObjectPropertySetter(
           ol.format.WMSCapabilities.readEXGeographicBoundingBox_),
       'BoundingBox': ol.xml.makeObjectPropertyPusher(


### PR DESCRIPTION
WMS_MS_Capatiblities prior 1.3 only supports SRS instead of attribute CRS. In the documentation of WMSCapabilities is no version restriction available. Please include the SRS in the parsed WMSCapabilities.

http://schemas.opengis.net/wms/1.1.1/WMS_MS_Capabilities.dtd