### PR TITLE
Skip unnecessary render functions

### DIFF
--- a/src/ol/renderer/canvas/canvasvectortilelayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectortilelayerrenderer.js
@@ -76,8 +76,13 @@ ol.renderer.canvas.VectorTileLayer.prototype.composeFrame = function(
     frameState, layerState, context) {
   var transform = this.getTransform(frameState, 0);
   this.dispatchPreComposeEvent(context, frameState, transform);
-  this.renderTileImages(context, frameState, layerState);
-  this.renderTileReplays_(context, frameState, layerState);
+  var renderMode = this.getLayer().getRenderMode();
+  if (renderMode !== ol.layer.VectorTileRenderType.VECTOR) {
+    this.renderTileImages(context, frameState, layerState);
+  }
+  if (renderMode !== ol.layer.VectorTileRenderType.IMAGE) {
+    this.renderTileReplays_(context, frameState, layerState);
+  }
   this.dispatchPostComposeEvent(context, frameState, transform);
 };
 
@@ -93,9 +98,6 @@ ol.renderer.canvas.VectorTileLayer.prototype.renderTileReplays_ = function(
 
   var layer = this.getLayer();
   var replays = ol.renderer.canvas.VECTOR_REPLAYS[layer.getRenderMode()];
-  if (!replays) {
-    return;
-  }
   var pixelRatio = frameState.pixelRatio;
   var skippedFeatureUids = layerState.managed ?
       frameState.skippedFeatureUids : {};

--- a/test/spec/ol/renderer/canvas/canvasvectortilelayerrenderer.test.js
+++ b/test/spec/ol/renderer/canvas/canvasvectortilelayerrenderer.test.js
@@ -66,8 +66,23 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
     it('uses lower resolution for pure vector rendering', function() {
       layer.renderMode_ = 'vector';
       var renderer = new ol.renderer.canvas.VectorTileLayer(layer);
-      expect(renderer).to.be.a(ol.renderer.canvas.VectorTileLayer);
       expect(renderer.zDirection).to.be(1);
+    });
+
+    it('does not render images for pure vector rendering', function() {
+      layer.renderMode_ = 'vector';
+      var renderer = new ol.renderer.canvas.VectorTileLayer(layer);
+      var spy = sinon.spy(renderer, 'renderTileImages');
+      map.renderSync();
+      expect(spy.callCount).to.be(0);
+    });
+
+    it('does not render replays for pure image rendering', function() {
+      layer.renderMode_ = 'image';
+      var renderer = new ol.renderer.canvas.VectorTileLayer(layer);
+      var spy = sinon.spy(renderer, 'renderTileReplays_');
+      map.renderSync();
+      expect(spy.callCount).to.be(0);
     });
 
     it('gives precedence to feature styles over layer styles', function() {


### PR DESCRIPTION
This fixes an issue introduced by c5f81a57067f4c180f0821c3dcb7f948d4a1f11c in #5177. @tsauerwein, I knew there was a reason for the if condition, but couldn't remember it. I think with the way I have implemented it now, it is much clearer.