### PR TITLE
Fix cruft on kml scale output

### DIFF
--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -2484,7 +2484,9 @@ ol.format.KML.writePolyStyle_ = function(node, style, objectStack) {
  * @private
  */
 ol.format.KML.writeScaleTextNode_ = function(node, scale) {
-  ol.format.XSD.writeDecimalTextNode(node, scale * scale);
+  // the Math is to remove any excess decimals created by float arithmetic
+  ol.format.XSD.writeDecimalTextNode(node,
+      Math.round(scale * scale * 1e6) / 1e6);
 };
 
 


### PR DESCRIPTION
I mentioned this in #3953. As this is easier to fix than the output coordinates, here's a PR to fix it; I'll look into the coordinates tomorrow.

Problem is that the default scale for text/labels is 0.8. `writeScaleTextNode_()` does 0.8*0.8, which produces not 0.64 as you might imagine but 0.6400000000000001. The change in this PR gets rid of this unwanted junk at the end.

Not sure what the best value for the no of decimal places is. I've picked 6, but this can easily be changed - or made a constant at the beginning of the file?