### PR TITLE
Add filter option to ol.format.WFS#writeGetFeature

### DIFF
--- a/examples/vector-wfs-getfeature.html
+++ b/examples/vector-wfs-getfeature.html
@@ -1,0 +1,13 @@
+---
+layout: example.html
+title: WFS - GetFeature
+shortdesc: Example of making a WFS GetFeature request with a filter.
+docs: >
+  This example generates a `GetFeature` request which uses a `PropertyIsEqualTo`
+  and a `PropertyIsLike` filter, and then posts the request to load the features
+  that match the query.
+tags: "vector, WFS, GetFeature, filter"
+cloak:
+  AkGbxXx6tDWf1swIhPJyoAVp06H0s0gDTYslNWWHZ6RoPqMpB9ld5FY1WutX8UoF: Your Bing Maps Key from http://www.bingmapsportal.com/ here
+---
+<div id="map" class="map"></div>

--- a/examples/vector-wfs-getfeature.js
+++ b/examples/vector-wfs-getfeature.js
@@ -1,0 +1,66 @@
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.format.ogc.filter');
+goog.require('ol.format.WFS');
+goog.require('ol.format.GeoJSON');
+goog.require('ol.layer.Tile');
+goog.require('ol.layer.Vector');
+goog.require('ol.source.BingMaps');
+goog.require('ol.source.Vector');
+goog.require('ol.style.Stroke');
+goog.require('ol.style.Style');
+
+
+var vectorSource = new ol.source.Vector();
+var vector = new ol.layer.Vector({
+  source: vectorSource,
+  style: new ol.style.Style({
+    stroke: new ol.style.Stroke({
+      color: 'rgba(0, 0, 255, 1.0)',
+      width: 2
+    })
+  })
+});
+
+var raster = new ol.layer.Tile({
+  source: new ol.source.BingMaps({
+    imagerySet: 'Aerial',
+    key: 'AkGbxXx6tDWf1swIhPJyoAVp06H0s0gDTYslNWWHZ6RoPqMpB9ld5FY1WutX8UoF'
+  })
+});
+
+var map = new ol.Map({
+  layers: [raster, vector],
+  target: document.getElementById('map'),
+  view: new ol.View({
+    center: [-8908887.277395891, 5381918.072437216],
+    maxZoom: 19,
+    zoom: 12
+  })
+});
+
+// generate a GetFeature request
+var f = ol.format.ogc.filter;
+var featureRequest = new ol.format.WFS().writeGetFeature({
+  srsName: 'EPSG:3857',
+  featureNS: 'http://openstreemap.org',
+  featurePrefix: 'osm',
+  featureTypes: ['water_areas'],
+  outputFormat: 'application/json',
+  filter: f.and(
+    f.like('name', 'Mississippi*'),
+    f.equalTo('waterway', 'riverbank')
+  )
+});
+
+// then post the request and add the received features to a layer
+fetch('http://demo.boundlessgeo.com/geoserver/wfs', {
+  method: 'POST',
+  body: new XMLSerializer().serializeToString(featureRequest)
+}).then(function(response) {
+  return response.json();
+}).then(function(json) {
+  var features = new ol.format.GeoJSON().readFeatures(json);
+  vectorSource.addFeatures(features);
+  map.getView().fit(vectorSource.getExtent(), /** @type {ol.Size} */ (map.getSize()));
+});

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -2049,7 +2049,8 @@ olx.format.WFSOptions.prototype.schemaLocation;
  *     propertyNames: (Array.<string>|undefined),
  *     startIndex: (number|undefined),
  *     count: (number|undefined),
- *     bbox: (ol.Extent|undefined)}}
+ *     bbox: (ol.Extent|undefined),
+ *     filter: (ol.format.ogc.filter.Filter|undefined)}}
  * @api
  */
 olx.format.WFSWriteGetFeatureOptions;
@@ -2153,6 +2154,14 @@ olx.format.WFSWriteGetFeatureOptions.prototype.count;
  * @api
  */
 olx.format.WFSWriteGetFeatureOptions.prototype.bbox;
