### PR TITLE
Remove outdated fixme from framestate.js

### DIFF
--- a/src/ol/framestate.js
+++ b/src/ol/framestate.js
@@ -1,5 +1,3 @@
-// FIXME factor out common code between usedTiles and wantedTiles
-
 goog.provide('ol.PostRenderFunction');
 goog.provide('ol.PreRenderFunction');
 


### PR DESCRIPTION
AFAICS the vars referred to here don't exist anywhere in the code, so I assume this fixme is left over from some previous version of the code.