### PR TITLE
Document typedefs and enums used by API symbols

### DIFF
--- a/config/jsdoc/api/plugins/api.js
+++ b/config/jsdoc/api/plugins/api.js
@@ -78,8 +78,10 @@ function includeAugments(doclet) {
 
 function extractTypes(item) {
   item.type.names.forEach(function(type) {
-    types[type] = true;
-    //TODO handle Array.<type> etc.
+    var match = type.match(/^(.*<)?([^>]*)>?$/);
+    if (match) {
+      types[match[2]] = true;
+    }
   });
 }
 

--- a/config/jsdoc/api/plugins/api.js
+++ b/config/jsdoc/api/plugins/api.js
@@ -105,6 +105,9 @@ exports.handlers = {
     var doclet = e.doclet;
     // Keep track of api items - needed in parseComplete to determine classes
     // with api members.
+    if (doclet.meta.filename == 'olx.js' && doclet.kind == 'typedef') {
+      doclet.undocumented = false;
+    }
     if (doclet.stability) {
       api.push(doclet);
     }
@@ -145,7 +148,7 @@ exports.handlers = {
         // constructor from the docs.
         doclet._hideConstructor = true;
         includeAugments(doclet);
-      } else if (!doclet._hideConstructor && !(doclet.kind == 'typedef' && doclet.longname in types)) {
+      } else if (doclet.undocumented !== false && !doclet._hideConstructor && !(doclet.kind == 'typedef' && doclet.longname in types)) {
         // Remove all other undocumented symbols
         doclet.undocumented = true;
       }

--- a/config/jsdoc/api/plugins/typedefs.js
+++ b/config/jsdoc/api/plugins/typedefs.js
@@ -89,10 +89,6 @@ exports.handlers = {
   newDoclet: function(e) {
     var doclet = e.doclet;
     if (doclet.meta.filename == 'olx.js') {
-      // do nothing if not marked @api
-      if (!doclet.stability) {
-        return;
-      }
       if (doclet.kind == 'typedef') {
         lastOlxTypedef = doclet;
         olxTypeNames.push(doclet.longname);

--- a/config/jsdoc/api/template/tmpl/navigation.tmpl
+++ b/config/jsdoc/api/template/tmpl/navigation.tmpl
@@ -39,7 +39,7 @@ var self = this;
             <?js
                 item.typedefs.forEach(function (v) {
             ?>
-                <li data-name="<?js= v.longname ?>" class="<?js= v.stability !== 'stable' ? 'unstable' : ''?>">
+                <li data-name="<?js= v.longname ?>" class="<?js= (v.stability && v.stability !== 'stable') ? 'unstable' : ''?>">
                     <?js= self.linkto(v.longname, v.name) ?>
                 </li>
             <?js
@@ -56,7 +56,7 @@ var self = this;
 
                 item.methods.forEach(function (v) {
             ?>
-                <li data-name="<?js= v.longname ?>" class="<?js= v.stability !== 'stable' ? 'unstable' : ''?>">
+                <li data-name="<?js= v.longname ?>" class="<?js= (v.stability && v.stability !== 'stable') ? 'unstable' : ''?>">
                     <?js= self.linkto(v.longname, v.name) ?>
                 </li>
             <?js
@@ -73,7 +73,7 @@ var self = this;
                 item.fires.forEach(function (v) {
                     v = self.find({longname: v})[0] || {longname: v, name: v.split(/#?event:/)[1]};
             ?>
-                <li data-name="<?js= v.longname ?>" class="<?js= (v.stability != 'stable' ? 'unstable' : '') ?>">
+                <li data-name="<?js= v.longname ?>" class="<?js= (v.stability && v.stability != 'stable') ? 'unstable' : '' ?>">
                     <?js= self.linkto(v.longname, v.name) ?>
                 </li>
             <?js

--- a/config/jsdoc/api/template/tmpl/observables.tmpl
+++ b/config/jsdoc/api/template/tmpl/observables.tmpl
@@ -21,7 +21,7 @@
         var setter = prop.readonly ? 'no' : 'yes';
   ?>
 
-    <tr class="<?js= prop.stability !== 'stable' ? 'unstable' : '' ?>">
+    <tr class="<?js= (prop.stability && prop.stability !== 'stable') ? 'unstable' : '' ?>">
       <td class="name"><code><?js= prop.name ?></code></td>
       <td class="type">
       <?js if (prop.type && prop.type.names) {?>

--- a/config/jsdoc/api/template/tmpl/stability.tmpl
+++ b/config/jsdoc/api/template/tmpl/stability.tmpl
@@ -2,6 +2,6 @@
 var data = obj;
 var self = this;
 
-if (data.stability != 'stable') { ?>
+if (data.stability && data.stability != 'stable') { ?>
 <span class="stability <?js= data.stability ?>"><?js= data.stability ?></span>
 <?js } ?>

--- a/config/jsdoc/api/template/tmpl/tutorial.tmpl
+++ b/config/jsdoc/api/template/tmpl/tutorial.tmpl
@@ -1,5 +1,5 @@
 <section>
-    
+
 <header>
     <?js if (children.length > 0) { ?>
     <ul><?js
@@ -10,10 +10,10 @@
     <?js } ?>
 
     <h2><?js= header ?></h2>
-</header>  
+</header>
 
 <article>
     <?js= content ?>
 </article>
 
-</section>  
+</section>

--- a/examples/color-manipulation.js
+++ b/examples/color-manipulation.js
@@ -22,8 +22,8 @@ var twoPi = 2 * Math.PI;
 
 /**
  * Convert an RGB pixel into an HCL pixel.
- * @param {ol.raster.Pixel} pixel A pixel in RGB space.
- * @return {ol.raster.Pixel} A pixel in HCL space.
+ * @param {Array.<number>} pixel A pixel in RGB space.
+ * @return {Array.<number>} A pixel in HCL space.
  */
 function rgb2hcl(pixel) {
   var red = rgb2xyz(pixel[0]);
@@ -57,8 +57,8 @@ function rgb2hcl(pixel) {
 
 /**
  * Convert an HCL pixel into an RGB pixel.
- * @param {ol.raster.Pixel} pixel A pixel in HCL space.
- * @return {ol.raster.Pixel} A pixel in RGB space.
+ * @param {Array.<number>} pixel A pixel in HCL space.
+ * @return {Array.<number>} A pixel in RGB space.
  */
 function hcl2rgb(pixel) {
   var h = pixel[0];

--- a/examples/raster.js
+++ b/examples/raster.js
@@ -15,7 +15,7 @@ var bins = 10;
 /**
  * Calculate the Vegetation Greenness Index (VGI) from an input pixel.  This
  * is a rough estimate assuming that pixel values correspond to reflectance.
- * @param {ol.raster.Pixel} pixel An array of [R, G, B, A] values.
+ * @param {Array.<number>} pixel An array of [R, G, B, A] values.
  * @return {number} The VGI value for the given pixel.
  */
 function vgi(pixel) {

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -11,7 +11,6 @@ var olx;
 /**
  * @typedef {{html: string,
  *     tileRanges: (Object.<string, Array.<ol.TileRange>>|undefined)}}
- * @api
  */
 olx.AttributionOptions;
 
@@ -26,7 +25,6 @@ olx.AttributionOptions.prototype.html;
 
 /**
  * @typedef {{tracking: (boolean|undefined)}}
- * @api
  */
 olx.DeviceOrientationOptions;
 
@@ -43,7 +41,6 @@ olx.DeviceOrientationOptions.prototype.tracking;
  * @typedef {{tracking: (boolean|undefined),
  *     trackingOptions: (GeolocationPositionOptions|undefined),
  *     projection: ol.proj.ProjectionLike}}
- * @api
  */
 olx.GeolocationOptions;
 
@@ -76,7 +73,6 @@ olx.GeolocationOptions.prototype.projection;
 /**
  * Object literal with config options for the map logo.
  * @typedef {{href: (string), src: (string)}}
- * @api
  */
 olx.LogoOptions;
 
@@ -102,7 +98,6 @@ olx.LogoOptions.prototype.src;
  *     maxLines: (number|undefined),
  *     strokeStyle: (ol.style.Stroke|undefined),
  *     targetSize: (number|undefined)}}
- * @api
  */
 olx.GraticuleOptions;
 
@@ -150,7 +145,6 @@ olx.GraticuleOptions.prototype.targetSize;
 /**
  * Object literal with config options for interactions.
  * @typedef {{handleEvent: function(ol.MapBrowserEvent):boolean}}
- * @api
  */
 olx.interaction.InteractionOptions;
 
@@ -180,7 +174,6 @@ olx.interaction.InteractionOptions.prototype.handleEvent;
  *     renderer: (ol.RendererType|Array.<ol.RendererType|string>|string|undefined),
  *     target: (Element|string|undefined),
  *     view: (ol.View|undefined)}}
- * @api
  */
 olx.MapOptions;
 
@@ -321,7 +314,6 @@ olx.MapOptions.prototype.view;
  *     autoPan: (boolean|undefined),
  *     autoPanAnimation: (olx.animation.PanOptions|undefined),
  *     autoPanMargin: (number|undefined)}}
- * @api stable
  */
 olx.OverlayOptions;
 
@@ -434,7 +426,6 @@ olx.OverlayOptions.prototype.autoPanMargin;
  *     metersPerUnit: (number|undefined),
  *     worldExtent: (ol.Extent|undefined),
  *     getPointResolution: (function(number, ol.Coordinate):number|undefined) }}
- * @api
  */
 olx.ProjectionOptions;
 
@@ -522,7 +513,6 @@ olx.ProjectionOptions.prototype.getPointResolution;
  *     rotation: (number|undefined),
  *     zoom: (number|undefined),
  *     zoomFactor: (number|undefined)}}
- * @api
  */
 olx.ViewOptions;
 
@@ -683,7 +673,6 @@ olx.animation;
  *     start: (number|undefined),
  *     duration: (number|undefined),
  *     easing: (function(number):number|undefined)}}
- * @api
  */
 olx.animation.BounceOptions;
 
@@ -727,7 +716,6 @@ olx.animation.BounceOptions.prototype.easing;
  *     start: (number|undefined),
  *     duration: (number|undefined),
  *     easing: (function(number):number|undefined)}}
- * @api
  */
 olx.animation.PanOptions;
 
@@ -771,7 +759,6 @@ olx.animation.PanOptions.prototype.easing;
  *     start: (number|undefined),
  *     duration: (number|undefined),
  *     easing: (function(number):number|undefined)}}
- * @api
  */
 olx.animation.RotateOptions;
 
@@ -824,7 +811,6 @@ olx.animation.RotateOptions.prototype.easing;
  *     start: (number|undefined),
  *     duration: (number|undefined),
  *     easing: (function(number):number|undefined)}}
- * @api
  */
 olx.animation.ZoomOptions;
 
@@ -879,7 +865,6 @@ olx.control;
  *     collapseLabel: (string|Node|undefined),
  *     render: (function(ol.MapEvent)|undefined),
  *     target: (Element|undefined)}}
