### PR TITLE
Add autoPanIncludeMargin to the overlay options

### DIFF
--- a/examples/popup.js
+++ b/examples/popup.js
@@ -21,6 +21,7 @@ var closer = document.getElementById('popup-closer');
 var overlay = new ol.Overlay(/** @type {olx.OverlayOptions} */ ({
   element: container,
   autoPan: true,
+  autoPanIncludeMargin: true,
   autoPanAnimation: {
     duration: 250
   }

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -318,6 +318,7 @@ olx.MapOptions.prototype.view;
  *     insertFirst: (boolean|undefined),
  *     autoPan: (boolean|undefined),
  *     autoPanAnimation: (olx.animation.PanOptions|undefined),
+ *     autoPanIncludeMargin: (boolean|undefined),
  *     autoPanMargin: (number|undefined)}}
  * @api stable
  */
@@ -411,6 +412,16 @@ olx.OverlayOptions.prototype.autoPan;
  * @api
  */
 olx.OverlayOptions.prototype.autoPanAnimation;
+
+
+/**
+ * When set, the `autoPanMargin` value is included in the calculation to
+ * determine whether to automatically pan the map when the overlay is close
+ * to an edge. The default is `false`.
+ * @type {boolean|undefined}
+ * @api
+ */
+olx.OverlayOptions.prototype.autoPanIncludeMargin;
 
 
 /**

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -114,6 +114,13 @@ ol.Overlay = function(options) {
 
   /**
    * @private
+   * @type {boolean}
+   */
+  this.autoPanIncludeMargin_ = options.autoPanIncludeMargin !== undefined ?
+      options.autoPanIncludeMargin : false;
+
+  /**
+   * @private
    * @type {number}
    */
   this.autoPanMargin_ = options.autoPanMargin !== undefined ?
@@ -383,12 +390,16 @@ ol.Overlay.prototype.panIntoView_ = function() {
   }
 
   var mapRect = this.getRect_(map.getTargetElement(), map.getSize());
+  var margin = this.autoPanMargin_;
+  var incMargin = this.autoPanIncludeMargin_
+  if (incMargin) {
+    ol.extent.buffer(mapRect, -margin, mapRect);
+  }
   var element = this.getElement();
   goog.asserts.assert(element, 'element should be defined');
   var overlayRect = this.getRect_(element,
       [ol.dom.outerWidth(element), ol.dom.outerHeight(element)]);
 
-  var margin = this.autoPanMargin_;
   if (!ol.extent.containsExtent(mapRect, overlayRect)) {
     // the overlay is not completely inside the viewport, so pan the map
     var offsetLeft = overlayRect[0] - mapRect[0];
@@ -399,17 +410,17 @@ ol.Overlay.prototype.panIntoView_ = function() {
     var delta = [0, 0];
     if (offsetLeft < 0) {
       // move map to the left
-      delta[0] = offsetLeft - margin;
+      delta[0] = offsetLeft - (incMargin ? 0 : margin);
     } else if (offsetRight < 0) {
       // move map to the right
-      delta[0] = Math.abs(offsetRight) + margin;
+      delta[0] = Math.abs(offsetRight) + (incMargin ? 0 : margin);
     }
     if (offsetTop < 0) {
       // move map up
-      delta[1] = offsetTop - margin;
+      delta[1] = offsetTop - (incMargin ? 0 : margin);
     } else if (offsetBottom < 0) {
       // move map down
-      delta[1] = Math.abs(offsetBottom) + margin;
+      delta[1] = Math.abs(offsetBottom) + (incMargin ? 0 : margin);
     }
 
     if (delta[0] !== 0 || delta[1] !== 0) {


### PR DESCRIPTION
This PR introduces the `autoPanIncludeMargin` options for the `ol.Overlay` object.  When set, the `autoPanMargin` value is taken into account when calculating whether the map should be automatically panned or not, which allows overlays to close to an edge (within the buffer created by the margin) to make the map automatically pan.

That option is set to `false` by default to keep the existing behaviour "as-is".

Opened for discussions.