### PR TITLE
Remove unused ol.TileCoordTransformType

### DIFF
--- a/src/ol/tileurlfunction.js
+++ b/src/ol/tileurlfunction.js
@@ -25,13 +25,6 @@ ol.TileUrlFunctionType;
 
 
 /**
- * @typedef {function(ol.TileCoord, ol.proj.Projection, ol.TileCoord=):
- *     ol.TileCoord}
- */
-ol.TileCoordTransformType;
-
-
-/**
  * @param {string} template Template.
  * @param {ol.tilegrid.TileGrid} tileGrid Tile grid.
  * @return {ol.TileUrlFunctionType} Tile URL function.


### PR DESCRIPTION
I noticed whilst investigating typedefs that this one is not api and isn't used anywhere else in the library. Any reason for keeping it?