### PR TITLE
Select interaction default styling function can now handle geometry less features

### DIFF
--- a/src/ol/interaction/select.js
+++ b/src/ol/interaction/select.js
@@ -301,6 +301,9 @@ ol.interaction.Select.getDefaultStyleFunction = function() {
       styles[ol.geom.GeometryType.LINE_STRING]);
 
   return function(feature, resolution) {
+    if (!feature.getGeometry()) {
+      return null;
+    }
     return styles[feature.getGeometry().getType()];
   };
 };


### PR DESCRIPTION
This fix make sure the feature passed to the default styling function of the select interaction don't crash when trying to return the style of a feature without geometry.