### PR TITLE
Fix icon example to anchor popup to feature location

### DIFF
--- a/examples/icon.js
+++ b/examples/icon.js
@@ -59,7 +59,8 @@ var element = document.getElementById('popup');
 var popup = new ol.Overlay({
   element: element,
   positioning: 'bottom-center',
-  stopEvent: false
+  stopEvent: false,
+  offset: [0, -50]
 });
 map.addOverlay(popup);
 
@@ -70,7 +71,8 @@ map.on('click', function(evt) {
         return feature;
       });
   if (feature) {
-    popup.setPosition(evt.coordinate);
+    var coordinates = feature.getGeometry().getCoordinates();
+    popup.setPosition(coordinates);
     $(element).popover({
       'placement': 'top',
       'html': true,


### PR DESCRIPTION
In the  [icon example](http://openlayers.org/en/latest/examples/icon.html), the icon popup is anchored to the coordinates of the mouse click. This meant that if you zoomed in after clicking, the popup would not be in the correct location (demonstrated below).

![screen shot 2016-06-02 at 3 25 14 pm](https://cloud.githubusercontent.com/assets/410285/15758184/575e1b6a-28d7-11e6-91a1-341f664f7c3f.png)

This PR fixes the example by anchoring to the feature location instead of the click location, and adding an offset to the overlay.