### PR TITLE
Fix feature without geometry error in renderers

### DIFF
--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -271,20 +271,22 @@ ol.renderer.canvas.VectorLayer.prototype.prepareFrame = function(frameState, lay
    * @this {ol.renderer.canvas.VectorLayer}
    */
   var renderFeature = function(feature) {
-    var styles;
-    var styleFunction = feature.getStyleFunction();
-    if (styleFunction) {
-      styles = styleFunction.call(feature, resolution);
-    } else {
-      styleFunction = vectorLayer.getStyleFunction();
+    if (feature.getGeometry()) {
+      var styles;
+      var styleFunction = feature.getStyleFunction();
       if (styleFunction) {
-        styles = styleFunction(feature, resolution);
+        styles = styleFunction.call(feature, resolution);
+      } else {
+        styleFunction = vectorLayer.getStyleFunction();
+        if (styleFunction) {
+          styles = styleFunction(feature, resolution);
+        }
       }
-    }
-    if (styles) {
-      var dirty = this.renderFeature(
-          feature, resolution, pixelRatio, styles, replayGroup);
-      this.dirty_ = this.dirty_ || dirty;
+      if (styles) {
+        var dirty = this.renderFeature(
+            feature, resolution, pixelRatio, styles, replayGroup);
+        this.dirty_ = this.dirty_ || dirty;
+      }
     }
   };
   if (vectorLayerRenderOrder) {

--- a/src/ol/renderer/dom/domvectorlayerrenderer.js
+++ b/src/ol/renderer/dom/domvectorlayerrenderer.js
@@ -281,20 +281,22 @@ ol.renderer.dom.VectorLayer.prototype.prepareFrame = function(frameState, layerS
    * @this {ol.renderer.dom.VectorLayer}
    */
   var renderFeature = function(feature) {
-    var styles;
-    var styleFunction = feature.getStyleFunction();
-    if (styleFunction) {
-      styles = styleFunction.call(feature, resolution);
-    } else {
-      styleFunction = vectorLayer.getStyleFunction();
+    if (feature.getGeometry()) {
+      var styles;
+      var styleFunction = feature.getStyleFunction();
       if (styleFunction) {
-        styles = styleFunction(feature, resolution);
+        styles = styleFunction.call(feature, resolution);
+      } else {
+        styleFunction = vectorLayer.getStyleFunction();
+        if (styleFunction) {
+          styles = styleFunction(feature, resolution);
+        }
       }
-    }
-    if (styles) {
-      var dirty = this.renderFeature(
-          feature, resolution, pixelRatio, styles, replayGroup);
-      this.dirty_ = this.dirty_ || dirty;
+      if (styles) {
+        var dirty = this.renderFeature(
+            feature, resolution, pixelRatio, styles, replayGroup);
+        this.dirty_ = this.dirty_ || dirty;
+      }
     }
   };
   if (vectorLayerRenderOrder) {

--- a/src/ol/renderer/webgl/webglvectorlayerrenderer.js
+++ b/src/ol/renderer/webgl/webglvectorlayerrenderer.js
@@ -241,20 +241,22 @@ ol.renderer.webgl.VectorLayer.prototype.prepareFrame = function(frameState, laye
    * @this {ol.renderer.webgl.VectorLayer}
    */
   var renderFeature = function(feature) {
-    var styles;
-    var styleFunction = feature.getStyleFunction();
-    if (styleFunction) {
-      styles = styleFunction.call(feature, resolution);
-    } else {
-      styleFunction = vectorLayer.getStyleFunction();
+    if (feature.getGeometry()) {
+      var styles;
+      var styleFunction = feature.getStyleFunction();
       if (styleFunction) {
-        styles = styleFunction(feature, resolution);
+        styles = styleFunction.call(feature, resolution);
+      } else {
+        styleFunction = vectorLayer.getStyleFunction();
+        if (styleFunction) {
+          styles = styleFunction(feature, resolution);
+        }
       }
-    }
-    if (styles) {
-      var dirty = this.renderFeature(
-          feature, resolution, pixelRatio, styles, replayGroup);
-      this.dirty_ = this.dirty_ || dirty;
+      if (styles) {
+        var dirty = this.renderFeature(
+            feature, resolution, pixelRatio, styles, replayGroup);
+        this.dirty_ = this.dirty_ || dirty;
+      }
     }
   };
   if (vectorLayerRenderOrder) {


### PR DESCRIPTION
This pull request make sure that we don't try to get a style object for a feature without geometry in the renderer. Trying to fetch a style via the style function on an empty geometry cause an error.