### PR TITLE
Get raster sources working again

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -1329,8 +1329,7 @@ ol.Map.prototype.renderFrame_ = function(time) {
     preRenderFunctions.length = n;
 
     frameState.extent = ol.extent.getForViewAndSize(viewState.center,
-        viewState.resolution, viewState.rotation, frameState.size,
-        this.frameState_ ? this.frameState_.extent : undefined);
+        viewState.resolution, viewState.rotation, frameState.size);
   }
 
   this.frameState_ = frameState;


### PR DESCRIPTION
This reverts 8e1ffbf91e4430e1ad15d1f035f70b447a549c7d

We should take a bit more time with this, but this is required to get raster sources working again.