### PR TITLE
Remove goog.functions

### DIFF
--- a/src/ol/events/condition.js
+++ b/src/ol/events/condition.js
@@ -2,9 +2,9 @@ goog.provide('ol.events.ConditionType');
 goog.provide('ol.events.condition');
 
 goog.require('goog.asserts');
-goog.require('goog.functions');
 goog.require('ol.MapBrowserEvent.EventType');
 goog.require('ol.MapBrowserPointerEvent');
+goog.require('ol.functions');
 
 
 /**
@@ -59,7 +59,7 @@ ol.events.condition.altShiftKeysOnly = function(mapBrowserEvent) {
  * @function
  * @api stable
  */
-ol.events.condition.always = goog.functions.TRUE;
+ol.events.condition.always = ol.functions.TRUE;
 
 
 /**
@@ -98,7 +98,7 @@ ol.events.condition.mouseActionButton = function(mapBrowserEvent) {
  * @function
  * @api stable
  */
-ol.events.condition.never = goog.functions.FALSE;
+ol.events.condition.never = ol.functions.FALSE;
 
 
 /**

--- a/src/ol/functions.js
+++ b/src/ol/functions.js
@@ -1,0 +1,13 @@
+goog.provide('ol.functions');
+
+ol.functions.TRUE = function() {
+  return true;
+};
+
+ol.functions.FALSE = function() {
+  return false;
+};
+
+ol.functions.NULL = function() {
+  return null;
+}

--- a/src/ol/functions.js
+++ b/src/ol/functions.js
@@ -11,3 +11,20 @@ ol.functions.FALSE = function() {
 ol.functions.NULL = function() {
   return null;
 }
+
+/**
+* @param {...Function} args A list of functions.
+* @returns {function(...?):boolean} A function that ANDs its component functions.
+*/
+ol.functions.and = function(args) {
+  var functions = arguments;
+  var length = functions.length;
+  return function() {
+    for (var i = 0; i < length; i++) {
+      if (!functions[i].apply(this, arguments)) {
+        return false;
+      }
+    }
+    return true;
+  };
+};

--- a/src/ol/functions.js
+++ b/src/ol/functions.js
@@ -28,3 +28,13 @@ ol.functions.and = function(args) {
     return true;
   };
 };
+
+/**
+* @param {TEMPLATE=} arg Argument to be returned.
+* @param {...*} opt_args Other arguments
+* @returns {TEMPLATE} First argument that is returned.
+* @template TEMPLATE
+*/
+ol.functions.identity = function(arg, opt_args) {
+  return arg;
+}