+
+
+/**
+ * OGC filter condition. See {@link ol.format.ogc.filter} for more information.
+ * @type {ol.format.ogc.filter.Filter|undefined}
+ * @api
+ */
+olx.format.WFSWriteGetFeatureOptions.prototype.filter;
 
 
 /**

--- a/src/ol/format/ogc/filter.js
+++ b/src/ol/format/ogc/filter.js
@@ -1,0 +1,637 @@
+goog.provide('ol.format.ogc.filter');
+goog.provide('ol.format.ogc.filter.Filter');
+goog.provide('ol.format.ogc.filter.Logical');
+goog.provide('ol.format.ogc.filter.LogicalBinary');
+goog.provide('ol.format.ogc.filter.And');
+goog.provide('ol.format.ogc.filter.Or');
+goog.provide('ol.format.ogc.filter.Not');
+goog.provide('ol.format.ogc.filter.Bbox');
+goog.provide('ol.format.ogc.filter.Comparison');
+goog.provide('ol.format.ogc.filter.ComparisonBinary');
+goog.provide('ol.format.ogc.filter.EqualTo');
+goog.provide('ol.format.ogc.filter.NotEqualTo');
+goog.provide('ol.format.ogc.filter.LessThan');
+goog.provide('ol.format.ogc.filter.LessThanOrEqualTo');
+goog.provide('ol.format.ogc.filter.GreaterThan');
+goog.provide('ol.format.ogc.filter.GreaterThanOrEqualTo');
+goog.provide('ol.format.ogc.filter.IsNull');
+goog.provide('ol.format.ogc.filter.IsBetween');
+goog.provide('ol.format.ogc.filter.IsLike');
+
+goog.require('ol.Object');
+
+
+/**
+ * Create a logical `<And>` operator between two filter conditions.
+ *
+ * @param {!ol.format.ogc.filter.Filter} conditionA First filter condition.
+ * @param {!ol.format.ogc.filter.Filter} conditionB Second filter condition.
+ * @returns {!ol.format.ogc.filter.And} `<And>` operator.
+ * @api
+ */
+ol.format.ogc.filter.and = function(conditionA, conditionB) {
+  return new ol.format.ogc.filter.And(conditionA, conditionB);
+};
+
+
+/**
+ * Create a logical `<Or>` operator between two filter conditions.
+ *
+ * @param {!ol.format.ogc.filter.Filter} conditionA First filter condition.
+ * @param {!ol.format.ogc.filter.Filter} conditionB Second filter condition.
+ * @returns {!ol.format.ogc.filter.Or} `<Or>` operator.
+ * @api
+ */
+ol.format.ogc.filter.or = function(conditionA, conditionB) {
+  return new ol.format.ogc.filter.Or(conditionA, conditionB);
+};
+
+
+/**
+ * Represents a logical `<Not>` operator for a filter condition.
+ *
+ * @param {!ol.format.ogc.filter.Filter} condition Filter condition.
+ * @returns {!ol.format.ogc.filter.Not} `<Not>` operator.
+ * @api
+ */
+ol.format.ogc.filter.not = function(condition) {
+  return new ol.format.ogc.filter.Not(condition);
+};
+
+
+/**
+ * Create a `<BBOX>` operator to test whether a geometry-valued property
+ * intersects a fixed bounding box
+ *
+ * @param {!string} geometryName Geometry name to use.
+ * @param {!ol.Extent} extent Extent.
+ * @param {string=} opt_srsName SRS name. No srsName attribute will be
+ *    set on geometries when this is not provided.
+ * @returns {!ol.format.ogc.filter.Bbox} `<BBOX>` operator.
+ * @api
+ */
+ol.format.ogc.filter.bbox = function(geometryName, extent, opt_srsName) {
+  return new ol.format.ogc.filter.Bbox(geometryName, extent, opt_srsName);
+};
+
+
+/**
+ * Creates a `<PropertyIsEqualTo>` comparison operator.
+ *
+ * @param {!string} propertyName Name of the context property to compare.
+ * @param {!(string|number)} expression The value to compare.
+ * @param {boolean=} opt_matchCase Case-sensitive?
+ * @returns {!ol.format.ogc.filter.EqualTo} `<PropertyIsEqualTo>` operator.
+ * @api
+ */
+ol.format.ogc.filter.equalTo = function(propertyName, expression, opt_matchCase) {
+  return new ol.format.ogc.filter.EqualTo(propertyName, expression, opt_matchCase);
+};
+
+
+/**
+ * Creates a `<PropertyIsNotEqualTo>` comparison operator.
+ *
+ * @param {!string} propertyName Name of the context property to compare.
+ * @param {!(string|number)} expression The value to compare.
+ * @param {boolean=} opt_matchCase Case-sensitive?
+ * @returns {!ol.format.ogc.filter.NotEqualTo} `<PropertyIsNotEqualTo>` operator.
+ * @api
+ */
+ol.format.ogc.filter.notEqualTo = function(propertyName, expression, opt_matchCase) {
+  return new ol.format.ogc.filter.NotEqualTo(propertyName, expression, opt_matchCase);
+};
+
+
+/**
+ * Creates a `<PropertyIsLessThan>` comparison operator.
+ *
+ * @param {!string} propertyName Name of the context property to compare.
+ * @param {!number} expression The value to compare.
+ * @returns {!ol.format.ogc.filter.LessThan} `<PropertyIsLessThan>` operator.
+ * @api
+ */
+ol.format.ogc.filter.lessThan = function(propertyName, expression) {
+  return new ol.format.ogc.filter.LessThan(propertyName, expression);
+};
+
+
+/**
+ * Creates a `<PropertyIsLessThanOrEqualTo>` comparison operator.
+ *
+ * @param {!string} propertyName Name of the context property to compare.
+ * @param {!number} expression The value to compare.
+ * @returns {!ol.format.ogc.filter.LessThanOrEqualTo} `<PropertyIsLessThanOrEqualTo>` operator.
+ * @api
+ */
+ol.format.ogc.filter.lessThanOrEqualTo = function(propertyName, expression) {
+  return new ol.format.ogc.filter.LessThanOrEqualTo(propertyName, expression);
+};
+
+
+/**
+ * Creates a `<PropertyIsGreaterThan>` comparison operator.
+ *
+ * @param {!string} propertyName Name of the context property to compare.
+ * @param {!number} expression The value to compare.
+ * @returns {!ol.format.ogc.filter.GreaterThan} `<PropertyIsGreaterThan>` operator.
+ * @api
+ */
+ol.format.ogc.filter.greaterThan = function(propertyName, expression) {
+  return new ol.format.ogc.filter.GreaterThan(propertyName, expression);
+};
+
+
+/**
+ * Creates a `<PropertyIsGreaterThanOrEqualTo>` comparison operator.
+ *
+ * @param {!string} propertyName Name of the context property to compare.
+ * @param {!number} expression The value to compare.
+ * @returns {!ol.format.ogc.filter.GreaterThanOrEqualTo} `<PropertyIsGreaterThanOrEqualTo>` operator.
+ * @api
+ */
+ol.format.ogc.filter.greaterThanOrEqualTo = function(propertyName, expression) {
+  return new ol.format.ogc.filter.GreaterThanOrEqualTo(propertyName, expression);
+};
+
+
+/**
+ * Creates a `<PropertyIsNull>` comparison operator to test whether a property value
+ * is null.
+ *
+ * @param {!string} propertyName Name of the context property to compare.
+ * @returns {!ol.format.ogc.filter.IsNull} `<PropertyIsNull>` operator.
+ * @api
+ */
+ol.format.ogc.filter.isNull = function(propertyName) {
+  return new ol.format.ogc.filter.IsNull(propertyName);
+};
+
+
+/**
+ * Creates a `<PropertyIsBetween>` comparison operator to test whether an expression
+ * value lies within a range given by a lower and upper bound (inclusive).
+ *
+ * @param {!string} propertyName Name of the context property to compare.
+ * @param {!number} lowerBoundary The lower bound of the range.
+ * @param {!number} upperBoundary The upper bound of the range.
+ * @returns {!ol.format.ogc.filter.IsBetween} `<PropertyIsBetween>` operator.
+ * @api
+ */
+ol.format.ogc.filter.between = function(propertyName, lowerBoundary, upperBoundary) {
+  return new ol.format.ogc.filter.IsBetween(propertyName, lowerBoundary, upperBoundary);
+};
+
+
+/**
+ * Represents a `<PropertyIsLike>` comparison operator that matches a string property
+ * value against a text pattern.
+ *
+ * @param {!string} propertyName Name of the context property to compare.
+ * @param {!string} pattern Text pattern.
+ * @param {string=} opt_wildCard Pattern character which matches any sequence of
+ *    zero or more string characters. Default is '*'.
+ * @param {string=} opt_singleChar pattern character which matches any single
+ *    string character. Default is '.'.
+ * @param {string=} opt_escapeChar Escape character which can be used to escape
+ *    the pattern characters. Default is '!'.
+ * @param {boolean=} opt_matchCase Case-sensitive?
+ * @returns {!ol.format.ogc.filter.IsLike} `<PropertyIsLike>` operator.
+ * @api
+ */
+ol.format.ogc.filter.like = function(propertyName, pattern,
+    opt_wildCard, opt_singleChar, opt_escapeChar, opt_matchCase) {
+  return new ol.format.ogc.filter.IsLike(propertyName, pattern,
+    opt_wildCard, opt_singleChar, opt_escapeChar, opt_matchCase);
+};
+
+
+/**
+ * @classdesc
+ * Abstract class; normally only used for creating subclasses and not instantiated in apps.
+ * Base class for WFS GetFeature filters.
+ *
+ * @constructor
+ * @param {!string} tagName The XML tag name for this filter.
+ * @extends {ol.Object}
+ * @api
+ */
+ol.format.ogc.filter.Filter = function(tagName) {
+
+  goog.base(this);
+
+  /**
+   * @private
+   * @type {!string}
+   */
+  this.tagName_ = tagName;
+};
+goog.inherits(ol.format.ogc.filter.Filter, ol.Object);
+
+/**
+ * The XML tag name for a filter.
+ * @returns {!string} Name.
+ */
+ol.format.ogc.filter.Filter.prototype.getTagName = function() {
+  return this.tagName_;
+};
+
+
+// Logical filters
+
+
+/**
+ * @classdesc
+ * Abstract class; normally only used for creating subclasses and not instantiated in apps.
+ * Base class for WFS GetFeature logical filters.
+ *
+ * @constructor
+ * @param {!string} tagName The XML tag name for this filter.
+ * @extends {ol.format.ogc.filter.Filter}
+ */
+ol.format.ogc.filter.Logical = function(tagName) {
+  goog.base(this, tagName);
+};
+goog.inherits(ol.format.ogc.filter.Logical, ol.format.ogc.filter.Filter);
+
+
+/**
+ * @classdesc
+ * Abstract class; normally only used for creating subclasses and not instantiated in apps.
+ * Base class for WFS GetFeature binary logical filters.
+ *
+ * @constructor
+ * @param {!string} tagName The XML tag name for this filter.
+ * @param {!ol.format.ogc.filter.Filter} conditionA First filter condition.
+ * @param {!ol.format.ogc.filter.Filter} conditionB Second filter condition.
+ * @extends {ol.format.ogc.filter.Logical}
+ */
+ol.format.ogc.filter.LogicalBinary = function(tagName, conditionA, conditionB) {
+
+  goog.base(this, tagName);
+
+  /**
+   * @public
+   * @type {!ol.format.ogc.filter.Filter}
+   */
+  this.conditionA = conditionA;
+
+  /**
+   * @public
+   * @type {!ol.format.ogc.filter.Filter}
+   */
+  this.conditionB = conditionB;
+
+};
+goog.inherits(ol.format.ogc.filter.LogicalBinary, ol.format.ogc.filter.Logical);
+
+
+/**
+ * @classdesc
+ * Represents a logical `<And>` operator between two filter conditions.
+ *
+ * @constructor
+ * @param {!ol.format.ogc.filter.Filter} conditionA First filter condition.
+ * @param {!ol.format.ogc.filter.Filter} conditionB Second filter condition.
+ * @extends {ol.format.ogc.filter.LogicalBinary}
+ * @api
+ */
+ol.format.ogc.filter.And = function(conditionA, conditionB) {
+  goog.base(this, 'And', conditionA, conditionB);
+};
+goog.inherits(ol.format.ogc.filter.And, ol.format.ogc.filter.LogicalBinary);
+
+
+/**
+ * @classdesc
+ * Represents a logical `<Or>` operator between two filter conditions.
+ *
+ * @constructor
+ * @param {!ol.format.ogc.filter.Filter} conditionA First filter condition.
+ * @param {!ol.format.ogc.filter.Filter} conditionB Second filter condition.
+ * @extends {ol.format.ogc.filter.LogicalBinary}
+ * @api
+ */
+ol.format.ogc.filter.Or = function(conditionA, conditionB) {
+  goog.base(this, 'Or', conditionA, conditionB);
+};
+goog.inherits(ol.format.ogc.filter.Or, ol.format.ogc.filter.LogicalBinary);
+
+
+/**
+ * @classdesc
+ * Represents a logical `<Not>` operator for a filter condition.
+ *
+ * @constructor
+ * @param {!ol.format.ogc.filter.Filter} condition Filter condition.
+ * @extends {ol.format.ogc.filter.Logical}
+ * @api
+ */
+ol.format.ogc.filter.Not = function(condition) {
+
+  goog.base(this, 'Not');
+
+  /**
+   * @public
+   * @type {!ol.format.ogc.filter.Filter}
+   */
+  this.condition = condition;
+};
+goog.inherits(ol.format.ogc.filter.Not, ol.format.ogc.filter.Logical);
+
+
+// Spatial filters
+
+
+/**
+ * @classdesc
+ * Represents a `<BBOX>` operator to test whether a geometry-valued property
+ * intersects a fixed bounding box
+ *
+ * @constructor
+ * @param {!string} geometryName Geometry name to use.
+ * @param {!ol.Extent} extent Extent.
+ * @param {string=} opt_srsName SRS name. No srsName attribute will be
+ *    set on geometries when this is not provided.
+ * @extends {ol.format.ogc.filter.Filter}
+ * @api
+ */
+ol.format.ogc.filter.Bbox = function(geometryName, extent, opt_srsName) {
+
+  goog.base(this, 'BBOX');
+
+  /**
+   * @public
+   * @type {!string}
+   */
+  this.geometryName = geometryName;
+
+  /**
+   * @public
+   * @type {!ol.Extent}
+   */
+  this.extent = extent;
+
+  /**
+   * @public
+   * @type {string|undefined}
+   */
+  this.srsName = opt_srsName;
+};
+goog.inherits(ol.format.ogc.filter.Bbox, ol.format.ogc.filter.Filter);
+
+
+// Property comparison filters
+
+
+/**
+ * @classdesc
+ * Abstract class; normally only used for creating subclasses and not instantiated in apps.
+ * Base class for WFS GetFeature property comparison filters.
+ *
+ * @constructor
+ * @param {!string} tagName The XML tag name for this filter.
+ * @param {!string} propertyName Name of the context property to compare.
+ * @extends {ol.format.ogc.filter.Filter}
+ * @api
+ */
+ol.format.ogc.filter.Comparison = function(tagName, propertyName) {
+
+  goog.base(this, tagName);
+
+  /**
+   * @public
+   * @type {!string}
+   */
+  this.propertyName = propertyName;
+};
+goog.inherits(ol.format.ogc.filter.Comparison, ol.format.ogc.filter.Filter);
+
+
+/**
+ * @classdesc
+ * Abstract class; normally only used for creating subclasses and not instantiated in apps.
+ * Base class for WFS GetFeature property binary comparison filters.
+ *
+ * @constructor
+ * @param {!string} tagName The XML tag name for this filter.
+ * @param {!string} propertyName Name of the context property to compare.
+ * @param {!(string|number)} expression The value to compare.
+ * @param {boolean=} opt_matchCase Case-sensitive?
+ * @extends {ol.format.ogc.filter.Comparison}
+ * @api
+ */
+ol.format.ogc.filter.ComparisonBinary = function(
+    tagName, propertyName, expression, opt_matchCase) {
+
+  goog.base(this, tagName, propertyName);
+
+  /**
+   * @public
+   * @type {!(string|number)}
+   */
+  this.expression = expression;
+
+  /**
+   * @public
+   * @type {boolean|undefined}
+   */
+  this.matchCase = opt_matchCase;
+};
+goog.inherits(ol.format.ogc.filter.ComparisonBinary, ol.format.ogc.filter.Comparison);
+
+
+/**
+ * @classdesc
+ * Represents a `<PropertyIsEqualTo>` comparison operator.
+ *
+ * @constructor
+ * @param {!string} propertyName Name of the context property to compare.
+ * @param {!(string|number)} expression The value to compare.
+ * @param {boolean=} opt_matchCase Case-sensitive?
+ * @extends {ol.format.ogc.filter.ComparisonBinary}
+ * @api
+ */
+ol.format.ogc.filter.EqualTo = function(propertyName, expression, opt_matchCase) {
+  goog.base(this, 'PropertyIsEqualTo', propertyName, expression, opt_matchCase);
+};
+goog.inherits(ol.format.ogc.filter.EqualTo, ol.format.ogc.filter.ComparisonBinary);
+
+
+/**
+ * @classdesc
+ * Represents a `<PropertyIsNotEqualTo>` comparison operator.
+ *
+ * @constructor
+ * @param {!string} propertyName Name of the context property to compare.
+ * @param {!(string|number)} expression The value to compare.
+ * @param {boolean=} opt_matchCase Case-sensitive?
+ * @extends {ol.format.ogc.filter.ComparisonBinary}
+ * @api
+ */
+ol.format.ogc.filter.NotEqualTo = function(propertyName, expression, opt_matchCase) {
+  goog.base(this, 'PropertyIsNotEqualTo', propertyName, expression, opt_matchCase);
+};
+goog.inherits(ol.format.ogc.filter.NotEqualTo, ol.format.ogc.filter.ComparisonBinary);
+
+
+/**
+ * @classdesc
+ * Represents a `<PropertyIsLessThan>` comparison operator.
+ *
+ * @constructor
+ * @param {!string} propertyName Name of the context property to compare.
+ * @param {!number} expression The value to compare.
+ * @extends {ol.format.ogc.filter.ComparisonBinary}
+ * @api
+ */
+ol.format.ogc.filter.LessThan = function(propertyName, expression) {
+  goog.base(this, 'PropertyIsLessThan', propertyName, expression);
+};
+goog.inherits(ol.format.ogc.filter.LessThan, ol.format.ogc.filter.ComparisonBinary);
+
+
+/**
+ * @classdesc
+ * Represents a `<PropertyIsLessThanOrEqualTo>` comparison operator.
+ *
+ * @constructor
+ * @param {!string} propertyName Name of the context property to compare.
+ * @param {!number} expression The value to compare.
+ * @extends {ol.format.ogc.filter.ComparisonBinary}
+ * @api
+ */
+ol.format.ogc.filter.LessThanOrEqualTo = function(propertyName, expression) {
+  goog.base(this, 'PropertyIsLessThanOrEqualTo', propertyName, expression);
+};
+goog.inherits(ol.format.ogc.filter.LessThanOrEqualTo, ol.format.ogc.filter.ComparisonBinary);
+
+
+/**
+ * @classdesc
+ * Represents a `<PropertyIsGreaterThan>` comparison operator.
+ *
+ * @constructor
+ * @param {!string} propertyName Name of the context property to compare.
+ * @param {!number} expression The value to compare.
+ * @extends {ol.format.ogc.filter.ComparisonBinary}
+ * @api
+ */
+ol.format.ogc.filter.GreaterThan = function(propertyName, expression) {
+  goog.base(this, 'PropertyIsGreaterThan', propertyName, expression);
+};
+goog.inherits(ol.format.ogc.filter.GreaterThan, ol.format.ogc.filter.ComparisonBinary);
+
+
+/**
+ * @classdesc
+ * Represents a `<PropertyIsGreaterThanOrEqualTo>` comparison operator.
+ *
+ * @constructor
+ * @param {!string} propertyName Name of the context property to compare.
+ * @param {!number} expression The value to compare.
+ * @extends {ol.format.ogc.filter.ComparisonBinary}
+ * @api
+ */
+ol.format.ogc.filter.GreaterThanOrEqualTo = function(propertyName, expression) {
+  goog.base(this, 'PropertyIsGreaterThanOrEqualTo', propertyName, expression);
+};
+goog.inherits(ol.format.ogc.filter.GreaterThanOrEqualTo, ol.format.ogc.filter.ComparisonBinary);
+
+
+/**
+ * @classdesc
+ * Represents a `<PropertyIsNull>` comparison operator.
+ *
+ * @constructor
+ * @param {!string} propertyName Name of the context property to compare.
+ * @extends {ol.format.ogc.filter.Comparison}
+ * @api
+ */
+ol.format.ogc.filter.IsNull = function(propertyName) {
+  goog.base(this, 'PropertyIsNull', propertyName);
+};
+goog.inherits(ol.format.ogc.filter.IsNull, ol.format.ogc.filter.Comparison);
+
+
+/**
+ * @classdesc
+ * Represents a `<PropertyIsBetween>` comparison operator.
+ *
+ * @constructor
+ * @param {!string} propertyName Name of the context property to compare.
+ * @param {!number} lowerBoundary The lower bound of the range.
+ * @param {!number} upperBoundary The upper bound of the range.
+ * @extends {ol.format.ogc.filter.Comparison}
+ * @api
+ */
+ol.format.ogc.filter.IsBetween = function(propertyName, lowerBoundary, upperBoundary) {
+  goog.base(this, 'PropertyIsBetween', propertyName);
+
+  /**
+   * @public
+   * @type {!number}
+   */
+  this.lowerBoundary = lowerBoundary;
+
+  /**
+   * @public
+   * @type {!number}
+   */
+  this.upperBoundary = upperBoundary;
+};
+goog.inherits(ol.format.ogc.filter.IsBetween, ol.format.ogc.filter.Comparison);
+
+
+/**
+ * @classdesc
+ * Represents a `<PropertyIsLike>` comparison operator.
+ *
+ * @constructor
+ * @param {!string} propertyName Name of the context property to compare.
+ * @param {!string} pattern Text pattern.
+ * @param {string=} opt_wildCard Pattern character which matches any sequence of
+ *    zero or more string characters. Default is '*'.
+ * @param {string=} opt_singleChar pattern character which matches any single
+ *    string character. Default is '.'.
+ * @param {string=} opt_escapeChar Escape character which can be used to escape
+ *    the pattern characters. Default is '!'.
+ * @param {boolean=} opt_matchCase Case-sensitive?
+ * @extends {ol.format.ogc.filter.Comparison}
+ * @api
+ */
+ol.format.ogc.filter.IsLike = function(propertyName, pattern,
+    opt_wildCard, opt_singleChar, opt_escapeChar, opt_matchCase) {
+  goog.base(this, 'PropertyIsLike', propertyName);
+
+  /**
+   * @public
+   * @type {!string}
+   */
+  this.pattern = pattern;
+
+  /**
+   * @public
+   * @type {!string}
+   */
+  this.wildCard = (opt_wildCard !== undefined) ? opt_wildCard : '*';
+
+  /**
+   * @public
+   * @type {!string}
+   */
+  this.singleChar = (opt_singleChar !== undefined) ? opt_singleChar : '.';
+
+  /**
+   * @public
+   * @type {!string}
+   */
+  this.escapeChar = (opt_escapeChar !== undefined) ? opt_escapeChar : '!';
+
+  /**
+   * @public
+   * @type {boolean|undefined}
+   */
+  this.matchCase = opt_matchCase;
+};
+goog.inherits(ol.format.ogc.filter.IsLike, ol.format.ogc.filter.Comparison);

