### PR TITLE
Use fs-extra as fs, remove usage of graceful-fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "derequire": "2.0.3",
     "fs-extra": "0.26.6",
     "glob": "6.0.4",
-    "graceful-fs": "4.1.3",
     "handlebars": "4.0.5",
     "jsdoc": "3.4.0",
     "marked": "0.3.5",

--- a/tasks/build-ext.js
+++ b/tasks/build-ext.js
@@ -1,8 +1,7 @@
-var fs = require('fs');
+var fs = require('fs-extra');
 var path = require('path');
 
 var async = require('async');
-var fse = require('fs-extra');
 var browserify = require('browserify');
 var derequire = require('derequire');
 
@@ -95,7 +94,7 @@ function buildModules(modules, callback) {
     var output = path.join(buildDir, mod.name) + '.js';
     async.waterfall([
       wrapModule.bind(null, mod),
-      fse.outputFile.bind(fse, output)
+      fs.outputFile.bind(fs, output)
     ], done);
   }, callback);
 }

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -5,8 +5,7 @@ var path = require('path');
 
 var async = require('async');
 var closure = require('closure-util');
-var fse = require('fs-extra');
-var fs = require('graceful-fs');
+var fs = require('fs-extra');
 var nomnom = require('nomnom');
 var temp = require('temp').track();
 var exec = require('child_process').exec;
@@ -285,7 +284,7 @@ if (require.main === module) {
   async.waterfall([
     readConfig.bind(null, options.config),
     main,
-    fse.outputFile.bind(fse, options.output)
+    fs.outputFile.bind(fs, options.output)
   ], function(err) {
     if (err) {
       log.error(err.message);

--- a/tasks/generate-exports.js
+++ b/tasks/generate-exports.js
@@ -1,7 +1,6 @@
-var fs = require('fs');
+var fs = require('fs-extra');
 
 var async = require('async');
-var fse = require('fs-extra');
 var nomnom = require('nomnom');
 
 var generateInfo = require('./generate-info');
@@ -225,7 +224,7 @@ if (require.main === module) {
   async.waterfall([
     getConfig.bind(null, options.config),
     main,
-    fse.outputFile.bind(fse, options.output)
+    fs.outputFile.bind(fs, options.output)
   ], function(err) {
     if (err) {
       process.stderr.write(err.message + '\n');

--- a/tasks/generate-externs.js
+++ b/tasks/generate-externs.js
@@ -1,5 +1,5 @@
 var async = require('async');
-var fse = require('fs-extra');
+var fs = require('fs-extra');
 var nomnom = require('nomnom');
 
 var generateInfo = require('./generate-info');
@@ -210,7 +210,7 @@ if (require.main === module) {
 
   async.waterfall([
     main,
-    fse.outputFile.bind(fse, options.output)
+    fs.outputFile.bind(fs, options.output)
   ], function(err) {
     if (err) {
       process.stderr.write(err.message + '\n');

--- a/tasks/generate-info.js
+++ b/tasks/generate-info.js
@@ -1,9 +1,8 @@
-var fs = require('fs');
+var fs = require('fs-extra');
 var path = require('path');
 var spawn = require('child_process').spawn;
 
 var async = require('async');
-var fse = require('fs-extra');
 var walk = require('walk').walk;
 var isWindows = process.platform.indexOf('win') === 0;
 
@@ -253,7 +252,7 @@ function addSymbolProvides(info, callback) {
 function writeInfo(info, callback) {
   if (info) {
     var str = JSON.stringify(info, null, '  ');
-    fse.outputFile(infoPath, str, callback);
+    fs.outputFile(infoPath, str, callback);
   } else {
     process.nextTick(function() {
       callback(null);

--- a/tasks/generate-requires.js
+++ b/tasks/generate-requires.js
@@ -1,4 +1,4 @@
-var fs = require('graceful-fs');
+var fs = require('fs-extra');
 
 // The number of files that we need to generate goog.require's for.
 var numFiles = process.argv.length - 1;

--- a/tasks/serve.js
+++ b/tasks/serve.js
@@ -10,7 +10,7 @@ var url = require('url');
 var Gaze = require('gaze').Gaze;
 var closure = require('closure-util');
 var debounce = require('debounce');
-var fse = require('fs-extra');
+var fs = require('fs-extra');
 var nomnom = require('nomnom');
 
 var buildExamples = require('./build-examples');
@@ -89,7 +89,7 @@ function buildExamplesOrFatal(opt_callback) {
     // This is awkward, but then so is CSS itself
     var src = path.join(__dirname, '..', 'css', 'ol.css');
     var dest = path.join(__dirname, '..', 'build', 'css', 'ol.css');
-    fse.copy(src, dest, function(err2) {
+    fs.copy(src, dest, function(err2) {
       if (err2) {
         log.error('serve', 'Failed to copy CSS.');
         log.error('serve', err.message);

--- a/tasks/test-coverage.js
+++ b/tasks/test-coverage.js
@@ -7,8 +7,7 @@
  *      async.waterfall.
  */
 
-var fs = require('fs');
-var fse = require('fs-extra');
+var fs = require('fs-extra');
 var istanbul = require('istanbul');
 var path = require('path');
 var glob = require('glob');
@@ -58,9 +57,9 @@ var setupBackupAndInstrumentationDir = function() {
   }
 
   log('• copy src files to backup folder');
-  fse.copySync(dir, backupDir, copyOpts);
+  fs.copySync(dir, backupDir, copyOpts);
   log('• copy src files to instrumentation folder');
-  fse.copySync(dir, instrumentedDir, copyOpts);
+  fs.copySync(dir, instrumentedDir, copyOpts);
 };
 
 /**
@@ -70,11 +69,11 @@ var setupBackupAndInstrumentationDir = function() {
  */
 var revertBackupAndInstrumentationDir = function() {
   log('• copy original src back to src folder');
-  fse.copySync(backupDir, dir, copyOpts);
+  fs.copySync(backupDir, dir, copyOpts);
   log('• delete backup directory');
-  fse.removeSync(backupDir);
+  fs.removeSync(backupDir);
   log('• delete instrumentation directory');
-  fse.removeSync(instrumentedDir);
+  fs.removeSync(instrumentedDir);
 };
 
 
@@ -132,7 +131,7 @@ var foundAllJavaScriptSourceFiles = function(err, files) {
   log('  • done. ' + cnt + ' files instrumented');
   log('• copy instrumented src back to src folder');
 
-  fse.copySync(instrumentedDir, dir, copyOpts);
+  fs.copySync(instrumentedDir, dir, copyOpts);
 
   log('• run test suite on instrumented code');
   runTestsuite({coverage: true, reporter: 'dot'}, collectAndWriteCoverageData);


### PR DESCRIPTION
This PR suggests to import `fs-extra` as fs and to no longer import either `fs` or `graceful-fs`.

Since [`v0.15.0`](https://github.com/jprichardson/node-fs-extra/releases/tag/0.15.0) `fs-extra` includes graceful-fs and should behave identically.