### PR TITLE
Improve docs/examples for loadingstrategy

### DIFF
--- a/examples/vector-esri-edit.html
+++ b/examples/vector-esri-edit.html
@@ -4,7 +4,7 @@ title: Editable ArcGIS REST Feature Service
 shortdesc: Example of using an ArcGIS REST Feature Service in an editing application.
 docs: >
   This example loads features from ArcGIS REST Feature Service and allows to add new features or update existing features.
-tags: "vector, esri, ArcGIS, REST, Feature, Service, bbox, loading, server, edit, updateFeature, addFeature"
+tags: "vector, esri, ArcGIS, REST, Feature, Service, loading, server, edit, updateFeature, addFeature"
 resources:
   - https://code.jquery.com/jquery-1.11.2.min.js
 ---

--- a/examples/vector-esri.html
+++ b/examples/vector-esri.html
@@ -1,10 +1,10 @@
 ---
 layout: example.html
 title: ArcGIS REST Feature Service
-shortdesc: Example of using an ArcGIS REST Feature Service with a BBOX strategy.
+shortdesc: Example of using an ArcGIS REST Feature Service with a Tile strategy.
 docs: >
   This example loads new features from ArcGIS REST Feature Service when the view extent changes.
-tags: "vector, esri, ArcGIS, REST, Feature, Service, bbox, loading, server"
+tags: "vector, esri, ArcGIS, REST, Feature, Service, loading, server"
 resources:
   - https://code.jquery.com/jquery-1.11.2.min.js
 ---

--- a/examples/vector-wfs.js
+++ b/examples/vector-wfs.js
@@ -18,9 +18,7 @@ var vectorSource = new ol.source.Vector({
         'outputFormat=application/json&srsname=EPSG:3857&' +
         'bbox=' + extent.join(',') + ',EPSG:3857';
   },
-  strategy: ol.loadingstrategy.tile(ol.tilegrid.createXYZ({
-    maxZoom: 19
-  }))
+  strategy: ol.loadingstrategy.bbox
 });
 
 

--- a/src/ol/loadingstrategy.js
+++ b/src/ol/loadingstrategy.js
@@ -5,6 +5,8 @@ goog.require('ol.TileCoord');
 
 
 /**
+ * One of `all`, `bbox`, `tile`.
+ *
  * @typedef {function(ol.Extent, number): Array.<ol.Extent>}
  * @api
  */


### PR DESCRIPTION
I was looking for docs on the bbox loadingstrategy. The typedef currently has no description, so I've added a minimal one. I searched the examples for 'bbox', and it finds 3, none of which actually uses a bbox strategy :confused: So I've removed the bbox description from the ESRI examples, and changed the WFS example so that does use `ol.loadingstrategy.bbox` - AFAICS this continues to work with no problem, so I'm not sure why it currently uses a Tile strategy, which seems like an unnecessary complication. No doubt someone will let me know if I'm missing something ;-)