- * @api
  */
 olx.control.AttributionOptions;
 
@@ -958,7 +943,6 @@ olx.control.AttributionOptions.prototype.render;
  * @typedef {{element: (Element|undefined),
  *     render: (function(ol.MapEvent)|undefined),
  *     target: (Element|string|undefined)}}
- * @api stable
  */
 olx.control.ControlOptions;
 
@@ -997,7 +981,6 @@ olx.control.ControlOptions.prototype.target;
  *     rotateOptions: (olx.control.RotateOptions|undefined),
  *     zoom: (boolean|undefined),
  *     zoomOptions: (olx.control.ZoomOptions|undefined)}}
- * @api
  */
 olx.control.DefaultsOptions;
 
@@ -1058,7 +1041,6 @@ olx.control.DefaultsOptions.prototype.zoomOptions;
  *     keys: (boolean|undefined),
  *     target: (Element|undefined),
  *     source: (Element|string|undefined)}}
- * @api
  */
 olx.control.FullScreenOptions;
 
@@ -1127,7 +1109,6 @@ olx.control.FullScreenOptions.prototype.source;
  *     render: (function(ol.MapEvent)|undefined),
  *     target: (Element|undefined),
  *     undefinedHTML: (string|undefined)}}
- * @api stable
  */
 olx.control.MousePositionOptions;
 
@@ -1191,7 +1172,6 @@ olx.control.MousePositionOptions.prototype.undefinedHTML;
  *     target: (Element|undefined),
  *     tipLabel: (string|undefined),
  *     view: (ol.View|undefined)}}
- * @api
  */
 olx.control.OverviewMapOptions;
 
@@ -1281,7 +1261,6 @@ olx.control.OverviewMapOptions.prototype.view;
  *     render: (function(ol.MapEvent)|undefined),
  *     target: (Element|undefined),
  *     units: (ol.control.ScaleLineUnits|string|undefined)}}
- * @api stable
  */
 olx.control.ScaleLineOptions;
 
@@ -1336,7 +1315,6 @@ olx.control.ScaleLineOptions.prototype.units;
  *     render: (function(ol.MapEvent)|undefined),
  *     resetNorth: (function()|undefined),
  *     autoHide: (boolean|undefined)}}
- * @api stable
  */
 olx.control.RotateOptions;
 
@@ -1417,7 +1395,6 @@ olx.control.RotateOptions.prototype.target;
  *     zoomOutTipLabel: (string|undefined),
  *     delta: (number|undefined),
  *     target: (Element|undefined)}}
- * @api stable
  */
 olx.control.ZoomOptions;
 
@@ -1494,7 +1471,6 @@ olx.control.ZoomOptions.prototype.target;
  *     maxResolution: (number|undefined),
  *     minResolution: (number|undefined),
  *     render: (function(ol.MapEvent)|undefined)}}
- * @api
  */
 olx.control.ZoomSliderOptions;
 
@@ -1546,7 +1522,6 @@ olx.control.ZoomSliderOptions.prototype.render;
  *     label: (string|Node|undefined),
  *     tipLabel: (string|undefined),
  *     extent: (ol.Extent|undefined)}}
