### PR TITLE
Improve examples pages on mobile devices a bit

### DIFF
--- a/config/examples/example.html
+++ b/config/examples/example.html
@@ -20,14 +20,17 @@
     <header class="navbar" role="navigation">
       <div class="container">
         <div class="display-table pull-left" id="navbar-logo-container">
-          <a class="navbar-brand" href="./"><img src="./resources/logo-70x70.png">&nbsp;OpenLayers 3 Examples</a>
+          <a class="navbar-brand" href="./"><img src="./resources/logo-70x70.png">&nbsp;OpenLayers Examples</a>
         </div>
-        <ul class="nav navbar-nav pull-right">
-          <li><a href="../doc">Docs</a></li>
-          <li><a class="active" href="index.html">Examples</a></li>
-          <li><a href="../apidoc">API</a></li>
-          <li><a href="https://github.com/openlayers/ol3">Code</a></li>
-        </ul>
+        <!-- menu items that get hidden below 768px width -->
+        <nav class='collapse navbar-collapse navbar-responsive-collapse'>
+          <ul class="nav navbar-nav pull-right">
+            <li><a href="../doc">Docs</a></li>
+            <li><a class="active" href="index.html">Examples</a></li>
+            <li><a href="../apidoc">API</a></li>
+            <li><a href="https://github.com/openlayers/ol3">Code</a></li>
+          </ul>
+        </nav>
       </div>
     </header>
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -190,12 +190,15 @@
             <span id="count"></span>
           </form>
         </div>
-        <ul class="nav navbar-nav pull-right">
-          <li><a href="../doc">Docs</a></li>
-          <li><a class="active" href="index.html">Examples</a></li>
-          <li><a href="../apidoc">API</a></li>
-          <li><a href="https://github.com/openlayers/ol3">Code</a></li>
-        </ul>
+        <!-- menu items that get hidden below 768px width -->
+        <nav class='collapse navbar-collapse navbar-responsive-collapse'>
+          <ul class="nav navbar-nav pull-right">
+            <li><a href="../doc">Docs</a></li>
+            <li><a class="active" href="index.html">Examples</a></li>
+            <li><a href="../apidoc">API</a></li>
+            <li><a href="https://github.com/openlayers/ol3">Code</a></li>
+          </ul>
+        </nav>
       </div>
     </header>
 


### PR DESCRIPTION
Only show navigation when there is enough space.

This does not make the example page look perfect on narrow screens, but at least it makes the example navigation and the examples themselves usable again.