### PR TITLE
No special treatment for unmanaged layers in forEachFeatureAtPixel

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -1,5 +1,9 @@
 ## Upgrade notes
 
+#### Map forEachFeatureAtPixel callback changes
+
+Previously, unmanaged layers (i.e. layers that were not configured as `layers` array/collection on the map or added with `ol.Map#addLayer()`), were reported as `null` in the `ol.Map#forEachFeatureAtPixel()` callback. Now, they are reported like regular layers.
+
 ### v3.15.0
 
 #### Internet Explorer 9 support

--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -280,6 +280,7 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
     // Replace the currently selected feature(s) with the feature(s) at the
     // pixel, or clear the selected feature(s) if there is no feature at
     // the pixel.
+    ol.object.clear(this.featureLayerAssociation_);
     map.forEachFeatureAtPixel(mapBrowserEvent.pixel,
         /**
          * @param {ol.Feature|ol.render.Feature} feature Feature.
@@ -303,16 +304,6 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
         features.clear();
       }
       features.extend(selected);
-      // Modify object this.featureLayerAssociation_
-      if (selected.length === 0) {
-        ol.object.clear(this.featureLayerAssociation_);
-      } else {
-        if (deselected.length > 0) {
-          deselected.forEach(function(feature) {
-            this.removeFeatureLayerAssociation_(feature);
-          }, this);
-        }
-      }
     }
   } else {
     // Modify the currently selected feature(s).

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -601,9 +601,8 @@ ol.Map.prototype.disposeInternal = function() {
  *     called with two arguments. The first argument is one
  *     {@link ol.Feature feature} or
  *     {@link ol.render.Feature render feature} at the pixel, the second is
- *     the {@link ol.layer.Layer layer} of the feature and will be null for
- *     unmanaged layers. To stop detection, callback functions can return a
- *     truthy value.
+ *     the {@link ol.layer.Layer layer} of the feature. To stop detection,
+ *     callback functions can return a truthy value.
  * @param {S=} opt_this Value to use as `this` when executing `callback`.
  * @param {(function(this: U, ol.layer.Layer): boolean)=} opt_layerFilter Layer
  *     filter function. The filter function will receive one argument, the

--- a/src/ol/renderer/maprenderer.js
+++ b/src/ol/renderer/maprenderer.js
@@ -136,11 +136,7 @@ ol.renderer.Map.prototype.forEachFeatureAtCoordinate = function(coordinate, fram
    */
   function forEachFeatureAtCoordinate(feature, layer) {
     goog.asserts.assert(feature !== undefined, 'received a feature');
-    var key = goog.getUid(feature).toString();
-    var managed = frameState.layerStates[goog.getUid(layer)].managed;
-    if (!(key in frameState.skippedFeatureUids && !managed)) {
-      return callback.call(thisArg, feature, managed ? layer : null);
-    }
+    return callback.call(thisArg, feature, layer);
   }
 
   var projection = viewState.projection;

--- a/test/spec/ol/interaction/selectinteraction.test.js
+++ b/test/spec/ol/interaction/selectinteraction.test.js
@@ -181,6 +181,16 @@ describe('ol.interaction.Select', function() {
 
       var features = select.getFeatures();
       expect(features.getLength()).to.equal(4);
+      expect(select.getLayer(features.item(0))).to.equal(layer);
+
+      // Select again to make sure the internal layer isn't reported
+      simulateEvent(ol.MapBrowserEvent.EventType.SINGLECLICK, 10, -20);
+
+      expect(listenerSpy.callCount).to.be(2);
+
+      features = select.getFeatures();
+      expect(features.getLength()).to.equal(4);
+      expect(select.getLayer(features.item(0))).to.equal(layer);
     });
   });
 
@@ -311,6 +321,8 @@ describe('ol.interaction.Select', function() {
       });
       interaction.on('select', listenerSpy);
 
+      simulateEvent(ol.MapBrowserEvent.EventType.SINGLECLICK, 10, -20);
+      // Select again to make sure that the internal layer doesn't get reported.
       simulateEvent(ol.MapBrowserEvent.EventType.SINGLECLICK, 10, -20);
     });
   });

--- a/test/spec/ol/renderer/canvas/canvasmaprenderer.test.js
+++ b/test/spec/ol/renderer/canvas/canvasmaprenderer.test.js
@@ -64,7 +64,7 @@ describe('ol.renderer.canvas.Map', function() {
       expect(cb.firstCall.args[1]).to.be(layer);
     });
 
-    it('also calls callback with main layer when skipped feature on unmanaged layer', function() {
+    it('also calls callback with original layer when skipped feature on unmanaged layer', function() {
       var feature = layer.getSource().getFeatures()[0];
       var managedLayer = new ol.layer.Vector({
         source: new ol.source.Vector({
@@ -77,6 +77,7 @@ describe('ol.renderer.canvas.Map', function() {
       map.renderSync();
       var cb = sinon.spy();
       map.forEachFeatureAtPixel(map.getPixelFromCoordinate([0, 0]), cb);
+      expect(cb.callCount).to.be(2);
       expect(cb.firstCall.args[1]).to.be(layer);
       expect(cb.lastCall.args[1]).to.be(managedLayer);
     });

--- a/test/spec/ol/renderer/canvas/canvasmaprenderer.test.js
+++ b/test/spec/ol/renderer/canvas/canvasmaprenderer.test.js
@@ -55,16 +55,16 @@ describe('ol.renderer.canvas.Map', function() {
       expect(cb.firstCall.args[1]).to.be(layer);
     });
 
-    it('calls callback with null for unmanaged layers', function() {
+    it('calls callback with layer for unmanaged layers', function() {
       layer.setMap(map);
       map.renderSync();
       var cb = sinon.spy();
       map.forEachFeatureAtPixel(map.getPixelFromCoordinate([0, 0]), cb);
       expect(cb).to.be.called();
-      expect(cb.firstCall.args[1]).to.be(null);
+      expect(cb.firstCall.args[1]).to.be(layer);
     });
 
-    it('calls callback with main layer when skipped feature on unmanaged layer', function() {
+    it('also calls callback with main layer when skipped feature on unmanaged layer', function() {
       var feature = layer.getSource().getFeatures()[0];
       var managedLayer = new ol.layer.Vector({
         source: new ol.source.Vector({
@@ -77,8 +77,8 @@ describe('ol.renderer.canvas.Map', function() {
       map.renderSync();
       var cb = sinon.spy();
       map.forEachFeatureAtPixel(map.getPixelFromCoordinate([0, 0]), cb);
-      expect(cb.callCount).to.be(1);
-      expect(cb.firstCall.args[1]).to.be(managedLayer);
+      expect(cb.firstCall.args[1]).to.be(layer);
+      expect(cb.lastCall.args[1]).to.be(managedLayer);
     });
 
     it('filters managed layers', function() {


### PR DESCRIPTION
This pull request simplifies things, but changes the behaviour of `ol.Map#forEachFeatureAtPixel`. It also fixes #5219.

Since this is another one of [those changes](http://ahocevar.net/openlayers/2016/02/17/trilogy-of-error.html), I won't blame anyone if this doesn't pass the review phase.