- * @api stable
  */
 olx.control.ZoomToExtentOptions;
 
@@ -1604,7 +1579,6 @@ olx.format;
  * @typedef {{dataProjection: ol.proj.ProjectionLike,
  *     featureProjection: ol.proj.ProjectionLike,
  *     rightHanded: (boolean|undefined)}}
- * @api
  */
 olx.format.ReadOptions;
 
@@ -1635,7 +1609,6 @@ olx.format.ReadOptions.prototype.featureProjection;
  *     featureProjection: ol.proj.ProjectionLike,
  *     rightHanded: (boolean|undefined),
  *     decimals: (number|undefined)}}
- * @api
  */
 olx.format.WriteOptions;
 
@@ -1694,7 +1667,6 @@ olx.format.WriteOptions.prototype.decimals;
 /**
  * @typedef {{defaultDataProjection: ol.proj.ProjectionLike,
  *     geometryName: (string|undefined)}}
- * @api
  */
 olx.format.GeoJSONOptions;
 
@@ -1717,7 +1689,6 @@ olx.format.GeoJSONOptions.prototype.geometryName;
 
 /**
  * @typedef {{geometryName: (string|undefined)}}
- * @api
  */
 olx.format.EsriJSONOptions;
 
@@ -1738,7 +1709,6 @@ olx.format.EsriJSONOptions.prototype.geometryName;
  *     geometryName: (string|undefined),
  *     layers: (Array.<string>|undefined),
  *     layerName: (string|undefined)}}
- * @api
  */
 olx.format.MVTOptions;
 
@@ -1784,7 +1754,6 @@ olx.format.MVTOptions.prototype.layers;
 /**
  * @typedef {{factor: (number|undefined),
  *     geometryLayout: (ol.geom.GeometryLayout|undefined)}}
- * @api
  */
 olx.format.PolylineOptions;
 
@@ -1809,7 +1778,6 @@ olx.format.PolylineOptions.prototype.geometryLayout;
 
 /**
  * @typedef {{defaultDataProjection: ol.proj.ProjectionLike}}
- * @api
  */
 olx.format.TopoJSONOptions;
 
@@ -1824,7 +1792,6 @@ olx.format.TopoJSONOptions.prototype.defaultDataProjection;
 
 /**
  * @typedef {{altitudeMode: (ol.format.IGCZ|undefined)}}
- * @api
  */
 olx.format.IGCOptions;
 
@@ -1843,7 +1810,6 @@ olx.format.IGCOptions.prototype.altitudeMode;
  *     defaultStyle: (Array.<ol.style.Style>|undefined),
  *     showPointNames: (boolean|undefined),
  *     writeStyles: (boolean|undefined)}}
- * @api
  */
 olx.format.KMLOptions;
 
@@ -1889,7 +1855,6 @@ olx.format.KMLOptions.prototype.writeStyles;
  *     multiCurve: (boolean|undefined),
  *     multiSurface: (boolean|undefined),
  *     schemaLocation: (string|undefined)}}
- * @api
  */
 olx.format.GMLOptions;
 
@@ -1977,7 +1942,6 @@ olx.format.GMLOptions.prototype.schemaLocation;
 
 /**
  * @typedef {{readExtensions: (function(ol.Feature, Node)|undefined)}}
- * @api
  */
 olx.format.GPXOptions;
 
@@ -2000,7 +1964,6 @@ olx.format.GPXOptions.prototype.readExtensions;
  *     featureType: (Array.<string>|string|undefined),
  *     gmlFormat: (ol.format.GMLBase|undefined),
  *     schemaLocation: (string|undefined)}}
- * @api
  */
 olx.format.WFSOptions;
 
@@ -2052,7 +2015,6 @@ olx.format.WFSOptions.prototype.schemaLocation;
  *     count: (number|undefined),
  *     bbox: (ol.Extent|undefined),
  *     filter: (ol.format.ogc.filter.Filter|undefined)}}
- * @api
  */
 olx.format.WFSWriteGetFeatureOptions;
 
@@ -2173,7 +2135,6 @@ olx.format.WFSWriteGetFeatureOptions.prototype.filter;
  *     handle: (string|undefined),
  *     nativeElements: Array.<Object>,
  *     gmlOptions: (olx.format.GMLOptions|undefined)}}
- * @api stable
  */
 olx.format.WFSWriteTransactionOptions;
 
@@ -2237,7 +2198,6 @@ olx.format.WFSWriteTransactionOptions.prototype.gmlOptions;
 
 /**
  * @typedef {{splitCollection: (boolean|undefined)}}
- * @api
  */
 olx.format.WKTOptions;
 
@@ -2255,7 +2215,6 @@ olx.format.WKTOptions.prototype.splitCollection;
  * @typedef {{
  *     layers: (Array.<string>|undefined)
  * }}
- * @api
  */
 olx.format.WMSGetFeatureInfoOptions;
 
@@ -2288,7 +2247,6 @@ olx.interaction;
  *     pinchZoom: (boolean|undefined),
  *     zoomDelta: (number|undefined),
  *     zoomDuration: (number|undefined)}}
- * @api
  */
 olx.interaction.DefaultsOptions;
 
@@ -2376,7 +2334,6 @@ olx.interaction.DefaultsOptions.prototype.zoomDuration;
 /**
  * @typedef {{duration: (number|undefined),
  *     delta: (number|undefined)}}
- * @api
  */
 olx.interaction.DoubleClickZoomOptions;
 
@@ -2401,7 +2358,6 @@ olx.interaction.DoubleClickZoomOptions.prototype.delta;
  * @typedef {{formatConstructors: (Array.<function(new: ol.format.Feature)>|undefined),
  *     projection: ol.proj.ProjectionLike,
  *     target: (Element|undefined)}}
- * @api
  */
 olx.interaction.DragAndDropOptions;
 
@@ -2434,7 +2390,6 @@ olx.interaction.DragAndDropOptions.prototype.target;
  * @typedef {{className: (string|undefined),
  *     condition: (ol.events.ConditionType|undefined),
  *     boxEndCondition: (ol.interaction.DragBoxEndConditionType|undefined)}}
- * @api
  */
 olx.interaction.DragBoxOptions;
 
@@ -2478,7 +2433,6 @@ olx.interaction.DragBoxOptions.prototype.boxEndCondition;
 
 /**
  * @typedef {{kinetic: (ol.Kinetic|undefined)}}
- * @api
  */
 olx.interaction.DragPanOptions;
 
@@ -2494,7 +2448,6 @@ olx.interaction.DragPanOptions.prototype.kinetic;
 /**
  * @typedef {{condition: (ol.events.ConditionType|undefined),
  *     duration: (number|undefined)}}
- * @api
  */
 olx.interaction.DragRotateAndZoomOptions;
 
@@ -2520,7 +2473,6 @@ olx.interaction.DragRotateAndZoomOptions.prototype.duration;
 /**
  * @typedef {{condition: (ol.events.ConditionType|undefined),
  *     duration: (number|undefined)}}
- * @api
  */
 olx.interaction.DragRotateOptions;
 
