### PR TITLE
Handle multiple featureMember elements for different types (WFS format)

### DIFF
--- a/src/ol/format/gml/gmlbaseformat.js
+++ b/src/ol/format/gml/gmlbaseformat.js
@@ -106,13 +106,13 @@ ol.format.GMLBase.ONLY_WHITESPACE_RE_ = /^[\s\xa0]*$/;
 /**
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {Array.<ol.Feature>} Features.
+ * @return {Array.<ol.Feature> | undefined} Features.
  */
 ol.format.GMLBase.prototype.readFeaturesInternal = function(node, objectStack) {
   goog.asserts.assert(node.nodeType == goog.dom.NodeType.ELEMENT,
       'node.nodeType should be ELEMENT');
   var localName = node.localName;
-  var features;
+  var features = null;
   if (localName == 'FeatureCollection') {
     if (node.namespaceURI === 'http://www.opengis.net/wfs') {
       features = ol.xml.pushParseAndPop([],
@@ -154,8 +154,11 @@ ol.format.GMLBase.prototype.readFeaturesInternal = function(node, objectStack) {
           }
         }
       }
-      context['featureType'] = featureType;
-      context['featureNS'] = featureNS;
+      if (localName != 'featureMember') {
+        // recheck featureType for each featureMember
+        context['featureType'] = featureType;
+        context['featureNS'] = featureNS;
+      }
     }
     if (typeof featureNS === 'string') {
       var ns = featureNS;
@@ -178,9 +181,13 @@ ol.format.GMLBase.prototype.readFeaturesInternal = function(node, objectStack) {
       }
       parsersNS[featureNS[p]] = parsers;
     }
-    features = ol.xml.pushParseAndPop([], parsersNS, node, objectStack);
+    if (localName == 'featureMember') {
+      features = ol.xml.pushParseAndPop(undefined, parsersNS, node, objectStack);
+    } else {
+      features = ol.xml.pushParseAndPop([], parsersNS, node, objectStack);
+    }
   }
-  if (!features) {
+  if (features === null) {
     features = [];
   }
   return features;
@@ -628,7 +635,8 @@ ol.format.GMLBase.prototype.readFeaturesFromNode = function(node, opt_options) {
   if (opt_options) {
     ol.object.assign(options, this.getReadOptions(node, opt_options));
   }
-  return this.readFeaturesInternal(node, [options]);
+  var features = this.readFeaturesInternal(node, [options]);
+  return features || [];
 };
 
 

--- a/test/spec/ol/format/gml/multiple-typenames-mapserver.xml
+++ b/test/spec/ol/format/gml/multiple-typenames-mapserver.xml
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:wfs="http://www.opengis.net/wfs"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/WFS-basic.xsd
+                       http://mapserver.gis.umn.edu/mapserver https://server.com/mapserv?SERVICE=WFS&amp;VERSION=1.1.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=feature:information,feature:bus_stop&amp;OUTPUTFORMAT=XMLSCHEMA">
+      <gml:boundedBy>
+      	<gml:Box srsName="EPSG:21781">
+      		<gml:coordinates>539647.507960,151807.355864 540717.151197,152910.783525</gml:coordinates>
+      	</gml:Box>
+      </gml:boundedBy>
+    <gml:featureMember>
+      <ms:bus_stop fid="bus_stop.347267989">
+        <ms:osm_id>347267989</ms:osm_id>
+      </ms:bus_stop>
+    </gml:featureMember>
+    <gml:featureMember>
+      <ms:bus_stop fid="bus_stop.983813610">
+        <ms:osm_id>983813610</ms:osm_id>
+      </ms:bus_stop>
+    </gml:featureMember>
+    <gml:featureMember>
+      <ms:bus_stop fid="bus_stop.347549357">
+        <ms:osm_id>347549357</ms:osm_id>
+      </ms:bus_stop>
+    </gml:featureMember>
+    <gml:featureMember>
+      <ms:information fid="information.34751234">
+        <ms:osm_id>34751234</ms:osm_id>
+      </ms:information>
+    </gml:featureMember>
+    <gml:featureMember>
+      <ms:information fid="information.34751235">
+        <ms:osm_id>34751235</ms:osm_id>
+      </ms:information>
+    </gml:featureMember>
+</wfs:FeatureCollection>

--- a/test/spec/ol/format/wfsformat.test.js
+++ b/test/spec/ol/format/wfsformat.test.js
@@ -791,6 +791,34 @@ describe('ol.format.WFS', function() {
 
   });
 
+  describe('when parsing multiple feature types separately', function() {
+
+    var lineFeatures, polygonFeatures;
+    before(function(done) {
+      afterLoadText('spec/ol/format/gml/multiple-typenames.xml', function(xml) {
+        try {
+          lineFeatures = new ol.format.WFS({
+            featureNS: 'http://localhost:8080/official',
+            featureType: ['planet_osm_line']
+          }).readFeatures(xml);
+          polygonFeatures = new ol.format.WFS({
+            featureNS: 'http://localhost:8080/official',
+            featureType: ['planet_osm_polygon']
+          }).readFeatures(xml);
+        } catch (e) {
+          done(e);
+        }
+        done();
+      });
+    });
+
+    it('reads all features', function() {
+      expect(lineFeatures.length).to.be(3);
+      expect(polygonFeatures.length).to.be(9);
+    });
+
+  });
+
   describe('when parsing multiple feature types', function() {
 
     var features;
@@ -807,6 +835,57 @@ describe('ol.format.WFS', function() {
 
     it('reads all features with autoconfigure', function() {
       expect(features.length).to.be(12);
+    });
+
+  });
+
+  describe('when parsing multiple feature types (MapServer)', function() {
+
+    var features;
+    before(function(done) {
+      afterLoadText('spec/ol/format/gml/multiple-typenames-mapserver.xml', function(xml) {
+        try {
+          features = new ol.format.WFS().readFeatures(xml);
+        } catch (e) {
+          done(e);
+        }
+        done();
+      });
+    });
+
+    it('reads all features', function() {
+      expect(features.length).to.be(5);
+      features.forEach(function(feature) {
+        expect(feature instanceof ol.Feature).to.be(true);
+      });
+    });
+
+  });
+
+  describe('when parsing multiple feature types separately (MapServer)', function() {
+
+    var busFeatures, infoFeatures;
+    before(function(done) {
+      afterLoadText('spec/ol/format/gml/multiple-typenames-mapserver.xml', function(xml) {
+        try {
+          busFeatures = new ol.format.WFS({
+            featureNS: 'http://mapserver.gis.umn.edu/mapserver',
+            featureType: ['bus_stop']
+          }).readFeatures(xml);
+          infoFeatures = new ol.format.WFS({
+            featureNS: 'http://mapserver.gis.umn.edu/mapserver',
+            featureType: ['information']
+          }).readFeatures(xml);
+        } catch (e) {
+          done(e);
+        }
+        done();
+      });
+    });
+
+    it('reads all features', function() {
+      expect(busFeatures.length).to.be(3);
+      expect(infoFeatures.length).to.be(2);
     });
 
   });


### PR DESCRIPTION
Parsing a GML document with multiple `featureMember` elements for different types was not handled correctly. `parseFeatures` for example returned `[ol.Feature, ol.Feature, ol.Feature, Array[0], Array[0]]`. The proposed fix makes sure that the returned array only contains valid features.

Closes https://github.com/openlayers/ol3/issues/5357