--- a/src/ol/format/ogc/filter.jsdoc
+++ b/src/ol/format/ogc/filter.jsdoc
@@ -1,0 +1,29 @@
+/**
+ * This namespace contains convenience functions to create filters for
+ * {@link ol.format.WFS#writeGetFeature}.
+ *
+ * For example to generate a `GetFeature` request with a `PropertyIsEqualTo` filter:
+ *
+ *       var request = new ol.format.WFS().writeGetFeature({
+ *         srsName: 'urn:ogc:def:crs:EPSG::4326',
+ *         featureNS: 'http://www.openplans.org/topp',
+ *         featurePrefix: 'topp',
+ *         featureTypes: ['states'],
+ *         filter: ol.format.wfs.filter.equalTo('name', 'New York')
+ *       });
+ *
+ * Or to combine a `BBOX` filter with a `PropertyIsLike` filter:
+ *
+ *       var f = ol.format.wfs.filter;
+ *       var request = new ol.format.WFS().writeGetFeature({
+ *         srsName: 'urn:ogc:def:crs:EPSG::4326',
+ *         featureNS: 'http://www.openplans.org/topp',
+ *         featurePrefix: 'topp',
+ *         featureTypes: ['states'],
+ *         filter: f.and(
+ *           f.bbox('the_geom', [1, 2, 3, 4], 'urn:ogc:def:crs:EPSG::4326'),
+ *           f.like('name', 'New*')
+ *         )
+ *       });
+ * @namespace ol.format.ogc.filter
+ */

