### PR TITLE
(WIP) Fire pre/postcompose events on layer groups

### DIFF
--- a/src/ol/layer/layerbase.js
+++ b/src/ol/layer/layerbase.js
@@ -25,6 +25,7 @@ ol.layer.LayerProperty = {
 
 /**
  * @typedef {{layer: ol.layer.Layer,
+ *            parent: (ol.layer.Base|undefined),
  *            opacity: number,
  *            sourceState: ol.source.State,
  *            visible: boolean,

--- a/src/ol/layer/layergroup.js
+++ b/src/ol/layer/layergroup.js
@@ -212,6 +212,7 @@ ol.layer.Group.prototype.getLayerStatesArray = function(opt_states) {
   var i, ii, layerState;
   for (i = pos, ii = states.length; i < ii; i++) {
     layerState = states[i];
+    layerState.parent = this;
     layerState.opacity *= ownLayerState.opacity;
     layerState.visible = layerState.visible && ownLayerState.visible;
     layerState.maxResolution = Math.min(

--- a/test/spec/ol/layer/layergroup.test.js
+++ b/test/spec/ol/layer/layergroup.test.js
@@ -361,16 +361,22 @@ describe('ol.layer.Group', function() {
       var layerStatesArray = layerGroup.getLayerStatesArray();
       expect(layerStatesArray).to.be.a(Array);
       expect(layerStatesArray.length).to.be(2);
-      expect(layerStatesArray[0]).to.eql(layer1.getLayerState());
+      expect(layerStatesArray[0]).to.eql(ol.object.assign({
+        parent: layerGroup
+      }, layer1.getLayerState()));
 
-      // layer state should match except for layer reference
+      // layer state should match except for layer and parent reference
       var layerState = ol.object.assign({}, layerStatesArray[0]);
       delete layerState.layer;
+      expect(layerState.parent).to.equal(layerGroup);
+      delete layerState.parent;
       var groupState = ol.object.assign({}, layerGroup.getLayerState());
       delete groupState.layer;
       expect(layerState).to.eql(groupState);
 
-      expect(layerStatesArray[1]).to.eql(layer2.getLayerState());
+      expect(layerStatesArray[1]).to.eql(ol.object.assign({
+        parent: layerGroup
+      }, layer2.getLayerState()));
 
       layerGroup.dispose();
     });
@@ -412,9 +418,11 @@ describe('ol.layer.Group', function() {
       // compare layer state to group state
       var groupState, layerState;
 
-      // layer state should match except for layer reference
+      // layer state should match except for layer and parent reference
       layerState = ol.object.assign({}, layerStatesArray[0]);
       delete layerState.layer;
+      expect(layerState.parent).to.equal(layerGroup);
+      delete layerState.parent;
       groupState = ol.object.assign({}, layerGroup.getLayerState());
       delete groupState.layer;
       expect(layerState).to.eql(groupState);
@@ -423,6 +431,7 @@ describe('ol.layer.Group', function() {
       layerState = ol.object.assign({}, layerStatesArray[1]);
       delete layerState.layer;
       expect(layerState).to.eql({
+        parent: layerGroup,
         opacity: 0.25,
         visible: false,
         managed: true,


### PR DESCRIPTION
Opening this now to get comments.  Not ready for review.

We're relying heavily on `precompose` and `postcompose` layer events for manipulating the canvas context.  For layer groups, it is awkward to achieve the same.  It is possible to register for `precompose` on the first layer in the group and `postcompose` in the last layer, but this has problems.  Layers may not be rendered in group order, so first and last in the group may not be meaningful.  But the bigger problem is that layers with limited extent may go in and out of the rendering extent, meaning that you cannot always rely on `precompose` being fired on the first and `postcompose` on the last (and at times you may only get `precompose` but not `postcompose` or vice versa).

So it would be very convenient if the library dispatched `precompose` before composing any layers in a group and `postcompose` after composing all layers in a group.  Unfortunately, this is awkward to achieve with the way layer groups and layer rendering are handled.  The approach I think I'll take is to add a `parent` property to `ol.layer.LayerState` that is set when `group.getLayerStatesArray()` is called (and it will be a reference to the group for a layer).  Then when dispatching compose events in the layer renderer, we can check for `layerState.parent`.  To determine whether or not to dispatch the event on the parent, we'll need to store additional information on the frame state (so that events aren't dispatched on the parent for every layer in a group).

Any comments on this or alternative implementations are welcome.