### PR TITLE
Get rid of goog.log

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -7,12 +7,9 @@ goog.provide('ol.MapProperty');
 
 goog.require('goog.asserts');
 goog.require('goog.async.nextTick');
-goog.require('goog.debug.Console');
 goog.require('goog.dom');
 goog.require('goog.dom.classlist');
 goog.require('goog.functions');
-goog.require('goog.log');
-goog.require('goog.log.Level');
 goog.require('goog.style');
 goog.require('goog.vec.Mat4');
 goog.require('ol.Collection');
@@ -1603,12 +1600,3 @@ ol.Map.createOptionsInternal = function(options) {
 
 
 ol.proj.common.add();
-
-
-if (goog.DEBUG) {
-  (function() {
-    goog.debug.Console.autoInstall();
-    var logger = goog.log.getLogger('ol');
-    logger.setLevel(goog.log.Level.FINEST);
-  })();
-}

--- a/src/ol/webgl/context.js
+++ b/src/ol/webgl/context.js
@@ -1,7 +1,6 @@
 goog.provide('ol.webgl.Context');
 
 goog.require('goog.asserts');
-goog.require('goog.log');
 goog.require('ol');
 goog.require('ol.Disposable');
 goog.require('ol.array');
@@ -229,12 +228,6 @@ ol.webgl.Context.prototype.getShader = function(shaderObject) {
     var shader = gl.createShader(shaderObject.getType());
     gl.shaderSource(shader, shaderObject.getSource());
     gl.compileShader(shader);
-    if (goog.DEBUG) {
-      if (!gl.getShaderParameter(shader, goog.webgl.COMPILE_STATUS) &&
-          !gl.isContextLost()) {
-        goog.log.error(this.logger_, gl.getShaderInfoLog(shader));
-      }
-    }
     goog.asserts.assert(
         gl.getShaderParameter(shader, goog.webgl.COMPILE_STATUS) ||
         gl.isContextLost(),
@@ -265,12 +258,6 @@ ol.webgl.Context.prototype.getProgram = function(
     gl.attachShader(program, this.getShader(fragmentShaderObject));
     gl.attachShader(program, this.getShader(vertexShaderObject));
     gl.linkProgram(program);
-    if (goog.DEBUG) {
-      if (!gl.getProgramParameter(program, goog.webgl.LINK_STATUS) &&
-          !gl.isContextLost()) {
-        goog.log.error(this.logger_, gl.getProgramInfoLog(program));
-      }
-    }
     goog.asserts.assert(
         gl.getProgramParameter(program, goog.webgl.LINK_STATUS) ||
         gl.isContextLost(),
@@ -346,13 +333,6 @@ ol.webgl.Context.prototype.useProgram = function(program) {
     return true;
   }
 };
-
-
-/**
- * @private
- * @type {goog.log.Logger}
- */
-ol.webgl.Context.prototype.logger_ = goog.log.getLogger('ol.webgl.Context');
 
 
 /**


### PR DESCRIPTION
This PR suggests to remove `goog.log` usage in the quest for closure library independence.

From what I can find `goog.log` was only used in `src/ol/webgl/context.js` and in those instances duplicated with almost identical assertions. 