### PR TITLE
Reuse dragListenerKeys_ variable in ol.control.ZoomSlider

### DIFF
--- a/src/ol/control/zoomslidercontrol.js
+++ b/src/ol/control/zoomslidercontrol.js
@@ -59,10 +59,10 @@ ol.control.ZoomSlider = function(opt_options) {
   this.dragging_;
 
   /**
-   * @type {Array.<ol.events.Key>}
+   * @type {!Array.<ol.events.Key>}
    * @private
    */
-  this.dragListenerKeys_;
+  this.dragListenerKeys_ = [];
 
   /**
    * @type {number}
@@ -267,17 +267,17 @@ ol.control.ZoomSlider.prototype.handleDraggerStart_ = function(event) {
     this.previousY_ = event.clientY;
     this.dragging_ = true;
 
-    if (!this.dragListenerKeys_) {
+    if (this.dragListenerKeys_.length === 0) {
       var drag = this.handleDraggerDrag_;
       var end = this.handleDraggerEnd_;
-      this.dragListenerKeys_ = [
+      this.dragListenerKeys_.push(
         ol.events.listen(document, ol.events.EventType.MOUSEMOVE, drag, this),
         ol.events.listen(document, ol.events.EventType.TOUCHMOVE, drag, this),
         ol.events.listen(document, ol.pointer.EventType.POINTERMOVE, drag, this),
         ol.events.listen(document, ol.events.EventType.MOUSEUP, end, this),
         ol.events.listen(document, ol.events.EventType.TOUCHEND, end, this),
         ol.events.listen(document, ol.pointer.EventType.POINTERUP, end, this)
-      ];
+      );
     }
   }
 };
@@ -327,7 +327,7 @@ ol.control.ZoomSlider.prototype.handleDraggerEnd_ = function(event) {
     this.previousX_ = undefined;
     this.previousY_ = undefined;
     this.dragListenerKeys_.forEach(ol.events.unlistenByKey);
-    this.dragListenerKeys_ = null;
+    this.dragListenerKeys_.length = 0;
   }
 };
 

--- a/test/spec/ol/control/zoomslidercontrol.test.js
+++ b/test/spec/ol/control/zoomslidercontrol.test.js
@@ -119,7 +119,7 @@ describe('ol.control.ZoomSlider', function() {
       dragger.dispatchEvent(event);
       expect(control.currentResolution_).to.be(16);
       expect(control.dragging_).to.be(true);
-      expect(control.dragListenerKeys_).to.be.ok();
+      expect(control.dragListenerKeys_.length).to.be(6);
       event.type = ol.pointer.EventType.POINTERMOVE;
       event.clientX = 6 * control.widthLimit_ / 8;
       event.clientY = 0;
@@ -132,7 +132,7 @@ describe('ol.control.ZoomSlider', function() {
       event.type = ol.pointer.EventType.POINTERUP;
       dragger.dispatchEvent(event);
       expect(control.currentResolution_).to.be(1);
-      expect(control.dragListenerKeys_).to.be(null);
+      expect(control.dragListenerKeys_.length).to.be(0);
       expect(control.dragging_).to.be(false);
     });
     it('[vertical] handles a drag sequence', function() {
@@ -153,7 +153,7 @@ describe('ol.control.ZoomSlider', function() {
       dragger.dispatchEvent(event);
       expect(control.currentResolution_).to.be(0.0625);
       expect(control.dragging_).to.be(true);
-      expect(control.dragListenerKeys_).to.be.ok();
+      expect(control.dragListenerKeys_.length).to.be(6);
       event.type = ol.pointer.EventType.POINTERMOVE;
       event.clientX = 0;
       event.clientY = 2 * control.heightLimit_ / 8;
@@ -166,7 +166,7 @@ describe('ol.control.ZoomSlider', function() {
       event.type = ol.pointer.EventType.POINTERUP;
       dragger.dispatchEvent(event);
       expect(control.currentResolution_).to.be(1);
-      expect(control.dragListenerKeys_).to.be(null);
+      expect(control.dragListenerKeys_.length).to.be(0);
       expect(control.dragging_).to.be(false);
     });
   });


### PR DESCRIPTION
Memory optimization: avoids to create a new array.