--- a/src/ol/format/readme.md
+++ b/src/ol/format/readme.md
@@ -5,7 +5,7 @@
 * `readFeature` returning an `ol.Feature`
 * `readGeometry` returning an `ol.geom.Geometry`
 
-Having different functions for multiple return types allows both the user to specify what type of data he wants and for the Compiler to properly type check the code. Depending on the format, it is entirely reasonable to leave one or more of these methods unimplemented, or provide sensible default implementations.
+Having different functions for multiple return types allows both the user to specify what type of data they want and for the compiler to properly type check the code. Depending on the format, it is entirely reasonable to leave one or more of these methods unimplemented, or provide sensible default implementations.
 
 For example, `ol.format.GPX` only supports reading multiple features.  Therefore `readFeature` and `readGeometry` are unimplemented and will raise an exception if called.
 
@@ -19,7 +19,7 @@ If a file cannot be parsed, then the return value should be `null` for all three
 # Implementing XML formats
 
 This is an introduction for people looking to contribute an XML format reader to OpenLayers 3. After having read this document, you should read the code of and make sure that you understand the simpler XML format readers like `ol.format.GPX` before embarking on writing your own format reader.
-The document ends with guildelines for implementing a new format.
+The document ends with guidelines for implementing a new format.
 
 The `ol.xml` namespace contains a number of useful functions for parsing XML documents. All code in OpenLayers 3 that reads data from XML documents should use it. It has several features:
 