@@ -2548,7 +2500,6 @@ olx.interaction.DragRotateOptions.prototype.duration;
  *     condition: (ol.events.ConditionType|undefined),
  *     duration: (number|undefined),
  *     out: (boolean|undefined)}}
- * @api
  */
 olx.interaction.DragZoomOptions;
 
@@ -2602,7 +2553,6 @@ olx.interaction.DragZoomOptions.prototype.out;
  *     condition: (ol.events.ConditionType|undefined),
  *     freehandCondition: (ol.events.ConditionType|undefined),
  *     wrapX: (boolean|undefined)}}
- * @api
  */
 olx.interaction.DrawOptions;
 
@@ -2739,7 +2689,6 @@ olx.interaction.DrawOptions.prototype.wrapX;
  *     features: (ol.Collection.<ol.Feature>|undefined),
  *     layers: (undefined|Array.<ol.layer.Layer>|function(ol.layer.Layer): boolean)
  * }}
- * @api
  */
 olx.interaction.TranslateOptions;
 
@@ -2769,7 +2718,6 @@ olx.interaction.TranslateOptions.prototype.layers;
  * @typedef {{condition: (ol.events.ConditionType|undefined),
  *     duration: (number|undefined),
  *     pixelDelta: (number|undefined)}}
- * @api
  */
 olx.interaction.KeyboardPanOptions;
 
@@ -2805,7 +2753,6 @@ olx.interaction.KeyboardPanOptions.prototype.pixelDelta;
  * @typedef {{duration: (number|undefined),
  *     condition: (ol.events.ConditionType|undefined),
  *     delta: (number|undefined)}}
- * @api
  */
 olx.interaction.KeyboardZoomOptions;
 
@@ -2843,7 +2790,6 @@ olx.interaction.KeyboardZoomOptions.prototype.delta;
  *     style: (ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined),
  *     features: ol.Collection.<ol.Feature>,
  *     wrapX: (boolean|undefined)}}
- * @api
  */
 olx.interaction.ModifyOptions;
 
@@ -2907,7 +2853,6 @@ olx.interaction.ModifyOptions.prototype.wrapX;
 /**
  * @typedef {{duration: (number|undefined),
  *     useAnchor: (boolean|undefined)}}
- * @api
  */
 olx.interaction.MouseWheelZoomOptions;
 
@@ -2933,7 +2878,6 @@ olx.interaction.MouseWheelZoomOptions.prototype.useAnchor;
 /**
  * @typedef {{threshold: (number|undefined),
  *     duration: (number|undefined)}}
- * @api
  */
 olx.interaction.PinchRotateOptions;
 
@@ -2956,7 +2900,6 @@ olx.interaction.PinchRotateOptions.prototype.threshold;
 
 /**
  * @typedef {{duration: (number|undefined)}}
- * @api
  */
 olx.interaction.PinchZoomOptions;
 
@@ -2975,7 +2918,6 @@ olx.interaction.PinchZoomOptions.prototype.duration;
  *     handleEvent: (function(ol.MapBrowserEvent):boolean|undefined),
  *     handleMoveEvent: (function(ol.MapBrowserPointerEvent)|undefined),
  *     handleUpEvent: (function(ol.MapBrowserPointerEvent):boolean|undefined)}}
- * @api
  */
 olx.interaction.PointerOptions;
 
@@ -3039,7 +2981,6 @@ olx.interaction.PointerOptions.prototype.handleUpEvent;
  *     features: (ol.Collection.<ol.Feature>|undefined),
  *     filter: (ol.interaction.SelectFilterFunction|undefined),
  *     wrapX: (boolean|undefined)}}
- * @api
  */
 olx.interaction.SelectOptions;
 
@@ -3162,7 +3103,6 @@ olx.interaction.SelectOptions.prototype.wrapX;
  *     edge: (boolean|undefined),
  *     vertex: (boolean|undefined)
  * }}
- * @api
  */
 olx.interaction.SnapOptions;
 
@@ -3221,7 +3161,6 @@ olx.layer;
  *     zIndex: (number|undefined),
  *     minResolution: (number|undefined),
  *     maxResolution: (number|undefined)}}
- * @api
  */
 olx.layer.BaseOptions;
 
@@ -3284,7 +3223,6 @@ olx.layer.BaseOptions.prototype.maxResolution;
  *     zIndex: (number|undefined),
  *     minResolution: (number|undefined),
  *     maxResolution: (number|undefined)}}
- * @api
  */
 olx.layer.LayerOptions;
 
@@ -3357,7 +3295,6 @@ olx.layer.LayerOptions.prototype.maxResolution;
  *     minResolution: (number|undefined),
  *     maxResolution: (number|undefined),
  *     layers: (Array.<ol.layer.Base>|ol.Collection.<ol.layer.Base>|undefined)}}
- * @api
  */
 olx.layer.GroupOptions;
 
@@ -3432,7 +3369,6 @@ olx.layer.GroupOptions.prototype.layers;
  *     opacity: (number|undefined),
  *     source: (ol.source.Vector|undefined),
  *     visible: (boolean|undefined)}}
- * @api
  */
 olx.layer.HeatmapOptions;
 
@@ -3537,7 +3473,6 @@ olx.layer.HeatmapOptions.prototype.visible;
  *     extent: (ol.Extent|undefined),
  *     minResolution: (number|undefined),
  *     maxResolution: (number|undefined)}}
- * @api
  */
 olx.layer.ImageOptions;
 
@@ -3612,7 +3547,6 @@ olx.layer.ImageOptions.prototype.maxResolution;
  *     minResolution: (number|undefined),
  *     maxResolution: (number|undefined),
  *     useInterimTilesOnError: (boolean|undefined)}}
- * @api
  */
 olx.layer.TileOptions;
 
@@ -3706,7 +3640,6 @@ olx.layer.TileOptions.prototype.useInterimTilesOnError;
  *     updateWhileAnimating: (boolean|undefined),
  *     updateWhileInteracting: (boolean|undefined),
  *     visible: (boolean|undefined)}}
- * @api
  */
 olx.layer.VectorOptions;
 
@@ -3835,7 +3768,6 @@ olx.layer.VectorOptions.prototype.visible;
  *     updateWhileAnimating: (boolean|undefined),
  *     updateWhileInteracting: (boolean|undefined),
  *     visible: (boolean|undefined)}}
- * @api
  */
 olx.layer.VectorTileOptions;
 
@@ -3977,7 +3909,6 @@ olx.render;
 /**
  * @typedef {{size: (ol.Size|undefined),
  *     pixelRatio: (number|undefined)}}
- * @api
  */
 olx.render.ToContextOptions;
 
@@ -4017,7 +3948,6 @@ olx.source;
  *     reprojectionErrorThreshold: (number|undefined),
  *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
  *     wrapX: (boolean|undefined)}}
- * @api
  */
 olx.source.BingMapsOptions;
 
