### PR TITLE
Add readFeatures and readProjection as MVT experimental API

### DIFF
--- a/src/ol/format/mvtformat.js
+++ b/src/ol/format/mvtformat.js
@@ -147,6 +147,7 @@ ol.format.MVT.prototype.readRenderFeature_ = function(rawFeature, layer) {
 
 /**
  * @inheritDoc
+ * @api
  */
 ol.format.MVT.prototype.readFeatures = function(source, opt_options) {
   goog.asserts.assertInstanceof(source, ArrayBuffer);
@@ -180,6 +181,7 @@ ol.format.MVT.prototype.readFeatures = function(source, opt_options) {
 
 /**
  * @inheritDoc
+ * @api
  */
 ol.format.MVT.prototype.readProjection = function(source) {
   return this.defaultDataProjection;


### PR DESCRIPTION
My motivation to have these exposed are that they are needed if you want to implement a custom tileLoadFunction.