### PR TITLE
format/igc: Remove duplicate regex exec() call

### DIFF
--- a/src/ol/format/igcformat.js
+++ b/src/ol/format/igcformat.js
@@ -172,7 +172,6 @@ ol.format.IGC.prototype.readFeatureFromText = function(text, opt_options) {
         m = ol.format.IGC.H_RECORD_RE_.exec(line);
         if (m) {
           properties[m[1]] = m[2].trim();
-          m = ol.format.IGC.HFDTE_RECORD_RE_.exec(line);
         }
       }
     }


### PR DESCRIPTION
HFDTE_RECORD_RE_.exec(line) has already been called above