### PR TITLE
assert whether radius is a number in setRadius

### DIFF
--- a/src/ol/geom/circle.js
+++ b/src/ol/geom/circle.js
@@ -224,6 +224,8 @@ ol.geom.Circle.prototype.setFlatCoordinates = function(layout, flatCoordinates) 
  * @api
  */
 ol.geom.Circle.prototype.setRadius = function(radius) {
+  goog.asserts.assert(goog.isNumber(radius),
+      'radius should be a number');
   goog.asserts.assert(this.flatCoordinates,
       'truthy this.flatCoordinates expected');
   this.flatCoordinates[this.stride] = this.flatCoordinates[0] + radius;


### PR DESCRIPTION
If a number-like string is accidentally passed to this function strange things can happen because of JavaScript's type coercion.  I.e. string concatenation is performed instead of addition at the assignment of this.flatCoordinates[this.stride].

-Peter