@@ -4103,7 +4033,6 @@ olx.source.BingMapsOptions.prototype.wrapX;
  *     projection: ol.proj.ProjectionLike,
  *     source: ol.source.Vector,
  *     wrapX: (boolean|undefined)}}
- * @api
  */
 olx.source.ClusterOptions;
 
@@ -4196,7 +4125,6 @@ olx.source.ClusterOptions.prototype.wrapX;
  *     jsonp: (boolean|undefined),
  *     tileJSON: (TileJSON|undefined),
  *     url: (string|undefined)}}
- * @api
  */
 olx.source.TileUTFGridOptions;
 
@@ -4260,7 +4188,6 @@ olx.source.TileUTFGridOptions.prototype.url;
  *            url: (string|undefined),
  *            urls: (Array.<string>|undefined),
  *            wrapX: (boolean|undefined)}}
- * @api
  */
 olx.source.TileImageOptions;
 
@@ -4430,7 +4357,6 @@ olx.source.TileImageOptions.prototype.wrapX;
  *            url: (string|undefined),
  *            urls: (Array.<string>|undefined),
  *            wrapX: (boolean|undefined)}}
- * @api
  */
 olx.source.VectorTileOptions;
 
@@ -4578,7 +4504,6 @@ olx.source.VectorTileOptions.prototype.wrapX;
  *     resolutions: (Array.<number>|undefined),
  *     imageLoadFunction: (ol.ImageLoadFunctionType|undefined),
  *     params: (Object|undefined)}}
- * @api
  */
 olx.source.ImageMapGuideOptions;
 
@@ -4672,7 +4597,6 @@ olx.source.ImageMapGuideOptions.prototype.params;
  *     reprojectionErrorThreshold: (number|undefined),
  *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
  *     url: (string|undefined)}}
- * @api
  */
 olx.source.MapQuestOptions;
 
@@ -4727,7 +4651,6 @@ olx.source.MapQuestOptions.prototype.url;
  * @typedef {{projection: ol.proj.ProjectionLike,
  *     tileGrid: (ol.tilegrid.TileGrid|undefined),
  *     wrapX: (boolean|undefined)}}
- * @api
  */
 olx.source.TileDebugOptions;
 
@@ -4766,7 +4689,6 @@ olx.source.TileDebugOptions.prototype.wrapX;
  *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
  *     url: (string|undefined),
  *     wrapX: (boolean|undefined)}}
- * @api
  */
 olx.source.OSMOptions;
 
@@ -4866,7 +4788,6 @@ olx.source.OSMOptions.prototype.wrapX;
  *     ratio: (number|undefined),
  *     resolutions: (Array.<number>|undefined),
  *     url: (string|undefined)}}
- * @api
  */
 olx.source.ImageArcGISRestOptions;
 
@@ -4963,7 +4884,6 @@ olx.source.ImageArcGISRestOptions.prototype.url;
  *     ratio: (number|undefined),
  *     resolutions: (Array.<number>|undefined),
  *     state: (ol.source.State|undefined)}}
- * @api
  */
 olx.source.ImageCanvasOptions;
 
@@ -5042,7 +4962,6 @@ olx.source.ImageCanvasOptions.prototype.state;
  *     resolutions: (Array.<number>|undefined),
  *     source: ol.source.Vector,
  *     style: (ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined)}}
- * @api
  */
 olx.source.ImageVectorOptions;
 
@@ -5113,7 +5032,6 @@ olx.source.ImageVectorOptions.prototype.style;
  *     lib: (Object|undefined),
  *     threads: (number|undefined),
  *     operationType: (ol.raster.OperationType|undefined)}}
- * @api
  */
 olx.source.RasterOptions;
 
@@ -5178,7 +5096,6 @@ olx.source.RasterOptions.prototype.operationType;
  *     ratio: (number|undefined),
  *     resolutions: (Array.<number>|undefined),
  *     url: (string|undefined)}}
- * @api
  */
 olx.source.ImageWMSOptions;
 
@@ -5290,7 +5207,6 @@ olx.source.ImageWMSOptions.prototype.url;
  *     reprojectionErrorThreshold: (number|undefined),
  *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
  *     url: (string|undefined)}}
- * @api
  */
 olx.source.StamenOptions;
 
@@ -5373,7 +5289,6 @@ olx.source.StamenOptions.prototype.url;
  *     logo: (string|olx.LogoOptions|undefined),
  *     projection: ol.proj.ProjectionLike,
  *     url: string}}
- * @api
  */
 olx.source.ImageStaticOptions;
 
@@ -5461,7 +5376,6 @@ olx.source.ImageStaticOptions.prototype.url;
  *     url: (string|undefined),
  *     urls: (Array.<string>|undefined),
  *     wrapX: (boolean|undefined)}}
- * @api
  */
 olx.source.TileArcGISRestOptions;
 
@@ -5593,7 +5507,6 @@ olx.source.TileArcGISRestOptions.prototype.urls;
  *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
  *     url: string,
  *     wrapX: (boolean|undefined)}}
- * @api
  */
 olx.source.TileJSONOptions;
 
@@ -5692,7 +5605,6 @@ olx.source.TileJSONOptions.prototype.wrapX;
  *     url: (string|undefined),
  *     urls: (Array.<string>|undefined),
  *     wrapX: (boolean|undefined)}}
- * @api
  */
 olx.source.TileWMSOptions;
 
@@ -5864,7 +5776,6 @@ olx.source.TileWMSOptions.prototype.wrapX;
  *     url: (string|ol.FeatureUrlFunction|undefined),
  *     useSpatialIndex: (boolean|undefined),
  *     wrapX: (boolean|undefined)}}
- * @api
  */
 olx.source.VectorOptions;
 
@@ -5998,7 +5909,6 @@ olx.source.VectorOptions.prototype.wrapX;
  *                          ol.TileState, string, ?string,
  *                          ol.TileLoadFunctionType)|undefined),
  *     wrapX: (boolean|undefined)}}
- * @api
  */
 olx.source.WMTSOptions;
 
@@ -6208,7 +6118,6 @@ olx.source.WMTSOptions.prototype.wrapX;
  *     url: (string|undefined),
  *     urls: (Array.<string>|undefined),
  *     wrapX: (boolean|undefined)}}
- * @api
  */
 olx.source.XYZOptions;
 
@@ -6376,7 +6285,6 @@ olx.source.XYZOptions.prototype.wrapX;
  *     config: (Object|undefined),
  *     map: (string|undefined),
  *     account: string}}
- * @api
  */
 olx.source.CartoDBOptions;
 
@@ -6489,7 +6397,6 @@ olx.source.CartoDBOptions.prototype.account;
  *     url: !string,
  *     tierSizeCalculation: (string|undefined),
  *     size: ol.Size}}
- * @api
  */
 olx.source.ZoomifyOptions;
 
@@ -6576,7 +6483,6 @@ olx.style;
  *     snapToPixel: (boolean|undefined),
  *     stroke: (ol.style.Stroke|undefined),
  *     atlasManager: (ol.style.AtlasManager|undefined)}}
- * @api
  */
 olx.style.CircleOptions;
 
