### PR TITLE
Remove unneeded ol.VectorTile#disposeInternal function

### DIFF
--- a/src/ol/vectortile.js
+++ b/src/ol/vectortile.js
@@ -98,14 +98,6 @@ ol.VectorTile.prototype.getContext = function() {
 
 
 /**
- * @inheritDoc
- */
-ol.VectorTile.prototype.disposeInternal = function() {
-  goog.base(this, 'disposeInternal');
-};
-
-
-/**
  * Get the feature format assigned for reading this tile's features.
  * @return {ol.format.Feature} Feature format.
  * @api


### PR DESCRIPTION
This function only calls it's parent class; it can be removed