### PR TITLE
Use Node 6 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: node_js
 
 node_js:
-  - "4"
+  - "6"
 
 cache:
   directories:


### PR DESCRIPTION
If we continue using Node 4 on Travis, we should upgrade to `npm@3`.  I wanted to check first if all would pass with Node 6.