@@ -6631,7 +6537,6 @@ olx.style.CircleOptions.prototype.atlasManager;
 
 /**
  * @typedef {{color: (ol.Color|ol.ColorLike|undefined)}}
- * @api
  */
 olx.style.FillOptions;
 
@@ -6664,7 +6569,6 @@ olx.style.FillOptions.prototype.color;
  *     size: (ol.Size|undefined),
  *     imgSize: (ol.Size|undefined),
  *     src: (string|undefined)}}
- * @api
  */
 olx.style.IconOptions;
 
@@ -6841,7 +6745,6 @@ olx.style.IconOptions.prototype.src;
  *     rotation: (number|undefined),
  *     rotateWithView: (boolean|undefined),
  *     atlasManager: (ol.style.AtlasManager|undefined)}}
- * @api
  */
 olx.style.RegularShapeOptions;
 
@@ -6952,7 +6855,6 @@ olx.style.RegularShapeOptions.prototype.atlasManager;
  *     lineDash: (Array.<number>|undefined),
  *     miterLimit: (number|undefined),
  *     width: (number|undefined)}}
- * @api
  */
 olx.style.StrokeOptions;
 
@@ -7023,7 +6925,6 @@ olx.style.StrokeOptions.prototype.width;
  *     textBaseline: (string|undefined),
  *     fill: (ol.style.Fill|undefined),
  *     stroke: (ol.style.Stroke|undefined)}}
- * @api
  */
 olx.style.TextOptions;
 
@@ -7121,7 +7022,6 @@ olx.style.TextOptions.prototype.stroke;
  *     stroke: (ol.style.Stroke|undefined),
  *     text: (ol.style.Text|undefined),
  *     zIndex: (number|undefined)}}
- * @api
  */
 olx.style.StyleOptions;
 
@@ -7191,7 +7091,6 @@ olx.tilegrid;
  *     sizes: (Array.<ol.Size>|undefined),
  *     tileSize: (number|ol.Size|undefined),
  *     tileSizes: (Array.<number|ol.Size>|undefined)}}
- * @api
  */
 olx.tilegrid.TileGridOptions;
 
@@ -7272,7 +7171,6 @@ olx.tilegrid.TileGridOptions.prototype.tileSizes;
  *     sizes: (Array.<ol.Size>|undefined),
  *     tileSize: (number|ol.Size|undefined),
  *     tileSizes: (Array.<number|ol.Size>|undefined)}}
- * @api
  */
 olx.tilegrid.WMTSOptions;
 
@@ -7377,7 +7275,6 @@ olx.tilegrid.WMTSOptions.prototype.widths;
  *     maxZoom: (number|undefined),
  *     minZoom: (number|undefined),
  *     tileSize: (number|ol.Size|undefined)}}
- * @api
  */
 olx.tilegrid.XYZOptions;
 
@@ -7433,7 +7330,6 @@ olx.view;
  *     nearest: (boolean|undefined),
  *     maxZoom: (number|undefined),
  *     minResolution: (number|undefined)}}
- * @api
  */
 olx.view.FitOptions;
 
@@ -7504,7 +7400,6 @@ olx.view.FitOptions.prototype.maxZoom;
  *     viewState: olx.ViewState,
  *     viewHints: Array.<number>,
  *     wantedTiles: !Object.<string, Object.<string, boolean>>}}
- * @api
  */
 olx.FrameState;
 
@@ -7535,7 +7430,6 @@ olx.FrameState.prototype.viewState;
  *     projection: ol.proj.Projection,
  *     resolution: number,
  *     rotation: number}}
- * @api
  */
 olx.ViewState;
 
@@ -7572,7 +7466,6 @@ olx.ViewState.prototype.rotation;
  * @typedef {{initialSize: (number|undefined),
  *     maxSize: (number|undefined),
  *     space: (number|undefined)}}
- * @api
  */
 olx.style.AtlasManagerOptions;
 

