### PR TITLE
Add target option to attribution logo

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -98,6 +98,15 @@ olx.LogoOptions.prototype.src;
 
 
 /**
+ * Link target for the logo. If undefined, none will be set and clicking on
+ * the logo will open the link in the current tab.
+ * @type {string|undefined}
+ * @api
+ */
+olx.LogoOptions.prototype.target;
+
+
+/**
  * @typedef {{map: (ol.Map|undefined),
  *     maxLines: (number|undefined),
  *     strokeStyle: (ol.style.Stroke|undefined),
@@ -7329,7 +7338,7 @@ olx.view.FitOptions.prototype.maxZoom;
  *     index: number,
  *     layerStates: Object.<number, ol.layer.LayerState>,
  *     layerStatesArray: Array.<ol.layer.LayerState>,
- *     logos: Object.<string, string>,
+ *     logos: Object.<string, Array.<string>>,
  *     pixelRatio: number,
  *     pixelToCoordinateMatrix: ol.vec.Mat4.Number,
  *     postRenderFunctions: Array.<ol.PostRenderFunction>,

--- a/src/ol/control/attributioncontrol.js
+++ b/src/ol/control/attributioncontrol.js
@@ -306,13 +306,17 @@ ol.control.Attribution.prototype.insertLogos_ = function(frameState) {
     if (!(logoKey in logoElements)) {
       image = new Image();
       image.src = logoKey;
-      var logoValue = logos[logoKey];
+      var logoValue = logos[logoKey][0];
+      var logoTarget = logos[logoKey][1];
       if (logoValue === '') {
         logoElement = image;
       } else {
         logoElement = goog.dom.createDom('A', {
           'href': logoValue
         });
+        if (logoTarget !== undefined) {
+          logoElement.setAttribute('target', logoTarget);
+        }
         logoElement.appendChild(image);
       }
       this.logoLi_.appendChild(logoElement);

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -188,7 +188,7 @@ ol.Map = function(options) {
 
   /**
    * @private
-   * @type {Object.<string, string>}
+   * @type {Object.<string, Array.<string>>}
    */
   this.logos_ = optionsInternal.logos;
 
@@ -1449,7 +1449,7 @@ ol.Map.prototype.unskipFeature = function(feature) {
  * @typedef {{controls: ol.Collection.<ol.control.Control>,
  *            interactions: ol.Collection.<ol.interaction.Interaction>,
  *            keyboardEventTarget: (Element|Document),
- *            logos: Object.<string, string>,
+ *            logos: Object.<string, Array.<string>>,
  *            overlays: ol.Collection.<ol.Overlay>,
  *            rendererConstructor:
  *                function(new: ol.renderer.Map, Element, ol.Map),
@@ -1484,15 +1484,21 @@ ol.Map.createOptionsInternal = function(options) {
   var logos = {};
   if (options.logo === undefined ||
       (typeof options.logo === 'boolean' && options.logo)) {
-    logos[ol.OL3_LOGO_URL] = ol.OL3_URL;
+    logos[ol.OL3_LOGO_URL] = [ol.OL3_URL];
   } else {
     var logo = options.logo;
     if (typeof logo === 'string') {
-      logos[logo] = '';
+      logos[logo] = [''];
     } else if (goog.isObject(logo)) {
       goog.asserts.assertString(logo.href, 'logo.href should be a string');
       goog.asserts.assertString(logo.src, 'logo.src should be a string');
-      logos[logo.src] = logo.href;
+      logos[logo.src] = [logo.href];
+
+      if (logo.target !== undefined) {
+        goog.asserts.assertString(logo.target,
+            'logo.target should be a string');
+        logos[logo.src].push(logo.target);
+      }
     }
   }
 

--- a/src/ol/renderer/layerrenderer.js
+++ b/src/ol/renderer/layerrenderer.js
@@ -223,11 +223,17 @@ ol.renderer.Layer.prototype.updateLogos = function(frameState, source) {
   var logo = source.getLogo();
   if (logo !== undefined) {
     if (typeof logo === 'string') {
-      frameState.logos[logo] = '';
+      frameState.logos[logo] = [''];
     } else if (goog.isObject(logo)) {
       goog.asserts.assertString(logo.href, 'logo.href is a string');
       goog.asserts.assertString(logo.src, 'logo.src is a string');
-      frameState.logos[logo.src] = logo.href;
+      frameState.logos[logo.src] = [logo.href];
+
+      if (logo.target !== undefined) {
+        goog.asserts.assertString(logo.target,
+            'logo.target should be a string');
+        frameState.logos[logo.src].push(logo.target);
+      }
     }
   }
 };


### PR DESCRIPTION
The original problem I had can be found [here](https://groups.google.com/forum/#!topic/ol3-dev/waTmFWpSK7o). In short, I wanted to create an attribution logo that opened in a new tab when clicked.

This commit adds a target option to the LogoOptions. This makes it possible to left-click on an attribution logo and make it open in a new tab. For example, when creating a map:

```
var map = new ol.Map({
        target: 'map',
        layers: [
          new ol.layer.Tile({
            source: new ol.source.MapQuest({layer: 'sat'})
          })
        ],
        view: new ol.View({
          center: ol.proj.fromLonLat([37.41, 8.82]),
          zoom: 4
        }),
        logo: {
          'href': "http://www.google.ca",
          'src': "logo.jpg",
          'target': "_blank"
        }
      });
```

The logo will appear as logo.jpg, and when clicked, it will open a new tab to google.ca.
When this option is not set, the target for the logo's link is not set, and it acts like before.

To implement this, I had to change the logos dict format from `{src: href}` to `{src: [href, target]}`.