### PR TITLE
Don't draw a sketch line string when drawing a polygon

### DIFF
--- a/src/ol/interaction/drawinteraction.js
+++ b/src/ol/interaction/drawinteraction.js
@@ -243,14 +243,14 @@ ol.interaction.Draw = function(options) {
   this.sketchCoords_ = null;
 
   /**
-   * Sketch line. Used when drawing polygon.
+   * Sketch line. Used when drawing a circle.
    * @type {ol.Feature}
    * @private
    */
   this.sketchLine_ = null;
 
   /**
-   * Sketch line coordinates. Used when drawing a polygon or circle.
+   * Sketch line coordinates. Used when drawing a circle.
    * @type {Array.<ol.Coordinate>}
    * @private
    */
@@ -501,16 +501,12 @@ ol.interaction.Draw.prototype.startDrawing_ = function(event) {
     this.sketchCoords_ = start.slice();
   } else if (this.mode_ === ol.interaction.DrawMode.POLYGON) {
     this.sketchCoords_ = [[start.slice(), start.slice()]];
-    this.sketchLineCoords_ = this.sketchCoords_[0];
   } else {
     this.sketchCoords_ = [start.slice(), start.slice()];
     if (this.mode_ === ol.interaction.DrawMode.CIRCLE) {
       this.sketchLineCoords_ = this.sketchCoords_;
+      this.sketchLine_ = new ol.Feature(new ol.geom.LineString(this.sketchLineCoords_));
     }
-  }
-  if (this.sketchLineCoords_) {
-    this.sketchLine_ = new ol.Feature(
-        new ol.geom.LineString(this.sketchLineCoords_));
   }
   var geometry = this.geometryFunction_(this.sketchCoords_);
   goog.asserts.assert(geometry !== undefined, 'geometry should be defined');

--- a/src/ol/style/style.js
+++ b/src/ol/style/style.js
@@ -290,16 +290,6 @@ ol.style.createDefaultEditingStyles = function() {
   var white = [255, 255, 255, 1];
   var blue = [0, 153, 255, 1];
   var width = 3;
-  styles[ol.geom.GeometryType.POLYGON] = [
-    new ol.style.Style({
-      fill: new ol.style.Fill({
-        color: [255, 255, 255, 0.5]
-      })
-    })
-  ];
-  styles[ol.geom.GeometryType.MULTI_POLYGON] =
-      styles[ol.geom.GeometryType.POLYGON];
-
   styles[ol.geom.GeometryType.LINE_STRING] = [
     new ol.style.Style({
       stroke: new ol.style.Stroke({
@@ -314,6 +304,21 @@ ol.style.createDefaultEditingStyles = function() {
       })
     })
   ];
+
+  styles[ol.geom.GeometryType.POLYGON] = [
+    new ol.style.Style({
+      fill: new ol.style.Fill({
+        color: [255, 255, 255, 0.5]
+      })
+    })
+  ];
+  styles[ol.geom.GeometryType.POLYGON] =
+      styles[ol.geom.GeometryType.POLYGON].concat(
+          styles[ol.geom.GeometryType.LINE_STRING]
+      );
+  styles[ol.geom.GeometryType.MULTI_POLYGON] =
+      styles[ol.geom.GeometryType.POLYGON];
+
   styles[ol.geom.GeometryType.MULTI_LINE_STRING] =
       styles[ol.geom.GeometryType.LINE_STRING];
 


### PR DESCRIPTION
Add a stroke to the polygon sketch style and remove the sketch line when drawing a polygon.

Fixes #3235 

The default sketch style is changed from:
![draw_before](https://cloud.githubusercontent.com/assets/100959/14461262/fed561fc-00c1-11e6-8b21-1640cac52bfd.png)

to:
![draw_after](https://cloud.githubusercontent.com/assets/100959/14461267/052a990a-00c2-11e6-94e3-67a96680a78b.png)


work in progress

