### PR TITLE
Load the examples resources with HTTPS

### DIFF
--- a/config/examples/example.html
+++ b/config/examples/example.html
@@ -61,7 +61,7 @@
           <a id="copy-button"><i class="fa fa-clipboard"></i> Copy</a>
           <a id="jsfiddle-button"><i class="fa fa-jsfiddle"></i> Edit</a>
         </div>
-        <form method="POST" id="jsfiddle-form" target="_blank" action="http://jsfiddle.net/api/post/library/pure/">
+        <form method="POST" id="jsfiddle-form" target="_blank" action="https://jsfiddle.net/api/post/library/pure/">
           <textarea class="hidden" name="js">{{ js.source }}</textarea>
           <textarea class="hidden" name="css">{{ css.source }}</textarea>
           <textarea class="hidden" name="html">{{ contents }}</textarea>

--- a/config/jsdoc/api/template/static/styles/jaguar.css
+++ b/config/jsdoc/api/template/static/styles/jaguar.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Quattrocento+Sans:400,400italic,700);
+@import url(https://fonts.googleapis.com/css?family=Quattrocento+Sans:400,400italic,700);
 .navbar-inverse {
   border: 0;
 }

--- a/examples/custom-icon.js
+++ b/examples/custom-icon.js
@@ -8,7 +8,7 @@ logoElement.href = 'http://www.osgeo.org/';
 logoElement.target = '_blank';
 
 var logoImage = document.createElement('img');
-logoImage.src = 'http://www.osgeo.org/sites/all/themes/osgeo/logo.png';
+logoImage.src = 'https://www.osgeo.org/sites/all/themes/osgeo/logo.png';
 
 logoElement.appendChild(logoImage);
 

--- a/examples/custom-interactions.js
+++ b/examples/custom-interactions.js
@@ -150,7 +150,7 @@ var map = new ol.Map({
   layers: [
     new ol.layer.Tile({
       source: new ol.source.TileJSON({
-        url: 'http://api.tiles.mapbox.com/v3/mapbox.geography-class.json'
+        url: 'https://api.tiles.mapbox.com/v3/mapbox.geography-class.json?secure'
       })
     }),
     new ol.layer.Vector({

--- a/examples/d3.html
+++ b/examples/d3.html
@@ -6,7 +6,7 @@ docs: >
   <p>The example loads TopoJSON geometries and uses d3 (<code>d3.geo.path</code>) to render these geometries to a canvas element that is then used as the image of an ol3 image layer.</p>
 tags: "d3"
 resources:
-  - http://d3js.org/d3.v3.min.js
-  - http://d3js.org/topojson.v1.min.js
+  - https://d3js.org/d3.v3.min.js
+  - https://d3js.org/topojson.v1.min.js
 ---
 <div id="map" class="map"></div>

--- a/examples/icon-color.js
+++ b/examples/icon-color.js
@@ -55,7 +55,7 @@ var vectorLayer = new ol.layer.Vector({
 
 var rasterLayer = new ol.layer.Tile({
   source: new ol.source.TileJSON({
-    url: 'http://api.tiles.mapbox.com/v3/mapbox.geography-class.json',
+    url: 'https://api.tiles.mapbox.com/v3/mapbox.geography-class.json?secure',
     crossOrigin: ''
   })
 });

--- a/examples/icon.js
+++ b/examples/icon.js
@@ -39,7 +39,7 @@ var vectorLayer = new ol.layer.Vector({
 
 var rasterLayer = new ol.layer.Tile({
   source: new ol.source.TileJSON({
-    url: 'http://api.tiles.mapbox.com/v3/mapbox.geography-class.json',
+    url: 'https://api.tiles.mapbox.com/v3/mapbox.geography-class.json?secure',
     crossOrigin: ''
   })
 });

--- a/examples/layer-extent.js
+++ b/examples/layer-extent.js
@@ -17,8 +17,7 @@ var extents = {
 
 var base = new ol.layer.Tile({
   source: new ol.source.TileJSON({
-    url: 'http://api.tiles.mapbox.com/v3/' +
-        'mapbox.world-light.json',
+    url: 'https://api.tiles.mapbox.com/v3/mapbox.world-light.json?secure',
     crossOrigin: 'anonymous'
   })
 });
@@ -26,8 +25,7 @@ var base = new ol.layer.Tile({
 var overlay = new ol.layer.Tile({
   extent: extents.India,
   source: new ol.source.TileJSON({
-    url: 'http://api.tiles.mapbox.com/v3/' +
-        'mapbox.world-black.json',
+    url: 'https://api.tiles.mapbox.com/v3/mapbox.world-black.json?secure',
     crossOrigin: 'anonymous'
   })
 });

--- a/examples/layer-group.js
+++ b/examples/layer-group.js
@@ -14,15 +14,13 @@ var map = new ol.Map({
       layers: [
         new ol.layer.Tile({
           source: new ol.source.TileJSON({
-            url: 'http://api.tiles.mapbox.com/v3/' +
-                'mapbox.20110804-hoa-foodinsecurity-3month.json',
+            url: 'https://api.tiles.mapbox.com/v3/mapbox.20110804-hoa-foodinsecurity-3month.json?secure',
             crossOrigin: 'anonymous'
           })
         }),
         new ol.layer.Tile({
           source: new ol.source.TileJSON({
-            url: 'http://api.tiles.mapbox.com/v3/' +
-                'mapbox.world-borders-light.json',
+            url: 'https://api.tiles.mapbox.com/v3/mapbox.world-borders-light.json?secure',
             crossOrigin: 'anonymous'
           })
         })

--- a/examples/mapbox-vector-tiles-advanced.js
+++ b/examples/mapbox-vector-tiles-advanced.js
@@ -31,7 +31,7 @@ for (var z = zoomOffset / reuseZoomLevels; z <= 22 / reuseZoomLevels; ++z) {
   resolutions.push(156543.03392804097 / Math.pow(2, z * reuseZoomLevels));
 }
 function tileUrlFunction(tileCoord) {
-  return ('http://{a-d}.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6/' +
+  return ('https://{a-d}.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6/' +
       '{z}/{x}/{y}.vector.pbf?access_token=' + key)
       .replace('{z}', String(tileCoord[0] * reuseZoomLevels + zoomOffset))
       .replace('{x}', String(tileCoord[1]))

--- a/examples/mapbox-vector-tiles.js
+++ b/examples/mapbox-vector-tiles.js
@@ -25,7 +25,7 @@ var map = new ol.Map({
         format: new ol.format.MVT(),
         tileGrid: ol.tilegrid.createXYZ({maxZoom: 22}),
         tilePixelRatio: 16,
-        url: 'http://{a-d}.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6/' +
+        url: 'https://{a-d}.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6/' +
             '{z}/{x}/{y}.vector.pbf?access_token=' + key
       }),
       style: createMapboxStreetsV6Style()

--- a/examples/min-max-resolution.js
+++ b/examples/min-max-resolution.js
@@ -18,8 +18,7 @@ var map = new ol.Map({
     }),
     new ol.layer.Tile({
       source: new ol.source.TileJSON({
-        url: 'http://api.tiles.mapbox.com/v3/' +
-            'mapbox.natural-earth-hypso-bathy.json',
+        url: 'https://api.tiles.mapbox.com/v3/mapbox.natural-earth-hypso-bathy.json?secure',
         crossOrigin: 'anonymous'
       }),
       minResolution: 2000,

--- a/examples/popup.js
+++ b/examples/popup.js
@@ -45,8 +45,7 @@ var map = new ol.Map({
   layers: [
     new ol.layer.Tile({
       source: new ol.source.TileJSON({
-        url: 'http://api.tiles.mapbox.com/v3/' +
-            'mapbox.natural-earth-hypso-bathy.json',
+        url: 'https://api.tiles.mapbox.com/v3/mapbox.natural-earth-hypso-bathy.json?secure',
         crossOrigin: 'anonymous'
       })
     })

--- a/examples/raster.html
+++ b/examples/raster.html
@@ -20,7 +20,7 @@ docs: >
   </p>
 tags: "raster, pixel"
 resources:
-  - http://d3js.org/d3.v3.min.js
+  - https://d3js.org/d3.v3.min.js
 cloak:
   AkGbxXx6tDWf1swIhPJyoAVp06H0s0gDTYslNWWHZ6RoPqMpB9ld5FY1WutX8UoF: Your Bing Maps Key from http://www.bingmapsportal.com/ here
 ---

--- a/examples/reprojection-by-code.html
+++ b/examples/reprojection-by-code.html
@@ -8,7 +8,7 @@ docs: >
   in <a href="http://epsg.io/">EPSG.io</a> database.
 tags: "reprojection, projection, proj4js, epsg.io"
 resources:
-  - http://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.14/proj4.js
+  - https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.14/proj4.js
 ---
 <div id="map" class="map"></div>
 <form class="form-inline">

--- a/examples/reprojection-image.html
+++ b/examples/reprojection-image.html
@@ -6,6 +6,6 @@ docs: >
   This example shows client-side reprojection of single image source.
 tags: "reprojection, projection, proj4js, image, imagestatic"
 resources:
-  - http://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.14/proj4.js
+  - https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.14/proj4.js
 ---
 <div id="map" class="map"></div>

--- a/examples/reprojection.html
+++ b/examples/reprojection.html
@@ -6,7 +6,7 @@ docs: >
   This example shows client-side raster reprojection between various projections.
 tags: "reprojection, projection, proj4js, osm, wms, wmts, hidpi"
 resources:
-  - http://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.14/proj4.js
+  - https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.14/proj4.js
 ---
 <div id="map" class="map"></div>
 <form class="form-inline">

--- a/examples/reprojection.js
+++ b/examples/reprojection.js
@@ -87,7 +87,7 @@ layers['wms21781'] = new ol.layer.Tile({
       'LAYERS': 'ch.swisstopo.pixelkarte-farbe-pk1000.noscale',
       'FORMAT': 'image/jpeg'
     },
-    url: 'http://wms.geo.admin.ch/',
+    url: 'https://wms.geo.admin.ch/',
     projection: 'EPSG:21781'
   })
 });

--- a/examples/resources/layout.css
+++ b/examples/resources/layout.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Quattrocento+Sans:400,400italic,700);
+@import url(https://fonts.googleapis.com/css?family=Quattrocento+Sans:400,400italic,700);
 
 body {
   font-family: 'Quattrocento Sans', sans-serif;

--- a/examples/scaleline-indiana-east.html
+++ b/examples/scaleline-indiana-east.html
@@ -6,6 +6,6 @@ docs: >
   This example shows client-side reprojection of OpenStreetMap to NAD83 Indiana East, including a ScaleLine control with US units.
 tags: "reprojection, projection, openstreetmap, nad83, tile, scaleline"
 resources:
-  - http://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.14/proj4.js
+  - https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.14/proj4.js
 ---
 <div id="map" class="map"></div>

--- a/examples/semi-transparent-layer.js
+++ b/examples/semi-transparent-layer.js
@@ -13,7 +13,7 @@ var map = new ol.Map({
     }),
     new ol.layer.Tile({
       source: new ol.source.TileJSON({
-        url: 'http://api.tiles.mapbox.com/v3/mapbox.va-quake-aug.json',
+        url: 'https://api.tiles.mapbox.com/v3/mapbox.va-quake-aug.json?secure',
         crossOrigin: 'anonymous'
       })
     })

--- a/examples/sphere-mollweide.html
+++ b/examples/sphere-mollweide.html
@@ -6,6 +6,6 @@ docs: >
   Example of a Sphere Mollweide map with a Graticule component.
 tags: "graticule, Mollweide, projection, proj4js"
 resources:
-  - http://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.14/proj4.js
+  - https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.14/proj4.js
 ---
 <div id="map" class="map"></div>

--- a/examples/static-image.js
+++ b/examples/static-image.js
@@ -21,7 +21,7 @@ var map = new ol.Map({
     new ol.layer.Image({
       source: new ol.source.ImageStatic({
         attributions: '© <a href="http://xkcd.com/license.html">xkcd</a>',
-        url: 'http://imgs.xkcd.com/comics/online_communities.png',
+        url: 'https://imgs.xkcd.com/comics/online_communities.png',
         projection: projection,
         imageExtent: extent
       })

--- a/examples/tile-load-events.js
+++ b/examples/tile-load-events.js
@@ -78,7 +78,7 @@ Progress.prototype.hide = function() {
 var progress = new Progress(document.getElementById('progress'));
 
 var source = new ol.source.TileJSON({
-  url: 'http://api.tiles.mapbox.com/v3/mapbox.world-bright.json',
+  url: 'https://api.tiles.mapbox.com/v3/mapbox.world-bright.json?secure',
   crossOrigin: 'anonymous'
 });
 

--- a/examples/tilejson.js
+++ b/examples/tilejson.js
@@ -8,7 +8,7 @@ var map = new ol.Map({
   layers: [
     new ol.layer.Tile({
       source: new ol.source.TileJSON({
-        url: 'http://api.tiles.mapbox.com/v3/mapbox.geography-class.json',
+        url: 'https://api.tiles.mapbox.com/v3/mapbox.geography-class.json?secure',
         crossOrigin: 'anonymous'
       })
     })

--- a/examples/tileutfgrid.js
+++ b/examples/tileutfgrid.js
@@ -9,13 +9,13 @@ var key = 'pk.eyJ1IjoiYWhvY2V2YXIiLCJhIjoiRk1kMWZaSSJ9.E5BkluenyWQMsBLsuByrmg';
 
 var mapLayer = new ol.layer.Tile({
   source: new ol.source.TileJSON({
-    url: 'http://api.tiles.mapbox.com/v4/mapbox.geography-class.json?access_token=' + key
+    url: 'https://api.tiles.mapbox.com/v4/mapbox.geography-class.json?secure&access_token=' + key
   })
 });
 
 
 var gridSource = new ol.source.TileUTFGrid({
-  url: 'http://api.tiles.mapbox.com/v4/mapbox.geography-class.json?access_token=' + key
+  url: 'https://api.tiles.mapbox.com/v4/mapbox.geography-class.json?secure&access_token=' + key
 });
 
 var gridLayer = new ol.layer.Tile({source: gridSource});

--- a/examples/topojson.js
+++ b/examples/topojson.js
@@ -12,7 +12,7 @@ goog.require('ol.style.Style');
 
 var raster = new ol.layer.Tile({
   source: new ol.source.TileJSON({
-    url: 'http://api.tiles.mapbox.com/v3/mapbox.world-dark.json'
+    url: 'https://api.tiles.mapbox.com/v3/mapbox.world-dark.json?secure'
   })
 });
 

--- a/examples/vector-esri-edit.js
+++ b/examples/vector-esri-edit.js
@@ -57,7 +57,7 @@ var raster = new ol.layer.Tile({
   source: new ol.source.XYZ({
     attributions: 'Tiles © <a href="http://services.arcgisonline.com/ArcGIS/' +
         'rest/services/World_Topo_Map/MapServer">ArcGIS</a>',
-    url: 'http://server.arcgisonline.com/ArcGIS/rest/services/' +
+    url: 'https://server.arcgisonline.com/ArcGIS/rest/services/' +
         'World_Topo_Map/MapServer/tile/{z}/{y}/{x}'
   })
 });

--- a/examples/vector-esri.js
+++ b/examples/vector-esri.js
@@ -99,7 +99,7 @@ var raster = new ol.layer.Tile({
   source: new ol.source.XYZ({
     attributions: 'Tiles © <a href="http://services.arcgisonline.com/ArcGIS/' +
         'rest/services/World_Topo_Map/MapServer">ArcGIS</a>',
-    url: 'http://server.arcgisonline.com/ArcGIS/rest/services/' +
+    url: 'https://server.arcgisonline.com/ArcGIS/rest/services/' +
         'World_Topo_Map/MapServer/tile/{z}/{y}/{x}'
   })
 });

--- a/examples/wms-custom-proj.js
+++ b/examples/wms-custom-proj.js
@@ -45,7 +45,7 @@ var layers = [
   new ol.layer.Tile({
     extent: extent,
     source: new ol.source.TileWMS({
-      url: 'http://wms.geo.admin.ch/',
+      url: 'https://wms.geo.admin.ch/',
       crossOrigin: 'anonymous',
       attributions: '© <a href="http://www.geo.admin.ch/internet/geoportal/' +
           'en/home.html">Pixelmap 1:1000000 / geo.admin.ch</a>',
@@ -59,7 +59,7 @@ var layers = [
   new ol.layer.Tile({
     extent: extent,
     source: new ol.source.TileWMS({
-      url: 'http://wms.geo.admin.ch/',
+      url: 'https://wms.geo.admin.ch/',
       crossOrigin: 'anonymous',
       attributions: '© <a href="http://www.geo.admin.ch/internet/geoportal/' +
           'en/home.html">National parks / geo.admin.ch</a>',

--- a/examples/wms-image-custom-proj.html
+++ b/examples/wms-image-custom-proj.html
@@ -6,7 +6,7 @@ docs: >
   With [Proj4js](http://proj4js.org/) integration, OpenLayers can transform coordinates between arbitrary projections.
 tags: "wms, single image, proj4js, projection"
 resources:
-  - http://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.14/proj4.js
-  - http://epsg.io/21781-1753.js
+  - https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.14/proj4.js
+  - https://epsg.io/21781-1753.js
 ---
 <div id="map" class="map"></div>

--- a/examples/wms-image-custom-proj.js
+++ b/examples/wms-image-custom-proj.js
@@ -33,7 +33,7 @@ var layers = [
   new ol.layer.Image({
     extent: extent,
     source: new ol.source.ImageWMS({
-      url: 'http://wms.geo.admin.ch/',
+      url: 'https://wms.geo.admin.ch/',
       crossOrigin: 'anonymous',
       attributions: '© <a href="http://www.geo.admin.ch/internet/geoportal/' +
           'en/home.html">Pixelmap 1:1000000 / geo.admin.ch</a>',
@@ -47,7 +47,7 @@ var layers = [
   new ol.layer.Image({
     extent: extent,
     source: new ol.source.ImageWMS({
-      url: 'http://wms.geo.admin.ch/',
+      url: 'https://wms.geo.admin.ch/',
       crossOrigin: 'anonymous',
       attributions: '© <a href="http://www.geo.admin.ch/internet/geoportal/' +
           'en/home.html">National parks / geo.admin.ch</a>',

--- a/examples/wms-no-proj.js
+++ b/examples/wms-no-proj.js
@@ -17,7 +17,7 @@ var layers = [
         'LAYERS': 'ch.swisstopo.pixelkarte-farbe-pk1000.noscale',
         'FORMAT': 'image/jpeg'
       },
-      url: 'http://wms.geo.admin.ch/'
+      url: 'https://wms.geo.admin.ch/'
     })
   }),
   new ol.layer.Image({
@@ -27,7 +27,7 @@ var layers = [
       crossOrigin: 'anonymous',
       params: {'LAYERS': 'ch.bafu.schutzgebiete-paerke_nationaler_bedeutung'},
       serverType: 'mapserver',
-      url: 'http://wms.geo.admin.ch/'
+      url: 'https://wms.geo.admin.ch/'
     })
   })
 ];

--- a/examples/wmts-hidpi.js
+++ b/examples/wmts-hidpi.js
@@ -6,7 +6,7 @@ goog.require('ol.layer.Tile');
 goog.require('ol.source.WMTS');
 
 
-var capabilitiesUrl = 'http://www.basemap.at/wmts/1.0.0/WMTSCapabilities.xml';
+var capabilitiesUrl = 'https://www.basemap.at/wmts/1.0.0/WMTSCapabilities.xml';
 
 // HiDPI support:
 // * Use 'bmaphidpi' layer (pixel ratio 2) for device pixel ratio > 1

--- a/examples/wmts-ign.js
+++ b/examples/wmts-ign.js
@@ -43,7 +43,7 @@ var tileGrid = new ol.tilegrid.WMTS({
 var key = '2mqbg0z6cx7ube8gsou10nrt';
 
 var ign_source = new ol.source.WMTS({
-  url: 'http://wxs.ign.fr/' + key + '/wmts',
+  url: 'https://wxs.ign.fr/' + key + '/wmts',
   layer: 'GEOGRAPHICALGRIDSYSTEMS.MAPS',
   matrixSet: 'PM',
   format: 'image/jpeg',

--- a/examples/wmts.js
+++ b/examples/wmts.js
@@ -31,7 +31,7 @@ var map = new ol.Map({
       source: new ol.source.WMTS({
         attributions: 'Tiles © <a href="http://services.arcgisonline.com/arcgis/rest/' +
             'services/Demographics/USA_Population_Density/MapServer/">ArcGIS</a>',
-        url: 'http://services.arcgisonline.com/arcgis/rest/' +
+        url: 'https://services.arcgisonline.com/arcgis/rest/' +
             'services/Demographics/USA_Population_Density/MapServer/WMTS/',
         layer: '0',
         matrixSet: 'EPSG:3857',

--- a/examples/xyz-esri.js
+++ b/examples/xyz-esri.js
@@ -17,7 +17,7 @@ var map = new ol.Map({
     new ol.layer.Tile({
       source: new ol.source.XYZ({
         attributions: [attribution],
-        url: 'http://server.arcgisonline.com/ArcGIS/rest/services/' +
+        url: 'https://server.arcgisonline.com/ArcGIS/rest/services/' +
             'World_Topo_Map/MapServer/tile/{z}/{y}/{x}'
       })
     })


### PR DESCRIPTION
If available, load the examples resources with HTTPS instead of HTTP.

Some domains doesn't provide HTTPS:
 - demo.boundlessgeo.com
 - tile.opencyclemap.org
 - tile.openstreetmap.us
 - tiles.openseamap.org