--- a/src/ol/control/scalelinecontrol.js
+++ b/src/ol/control/scalelinecontrol.js
@@ -25,7 +25,6 @@ ol.control.ScaleLineProperty = {
  * Units for the scale line. Supported values are `'degrees'`, `'imperial'`,
  * `'nautical'`, `'metric'`, `'us'`.
  * @enum {string}
- * @api stable
  */
 ol.control.ScaleLineUnits = {
   DEGREES: 'degrees',

--- a/src/ol/format/igcformat.js
+++ b/src/ol/format/igcformat.js
@@ -13,7 +13,6 @@ goog.require('ol.proj');
 /**
  * IGC altitude/z. One of 'barometric', 'gps', 'none'.
  * @enum {string}
- * @api
  */
 ol.format.IGCZ = {
   BAROMETRIC: 'barometric',

--- a/src/ol/geom/geometry.js
+++ b/src/ol/geom/geometry.js
@@ -15,7 +15,6 @@ goog.require('ol.proj.Units');
  * `'Polygon'`, `'MultiPoint'`, `'MultiLineString'`, `'MultiPolygon'`,
  * `'GeometryCollection'`, `'Circle'`.
  * @enum {string}
- * @api stable
  */
 ol.geom.GeometryType = {
   POINT: 'Point',
@@ -35,7 +34,6 @@ ol.geom.GeometryType = {
  * or measure ('M') coordinate is available. Supported values are `'XY'`,
  * `'XYZ'`, `'XYM'`, `'XYZM'`.
  * @enum {string}
- * @api stable
  */
 ol.geom.GeometryLayout = {
   XY: 'XY',

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -31,7 +31,6 @@ ol.OverlayProperty = {
  * `'center-left'`, `'center-center'`, `'center-right'`, `'top-left'`,
  * `'top-center'`, `'top-right'`
  * @enum {string}
- * @api stable
  */
 ol.OverlayPositioning = {
   BOTTOM_LEFT: 'bottom-left',

--- a/src/ol/proj/proj.js
+++ b/src/ol/proj/proj.js
@@ -14,7 +14,6 @@ goog.require('ol.sphere.NORMAL');
  * Projection units: `'degrees'`, `'ft'`, `'m'`, `'pixels'`, `'tile-pixels'` or
  * `'us-ft'`.
  * @enum {string}
- * @api stable
  */
 ol.proj.Units = {
   DEGREES: 'degrees',

--- a/src/ol/raster/operation.js
+++ b/src/ol/raster/operation.js
@@ -4,7 +4,6 @@ goog.provide('ol.raster.OperationType');
 /**
  * Raster operation type. Supported values are `'pixel'` and `'image'`.
  * @enum {string}
- * @api
  */
 ol.raster.OperationType = {
   PIXEL: 'pixel',

--- a/src/ol/renderer/maprenderer.js
+++ b/src/ol/renderer/maprenderer.js
@@ -18,7 +18,6 @@ goog.require('ol.vec.Mat4');
 /**
  * Available renderers: `'canvas'`, `'dom'` or `'webgl'`.
  * @enum {string}
- * @api stable
  */
 ol.RendererType = {
   CANVAS: 'canvas',

--- a/src/ol/source/source.js
+++ b/src/ol/source/source.js
@@ -10,7 +10,6 @@ goog.require('ol.proj');
 /**
  * State of the source, one of 'undefined', 'loading', 'ready' or 'error'.
  * @enum {string}
- * @api
  */
 ol.source.State = {
   UNDEFINED: 'undefined',

--- a/src/ol/source/wmssource.js
+++ b/src/ol/source/wmssource.js
@@ -7,7 +7,6 @@ goog.provide('ol.source.wms.ServerType');
  *     `'qgis'`. These are servers that have vendor parameters beyond the WMS
  *     specification that OpenLayers can make use of.
  * @enum {string}
- * @api
  */
 ol.source.wms.ServerType = {
   CARMENTA_SERVER: 'carmentaserver',

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -15,7 +15,6 @@ goog.require('ol.tilegrid.WMTS');
 /**
  * Request encoding. One of 'KVP', 'REST'.
  * @enum {string}
- * @api
  */
 ol.source.WMTSRequestEncoding = {
   KVP: 'KVP',  // see spec §8

--- a/src/ol/style/iconstyle.js
+++ b/src/ol/style/iconstyle.js
@@ -16,7 +16,6 @@ goog.require('ol.style.ImageState');
 /**
  * Icon anchor units. One of 'fraction', 'pixels'.
  * @enum {string}
- * @api
  */
 ol.style.IconAnchorUnits = {
   FRACTION: 'fraction',
@@ -27,7 +26,6 @@ ol.style.IconAnchorUnits = {
 /**
  * Icon origin. One of 'bottom-left', 'bottom-right', 'top-left', 'top-right'.
  * @enum {string}
- * @api
  */
 ol.style.IconOrigin = {
   BOTTOM_LEFT: 'bottom-left',

--- a/src/ol/typedefs.js
+++ b/src/ol/typedefs.js
@@ -32,7 +32,6 @@ goog.provide('ol.style.AtlasBlock');
 
 /**
  * @typedef {string|Array.<string>|ol.Attribution|Array.<ol.Attribution>}
- * @api
  */
 ol.AttributionLike;
 
@@ -54,7 +53,6 @@ ol.CanvasFillState;
  *
  * @typedef {function(this:ol.source.ImageCanvas, ol.Extent, number,
  *     number, ol.Size, ol.proj.Projection): HTMLCanvasElement}
- * @api
  */
 ol.CanvasFunctionType;
 
@@ -90,7 +88,6 @@ ol.CenterConstraintType;
  * alpha should be a float in the range 0..1 inclusive. If no alpha value is
  * given then `1` will be used.
  * @typedef {Array.<number>}
- * @api
  */
 ol.Color;
 
@@ -100,7 +97,6 @@ ol.Color;
  * Represents a color, pattern, or gradient.
  *
  * @typedef {string|CanvasPattern|CanvasGradient}
- * @api
  */
 ol.ColorLike;
 
@@ -108,7 +104,6 @@ ol.ColorLike;
 /**
  * An array of numbers representing an xy coordinate. Example: `[16, 48]`.
  * @typedef {Array.<number>} ol.Coordinate
- * @api stable
  */
 ol.Coordinate;
 
@@ -118,7 +113,6 @@ ol.Coordinate;
  * `{string}`.
  *
  * @typedef {function((ol.Coordinate|undefined)): string}
- * @api stable
  */
 ol.CoordinateFormatType;
 
@@ -126,7 +120,6 @@ ol.CoordinateFormatType;
 /**
  * An array of numbers representing an extent: `[minx, miny, maxx, maxy]`.
  * @typedef {Array.<number>}
- * @api stable
  */
 ol.Extent;
 
@@ -142,7 +135,6 @@ ol.Extent;
  *
  * The function is responsible for loading the features and adding them to the
  * source.
- * @api
  * @typedef {function(this:ol.source.Vector, ol.Extent, number,
  *                    ol.proj.Projection)}
  */
@@ -156,7 +148,6 @@ ol.FeatureLoader;
  *
  * @typedef {function(this: ol.Feature, number):
  *     (ol.style.Style|Array.<ol.style.Style>)}
- * @api stable
  */
 ol.FeatureStyleFunction;
 
@@ -169,7 +160,6 @@ ol.FeatureStyleFunction;
  * a `{number}` representing the resolution (map units per pixel) and an
  * {@link ol.proj.Projection} for the projection  as arguments and returns a
  * `{string}` representing the URL.
- * @api
  * @typedef {function(ol.Extent, number, ol.proj.Projection) : string}
  */
 ol.FeatureUrlFunction;
@@ -201,7 +191,6 @@ ol.ImageCanvasLoader;
  * image element would be set to a data URI when the content is loaded.
  *
  * @typedef {function(ol.Image, string)}
- * @api
  */
 ol.ImageLoadFunctionType;
 
@@ -238,7 +227,6 @@ ol.LayerState;
  * One of `all`, `bbox`, `tile`.
  *
  * @typedef {function(ol.Extent, number): Array.<ol.Extent>}
- * @api
  */
 ol.LoadingStrategy;
 
@@ -269,7 +257,6 @@ ol.MapOptionsInternal;
  * An array with two elements, representing a pixel. The first element is the
  * x-coordinate, the second the y-coordinate of the pixel.
  * @typedef {Array.<number>}
- * @api stable
  */
 ol.Pixel;
 
@@ -286,7 +273,6 @@ ol.PostRenderFunction;
  * second argument. Return `true` to keep this function for the next frame,
  * `false` to remove it.
  * @typedef {function(ol.Map, ?olx.FrameState): boolean}
- * @api
  */
 ol.PreRenderFunction;
 
@@ -327,7 +313,6 @@ ol.RotationConstraintType;
 /**
  * An array of numbers representing a size: `[width, height]`.
  * @typedef {Array.<number>}
- * @api stable
  */
 ol.Size;
 
@@ -399,7 +384,6 @@ ol.SourceUrlTileOptions;
  * An array of three numbers representing the location of a tile in a tile
  * grid. The order is `z`, `x`, and `y`. `z` is the zoom level.
  * @typedef {Array.<number>} ol.TileCoord
- * @api
  */
 ol.TileCoord;
 
@@ -409,7 +393,6 @@ ol.TileCoord;
  * the url as arguments.
  *
  * @typedef {function(ol.Tile, string)}
- * @api
  */
 ol.TileLoadFunctionType;
 
@@ -444,7 +427,6 @@ ol.TileReplayState;
  *
  * @typedef {function(ol.TileCoord, number,
  *           ol.proj.Projection): (string|undefined)}
- * @api
  */
 ol.TileUrlFunctionType;
 
@@ -456,7 +438,6 @@ ol.TileUrlFunctionType;
  * returns the output array.
  *
  * @typedef {function(Array.<number>, Array.<number>=, number=): Array.<number>}
- * @api stable
  */
 ol.TransformFunction;
 
@@ -478,7 +459,6 @@ ol.WebglTextureCacheEntry;
  * Number of features; bounds/extent.
  * @typedef {{numberOfFeatures: number,
  *            bounds: ol.Extent}}
- * @api stable
  */
 ol.WFSFeatureCollectionMetadata;
 
@@ -489,7 +469,6 @@ ol.WFSFeatureCollectionMetadata;
  *            totalInserted: number,
  *            totalUpdated: number,
  *            insertIds: Array.<string>}}
- * @api stable
  */
 ol.WFSTransactionResponse;
 
@@ -526,7 +505,6 @@ ol.XmlSerializer;
  * `{boolean}`. If the condition is met, true should be returned.
  *
  * @typedef {function(ol.MapBrowserEvent): boolean}
- * @api stable
  */
 ol.events.ConditionType;
 
@@ -550,7 +528,6 @@ ol.events.EventTargetLike;
  *     listener: ol.events.ListenerFunctionType,
  *     target: (EventTarget|ol.events.EventTarget),
  *     type: string}}
- * @api
  */
 ol.events.Key;
 
@@ -560,7 +537,6 @@ ol.events.Key;
  * When the function returns `false`, event propagation will stop.
  *
  * @typedef {function(ol.events.Event)|function(ol.events.Event): boolean}
- * @api
  */
 ol.events.ListenerFunctionType;
 
@@ -570,7 +546,6 @@ ol.events.ListenerFunctionType;
  * {@link ol.Pixel}s and returns a `{boolean}`. If the condition is met,
  * true should be returned.
  * @typedef {function(ol.MapBrowserEvent, ol.Pixel, ol.Pixel):boolean}
- * @api
  */
 ol.interaction.DragBoxEndConditionType;
 
@@ -583,7 +558,6 @@ ol.interaction.DragBoxEndConditionType;
  * @typedef {function(!(ol.Coordinate|Array.<ol.Coordinate>|
  *     Array.<Array.<ol.Coordinate>>), ol.geom.SimpleGeometry=):
  *     ol.geom.SimpleGeometry}
- * @api
  */
 ol.interaction.DrawGeometryFunctionType;
 
@@ -604,7 +578,6 @@ ol.interaction.SegmentDataType;
  * or `false` otherwise.
  * @typedef {function((ol.Feature|ol.render.Feature), ol.layer.Layer):
  *     boolean}
- * @api
  */
 ol.interaction.SelectFilterFunction;
 
@@ -632,7 +605,6 @@ ol.interaction.SnapSegmentDataType;
  * A projection as {@link ol.proj.Projection}, SRS identifier string or
  * undefined.
  * @typedef {ol.proj.Projection|string|undefined} ol.proj.ProjectionLike
- * @api stable
  */
 ol.proj.ProjectionLike;
 
@@ -651,7 +623,6 @@ ol.proj.ProjectionLike;
  *
  * @typedef {function((Array.<ol.raster.Pixel>|Array.<ImageData>), Object):
  *     (Array.<ol.raster.Pixel>|Array.<ImageData>)}
- * @api
  */
 ol.raster.Operation;
 
@@ -659,7 +630,6 @@ ol.raster.Operation;
 /**
  * An array of numbers representing pixel values.
  * @typedef {Array.<number>} ol.raster.Pixel
- * @api
  */
 ol.raster.Pixel;
 
@@ -713,7 +683,6 @@ ol.style.ImageOptions;
  *
  * @typedef {function((ol.Feature|ol.render.Feature)):
  *     (ol.geom.Geometry|ol.render.Feature|undefined)}
- * @api
  */
 ol.style.GeometryFunction;
 
@@ -739,6 +708,5 @@ ol.style.RegularShapeRenderOptions;
  *
  * @typedef {function((ol.Feature|ol.render.Feature), number):
  *     (ol.style.Style|Array.<ol.style.Style>)}
- * @api
  */
 ol.style.StyleFunction;

--- a/src/ol/typedefs.js
+++ b/src/ol/typedefs.js
@@ -611,27 +611,21 @@ ol.proj.ProjectionLike;
 
 /**
  * A function that takes an array of input data, performs some operation, and
- * returns an array of ouput data.  For `'pixel'` type operations, functions
- * will be called with an array of {@link ol.raster.Pixel} data and should
- * return an array of the same.  For `'image'` type operations, functions will
- * be called with an array of {@link ImageData
- * https://developer.mozilla.org/en-US/docs/Web/API/ImageData} and should return
- * an array of the same.  The operations are called with a second "data"
- * argument, which can be used for storage.  The data object is accessible
- * from raster events, where it can be initialized in "beforeoperations" and
- * accessed again in "afteroperations".
+ * returns an array of ouput data.
+ * For `pixel` type operations, the function will be called with an array of
+ * pixels, where each pixel is an array of four numbers (`[r, g, b, a]`) in the
+ * range of 0 - 255. It should return an array of the same.
+ * For `'image'` type operations, functions will be called with an array of
+ * {@link ImageData https://developer.mozilla.org/en-US/docs/Web/API/ImageData}
+ * and should return an array of the same.  The operations are called with a
+ * second "data" argument, which can be used for storage.  The data object is
+ * accessible from raster events, where it can be initialized in
+ * "beforeoperations" and accessed again in "afteroperations".
  *
- * @typedef {function((Array.<ol.raster.Pixel>|Array.<ImageData>), Object):
- *     (Array.<ol.raster.Pixel>|Array.<ImageData>)}
+ * @typedef {function((Array.<Array.<number>>|Array.<ImageData>), Object):
+ *     (Array.<Array.<number>>|Array.<ImageData>)}
  */
 ol.raster.Operation;
-
-
-/**
- * An array of numbers representing pixel values.
- * @typedef {Array.<number>} ol.raster.Pixel
- */
-ol.raster.Pixel;
 
 
 /**

--- a/src/ol/typedefs.js
+++ b/src/ol/typedefs.js
@@ -614,16 +614,17 @@ ol.proj.ProjectionLike;
  * returns an array of ouput data.
  * For `pixel` type operations, the function will be called with an array of
  * pixels, where each pixel is an array of four numbers (`[r, g, b, a]`) in the
- * range of 0 - 255. It should return an array of the same.
+ * range of 0 - 255. It should return a single pixel array.
  * For `'image'` type operations, functions will be called with an array of
  * {@link ImageData https://developer.mozilla.org/en-US/docs/Web/API/ImageData}
- * and should return an array of the same.  The operations are called with a
- * second "data" argument, which can be used for storage.  The data object is
- * accessible from raster events, where it can be initialized in
+ * and should return a single {@link ImageData
+ * https://developer.mozilla.org/en-US/docs/Web/API/ImageData}.  The operations
+ * are called with a second "data" argument, which can be used for storage.  The
+ * data object is accessible from raster events, where it can be initialized in
  * "beforeoperations" and accessed again in "afteroperations".
  *
  * @typedef {function((Array.<Array.<number>>|Array.<ImageData>), Object):
- *     (Array.<Array.<number>>|Array.<ImageData>)}
+ *     (Array.<number>|ImageData)}
  */
 ol.raster.Operation;
 


### PR DESCRIPTION
With this change, it is no longer necessary to add `@api` annotations to typedefs and enums that are used by API symbols.

This is an alternative to #5425.