--- a/test/spec/ol/format/wfsformat.test.js
+++ b/test/spec/ol/format/wfsformat.test.js
@@ -1,4 +1,5 @@
 goog.provide('ol.test.format.WFS');
+goog.require('ol.format.ogc.filter');
 
 describe('ol.format.WFS', function() {
 
@@ -245,6 +246,260 @@ describe('ol.format.WFS', function() {
         featureTypes: ['states'],
         geometryName: 'the_geom',
         bbox: [1, 2, 3, 4]
+      });
+      expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
+    });
+
+    it('creates a property filter', function() {
+      var text =
+          '<wfs:Query xmlns:wfs="http://www.opengis.net/wfs" ' +
+          '    typeName="topp:states" srsName="urn:ogc:def:crs:EPSG::4326" ' +
+          '    xmlns:topp="http://www.openplans.org/topp">' +
+          '  <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">' +
+          '    <ogc:PropertyIsEqualTo matchCase="false">' +
+          '      <ogc:PropertyName>name</ogc:PropertyName>' +
+          '      <ogc:Literal>New York</ogc:Literal>' +
+          '    </ogc:PropertyIsEqualTo>' +
+          '  </ogc:Filter>' +
+          '</wfs:Query>';
+      var serialized = new ol.format.WFS().writeGetFeature({
+        srsName: 'urn:ogc:def:crs:EPSG::4326',
+        featureNS: 'http://www.openplans.org/topp',
+        featurePrefix: 'topp',
+        featureTypes: ['states'],
+        filter: ol.format.ogc.filter.equalTo('name', 'New York', false)
+      });
+      expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
+    });
+
+    it('creates two property filters', function() {
+      var text =
+          '<wfs:Query xmlns:wfs="http://www.opengis.net/wfs" ' +
+          '    typeName="topp:states" srsName="urn:ogc:def:crs:EPSG::4326" ' +
+          '    xmlns:topp="http://www.openplans.org/topp">' +
+          '  <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">' +
+          '    <ogc:Or>' +
+          '      <ogc:PropertyIsEqualTo>' +
+          '        <ogc:PropertyName>name</ogc:PropertyName>' +
+          '        <ogc:Literal>New York</ogc:Literal>' +
+          '      </ogc:PropertyIsEqualTo>' +
+          '      <ogc:PropertyIsEqualTo>' +
+          '        <ogc:PropertyName>area</ogc:PropertyName>' +
+          '        <ogc:Literal>1234</ogc:Literal>' +
+          '      </ogc:PropertyIsEqualTo>' +
+          '    </ogc:Or>' +
+          '  </ogc:Filter>' +
+          '</wfs:Query>';
+      var f = ol.format.ogc.filter;
+      var serialized = new ol.format.WFS().writeGetFeature({
+        srsName: 'urn:ogc:def:crs:EPSG::4326',
+        featureNS: 'http://www.openplans.org/topp',
+        featurePrefix: 'topp',
+        featureTypes: ['states'],
+        filter: f.or(f.equalTo('name', 'New York'), f.equalTo('area', 1234))
+      });
+      expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
+    });
+
+    it('creates greater/less than property filters', function() {
+      var text =
+          '<wfs:Query xmlns:wfs="http://www.opengis.net/wfs" ' +
+          '    typeName="topp:states" srsName="urn:ogc:def:crs:EPSG::4326" ' +
+          '    xmlns:topp="http://www.openplans.org/topp">' +
+          '  <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">' +
+          '    <ogc:Or>' +
+          '      <ogc:And>' +
+          '        <ogc:PropertyIsGreaterThan>' +
+          '          <ogc:PropertyName>area</ogc:PropertyName>' +
+          '          <ogc:Literal>100</ogc:Literal>' +
+          '        </ogc:PropertyIsGreaterThan>' +
+          '        <ogc:PropertyIsGreaterThanOrEqualTo>' +
+          '          <ogc:PropertyName>pop</ogc:PropertyName>' +
+          '          <ogc:Literal>20000</ogc:Literal>' +
+          '        </ogc:PropertyIsGreaterThanOrEqualTo>' +
+          '      </ogc:And>' +
+          '      <ogc:And>' +
+          '        <ogc:PropertyIsLessThan>' +
+          '          <ogc:PropertyName>area</ogc:PropertyName>' +
+          '          <ogc:Literal>100</ogc:Literal>' +
+          '        </ogc:PropertyIsLessThan>' +
+          '        <ogc:PropertyIsLessThanOrEqualTo>' +
+          '          <ogc:PropertyName>pop</ogc:PropertyName>' +
+          '          <ogc:Literal>20000</ogc:Literal>' +
+          '        </ogc:PropertyIsLessThanOrEqualTo>' +
+          '      </ogc:And>' +
+          '    </ogc:Or>' +
+          '  </ogc:Filter>' +
+          '</wfs:Query>';
+      var f = ol.format.ogc.filter;
+      var serialized = new ol.format.WFS().writeGetFeature({
+        srsName: 'urn:ogc:def:crs:EPSG::4326',
+        featureNS: 'http://www.openplans.org/topp',
+        featurePrefix: 'topp',
+        featureTypes: ['states'],
+        filter: f.or(
+          f.and(
+            f.greaterThan('area', 100),
+            f.greaterThanOrEqualTo('pop', 20000)
+          ),
+          f.and(
+            f.lessThan('area', 100),
+            f.lessThanOrEqualTo('pop', 20000)
+          )
+        )
+      });
+      expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
+    });
+
+    it('creates isBetween property filter', function() {
+      var text =
+          '<wfs:Query xmlns:wfs="http://www.opengis.net/wfs" ' +
+          '    typeName="topp:states" srsName="urn:ogc:def:crs:EPSG::4326" ' +
+          '    xmlns:topp="http://www.openplans.org/topp">' +
+          '  <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">' +
+          '    <ogc:PropertyIsBetween>' +
+          '      <ogc:PropertyName>area</ogc:PropertyName>' +
+          '      <ogc:LowerBoundary>100</ogc:LowerBoundary>' +
+          '      <ogc:UpperBoundary>1000</ogc:UpperBoundary>' +
+          '    </ogc:PropertyIsBetween>' +
+          '  </ogc:Filter>' +
+          '</wfs:Query>';
+      var f = ol.format.ogc.filter;
+      var serialized = new ol.format.WFS().writeGetFeature({
+        srsName: 'urn:ogc:def:crs:EPSG::4326',
+        featureNS: 'http://www.openplans.org/topp',
+        featurePrefix: 'topp',
+        featureTypes: ['states'],
+        filter: f.between('area', 100, 1000)
+      });
+      expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
+    });
+
+    it('creates isNull property filter', function() {
+      var text =
+          '<wfs:Query xmlns:wfs="http://www.opengis.net/wfs" ' +
+          '    typeName="topp:states" srsName="urn:ogc:def:crs:EPSG::4326" ' +
+          '    xmlns:topp="http://www.openplans.org/topp">' +
+          '  <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">' +
+          '    <ogc:PropertyIsNull>' +
+          '      <ogc:PropertyName>area</ogc:PropertyName>' +
+          '    </ogc:PropertyIsNull>' +
+          '  </ogc:Filter>' +
+          '</wfs:Query>';
+      var f = ol.format.ogc.filter;
+      var serialized = new ol.format.WFS().writeGetFeature({
+        srsName: 'urn:ogc:def:crs:EPSG::4326',
+        featureNS: 'http://www.openplans.org/topp',
+        featurePrefix: 'topp',
+        featureTypes: ['states'],
+        filter: f.isNull('area')
+      });
+      expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
+    });
+
+    it('creates isLike property filter', function() {
+      var text =
+          '<wfs:Query xmlns:wfs="http://www.opengis.net/wfs" ' +
+          '    typeName="topp:states" srsName="urn:ogc:def:crs:EPSG::4326" ' +
+          '    xmlns:topp="http://www.openplans.org/topp">' +
+          '  <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">' +
+          '    <ogc:PropertyIsLike wildCard="*" singleChar="." escapeChar="!">' +
+          '      <ogc:PropertyName>name</ogc:PropertyName>' +
+          '      <ogc:Literal>New*</ogc:Literal>' +
+          '    </ogc:PropertyIsLike>' +
+          '  </ogc:Filter>' +
+          '</wfs:Query>';
+      var f = ol.format.ogc.filter;
+      var serialized = new ol.format.WFS().writeGetFeature({
+        srsName: 'urn:ogc:def:crs:EPSG::4326',
+        featureNS: 'http://www.openplans.org/topp',
+        featurePrefix: 'topp',
+        featureTypes: ['states'],
+        filter: f.like('name', 'New*')
+      });
+      expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
+    });
+
+    it('creates isLike property filter with arguments', function() {
+      var text =
+          '<wfs:Query xmlns:wfs="http://www.opengis.net/wfs" ' +
+          '    typeName="topp:states" srsName="urn:ogc:def:crs:EPSG::4326" ' +
+          '    xmlns:topp="http://www.openplans.org/topp">' +
+          '  <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">' +
+          '    <ogc:PropertyIsLike wildCard="*" singleChar="." escapeChar="!" matchCase="false">' +
+          '      <ogc:PropertyName>name</ogc:PropertyName>' +
+          '      <ogc:Literal>New*</ogc:Literal>' +
+          '    </ogc:PropertyIsLike>' +
+          '  </ogc:Filter>' +
+          '</wfs:Query>';
+      var f = ol.format.ogc.filter;
+      var serialized = new ol.format.WFS().writeGetFeature({
+        srsName: 'urn:ogc:def:crs:EPSG::4326',
+        featureNS: 'http://www.openplans.org/topp',
+        featurePrefix: 'topp',
+        featureTypes: ['states'],
+        filter: f.like('name', 'New*', '*', '.', '!', false)
+      });
+      expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
+    });
+
+    it('creates a Not filter', function() {
+      var text =
+          '<wfs:Query xmlns:wfs="http://www.opengis.net/wfs" ' +
+          '    typeName="topp:states" srsName="urn:ogc:def:crs:EPSG::4326" ' +
+          '    xmlns:topp="http://www.openplans.org/topp">' +
+          '  <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">' +
+          '    <ogc:Not>' +
+          '      <ogc:PropertyIsEqualTo>' +
+          '        <ogc:PropertyName>name</ogc:PropertyName>' +
+          '        <ogc:Literal>New York</ogc:Literal>' +
+          '      </ogc:PropertyIsEqualTo>' +
+          '    </ogc:Not>' +
+          '  </ogc:Filter>' +
+          '</wfs:Query>';
+      var f = ol.format.ogc.filter;
+      var serialized = new ol.format.WFS().writeGetFeature({
+        srsName: 'urn:ogc:def:crs:EPSG::4326',
+        featureNS: 'http://www.openplans.org/topp',
+        featurePrefix: 'topp',
+        featureTypes: ['states'],
+        filter: f.not(f.equalTo('name', 'New York'))
+      });
+      expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
+    });
+
+    it('creates an AND filter', function() {
+      var text =
+          '<wfs:Query xmlns:wfs="http://www.opengis.net/wfs" ' +
+          '    typeName="topp:states" srsName="urn:ogc:def:crs:EPSG::4326" ' +
+          '    xmlns:topp="http://www.openplans.org/topp">' +
+          '  <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">' +
+          '    <ogc:And>' +
+          '      <ogc:PropertyIsEqualTo>' +
+          '        <ogc:PropertyName>name</ogc:PropertyName>' +
+          '        <ogc:Literal>New York</ogc:Literal>' +
+          '      </ogc:PropertyIsEqualTo>' +
+          '      <ogc:BBOX>' +
+          '        <ogc:PropertyName>the_geom</ogc:PropertyName>' +
+          '        <gml:Envelope xmlns:gml="http://www.opengis.net/gml" ' +
+          '            srsName="urn:ogc:def:crs:EPSG::4326">' +
+          '          <gml:lowerCorner>1 2</gml:lowerCorner>' +
+          '          <gml:upperCorner>3 4</gml:upperCorner>' +
+          '        </gml:Envelope>' +
+          '      </ogc:BBOX>' +
+          '    </ogc:And>' +
+          '  </ogc:Filter>' +
+          '</wfs:Query>';
+      var f = ol.format.ogc.filter;
+      var serialized = new ol.format.WFS().writeGetFeature({
+        srsName: 'urn:ogc:def:crs:EPSG::4326',
+        featureNS: 'http://www.openplans.org/topp',
+        featurePrefix: 'topp',
+        featureTypes: ['states'],
+        filter: f.and(
+          f.equalTo('name', 'New York'),
+          f.bbox('the_geom', [1, 2, 3, 4], 'urn:ogc:def:crs:EPSG::4326')
+        )
       });
       expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
     });


### PR DESCRIPTION
 [ol.format.WFS#writeGetFeature](http://openlayers.org/en/master/apidoc/ol.format.WFS.html#writeGetFeature) currently only allows to set a bbox filter, this PR proposes to add a `filter` option which supports a sub-set of the OGC filters.

Example:
```javascript
var request = new ol.format.WFS().writeGetFeature({
  ...
  filter: ol.format.wfs.filter.equalTo('name', 'New York')
});
```
Or:
```javascript
var f = ol.format.wfs.filter;
var request = new ol.format.WFS().writeGetFeature({
  ...
  filter: f.or(f.equalTo('name', 'New York'), f.equalTo('area', 1234))
});
```

The following filters are currently supported:

* Not/And/Or
* PropertyIsEqualTo/PropertyIsNotEqualTo
* PropertyIsLessThan/PropertyIsLessThanOrEqualTo
* PropertyIsGreaterThan/PropertyIsGreaterThanOrEqualTo
* PropertyIsLike
* PropertyIsNull
* PropertyIsBetween
* BBOX