--- a/src/ol/functions.js
+++ b/src/ol/functions.js
@@ -20,14 +20,41 @@ ol.functions.and = function(args) {
   var functions = arguments;
   var length = functions.length;
   return function() {
+    // Guard against deoptimization with bound functions.
+    var args = new Array(arguments.length);
+    for (var k = 0; k < args.length; k++) {
+      args[k] = arguments[k];
+    }
     for (var i = 0; i < length; i++) {
-      if (!functions[i].apply(this, arguments)) {
+      if (!functions[i].apply(this, args)) {
         return false;
       }
     }
     return true;
   };
 };
+
+/**
+* @param {...Function} args A list of functions.
+* @returns {!Function} A function that calls each of the functions.
+*/
+ol.functions.sequence = function(args) {
+  var functions = arguments;
+  var length = functions.length;
+  return function() {
+    // Guard against deoptimization with bound functions.
+    var args = new Array(arguments.length);
+    for (var k = 0; k < args.length; k++) {
+      args[k] = arguments[k];
+    }
+    var result;
+    for (var i = 0; i < length; i++) {
+      result = functions[i].apply(this, args);
+    }
+    return result;
+  };
+};
+
 
 /**
 * @param {TEMPLATE=} arg Argument to be returned.

--- a/src/ol/geom/geometry.js
+++ b/src/ol/geom/geometry.js
@@ -3,9 +3,9 @@ goog.provide('ol.geom.GeometryLayout');
 goog.provide('ol.geom.GeometryType');
 
 goog.require('goog.asserts');
-goog.require('goog.functions');
 goog.require('ol.Object');
 goog.require('ol.extent');
+goog.require('ol.functions');
 goog.require('ol.proj');
 goog.require('ol.proj.Units');
 
@@ -151,7 +151,7 @@ ol.geom.Geometry.prototype.computeExtent = goog.abstractMethod;
  * @param {number} y Y.
  * @return {boolean} Contains (x, y).
  */
-ol.geom.Geometry.prototype.containsXY = goog.functions.FALSE;
+ol.geom.Geometry.prototype.containsXY = ol.functions.FALSE;
 
 
 /**

--- a/src/ol/geom/simplegeometry.js
+++ b/src/ol/geom/simplegeometry.js
@@ -1,8 +1,8 @@
 goog.provide('ol.geom.SimpleGeometry');
 
 goog.require('goog.asserts');
-goog.require('goog.functions');
 goog.require('ol.extent');
+goog.require('ol.functions');
 goog.require('ol.geom.Geometry');
 goog.require('ol.geom.GeometryLayout');
 goog.require('ol.geom.flat.transform');
@@ -84,7 +84,7 @@ ol.geom.SimpleGeometry.getStrideForLayout = function(layout) {
 /**
  * @inheritDoc
  */
-ol.geom.SimpleGeometry.prototype.containsXY = goog.functions.FALSE;
+ol.geom.SimpleGeometry.prototype.containsXY = ol.functions.FALSE;
 
 
 /**

--- a/src/ol/interaction/draganddropinteraction.js
+++ b/src/ol/interaction/draganddropinteraction.js
@@ -4,8 +4,8 @@ goog.provide('ol.interaction.DragAndDrop');
 goog.provide('ol.interaction.DragAndDropEvent');
 
 goog.require('goog.asserts');
-goog.require('goog.functions');
 goog.require('ol.events');
+goog.require('ol.functions');
 goog.require('ol.events.Event');
 goog.require('ol.events.EventType');
 goog.require('ol.interaction.Interaction');
@@ -134,7 +134,7 @@ ol.interaction.DragAndDrop.prototype.handleResult_ = function(file, event) {
  * @this {ol.interaction.DragAndDrop}
  * @api
  */
-ol.interaction.DragAndDrop.handleEvent = goog.functions.TRUE;
+ol.interaction.DragAndDrop.handleEvent = ol.functions.TRUE;
 
 
 /**

--- a/src/ol/interaction/dragpaninteraction.js
+++ b/src/ol/interaction/dragpaninteraction.js
@@ -7,6 +7,7 @@ goog.require('ol.PreRenderFunction');
 goog.require('ol.ViewHint');
 goog.require('ol.coordinate');
 goog.require('ol.events.condition');
+goog.require('ol.functions');
 goog.require('ol.interaction.Pointer');
 
 
@@ -165,4 +166,4 @@ ol.interaction.DragPan.handleDownEvent_ = function(mapBrowserEvent) {
 /**
  * @inheritDoc
  */
-ol.interaction.DragPan.prototype.shouldStopEvent = goog.functions.FALSE;
+ol.interaction.DragPan.prototype.shouldStopEvent = ol.functions.FALSE;

--- a/src/ol/interaction/dragrotateinteraction.js
+++ b/src/ol/interaction/dragrotateinteraction.js
@@ -128,4 +128,4 @@ ol.interaction.DragRotate.handleDownEvent_ = function(mapBrowserEvent) {
 /**
  * @inheritDoc
  */
-ol.interaction.DragRotate.prototype.shouldStopEvent = goog.functions.FALSE;
+ol.interaction.DragRotate.prototype.shouldStopEvent = ol.functions.FALSE;

--- a/src/ol/interaction/drawinteraction.js
+++ b/src/ol/interaction/drawinteraction.js
@@ -741,7 +741,7 @@ ol.interaction.Draw.prototype.extend = function(feature) {
 /**
  * @inheritDoc
  */
-ol.interaction.Draw.prototype.shouldStopEvent = goog.functions.FALSE;
+ol.interaction.Draw.prototype.shouldStopEvent = ol.functions.FALSE;
 
 
 /**

--- a/src/ol/interaction/keyboardpaninteraction.js
+++ b/src/ol/interaction/keyboardpaninteraction.js
@@ -1,13 +1,13 @@
 goog.provide('ol.interaction.KeyboardPan');
 
 goog.require('goog.asserts');
-goog.require('goog.functions');
 goog.require('ol');
 goog.require('ol.coordinate');
 goog.require('ol.events.ConditionType');
 goog.require('ol.events.EventType');
 goog.require('ol.events.KeyCode');
 goog.require('ol.events.condition');
+goog.require('ol.functions');
 goog.require('ol.interaction.Interaction');
 
 
@@ -42,7 +42,7 @@ ol.interaction.KeyboardPan = function(opt_options) {
    */
   this.condition_ = options.condition !== undefined ?
       options.condition :
-      goog.functions.and(ol.events.condition.noModifierKeys,
+      ol.functions.and(ol.events.condition.noModifierKeys,
           ol.events.condition.targetNotEditable);
 
   /**

--- a/src/ol/interaction/modifyinteraction.js
+++ b/src/ol/interaction/modifyinteraction.js
@@ -5,7 +5,6 @@ goog.require('goog.asserts');
 goog.require('ol.events');
 goog.require('ol.events.Event');
 goog.require('ol.events.EventType');
-goog.require('goog.functions');
 goog.require('ol');
 goog.require('ol.Collection');
 goog.require('ol.CollectionEventType');
@@ -17,6 +16,7 @@ goog.require('ol.array');
 goog.require('ol.coordinate');
 goog.require('ol.events.condition');
 goog.require('ol.extent');
+goog.require('ol.functions');
 goog.require('ol.geom.GeometryType');
 goog.require('ol.geom.LineString');
 goog.require('ol.geom.MultiLineString');
@@ -118,7 +118,7 @@ ol.interaction.Modify = function(options) {
    */
   this.deleteCondition_ = options.deleteCondition ?
       options.deleteCondition :
-      /** @type {ol.events.ConditionType} */ (goog.functions.and(
+      /** @type {ol.events.ConditionType} */ (ol.functions.and(
           ol.events.condition.noModifierKeys,
           ol.events.condition.singleClick));
 

--- a/src/ol/interaction/pinchrotateinteraction.js
+++ b/src/ol/interaction/pinchrotateinteraction.js
@@ -1,10 +1,10 @@
 goog.provide('ol.interaction.PinchRotate');
 
 goog.require('goog.asserts');
-goog.require('goog.functions');
 goog.require('ol');
 goog.require('ol.Coordinate');
 goog.require('ol.ViewHint');
+goog.require('ol.functions');
 goog.require('ol.interaction.Interaction');
 goog.require('ol.interaction.Pointer');
 
@@ -170,4 +170,4 @@ ol.interaction.PinchRotate.handleDownEvent_ = function(mapBrowserEvent) {
 /**
  * @inheritDoc
  */
-ol.interaction.PinchRotate.prototype.shouldStopEvent = goog.functions.FALSE;
+ol.interaction.PinchRotate.prototype.shouldStopEvent = ol.functions.FALSE;

--- a/src/ol/interaction/pinchzoominteraction.js
+++ b/src/ol/interaction/pinchzoominteraction.js
@@ -1,10 +1,10 @@
 goog.provide('ol.interaction.PinchZoom');
 
 goog.require('goog.asserts');
-goog.require('goog.functions');
 goog.require('ol');
 goog.require('ol.Coordinate');
 goog.require('ol.ViewHint');
+goog.require('ol.functions');
 goog.require('ol.interaction.Interaction');
 goog.require('ol.interaction.Pointer');
 
@@ -153,4 +153,4 @@ ol.interaction.PinchZoom.handleDownEvent_ = function(mapBrowserEvent) {
 /**
  * @inheritDoc
  */
-ol.interaction.PinchZoom.prototype.shouldStopEvent = goog.functions.FALSE;
+ol.interaction.PinchZoom.prototype.shouldStopEvent = ol.functions.FALSE;

--- a/src/ol/interaction/pointerinteraction.js
+++ b/src/ol/interaction/pointerinteraction.js
@@ -1,10 +1,10 @@
 goog.provide('ol.interaction.Pointer');
 
-goog.require('goog.functions');
 goog.require('ol');
 goog.require('ol.MapBrowserEvent.EventType');
 goog.require('ol.MapBrowserPointerEvent');
 goog.require('ol.Pixel');
+goog.require('ol.functions');
 goog.require('ol.interaction.Interaction');
 goog.require('ol.object');
 
@@ -215,4 +215,4 @@ ol.interaction.Pointer.handleEvent = function(mapBrowserEvent) {
  * @return {boolean} Should the event be stopped?
  * @protected
  */
-ol.interaction.Pointer.prototype.shouldStopEvent = goog.functions.identity;
+ol.interaction.Pointer.prototype.shouldStopEvent = ol.functions.identity;

--- a/src/ol/interaction/pointerinteraction.js
+++ b/src/ol/interaction/pointerinteraction.js
@@ -150,7 +150,7 @@ ol.interaction.Pointer.handleDragEvent = ol.nullFunction;
  * @return {boolean} Capture dragging.
  * @this {ol.interaction.Pointer}
  */
-ol.interaction.Pointer.handleUpEvent = goog.functions.FALSE;
+ol.interaction.Pointer.handleUpEvent = ol.functions.FALSE;
 
 
 /**
@@ -158,7 +158,7 @@ ol.interaction.Pointer.handleUpEvent = goog.functions.FALSE;
  * @return {boolean} Capture dragging.
  * @this {ol.interaction.Pointer}
  */
-ol.interaction.Pointer.handleDownEvent = goog.functions.FALSE;
+ol.interaction.Pointer.handleDownEvent = ol.functions.FALSE;
 
 
 /**

--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -4,13 +4,13 @@ goog.provide('ol.interaction.SelectEventType');
 goog.provide('ol.interaction.SelectFilterFunction');
 
 goog.require('goog.asserts');
-goog.require('goog.functions');
 goog.require('ol.CollectionEventType');
 goog.require('ol.Feature');
 goog.require('ol.array');
 goog.require('ol.events');
 goog.require('ol.events.Event');
 goog.require('ol.events.condition');
+goog.require('ol.functions');
 goog.require('ol.geom.GeometryType');
 goog.require('ol.interaction.Interaction');
 goog.require('ol.layer.Vector');
@@ -148,7 +148,7 @@ ol.interaction.Select = function(opt_options) {
    * @type {ol.interaction.SelectFilterFunction}
    */
   this.filter_ = options.filter ? options.filter :
-      goog.functions.TRUE;
+      ol.functions.TRUE;
 
   var featureOverlay = new ol.layer.Vector({
     source: new ol.source.Vector({
@@ -190,7 +190,7 @@ ol.interaction.Select = function(opt_options) {
       };
     }
   } else {
-    layerFilter = goog.functions.TRUE;
+    layerFilter = ol.functions.TRUE;
   }
 
   /**

--- a/src/ol/interaction/snapinteraction.js
+++ b/src/ol/interaction/snapinteraction.js
@@ -49,7 +49,7 @@ ol.interaction.Snap = function(opt_options) {
 
   goog.base(this, {
     handleEvent: ol.interaction.Snap.handleEvent_,
-    handleDownEvent: goog.functions.TRUE,
+    handleDownEvent: ol.functions.TRUE,
     handleUpEvent: ol.interaction.Snap.handleUpEvent_
   });
 
@@ -352,7 +352,7 @@ ol.interaction.Snap.prototype.setMap = function(map) {
 /**
  * @inheritDoc
  */
-ol.interaction.Snap.prototype.shouldStopEvent = goog.functions.FALSE;
+ol.interaction.Snap.prototype.shouldStopEvent = ol.functions.FALSE;
 
 
 /**

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -9,7 +9,6 @@ goog.require('goog.asserts');
 goog.require('goog.async.nextTick');
 goog.require('goog.dom');
 goog.require('goog.dom.classlist');
-goog.require('goog.functions');
 goog.require('goog.style');
 goog.require('goog.vec.Mat4');
 goog.require('ol.Collection');
@@ -36,6 +35,7 @@ goog.require('ol.events');
 goog.require('ol.events.Event');
 goog.require('ol.events.EventType');
 goog.require('ol.extent');
+goog.require('ol.functions');
 goog.require('ol.has');
 goog.require('ol.interaction');
 goog.require('ol.layer.Base');
@@ -628,7 +628,7 @@ ol.Map.prototype.forEachFeatureAtPixel = function(pixel, callback, opt_this, opt
   var coordinate = this.getCoordinateFromPixel(pixel);
   var thisArg = opt_this !== undefined ? opt_this : null;
   var layerFilter = opt_layerFilter !== undefined ?
-      opt_layerFilter : goog.functions.TRUE;
+      opt_layerFilter : ol.functions.TRUE;
   var thisArg2 = opt_this2 !== undefined ? opt_this2 : null;
   return this.renderer_.forEachFeatureAtCoordinate(
       coordinate, this.frameState_, callback, thisArg,
@@ -664,7 +664,7 @@ ol.Map.prototype.forEachLayerAtPixel = function(pixel, callback, opt_this, opt_l
   }
   var thisArg = opt_this !== undefined ? opt_this : null;
   var layerFilter = opt_layerFilter !== undefined ?
-      opt_layerFilter : goog.functions.TRUE;
+      opt_layerFilter : ol.functions.TRUE;
   var thisArg2 = opt_this2 !== undefined ? opt_this2 : null;
   return this.renderer_.forEachLayerAtPixel(
       pixel, this.frameState_, callback, thisArg,
@@ -693,7 +693,7 @@ ol.Map.prototype.hasFeatureAtPixel = function(pixel, opt_layerFilter, opt_this) 
   }
   var coordinate = this.getCoordinateFromPixel(pixel);
   var layerFilter = opt_layerFilter !== undefined ?
-      opt_layerFilter : goog.functions.TRUE;
+      opt_layerFilter : ol.functions.TRUE;
   var thisArg = opt_this !== undefined ? opt_this : null;
   return this.renderer_.hasFeatureAtCoordinate(
       coordinate, this.frameState_, layerFilter, thisArg);

--- a/src/ol/render/webgl/webglreplay.js
+++ b/src/ol/render/webgl/webglreplay.js
@@ -2,9 +2,9 @@ goog.provide('ol.render.webgl.ImageReplay');
 goog.provide('ol.render.webgl.ReplayGroup');
 
 goog.require('goog.asserts');
-goog.require('goog.functions');
 goog.require('goog.vec.Mat4');
 goog.require('ol.extent');
+goog.require('ol.functions');
 goog.require('ol.object');
 goog.require('ol.render.IReplayGroup');
 goog.require('ol.render.VectorContext');
@@ -954,7 +954,7 @@ ol.render.webgl.ReplayGroup.prototype.getDeleteResourcesFunction = function(cont
     functions.push(
         this.replays_[replayKey].getDeleteResourcesFunction(context));
   }
-  return goog.functions.sequence.apply(null, functions);
+  return ol.functions.sequence.apply(null, functions);
 };
 
 

--- a/src/ol/renderer/canvas/canvasimagelayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasimagelayerrenderer.js
@@ -1,12 +1,12 @@
 goog.provide('ol.renderer.canvas.ImageLayer');
 
 goog.require('goog.asserts');
-goog.require('goog.functions');
 goog.require('goog.vec.Mat4');
 goog.require('ol.ImageBase');
 goog.require('ol.ViewHint');
 goog.require('ol.dom');
 goog.require('ol.extent');
+goog.require('ol.functions');
 goog.require('ol.layer.Image');
 goog.require('ol.proj');
 goog.require('ol.renderer.canvas.Layer');
@@ -87,7 +87,7 @@ ol.renderer.canvas.ImageLayer.prototype.forEachLayerAtPixel = function(pixel, fr
     ol.vec.Mat4.multVec2(
         frameState.pixelToCoordinateMatrix, coordinate, coordinate);
     var hasFeature = this.forEachFeatureAtCoordinate(
-        coordinate, frameState, goog.functions.TRUE, this);
+        coordinate, frameState, ol.functions.TRUE, this);
 
     if (hasFeature) {
       return callback.call(thisArg, this.getLayer());

--- a/src/ol/renderer/layerrenderer.js
+++ b/src/ol/renderer/layerrenderer.js
@@ -3,12 +3,12 @@ goog.provide('ol.renderer.Layer');
 goog.require('goog.asserts');
 goog.require('ol.events');
 goog.require('ol.events.EventType');
-goog.require('goog.functions');
 goog.require('ol');
 goog.require('ol.ImageState');
 goog.require('ol.Observable');
 goog.require('ol.TileRange');
 goog.require('ol.TileState');
+goog.require('ol.functions');
 goog.require('ol.layer.Layer');
 goog.require('ol.source.Source');
 goog.require('ol.source.State');
@@ -63,7 +63,7 @@ ol.renderer.Layer.prototype.forEachLayerAtPixel = function(pixel, frameState, ca
       frameState.pixelToCoordinateMatrix, coordinate, coordinate);
 
   var hasFeature = this.forEachFeatureAtCoordinate(
-      coordinate, frameState, goog.functions.TRUE, this);
+      coordinate, frameState, ol.functions.TRUE, this);
 
   if (hasFeature) {
     return callback.call(thisArg, this.layer_);
@@ -78,7 +78,7 @@ ol.renderer.Layer.prototype.forEachLayerAtPixel = function(pixel, frameState, ca
  * @param {olx.FrameState} frameState Frame state.
  * @return {boolean} Is there a feature at the given coordinate?
  */
-ol.renderer.Layer.prototype.hasFeatureAtCoordinate = goog.functions.FALSE;
+ol.renderer.Layer.prototype.hasFeatureAtCoordinate = ol.functions.FALSE;
 
 
 /**

--- a/src/ol/renderer/maprenderer.js
+++ b/src/ol/renderer/maprenderer.js
@@ -2,13 +2,13 @@ goog.provide('ol.RendererType');
 goog.provide('ol.renderer.Map');
 
 goog.require('goog.asserts');
-goog.require('goog.functions');
 goog.require('goog.vec.Mat4');
 goog.require('ol');
 goog.require('ol.Disposable');
 goog.require('ol.events');
 goog.require('ol.events.EventType');
 goog.require('ol.extent');
+goog.require('ol.functions');
 goog.require('ol.layer.Layer');
 goog.require('ol.renderer.Layer');
 goog.require('ol.style.IconImageCache');
@@ -232,7 +232,7 @@ ol.renderer.Map.prototype.forEachLayerAtPixel = function(pixel, frameState, call
  */
 ol.renderer.Map.prototype.hasFeatureAtCoordinate = function(coordinate, frameState, layerFilter, thisArg) {
   var hasFeature = this.forEachFeatureAtCoordinate(
-      coordinate, frameState, goog.functions.TRUE, this, layerFilter, thisArg);
+      coordinate, frameState, ol.functions.TRUE, this, layerFilter, thisArg);
 
   return hasFeature !== undefined;
 };

--- a/src/ol/renderer/webgl/webglimagelayerrenderer.js
+++ b/src/ol/renderer/webgl/webglimagelayerrenderer.js
@@ -1,7 +1,6 @@
 goog.provide('ol.renderer.webgl.ImageLayer');
 
 goog.require('goog.asserts');
-goog.require('goog.functions');
 goog.require('goog.vec.Mat4');
 goog.require('goog.webgl');
 goog.require('ol.Coordinate');
@@ -10,6 +9,7 @@ goog.require('ol.ImageBase');
 goog.require('ol.ViewHint');
 goog.require('ol.dom');
 goog.require('ol.extent');
+goog.require('ol.functions');
 goog.require('ol.layer.Image');
 goog.require('ol.proj');
 goog.require('ol.renderer.webgl.Layer');
@@ -221,7 +221,7 @@ ol.renderer.webgl.ImageLayer.prototype.updateProjectionMatrix_ = function(canvas
  */
 ol.renderer.webgl.ImageLayer.prototype.hasFeatureAtCoordinate = function(coordinate, frameState) {
   var hasFeature = this.forEachFeatureAtCoordinate(
-      coordinate, frameState, goog.functions.TRUE, this);
+      coordinate, frameState, ol.functions.TRUE, this);
   return hasFeature !== undefined;
 };
 
@@ -241,7 +241,7 @@ ol.renderer.webgl.ImageLayer.prototype.forEachLayerAtPixel = function(pixel, fra
     ol.vec.Mat4.multVec2(
         frameState.pixelToCoordinateMatrix, coordinate, coordinate);
     var hasFeature = this.forEachFeatureAtCoordinate(
-        coordinate, frameState, goog.functions.TRUE, this);
+        coordinate, frameState, ol.functions.TRUE, this);
 
     if (hasFeature) {
       return callback.call(thisArg, this.getLayer());

--- a/src/ol/style/atlasmanager.js
+++ b/src/ol/style/atlasmanager.js
@@ -2,8 +2,8 @@ goog.provide('ol.style.Atlas');
 goog.provide('ol.style.AtlasManager');
 
 goog.require('goog.asserts');
-goog.require('goog.functions');
 goog.require('ol');
+goog.require('ol.functions');
 
 
 /**
@@ -186,7 +186,7 @@ ol.style.AtlasManager.prototype.add = function(id, width, height,
   // the hit-detection atlas, to make sure that the offset is the same for
   // the original image and the hit-detection image.
   var renderHitCallback = opt_renderHitCallback !== undefined ?
-      opt_renderHitCallback : goog.functions.NULL;
+      opt_renderHitCallback : ol.functions.NULL;
 
   /** @type {?ol.style.AtlasInfo} */
   var hitInfo = this.add_(true,

--- a/src/ol/webgl/shader.js
+++ b/src/ol/webgl/shader.js
@@ -3,8 +3,8 @@ goog.provide('ol.webgl.Shader');
 goog.provide('ol.webgl.Vertex');
 goog.provide('ol.webgl.shader');
 
-goog.require('goog.functions');
 goog.require('goog.webgl');
+goog.require('ol.functions');
 goog.require('ol.webgl');
 
 
@@ -41,7 +41,7 @@ ol.webgl.Shader.prototype.getSource = function() {
 /**
  * @return {boolean} Is animated?
  */
-ol.webgl.Shader.prototype.isAnimated = goog.functions.FALSE;
+ol.webgl.Shader.prototype.isAnimated = ol.functions.FALSE;
 
 
 /**

--- a/test/spec/ol/functions.test.js
+++ b/test/spec/ol/functions.test.js
@@ -1,0 +1,58 @@
+goog.provide('ol.test.functions');
+
+describe('ol.functions', function() {
+
+  describe('ol.functions.TRUE', function() {
+
+    it('returns true', function() {
+      expect(ol.functions.TRUE()).to.be(true);
+    });
+
+  });
+
+  describe('ol.functions.TRUE', function() {
+
+    it('returns false', function() {
+      expect(ol.functions.FALSE()).to.be(false);
+    });
+
+  });
+
+  describe('ol.functions.NULL', function() {
+
+    it('returns null', function() {
+      expect(ol.functions.NULL()).to.be(null);
+    });
+
+  });
+
+  describe('ol.functions.and', function() {
+    //TODO
+    it('returns null', function() {
+      expect(ol.functions.NULL()).to.be(null);
+    });
+
+  });
+
+  describe('ol.functions.sequence', function() {
+    //TODO
+    it('returns null', function() {
+      expect(ol.functions.NULL()).to.be(null);
+    });
+
+  });
+
+  describe('ol.functions.identity', function() {
+
+    it('returns first argument', function() {
+      expect(ol.functions.identity()).to.be(undefined);
+      expect(ol.functions.identity('Test')).to.be('Test');
+      expect(ol.functions.identity('Test', 'Not')).to.be('Test');
+
+    });
+
+  });
+
+});
+
+goog.require('ol.functions');


### PR DESCRIPTION
The removes goog.functions.[TRUE,FALSE,NULL,sequence,identity,and] and replaces them with ol functions. This pull request adds another file, functions.js. Almost all the tests are finished, just need to add some for 'sequence' and 'and'.

One questions is what is the need for the identity function in Pointer?

Will squash down once ready to merge.