### PR TITLE
Fix geojson write GeometryCollection

### DIFF
--- a/src/ol/format/geojsonformat.js
+++ b/src/ol/format/geojsonformat.js
@@ -211,7 +211,9 @@ ol.format.GeoJSON.writeGeometryCollectionGeometry_ = function(
   goog.asserts.assertInstanceof(geometry, ol.geom.GeometryCollection,
       'geometry should be an ol.geom.GeometryCollection');
   var geometries = geometry.getGeometriesArray().map(function(geometry) {
-    return ol.format.GeoJSON.writeGeometry_(geometry, opt_options);
+    var options = ol.object.assign({}, opt_options);
+    delete options.featureProjection;
+    return ol.format.GeoJSON.writeGeometry_(geometry, options);
   });
   return /** @type {GeoJSONGeometryCollection} */ ({
     type: 'GeometryCollection',

--- a/test/spec/ol/format/geojsonformat.test.js
+++ b/test/spec/ol/format/geojsonformat.test.js
@@ -725,6 +725,28 @@ describe('ol.format.GeoJSON', function() {
           .to.be.lessThan(0.0000001);
     });
 
+    it('transforms and encodes geometry collection', function() {
+      var collection = new ol.geom.GeometryCollection([
+        new ol.geom.Point([2, 3]),
+        new ol.geom.LineString([[3, 2], [2, 1]])
+      ]);
+      var geojson = format.writeGeometry(collection, {
+        featureProjection: 'EPSG:3857'
+      });
+      var got = format.readGeometry(geojson, {
+        featureProjection: 'EPSG:3857'
+      });
+      var gotGeometries = got.getGeometries();
+      var geometries = collection.getGeometries();
+      expect(geometries[0].getCoordinates()[0]).to.roughlyEqual(
+          gotGeometries[0].getCoordinates()[0], 1e-8);
+      expect(geometries[0].getCoordinates()[1]).to.roughlyEqual(
+          gotGeometries[0].getCoordinates()[1], 1e-8);
+      expect(geometries[1].getCoordinates()[0][0]).to.roughlyEqual(
+          gotGeometries[1].getCoordinates()[0][0], 1e-8);
+      expect(geometries[1].getCoordinates()[0][1]).to.roughlyEqual(
+          gotGeometries[1].getCoordinates()[0][1], 1e-8);
+    });
   });
 
 });


### PR DESCRIPTION
I tested my changes mentioned in #3953 on a GeometryCollection, and found they didn't work. However, when I tried doing the same with the current master, I found that didn't work either. examples/geojson has a GeometryCollection so if you do something like
```
format=new ol.format.GeoJSON();
format.writeFeature(vectorSource.getFeatures()[6], {featureProjection:'EPSG:3857'});
```
you can see that the coordinates are all screwy. The reason for this is that `writeGeometry_` is getting run for the Collection as a whole and then for each individual geometry. `writeGeometry_` runs `ol.format.Feature#transformWithOptions()`, so the coordinates for each geometry are transformed twice. This PR calls write for the individual geoms without the projection options, so the 2nd transform doesn't occur.

From the fact that no-one's noticed this before, I conclude that GeometryCollections aren't used very much. :-) I think tests should be added for this case, but would prefer to include that in my fixes for #3953 so the rounding can be tested as well.