### PR TITLE
Stop GPX writing rtept properties

### DIFF
--- a/src/ol/format/gpxformat.js
+++ b/src/ol/format/gpxformat.js
@@ -432,6 +432,8 @@ ol.format.GPX.prototype.handleReadExtensions_ = function(features) {
 
 /**
  * Read the first feature from a GPX source.
+ * Routes (`<rte>`) are converted into LineString geometries, and tracks (`<trk>`)
+ * into MultiLineString. Any properties on route and track waypoints are ignored.
  *
  * @function
  * @param {Document|Node|Object|string} source Source.
@@ -466,6 +468,8 @@ ol.format.GPX.prototype.readFeatureFromNode = function(node, opt_options) {
 
 /**
  * Read all features from a GPX source.
+ * Routes (`<rte>`) are converted into LineString geometries, and tracks (`<trk>`)
+ * into MultiLineString. Any properties on route and track waypoints are ignored.
  *
  * @function
  * @param {Document|Node|Object|string} source Source.
@@ -569,7 +573,9 @@ ol.format.GPX.writeWptType_ = function(node, coordinate, objectStack) {
     default:
       // pass
   }
-  var orderedKeys = ol.format.GPX.WPT_TYPE_SEQUENCE_[namespaceURI];
+  var orderedKeys = (node.nodeName == 'rtept') ?
+      ol.format.GPX.RTEPT_TYPE_SEQUENCE_[namespaceURI] :
+      ol.format.GPX.WPT_TYPE_SEQUENCE_[namespaceURI];
   var values = ol.xml.makeSequence(properties, orderedKeys);
   ol.xml.pushSerializeAndPop(/** @type {ol.XmlNodeStackItem} */
       ({node: node, 'properties': properties}),
@@ -721,6 +727,17 @@ ol.format.GPX.RTE_SERIALIZERS_ = ol.xml.makeStructureNS(
       'rtept': ol.xml.makeArraySerializer(ol.xml.makeChildAppender(
           ol.format.GPX.writeWptType_))
     });
+
+
+/**
+ * @const
+ * @type {Object.<string, Array.<string>>}
+ * @private
+ */
+ol.format.GPX.RTEPT_TYPE_SEQUENCE_ = ol.xml.makeStructureNS(
+    ol.format.GPX.NAMESPACE_URIS_, [
+      'ele', 'time'
+    ]);
 
 
 /**

--- a/test/spec/ol/format/gpxformat.test.js
+++ b/test/spec/ol/format/gpxformat.test.js
@@ -117,6 +117,20 @@ describe('ol.format.GPX', function() {
       expect(serialized).to.xmleql(ol.xml.parse(text));
     });
 
+    it('does not write rte attributes in rtepts', function() {
+      var text =
+          '<gpx xmlns="http://www.topografix.com/GPX/1/1">' +
+          '  <rte>' +
+          '    <name>Name</name>' +
+          '    <rtept lat="1" lon="2"/>' +
+          '    <rtept lat="3" lon="4"/>' +
+          '  </rte>' +
+          '</gpx>';
+      var fs = format.readFeatures(text);
+      var serialized = format.writeFeaturesNode(fs);
+      expect(serialized).to.xmleql(ol.xml.parse(text));
+    });
+
   });
 
   describe('trk', function() {
@@ -291,6 +305,38 @@ describe('ol.format.GPX', function() {
         [[9, 8, 10, 1263115872], [12, 11, 13, 1263115932]]
       ]);
       expect(g.getLayout()).to.be(ol.geom.GeometryLayout.XYZM);
+      var serialized = format.writeFeaturesNode(fs);
+      expect(serialized).to.xmleql(ol.xml.parse(text));
+    });
+
+    it('does not write trk attributes in trkpts', function() {
+      var text =
+          '<gpx xmlns="http://www.topografix.com/GPX/1/1">' +
+          '  <trk>' +
+          '    <name>Name</name>' +
+          '    <trkseg>' +
+          '      <trkpt lat="1" lon="2">' +
+          '        <ele>3</ele>' +
+          '        <time>2010-01-10T09:29:12Z</time>' +
+          '      </trkpt>' +
+          '      <trkpt lat="5" lon="6">' +
+          '        <ele>7</ele>' +
+          '        <time>2010-01-10T09:30:12Z</time>' +
+          '      </trkpt>' +
+          '    </trkseg>' +
+          '    <trkseg>' +
+          '      <trkpt lat="8" lon="9">' +
+          '        <ele>10</ele>' +
+          '        <time>2010-01-10T09:31:12Z</time>' +
+          '      </trkpt>' +
+          '      <trkpt lat="11" lon="12">' +
+          '        <ele>13</ele>' +
+          '        <time>2010-01-10T09:32:12Z</time>' +
+          '      </trkpt>' +
+          '    </trkseg>' +
+          '  </trk>' +
+          '</gpx>';
+      var fs = format.readFeatures(text);
       var serialized = format.writeFeaturesNode(fs);
       expect(serialized).to.xmleql(ol.xml.parse(text));
     });


### PR DESCRIPTION
Fixes #5034 as proposed [there](https://github.com/openlayers/ol3/issues/5034#issuecomment-207815064). I think this fits in with the way the existing code works.

I've also added some docs for read rte and trk.