### PR TITLE
Remove sub-namespaces from all remaining typedefs

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -6,6 +6,29 @@ Users compiling their code with the library and using types in the `ol.raster` n
 * `ol.raster.Operation` to `ol.RasterOperation`
 * `ol.raster.OperationType` to `ol.RasterOperationType`
 
+#### All typedefs now in ol namespace
+
+Users compiling their code with the library should note that the following typedefs have been renamed; your code may need changing if you use these:
+* ol.events.ConditionType to ol.EventsConditionType
+* ol.events.EventTargetLike to ol.EventTargetLike
+* ol.events.Key to ol.EventsKey
+* ol.events.ListenerFunctionType to ol.EventsListenerFunctionType
+* ol.interaction.DragBoxEndConditionType to ol.DragBoxEndConditionType
+* ol.interaction.DrawGeometryFunctionType to ol.DrawGeometryFunctionType
+* ol.interaction.SegmentDataType to ol.ModifySegmentDataType
+* ol.interaction.SelectFilterFunction to ol.SelectFilterFunction
+* ol.interaction.SnapResultType to ol.SnapResultType
+* ol.interaction.SnapSegmentDataType to ol.SnapSegmentDataType
+* ol.proj.ProjectionLike to ol.ProjectionLike
+* ol.style.AtlasBlock to ol.AtlasBlock
+* ol.style.AtlasInfo to ol.AtlasInfo
+* ol.style.AtlasManagerInfo to ol.AtlasManagerInfo
+* ol.style.CircleRenderOptions to ol.CircleRenderOptions
+* ol.style.ImageOptions to ol.StyleImageOptions
+* ol.style.GeometryFunction to ol.StyleGeometryFunction
+* ol.style.RegularShapeRenderOptions to ol.RegularShapeRenderOptions
+* ol.style.StyleFunction to ol.StyleFunction
+
 ### v3.16.0
 
 #### Rendering change for tile sources

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -40,7 +40,7 @@ olx.DeviceOrientationOptions.prototype.tracking;
 /**
  * @typedef {{tracking: (boolean|undefined),
  *     trackingOptions: (GeolocationPositionOptions|undefined),
- *     projection: ol.proj.ProjectionLike}}
+ *     projection: ol.ProjectionLike}}
  */
 olx.GeolocationOptions;
 
@@ -64,7 +64,7 @@ olx.GeolocationOptions.prototype.trackingOptions;
 
 /**
  * The projection the position is reported in.
- * @type {ol.proj.ProjectionLike}
+ * @type {ol.ProjectionLike}
  * @api stable
  */
 olx.GeolocationOptions.prototype.projection;
@@ -507,7 +507,7 @@ olx.ProjectionOptions.prototype.getPointResolution;
  *     maxResolution: (number|undefined),
  *     minZoom: (number|undefined),
  *     maxZoom: (number|undefined),
- *     projection: ol.proj.ProjectionLike,
+ *     projection: ol.ProjectionLike,
  *     resolution: (number|undefined),
  *     resolutions: (Array.<number>|undefined),
  *     rotation: (number|undefined),
@@ -607,7 +607,7 @@ olx.ViewOptions.prototype.minZoom;
 
 /**
  * The projection. Default is `EPSG:3857` (Spherical Mercator).
- * @type {ol.proj.ProjectionLike}
+ * @type {ol.ProjectionLike}
  * @api stable
  */
 olx.ViewOptions.prototype.projection;
@@ -1105,7 +1105,7 @@ olx.control.FullScreenOptions.prototype.source;
 /**
  * @typedef {{className: (string|undefined),
  *     coordinateFormat: (ol.CoordinateFormatType|undefined),
- *     projection: ol.proj.ProjectionLike,
+ *     projection: ol.ProjectionLike,
  *     render: (function(ol.MapEvent)|undefined),
  *     target: (Element|undefined),
  *     undefinedHTML: (string|undefined)}}
@@ -1131,7 +1131,7 @@ olx.control.MousePositionOptions.prototype.coordinateFormat;
 
 /**
  * Projection.
- * @type {ol.proj.ProjectionLike}
+ * @type {ol.ProjectionLike}
  * @api stable
  */
 olx.control.MousePositionOptions.prototype.projection;
@@ -1576,8 +1576,8 @@ olx.format;
 
 
 /**
- * @typedef {{dataProjection: ol.proj.ProjectionLike,
- *     featureProjection: ol.proj.ProjectionLike,
+ * @typedef {{dataProjection: ol.ProjectionLike,
+ *     featureProjection: ol.ProjectionLike,
  *     rightHanded: (boolean|undefined)}}
  */
 olx.format.ReadOptions;
@@ -1589,7 +1589,7 @@ olx.format.ReadOptions;
  * the format is assigned (where set). If the projection can not be derived from
  * the data and if no `defaultDataProjection` is set for a format, the features
  * will not be reprojected.
- * @type {ol.proj.ProjectionLike}
+ * @type {ol.ProjectionLike}
  * @api stable
  */
 olx.format.ReadOptions.prototype.dataProjection;
@@ -1598,15 +1598,15 @@ olx.format.ReadOptions.prototype.dataProjection;
 /**
  * Projection of the feature geometries created by the format reader. If not
  * provided, features will be returned in the `dataProjection`.
- * @type {ol.proj.ProjectionLike}
+ * @type {ol.ProjectionLike}
  * @api stable
  */
 olx.format.ReadOptions.prototype.featureProjection;
 
 
 /**
- * @typedef {{dataProjection: ol.proj.ProjectionLike,
- *     featureProjection: ol.proj.ProjectionLike,
+ * @typedef {{dataProjection: ol.ProjectionLike,
+ *     featureProjection: ol.ProjectionLike,
  *     rightHanded: (boolean|undefined),
  *     decimals: (number|undefined)}}
  */
@@ -1618,7 +1618,7 @@ olx.format.WriteOptions;
  * `defaultDataProjection` of the format is assigned (where set). If no
  * `defaultDataProjection` is set for a format, the features will be returned
  * in the `featureProjection`.
- * @type {ol.proj.ProjectionLike}
+ * @type {ol.ProjectionLike}
  * @api stable
  */
 olx.format.WriteOptions.prototype.dataProjection;
@@ -1628,7 +1628,7 @@ olx.format.WriteOptions.prototype.dataProjection;
  * Projection of the feature geometries that will be serialized by the format
  * writer. If not provided, geometries are assumed to be in the
  * `dataProjection` if that is set; in other words, they are not transformed.
- * @type {ol.proj.ProjectionLike}
+ * @type {ol.ProjectionLike}
  * @api stable
  */
 olx.format.WriteOptions.prototype.featureProjection;
@@ -1665,7 +1665,7 @@ olx.format.WriteOptions.prototype.decimals;
 
 
 /**
- * @typedef {{defaultDataProjection: ol.proj.ProjectionLike,
+ * @typedef {{defaultDataProjection: ol.ProjectionLike,
  *     geometryName: (string|undefined)}}
  */
 olx.format.GeoJSONOptions;
@@ -1673,7 +1673,7 @@ olx.format.GeoJSONOptions;
 
 /**
  * Default data projection. Default is `EPSG:4326`.
- * @type {ol.proj.ProjectionLike}
+ * @type {ol.ProjectionLike}
  * @api stable
  */
 olx.format.GeoJSONOptions.prototype.defaultDataProjection;
@@ -1777,14 +1777,14 @@ olx.format.PolylineOptions.prototype.geometryLayout;
 
 
 /**
- * @typedef {{defaultDataProjection: ol.proj.ProjectionLike}}
+ * @typedef {{defaultDataProjection: ol.ProjectionLike}}
  */
 olx.format.TopoJSONOptions;
 
 
 /**
  * Default data projection. Default is `EPSG:4326`.
- * @type {ol.proj.ProjectionLike}
+ * @type {ol.ProjectionLike}
  * @api stable
  */
 olx.format.TopoJSONOptions.prototype.defaultDataProjection;
@@ -2356,7 +2356,7 @@ olx.interaction.DoubleClickZoomOptions.prototype.delta;
 
 /**
  * @typedef {{formatConstructors: (Array.<function(new: ol.format.Feature)>|undefined),
- *     projection: ol.proj.ProjectionLike,
+ *     projection: ol.ProjectionLike,
  *     target: (Element|undefined)}}
  */
 olx.interaction.DragAndDropOptions;
@@ -2372,7 +2372,7 @@ olx.interaction.DragAndDropOptions.prototype.formatConstructors;
 
 /**
  * Target projection. By default, the map's view's projection is used.
- * @type {ol.proj.ProjectionLike}
+ * @type {ol.ProjectionLike}
  * @api
  */
 olx.interaction.DragAndDropOptions.prototype.projection;
@@ -2388,8 +2388,8 @@ olx.interaction.DragAndDropOptions.prototype.target;
 
 /**
  * @typedef {{className: (string|undefined),
- *     condition: (ol.events.ConditionType|undefined),
- *     boxEndCondition: (ol.interaction.DragBoxEndConditionType|undefined)}}
+ *     condition: (ol.EventsConditionType|undefined),
+ *     boxEndCondition: (ol.DragBoxEndConditionType|undefined)}}
  */
 olx.interaction.DragBoxOptions;
 
@@ -2406,7 +2406,7 @@ olx.interaction.DragBoxOptions.prototype.className;
  * A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * Default is {@link ol.events.condition.always}.
- * @type {ol.events.ConditionType|undefined}
+ * @type {ol.EventsConditionType|undefined}
  * @api
  */
 olx.interaction.DragBoxOptions.prototype.condition;
@@ -2425,7 +2425,7 @@ olx.interaction.DragBoxOptions.prototype.condition;
  *     ol.DRAG_BOX_HYSTERESIS_PIXELS_SQUARED;
  * }
  * ```
- * @type {ol.interaction.DragBoxEndConditionType|undefined}
+ * @type {ol.DragBoxEndConditionType|undefined}
  * @api
  */
 olx.interaction.DragBoxOptions.prototype.boxEndCondition;
@@ -2446,7 +2446,7 @@ olx.interaction.DragPanOptions.prototype.kinetic;
 
 
 /**
- * @typedef {{condition: (ol.events.ConditionType|undefined),
+ * @typedef {{condition: (ol.EventsConditionType|undefined),
  *     duration: (number|undefined)}}
  */
 olx.interaction.DragRotateAndZoomOptions;
@@ -2456,7 +2456,7 @@ olx.interaction.DragRotateAndZoomOptions;
  * A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * Default is {@link ol.events.condition.shiftKeyOnly}.
- * @type {ol.events.ConditionType|undefined}
+ * @type {ol.EventsConditionType|undefined}
  * @api
  */
 olx.interaction.DragRotateAndZoomOptions.prototype.condition;
@@ -2471,7 +2471,7 @@ olx.interaction.DragRotateAndZoomOptions.prototype.duration;
 
 
 /**
- * @typedef {{condition: (ol.events.ConditionType|undefined),
+ * @typedef {{condition: (ol.EventsConditionType|undefined),
  *     duration: (number|undefined)}}
  */
 olx.interaction.DragRotateOptions;
@@ -2481,7 +2481,7 @@ olx.interaction.DragRotateOptions;
  * A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * Default is {@link ol.events.condition.altShiftKeysOnly}.
- * @type {ol.events.ConditionType|undefined}
+ * @type {ol.EventsConditionType|undefined}
  * @api
  */
 olx.interaction.DragRotateOptions.prototype.condition;
@@ -2497,7 +2497,7 @@ olx.interaction.DragRotateOptions.prototype.duration;
 
 /**
  * @typedef {{className: (string|undefined),
- *     condition: (ol.events.ConditionType|undefined),
+ *     condition: (ol.EventsConditionType|undefined),
  *     duration: (number|undefined),
  *     out: (boolean|undefined)}}
  */
@@ -2516,7 +2516,7 @@ olx.interaction.DragZoomOptions.prototype.className;
  * A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * Default is {@link ol.events.condition.shiftKeyOnly}.
- * @type {ol.events.ConditionType|undefined}
+ * @type {ol.EventsConditionType|undefined}
  * @api
  */
 olx.interaction.DragZoomOptions.prototype.condition;
@@ -2546,12 +2546,12 @@ olx.interaction.DragZoomOptions.prototype.out;
  *     type: ol.geom.GeometryType,
  *     maxPoints: (number|undefined),
  *     minPoints: (number|undefined),
- *     finishCondition: (ol.events.ConditionType|undefined),
- *     style: (ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined),
- *     geometryFunction: (ol.interaction.DrawGeometryFunctionType|undefined),
+ *     finishCondition: (ol.EventsConditionType|undefined),
+ *     style: (ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined),
+ *     geometryFunction: (ol.DrawGeometryFunctionType|undefined),
  *     geometryName: (string|undefined),
- *     condition: (ol.events.ConditionType|undefined),
- *     freehandCondition: (ol.events.ConditionType|undefined),
+ *     condition: (ol.EventsConditionType|undefined),
+ *     freehandCondition: (ol.EventsConditionType|undefined),
  *     wrapX: (boolean|undefined)}}
  */
 olx.interaction.DrawOptions;
@@ -2623,7 +2623,7 @@ olx.interaction.DrawOptions.prototype.minPoints;
 /**
  * A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether the drawing can be finished.
- * @type {ol.events.ConditionType|undefined}
+ * @type {ol.EventsConditionType|undefined}
  * @api
  */
 olx.interaction.DrawOptions.prototype.finishCondition;
@@ -2631,7 +2631,7 @@ olx.interaction.DrawOptions.prototype.finishCondition;
 
 /**
  * Style for sketch features.
- * @type {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined}
+ * @type {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined}
  * @api
  */
 olx.interaction.DrawOptions.prototype.style;
@@ -2639,7 +2639,7 @@ olx.interaction.DrawOptions.prototype.style;
 
 /**
  * Function that is called when a geometry's coordinates are updated.
- * @type {ol.interaction.DrawGeometryFunctionType|undefined}
+ * @type {ol.DrawGeometryFunctionType|undefined}
  * @api
  */
 olx.interaction.DrawOptions.prototype.geometryFunction;
@@ -2658,7 +2658,7 @@ olx.interaction.DrawOptions.prototype.geometryName;
  * to indicate whether that event should be handled.
  * By default {@link ol.events.condition.noModifierKeys}, i.e. a click, adds a
  * vertex or deactivates freehand drawing.
- * @type {ol.events.ConditionType|undefined}
+ * @type {ol.EventsConditionType|undefined}
  * @api
  */
 olx.interaction.DrawOptions.prototype.condition;
@@ -2670,7 +2670,7 @@ olx.interaction.DrawOptions.prototype.condition;
  * indicate whether that event should be handled. The default is
  * {@link ol.events.condition.shiftKeyOnly}, meaning that the Shift key
  * activates freehand drawing.
- * @type {ol.events.ConditionType|undefined}
+ * @type {ol.EventsConditionType|undefined}
  * @api
  */
 olx.interaction.DrawOptions.prototype.freehandCondition;
@@ -2715,7 +2715,7 @@ olx.interaction.TranslateOptions.prototype.layers;
 
 
 /**
- * @typedef {{condition: (ol.events.ConditionType|undefined),
+ * @typedef {{condition: (ol.EventsConditionType|undefined),
  *     duration: (number|undefined),
  *     pixelDelta: (number|undefined)}}
  */
@@ -2727,7 +2727,7 @@ olx.interaction.KeyboardPanOptions;
  * to indicate whether that event should be handled.
  * Default is {@link ol.events.condition.noModifierKeys} and
  * {@link ol.events.condition.targetNotEditable}.
- * @type {ol.events.ConditionType|undefined}
+ * @type {ol.EventsConditionType|undefined}
  * @api
  */
 olx.interaction.KeyboardPanOptions.prototype.condition;
@@ -2751,7 +2751,7 @@ olx.interaction.KeyboardPanOptions.prototype.pixelDelta;
 
 /**
  * @typedef {{duration: (number|undefined),
- *     condition: (ol.events.ConditionType|undefined),
+ *     condition: (ol.EventsConditionType|undefined),
  *     delta: (number|undefined)}}
  */
 olx.interaction.KeyboardZoomOptions;
@@ -2769,7 +2769,7 @@ olx.interaction.KeyboardZoomOptions.prototype.duration;
  * A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * Default is {@link ol.events.condition.targetNotEditable}.
- * @type {ol.events.ConditionType|undefined}
+ * @type {ol.EventsConditionType|undefined}
  * @api
  */
 olx.interaction.KeyboardZoomOptions.prototype.condition;
@@ -2784,10 +2784,10 @@ olx.interaction.KeyboardZoomOptions.prototype.delta;
 
 
 /**
- * @typedef {{condition: (ol.events.ConditionType|undefined),
- *     deleteCondition: (ol.events.ConditionType|undefined),
+ * @typedef {{condition: (ol.EventsConditionType|undefined),
+ *     deleteCondition: (ol.EventsConditionType|undefined),
  *     pixelTolerance: (number|undefined),
- *     style: (ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined),
+ *     style: (ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined),
  *     features: ol.Collection.<ol.Feature>,
  *     wrapX: (boolean|undefined)}}
  */
@@ -2799,7 +2799,7 @@ olx.interaction.ModifyOptions;
  * to indicate whether that event will be considered to add or move a vertex
  * to the sketch.
  * Default is {@link ol.events.condition.primaryAction}.
- * @type {ol.events.ConditionType|undefined}
+ * @type {ol.EventsConditionType|undefined}
  * @api
  */
 olx.interaction.ModifyOptions.prototype.condition;
@@ -2810,7 +2810,7 @@ olx.interaction.ModifyOptions.prototype.condition;
  * to indicate whether that event should be handled.
  * By default, {@link ol.events.condition.singleClick} with
  * {@link ol.events.condition.noModifierKeys} results in a vertex deletion.
- * @type {ol.events.ConditionType|undefined}
+ * @type {ol.EventsConditionType|undefined}
  * @api
  */
 olx.interaction.ModifyOptions.prototype.deleteCondition;
@@ -2828,7 +2828,7 @@ olx.interaction.ModifyOptions.prototype.pixelTolerance;
 /**
  * Style used for the features being modified. By default the default edit
  * style is used (see {@link ol.style}).
- * @type {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined}
+ * @type {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined}
  * @api
  */
 olx.interaction.ModifyOptions.prototype.style;
@@ -2971,15 +2971,15 @@ olx.interaction.PointerOptions.prototype.handleUpEvent;
 
 
 /**
- * @typedef {{addCondition: (ol.events.ConditionType|undefined),
- *     condition: (ol.events.ConditionType|undefined),
+ * @typedef {{addCondition: (ol.EventsConditionType|undefined),
+ *     condition: (ol.EventsConditionType|undefined),
  *     layers: (undefined|Array.<ol.layer.Layer>|function(ol.layer.Layer): boolean),
- *     style: (ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined),
- *     removeCondition: (ol.events.ConditionType|undefined),
- *     toggleCondition: (ol.events.ConditionType|undefined),
+ *     style: (ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined),
+ *     removeCondition: (ol.EventsConditionType|undefined),
+ *     toggleCondition: (ol.EventsConditionType|undefined),
  *     multi: (boolean|undefined),
  *     features: (ol.Collection.<ol.Feature>|undefined),
- *     filter: (ol.interaction.SelectFilterFunction|undefined),
+ *     filter: (ol.SelectFilterFunction|undefined),
  *     wrapX: (boolean|undefined)}}
  */
 olx.interaction.SelectOptions;
@@ -2990,7 +2990,7 @@ olx.interaction.SelectOptions;
  * to indicate whether that event should be handled.
  * By default, this is {@link ol.events.condition.never}. Use this if you want
  * to use different events for add and remove instead of `toggle`.
- * @type {ol.events.ConditionType|undefined}
+ * @type {ol.EventsConditionType|undefined}
  * @api
  */
 olx.interaction.SelectOptions.prototype.addCondition;
@@ -3005,7 +3005,7 @@ olx.interaction.SelectOptions.prototype.addCondition;
  * feature removes all from the selection.
  * See `toggle`, `add`, `remove` options for adding/removing extra features to/
  * from the selection.
- * @type {ol.events.ConditionType|undefined}
+ * @type {ol.EventsConditionType|undefined}
  * @api
  */
 olx.interaction.SelectOptions.prototype.condition;
@@ -3026,7 +3026,7 @@ olx.interaction.SelectOptions.prototype.layers;
 /**
  * Style for the selected features. By default the default edit style is used
  * (see {@link ol.style}).
- * @type {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined}
+ * @type {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined}
  * @api
  */
 olx.interaction.SelectOptions.prototype.style;
@@ -3037,7 +3037,7 @@ olx.interaction.SelectOptions.prototype.style;
  * to indicate whether that event should be handled.
  * By default, this is {@link ol.events.condition.never}. Use this if you want
  * to use different events for add and remove instead of `toggle`.
- * @type {ol.events.ConditionType|undefined}
+ * @type {ol.EventsConditionType|undefined}
  * @api
  */
 olx.interaction.SelectOptions.prototype.removeCondition;
@@ -3052,7 +3052,7 @@ olx.interaction.SelectOptions.prototype.removeCondition;
  * not currently selected, and removes it if it is.
  * See `add` and `remove` if you want to use different events instead of a
  * toggle.
- * @type {ol.events.ConditionType|undefined}
+ * @type {ol.EventsConditionType|undefined}
  * @api
  */
 olx.interaction.SelectOptions.prototype.toggleCondition;
@@ -3080,7 +3080,7 @@ olx.interaction.SelectOptions.prototype.features;
 /**
  * A function that takes an {@link ol.Feature} and an {@link ol.layer.Layer} and
  * returns `true` if the feature may be selected or `false` otherwise.
- * @type {ol.interaction.SelectFilterFunction|undefined}
+ * @type {ol.SelectFilterFunction|undefined}
  * @api
  */
 olx.interaction.SelectOptions.prototype.filter;
@@ -3636,7 +3636,7 @@ olx.layer.TileOptions.prototype.useInterimTilesOnError;
  *     renderBuffer: (number|undefined),
  *     source: (ol.source.Vector|undefined),
  *     map: (ol.Map|undefined),
- *     style: (ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined),
+ *     style: (ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined),
  *     updateWhileAnimating: (boolean|undefined),
  *     updateWhileInteracting: (boolean|undefined),
  *     visible: (boolean|undefined)}}
@@ -3720,7 +3720,7 @@ olx.layer.VectorOptions.prototype.source;
 /**
  * Layer style. See {@link ol.style} for default style which will be used if
  * this is not defined.
- * @type {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined}
+ * @type {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined}
  * @api stable
  */
 olx.layer.VectorOptions.prototype.style;
@@ -3764,7 +3764,7 @@ olx.layer.VectorOptions.prototype.visible;
  *     renderMode: (ol.layer.VectorTileRenderType|string|undefined),
  *     renderOrder: (function(ol.Feature, ol.Feature):number|undefined),
  *     source: (ol.source.VectorTile|undefined),
- *     style: (ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined),
+ *     style: (ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined),
  *     updateWhileAnimating: (boolean|undefined),
  *     updateWhileInteracting: (boolean|undefined),
  *     visible: (boolean|undefined)}}
@@ -3865,7 +3865,7 @@ olx.layer.VectorTileOptions.prototype.source;
 /**
  * Layer style. See {@link ol.style} for default style which will be used if
  * this is not defined.
- * @type {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined}
+ * @type {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined}
  * @api stable
  */
 olx.layer.VectorTileOptions.prototype.style;
@@ -4030,7 +4030,7 @@ olx.source.BingMapsOptions.prototype.wrapX;
  *     format: (ol.format.Feature|undefined),
  *     geometryFunction: (undefined|function(ol.Feature):ol.geom.Point),
  *     logo: (string|undefined),
- *     projection: ol.proj.ProjectionLike,
+ *     projection: ol.ProjectionLike,
  *     source: ol.source.Vector,
  *     wrapX: (boolean|undefined)}}
  */
@@ -4098,7 +4098,7 @@ olx.source.ClusterOptions.prototype.logo;
 
 /**
  * Projection.
- * @type {ol.proj.ProjectionLike}
+ * @type {ol.ProjectionLike}
  * @api
  */
 olx.source.ClusterOptions.prototype.projection;
@@ -4175,7 +4175,7 @@ olx.source.TileUTFGridOptions.prototype.url;
  *            crossOrigin: (null|string|undefined),
  *            logo: (string|olx.LogoOptions|undefined),
  *            opaque: (boolean|undefined),
- *            projection: ol.proj.ProjectionLike,
+ *            projection: ol.ProjectionLike,
  *            reprojectionErrorThreshold: (number|undefined),
  *            state: (ol.source.State|undefined),
  *            tileClass: (function(new: ol.ImageTile, ol.TileCoord,
@@ -4238,7 +4238,7 @@ olx.source.TileImageOptions.prototype.opaque;
 
 /**
  * Projection.
- * @type {ol.proj.ProjectionLike}
+ * @type {ol.ProjectionLike}
  * @api
  */
 olx.source.TileImageOptions.prototype.projection;
@@ -4345,7 +4345,7 @@ olx.source.TileImageOptions.prototype.wrapX;
  *            cacheSize: (number|undefined),
  *            format: (ol.format.Feature|undefined),
  *            logo: (string|olx.LogoOptions|undefined),
- *            projection: ol.proj.ProjectionLike,
+ *            projection: ol.ProjectionLike,
  *            state: (ol.source.State|undefined),
  *            tileClass: (function(new: ol.VectorTile, ol.TileCoord,
  *                 ol.TileState, string, ol.format.Feature,
@@ -4396,7 +4396,7 @@ olx.source.VectorTileOptions.prototype.logo;
 
 /**
  * Projection.
- * @type {ol.proj.ProjectionLike}
+ * @type {ol.ProjectionLike}
  * @api
  */
 olx.source.VectorTileOptions.prototype.projection;
@@ -4499,7 +4499,7 @@ olx.source.VectorTileOptions.prototype.wrapX;
  *     metersPerUnit: (number|undefined),
  *     hidpi: (boolean|undefined),
  *     useOverlay: (boolean|undefined),
- *     projection: ol.proj.ProjectionLike,
+ *     projection: ol.ProjectionLike,
  *     ratio: (number|undefined),
  *     resolutions: (Array.<number>|undefined),
  *     imageLoadFunction: (ol.ImageLoadFunctionType|undefined),
@@ -4551,7 +4551,7 @@ olx.source.ImageMapGuideOptions.prototype.useOverlay;
 
 /**
  * Projection.
- * @type {ol.proj.ProjectionLike}
+ * @type {ol.ProjectionLike}
  * @api
  */
 olx.source.ImageMapGuideOptions.prototype.projection;
@@ -4648,7 +4648,7 @@ olx.source.MapQuestOptions.prototype.url;
 
 
 /**
- * @typedef {{projection: ol.proj.ProjectionLike,
+ * @typedef {{projection: ol.ProjectionLike,
  *     tileGrid: (ol.tilegrid.TileGrid|undefined),
  *     wrapX: (boolean|undefined)}}
  */
@@ -4657,7 +4657,7 @@ olx.source.TileDebugOptions;
 
 /**
  * Projection.
- * @type {ol.proj.ProjectionLike}
+ * @type {ol.ProjectionLike}
  * @api
  */
 olx.source.TileDebugOptions.prototype.projection;
@@ -4784,7 +4784,7 @@ olx.source.OSMOptions.prototype.wrapX;
  *     logo: (string|olx.LogoOptions|undefined),
  *     imageLoadFunction: (ol.ImageLoadFunctionType|undefined),
  *     params: Object.<string,*>,
- *     projection: ol.proj.ProjectionLike,
+ *     projection: ol.ProjectionLike,
  *     ratio: (number|undefined),
  *     resolutions: (Array.<number>|undefined),
  *     url: (string|undefined)}}
@@ -4844,7 +4844,7 @@ olx.source.ImageArcGISRestOptions.prototype.params;
 
 /**
  * Projection.
- * @type {ol.proj.ProjectionLike}
+ * @type {ol.ProjectionLike}
  * @api
  */
 olx.source.ImageArcGISRestOptions.prototype.projection;
@@ -4880,7 +4880,7 @@ olx.source.ImageArcGISRestOptions.prototype.url;
  * @typedef {{attributions: (ol.AttributionLike|undefined),
  *     canvasFunction: ol.CanvasFunctionType,
  *     logo: (string|olx.LogoOptions|undefined),
- *     projection: ol.proj.ProjectionLike,
+ *     projection: ol.ProjectionLike,
  *     ratio: (number|undefined),
  *     resolutions: (Array.<number>|undefined),
  *     state: (ol.source.State|undefined)}}
@@ -4921,7 +4921,7 @@ olx.source.ImageCanvasOptions.prototype.logo;
 
 /**
  * Projection.
- * @type {ol.proj.ProjectionLike}
+ * @type {ol.ProjectionLike}
  * @api
  */
 olx.source.ImageCanvasOptions.prototype.projection;
@@ -4957,11 +4957,11 @@ olx.source.ImageCanvasOptions.prototype.state;
 /**
  * @typedef {{attributions: (ol.AttributionLike|undefined),
  *     logo: (string|olx.LogoOptions|undefined),
- *     projection: ol.proj.ProjectionLike,
+ *     projection: ol.ProjectionLike,
  *     ratio: (number|undefined),
  *     resolutions: (Array.<number>|undefined),
  *     source: ol.source.Vector,
- *     style: (ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined)}}
+ *     style: (ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined)}}
  */
 olx.source.ImageVectorOptions;
 
@@ -4984,7 +4984,7 @@ olx.source.ImageVectorOptions.prototype.logo;
 
 /**
  * Projection.
- * @type {ol.proj.ProjectionLike}
+ * @type {ol.ProjectionLike}
  * @api
  */
 olx.source.ImageVectorOptions.prototype.projection;
@@ -5020,7 +5020,7 @@ olx.source.ImageVectorOptions.prototype.source;
 
 /**
  * Style to use when rendering features to the canvas.
- * @type {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined}
+ * @type {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined}
  * @api
  */
 olx.source.ImageVectorOptions.prototype.style;
@@ -5093,7 +5093,7 @@ olx.source.RasterOptions.prototype.operationType;
  *     logo: (string|olx.LogoOptions|undefined),
  *     imageLoadFunction: (ol.ImageLoadFunctionType|undefined),
  *     params: Object.<string,*>,
- *     projection: ol.proj.ProjectionLike,
+ *     projection: ol.ProjectionLike,
  *     ratio: (number|undefined),
  *     resolutions: (Array.<number>|undefined),
  *     url: (string|undefined)}}
@@ -5167,7 +5167,7 @@ olx.source.ImageWMSOptions.prototype.params;
 
 /**
  * Projection.
- * @type {ol.proj.ProjectionLike}
+ * @type {ol.ProjectionLike}
  * @api
  */
 olx.source.ImageWMSOptions.prototype.projection;
@@ -5288,7 +5288,7 @@ olx.source.StamenOptions.prototype.url;
  *     imageLoadFunction: (ol.ImageLoadFunctionType|undefined),
  *     imageSize: (ol.Size|undefined),
  *     logo: (string|olx.LogoOptions|undefined),
- *     projection: ol.proj.ProjectionLike,
+ *     projection: ol.ProjectionLike,
  *     url: string}}
  */
 olx.source.ImageStaticOptions;
@@ -5341,7 +5341,7 @@ olx.source.ImageStaticOptions.prototype.logo;
 
 /**
  * Projection.
- * @type {ol.proj.ProjectionLike}
+ * @type {ol.ProjectionLike}
  * @api
  */
 olx.source.ImageStaticOptions.prototype.projection;
@@ -5371,7 +5371,7 @@ olx.source.ImageStaticOptions.prototype.url;
  *     params: (Object.<string, *>|undefined),
  *     logo: (string|olx.LogoOptions|undefined),
  *     tileGrid: (ol.tilegrid.TileGrid|undefined),
- *     projection: ol.proj.ProjectionLike,
+ *     projection: ol.ProjectionLike,
  *     reprojectionErrorThreshold: (number|undefined),
  *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
  *     url: (string|undefined),
@@ -5445,7 +5445,7 @@ olx.source.TileArcGISRestOptions.prototype.tileGrid;
 
 /**
  * Projection.
- * @type {ol.proj.ProjectionLike}
+ * @type {ol.ProjectionLike}
  * @api
  */
 olx.source.TileArcGISRestOptions.prototype.projection;
@@ -5599,7 +5599,7 @@ olx.source.TileJSONOptions.prototype.wrapX;
  *     logo: (string|olx.LogoOptions|undefined),
  *     tileGrid: (ol.tilegrid.TileGrid|undefined),
  *     maxZoom: (number|undefined),
- *     projection: ol.proj.ProjectionLike,
+ *     projection: ol.ProjectionLike,
  *     reprojectionErrorThreshold: (number|undefined),
  *     serverType: (ol.source.wms.ServerType|string|undefined),
  *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
@@ -5702,7 +5702,7 @@ olx.source.TileWMSOptions.prototype.maxZoom;
 
 /**
  * Projection.
- * @type {ol.proj.ProjectionLike}
+ * @type {ol.ProjectionLike}
  * @api
  */
 olx.source.TileWMSOptions.prototype.projection;
@@ -5892,7 +5892,7 @@ olx.source.VectorOptions.prototype.wrapX;
  *     crossOrigin: (string|null|undefined),
  *     logo: (string|olx.LogoOptions|undefined),
  *     tileGrid: ol.tilegrid.WMTS,
- *     projection: ol.proj.ProjectionLike,
+ *     projection: ol.ProjectionLike,
  *     reprojectionErrorThreshold: (number|undefined),
  *     requestEncoding: (ol.source.WMTSRequestEncoding|string|undefined),
  *     layer: string,
@@ -5960,7 +5960,7 @@ olx.source.WMTSOptions.prototype.tileGrid;
 
 /**
  * Projection.
- * @type {ol.proj.ProjectionLike}
+ * @type {ol.ProjectionLike}
  * @api
  */
 olx.source.WMTSOptions.prototype.projection;
@@ -6107,7 +6107,7 @@ olx.source.WMTSOptions.prototype.wrapX;
  *     crossOrigin: (null|string|undefined),
  *     logo: (string|olx.LogoOptions|undefined),
  *     opaque: (boolean|undefined),
- *     projection: ol.proj.ProjectionLike,
+ *     projection: ol.ProjectionLike,
  *     reprojectionErrorThreshold: (number|undefined),
  *     maxZoom: (number|undefined),
  *     minZoom: (number|undefined),
@@ -6169,7 +6169,7 @@ olx.source.XYZOptions.prototype.opaque;
 
 /**
  * Projection. Default is `EPSG:3857`.
- * @type {ol.proj.ProjectionLike}
+ * @type {ol.ProjectionLike}
  * @api
  */
 olx.source.XYZOptions.prototype.projection;
@@ -6279,7 +6279,7 @@ olx.source.XYZOptions.prototype.wrapX;
  *     cacheSize: (number|undefined),
  *     crossOrigin: (null|string|undefined),
  *     logo: (string|olx.LogoOptions|undefined),
- *     projection: ol.proj.ProjectionLike,
+ *     projection: ol.ProjectionLike,
  *     maxZoom: (number|undefined),
  *     minZoom: (number|undefined),
  *     wrapX: (boolean|undefined),
@@ -6328,7 +6328,7 @@ olx.source.CartoDBOptions.prototype.logo;
 
 /**
  * Projection. Default is `EPSG:3857`.
- * @type {ol.proj.ProjectionLike}
+ * @type {ol.ProjectionLike}
  * @api
  */
 olx.source.CartoDBOptions.prototype.projection;
@@ -7017,7 +7017,7 @@ olx.style.TextOptions.prototype.stroke;
 
 
 /**
- * @typedef {{geometry: (undefined|string|ol.geom.Geometry|ol.style.GeometryFunction),
+ * @typedef {{geometry: (undefined|string|ol.geom.Geometry|ol.StyleGeometryFunction),
  *     fill: (ol.style.Fill|undefined),
  *     image: (ol.style.Image|undefined),
  *     stroke: (ol.style.Stroke|undefined),
@@ -7030,7 +7030,7 @@ olx.style.StyleOptions;
 /**
  * Feature property or geometry or function returning a geometry to render for
  * this style.
- * @type {undefined|string|ol.geom.Geometry|ol.style.GeometryFunction}
+ * @type {undefined|string|ol.geom.Geometry|ol.StyleGeometryFunction}
  * @api
  */
 olx.style.StyleOptions.prototype.geometry;

--- a/src/ol/control/control.js
+++ b/src/ol/control/control.js
@@ -60,7 +60,7 @@ ol.control.Control = function(options) {
 
   /**
    * @protected
-   * @type {!Array.<ol.events.Key>}
+   * @type {!Array.<ol.EventsKey>}
    */
   this.listenerKeys = [];
 

--- a/src/ol/control/zoomslidercontrol.js
+++ b/src/ol/control/zoomslidercontrol.js
@@ -58,7 +58,7 @@ ol.control.ZoomSlider = function(opt_options) {
   this.dragging_;
 
   /**
-   * @type {!Array.<ol.events.Key>}
+   * @type {!Array.<ol.EventsKey>}
    * @private
    */
   this.dragListenerKeys_ = [];

--- a/src/ol/deviceorientation.js
+++ b/src/ol/deviceorientation.js
@@ -83,7 +83,7 @@ ol.DeviceOrientation = function(opt_options) {
 
   /**
    * @private
-   * @type {?ol.events.Key}
+   * @type {?ol.EventsKey}
    */
   this.listenerKey_ = null;
 

--- a/src/ol/events.js
+++ b/src/ol/events.js
@@ -3,7 +3,6 @@ goog.provide('ol.events.EventType');
 goog.provide('ol.events.KeyCode');
 
 goog.require('ol.object');
-goog.require('ol.EventTargetLike');
 
 
 /**

--- a/src/ol/events.js
+++ b/src/ol/events.js
@@ -3,7 +3,7 @@ goog.provide('ol.events.EventType');
 goog.provide('ol.events.KeyCode');
 
 goog.require('ol.object');
-goog.require('ol.events.EventTargetLike');
+goog.require('ol.EventTargetLike');
 
 
 /**
@@ -63,8 +63,8 @@ ol.events.LISTENER_MAP_PROP_ = 'olm_' + ((Math.random() * 1e4) | 0);
 
 
 /**
- * @param {ol.events.Key} listenerObj Listener object.
- * @return {ol.events.ListenerFunctionType} Bound listener.
+ * @param {ol.EventsKey} listenerObj Listener object.
+ * @return {ol.EventsListenerFunctionType} Bound listener.
  */
 ol.events.bindListener_ = function(listenerObj) {
   var boundListener = function(evt) {
@@ -81,15 +81,15 @@ ol.events.bindListener_ = function(listenerObj) {
 
 
 /**
- * Finds the matching {@link ol.events.Key} in the given listener
+ * Finds the matching {@link ol.EventsKey} in the given listener
  * array.
  *
- * @param {!Array<!ol.events.Key>} listeners Array of listeners.
+ * @param {!Array<!ol.EventsKey>} listeners Array of listeners.
  * @param {!Function} listener The listener function.
  * @param {Object=} opt_this The `this` value inside the listener.
  * @param {boolean=} opt_setDeleteIndex Set the deleteIndex on the matching
  *     listener, for {@link ol.events.unlistenByKey}.
- * @return {ol.events.Key|undefined} The matching listener object.
+ * @return {ol.EventsKey|undefined} The matching listener object.
  * @private
  */
 ol.events.findListener_ = function(listeners, listener, opt_this,
@@ -110,9 +110,9 @@ ol.events.findListener_ = function(listeners, listener, opt_this,
 
 
 /**
- * @param {ol.events.EventTargetLike} target Target.
+ * @param {ol.EventTargetLike} target Target.
  * @param {string} type Type.
- * @return {Array.<ol.events.Key>|undefined} Listeners.
+ * @return {Array.<ol.EventsKey>|undefined} Listeners.
  */
 ol.events.getListeners = function(target, type) {
   var listenerMap = target[ol.events.LISTENER_MAP_PROP_];
@@ -123,8 +123,8 @@ ol.events.getListeners = function(target, type) {
 /**
  * Get the lookup of listeners.  If one does not exist on the target, it is
  * created.
- * @param {ol.events.EventTargetLike} target Target.
- * @return {!Object.<string, Array.<ol.events.Key>>} Map of
+ * @param {ol.EventTargetLike} target Target.
+ * @return {!Object.<string, Array.<ol.EventsKey>>} Map of
  *     listeners by event type.
  * @private
  */
@@ -141,7 +141,7 @@ ol.events.getListenerMap_ = function(target) {
  * Clean up all listener objects of the given type.  All properties on the
  * listener objects will be removed, and if no listeners remain in the listener
  * map, it will be removed from the target.
- * @param {ol.events.EventTargetLike} target Target.
+ * @param {ol.EventTargetLike} target Target.
  * @param {string} type Type.
  * @private
  */
@@ -171,13 +171,13 @@ ol.events.removeListeners_ = function(target, type) {
  * This function efficiently binds a `listener` to a `this` object, and returns
  * a key for use with {@link ol.events.unlistenByKey}.
  *
- * @param {ol.events.EventTargetLike} target Event target.
+ * @param {ol.EventTargetLike} target Event target.
  * @param {string} type Event type.
- * @param {ol.events.ListenerFunctionType} listener Listener.
+ * @param {ol.EventsListenerFunctionType} listener Listener.
  * @param {Object=} opt_this Object referenced by the `this` keyword in the
  *     listener. Default is the `target`.
  * @param {boolean=} opt_once If true, add the listener as one-off listener.
- * @return {ol.events.Key} Unique key for the listener.
+ * @return {ol.EventsKey} Unique key for the listener.
  */
 ol.events.listen = function(target, type, listener, opt_this, opt_once) {
   var listenerMap = ol.events.getListenerMap_(target);
@@ -193,7 +193,7 @@ ol.events.listen = function(target, type, listener, opt_this, opt_once) {
       listenerObj.callOnce = false;
     }
   } else {
-    listenerObj = /** @type {ol.events.Key} */ ({
+    listenerObj = /** @type {ol.EventsKey} */ ({
       bindTo: opt_this,
       callOnce: !!opt_once,
       listener: listener,
@@ -221,12 +221,12 @@ ol.events.listen = function(target, type, listener, opt_this, opt_once) {
  * function, the self-unregistering listener will be turned into a permanent
  * listener.
  *
- * @param {ol.events.EventTargetLike} target Event target.
+ * @param {ol.EventTargetLike} target Event target.
  * @param {string} type Event type.
- * @param {ol.events.ListenerFunctionType} listener Listener.
+ * @param {ol.EventsListenerFunctionType} listener Listener.
  * @param {Object=} opt_this Object referenced by the `this` keyword in the
  *     listener. Default is the `target`.
- * @return {ol.events.Key} Key for unlistenByKey.
+ * @return {ol.EventsKey} Key for unlistenByKey.
  */
 ol.events.listenOnce = function(target, type, listener, opt_this) {
   return ol.events.listen(target, type, listener, opt_this, true);
@@ -240,9 +240,9 @@ ol.events.listenOnce = function(target, type, listener, opt_this) {
  * To return a listener, this function needs to be called with the exact same
  * arguments that were used for a previous {@link ol.events.listen} call.
  *
- * @param {ol.events.EventTargetLike} target Event target.
+ * @param {ol.EventTargetLike} target Event target.
  * @param {string} type Event type.
- * @param {ol.events.ListenerFunctionType} listener Listener.
+ * @param {ol.EventsListenerFunctionType} listener Listener.
  * @param {Object=} opt_this Object referenced by the `this` keyword in the
  *     listener. Default is the `target`.
  */
@@ -265,7 +265,7 @@ ol.events.unlisten = function(target, type, listener, opt_this) {
  * The argument passed to this function is the key returned from
  * {@link ol.events.listen} or {@link ol.events.listenOnce}.
  *
- * @param {ol.events.Key} key The key.
+ * @param {ol.EventsKey} key The key.
  */
 ol.events.unlistenByKey = function(key) {
   if (key && key.target) {
@@ -289,7 +289,7 @@ ol.events.unlistenByKey = function(key) {
  * Unregisters all event listeners on an event target. Inspired by
  * {@link https://google.github.io/closure-library/api/source/closure/goog/events/events.js.src.html}
  *
- * @param {ol.events.EventTargetLike} target Target.
+ * @param {ol.EventTargetLike} target Target.
  */
 ol.events.unlistenAll = function(target) {
   var listenerMap = ol.events.getListenerMap_(target);

--- a/src/ol/events/eventtarget.js
+++ b/src/ol/events/eventtarget.js
@@ -5,6 +5,7 @@ goog.require('ol.Disposable');
 goog.require('ol.events');
 goog.require('ol.events.Event');
 
+
 /**
  * @classdesc
  * A simplified implementation of the W3C DOM Level 2 EventTarget interface.

--- a/src/ol/events/eventtarget.js
+++ b/src/ol/events/eventtarget.js
@@ -41,7 +41,7 @@ ol.events.EventTarget = function() {
 
   /**
    * @private
-   * @type {!Object.<string, Array.<ol.events.ListenerFunctionType>>}
+   * @type {!Object.<string, Array.<ol.EventsListenerFunctionType>>}
    */
   this.listeners_ = {};
 
@@ -51,7 +51,7 @@ ol.inherits(ol.events.EventTarget, ol.Disposable);
 
 /**
  * @param {string} type Type.
- * @param {ol.events.ListenerFunctionType} listener Listener.
+ * @param {ol.EventsListenerFunctionType} listener Listener.
  */
 ol.events.EventTarget.prototype.addEventListener = function(type, listener) {
   var listeners = this.listeners_[type];
@@ -116,7 +116,7 @@ ol.events.EventTarget.prototype.disposeInternal = function() {
  * order that they will be called in.
  *
  * @param {string} type Type.
- * @return {Array.<ol.events.ListenerFunctionType>} Listeners.
+ * @return {Array.<ol.EventsListenerFunctionType>} Listeners.
  */
 ol.events.EventTarget.prototype.getListeners = function(type) {
   return this.listeners_[type];
@@ -137,7 +137,7 @@ ol.events.EventTarget.prototype.hasListener = function(opt_type) {
 
 /**
  * @param {string} type Type.
- * @param {ol.events.ListenerFunctionType} listener Listener.
+ * @param {ol.EventsListenerFunctionType} listener Listener.
  */
 ol.events.EventTarget.prototype.removeEventListener = function(type, listener) {
   var listeners = this.listeners_[type];

--- a/src/ol/feature.js
+++ b/src/ol/feature.js
@@ -86,7 +86,7 @@ ol.Feature = function(opt_geometryOrProperties) {
 
   /**
    * @private
-   * @type {?ol.events.Key}
+   * @type {?ol.EventsKey}
    */
   this.geometryChangeKey_ = null;
 

--- a/src/ol/format/ogc/filter.js
+++ b/src/ol/format/ogc/filter.js
@@ -18,8 +18,6 @@ goog.provide('ol.format.ogc.filter.IsNull');
 goog.provide('ol.format.ogc.filter.IsBetween');
 goog.provide('ol.format.ogc.filter.IsLike');
 
-goog.require('ol.Extent');
-
 
 /**
  * Create a logical `<And>` operator between two filter conditions.
@@ -365,7 +363,7 @@ ol.format.ogc.filter.Bbox = function(geometryName, extent, opt_srsName) {
 
   /**
    * @public
-   * @type {!ol.Extent}
+   * @type {ol.Extent}
    */
   this.extent = extent;
 

--- a/src/ol/geom/circle.js
+++ b/src/ol/geom/circle.js
@@ -6,7 +6,6 @@ goog.require('ol.geom.GeometryLayout');
 goog.require('ol.geom.GeometryType');
 goog.require('ol.geom.SimpleGeometry');
 goog.require('ol.geom.flat.deflate');
-goog.require('ol.proj');
 
 
 /**
@@ -244,9 +243,9 @@ ol.geom.Circle.prototype.setRadius = function(radius) {
  * correspond to the shape that would be obtained by transforming every point
  * of the original circle.
  *
- * @param {ol.proj.ProjectionLike} source The current projection.  Can be a
+ * @param {ol.ProjectionLike} source The current projection.  Can be a
  *     string identifier or a {@link ol.proj.Projection} object.
- * @param {ol.proj.ProjectionLike} destination The desired projection.  Can be a
+ * @param {ol.ProjectionLike} destination The desired projection.  Can be a
  *     string identifier or a {@link ol.proj.Projection} object.
  * @return {ol.geom.Circle} This geometry.  Note that original geometry is
  *     modified in place.

--- a/src/ol/geom/geometry.js
+++ b/src/ol/geom/geometry.js
@@ -251,9 +251,9 @@ ol.geom.Geometry.prototype.translate = goog.abstractMethod;
  * If you do not want the geometry modified in place, first `clone()` it and
  * then use this function on the clone.
  *
- * @param {ol.proj.ProjectionLike} source The current projection.  Can be a
+ * @param {ol.ProjectionLike} source The current projection.  Can be a
  *     string identifier or a {@link ol.proj.Projection} object.
- * @param {ol.proj.ProjectionLike} destination The desired projection.  Can be a
+ * @param {ol.ProjectionLike} destination The desired projection.  Can be a
  *     string identifier or a {@link ol.proj.Projection} object.
  * @return {ol.geom.Geometry} This geometry.  Note that original geometry is
  *     modified in place.

--- a/src/ol/image.js
+++ b/src/ol/image.js
@@ -49,7 +49,7 @@ ol.Image = function(extent, resolution, pixelRatio, attributions, src,
 
   /**
    * @private
-   * @type {Array.<ol.events.Key>}
+   * @type {Array.<ol.EventsKey>}
    */
   this.imageListenerKeys_ = null;
 

--- a/src/ol/imagetile.js
+++ b/src/ol/imagetile.js
@@ -46,7 +46,7 @@ ol.ImageTile = function(tileCoord, state, src, crossOrigin, tileLoadFunction) {
 
   /**
    * @private
-   * @type {Array.<ol.events.Key>}
+   * @type {Array.<ol.EventsKey>}
    */
   this.imageListenerKeys_ = null;
 

--- a/src/ol/interaction/draganddropinteraction.js
+++ b/src/ol/interaction/draganddropinteraction.js
@@ -46,7 +46,7 @@ ol.interaction.DragAndDrop = function(opt_options) {
 
   /**
    * @private
-   * @type {Array.<ol.events.Key>}
+   * @type {Array.<ol.EventsKey>}
    */
   this.dropListenKeys_ = null;
 

--- a/src/ol/interaction/dragboxinteraction.js
+++ b/src/ol/interaction/dragboxinteraction.js
@@ -120,14 +120,14 @@ ol.interaction.DragBox = function(opt_options) {
 
   /**
    * @private
-   * @type {ol.events.ConditionType}
+   * @type {ol.EventsConditionType}
    */
   this.condition_ = options.condition ?
       options.condition : ol.events.condition.always;
 
   /**
    * @private
-   * @type {ol.interaction.DragBoxEndConditionType}
+   * @type {ol.DragBoxEndConditionType}
    */
   this.boxEndCondition_ = options.boxEndCondition ?
       options.boxEndCondition : ol.interaction.DragBox.defaultBoxEndCondition;

--- a/src/ol/interaction/dragpaninteraction.js
+++ b/src/ol/interaction/dragpaninteraction.js
@@ -48,7 +48,7 @@ ol.interaction.DragPan = function(opt_options) {
 
   /**
    * @private
-   * @type {ol.events.ConditionType}
+   * @type {ol.EventsConditionType}
    */
   this.condition_ = options.condition ?
       options.condition : ol.events.condition.noModifierKeys;

--- a/src/ol/interaction/dragrotateandzoominteraction.js
+++ b/src/ol/interaction/dragrotateandzoominteraction.js
@@ -34,7 +34,7 @@ ol.interaction.DragRotateAndZoom = function(opt_options) {
 
   /**
    * @private
-   * @type {ol.events.ConditionType}
+   * @type {ol.EventsConditionType}
    */
   this.condition_ = options.condition ?
       options.condition : ol.events.condition.shiftKeyOnly;

--- a/src/ol/interaction/dragrotateinteraction.js
+++ b/src/ol/interaction/dragrotateinteraction.js
@@ -33,7 +33,7 @@ ol.interaction.DragRotate = function(opt_options) {
 
   /**
    * @private
-   * @type {ol.events.ConditionType}
+   * @type {ol.EventsConditionType}
    */
   this.condition_ = options.condition ?
       options.condition : ol.events.condition.altShiftKeysOnly;

--- a/src/ol/interaction/drawinteraction.js
+++ b/src/ol/interaction/drawinteraction.js
@@ -161,7 +161,7 @@ ol.interaction.Draw = function(options) {
   /**
    * A function to decide if a potential finish coordinate is permissable
    * @private
-   * @type {ol.events.ConditionType}
+   * @type {ol.EventsConditionType}
    */
   this.finishCondition_ = options.finishCondition ? options.finishCondition : ol.functions.TRUE;
 
@@ -213,7 +213,7 @@ ol.interaction.Draw = function(options) {
   }
 
   /**
-   * @type {ol.interaction.DrawGeometryFunctionType}
+   * @type {ol.DrawGeometryFunctionType}
    * @private
    */
   this.geometryFunction_ = geometryFunction;
@@ -294,14 +294,14 @@ ol.interaction.Draw = function(options) {
 
   /**
    * @private
-   * @type {ol.events.ConditionType}
+   * @type {ol.EventsConditionType}
    */
   this.condition_ = options.condition ?
       options.condition : ol.events.condition.noModifierKeys;
 
   /**
    * @private
-   * @type {ol.events.ConditionType}
+   * @type {ol.EventsConditionType}
    */
   this.freehandCondition_ = options.freehandCondition ?
       options.freehandCondition : ol.events.condition.shiftKeyOnly;
@@ -315,7 +315,7 @@ ol.inherits(ol.interaction.Draw, ol.interaction.Pointer);
 
 
 /**
- * @return {ol.style.StyleFunction} Styles.
+ * @return {ol.StyleFunction} Styles.
  */
 ol.interaction.Draw.getDefaultStyleFunction = function() {
   var styles = ol.style.createDefaultEditingStyles();
@@ -795,7 +795,7 @@ ol.interaction.Draw.prototype.updateState_ = function() {
  * @param {number=} opt_angle Angle of the first point in radians. 0 means East.
  *     Default is the angle defined by the heading from the center of the
  *     regular polygon to the current pointer position.
- * @return {ol.interaction.DrawGeometryFunctionType} Function that draws a
+ * @return {ol.DrawGeometryFunctionType} Function that draws a
  *     polygon.
  * @api
  */

--- a/src/ol/interaction/keyboardpaninteraction.js
+++ b/src/ol/interaction/keyboardpaninteraction.js
@@ -46,7 +46,7 @@ ol.interaction.KeyboardPan = function(opt_options) {
 
   /**
    * @private
-   * @type {ol.events.ConditionType}
+   * @type {ol.EventsConditionType}
    */
   this.condition_ = options.condition !== undefined ?
       options.condition : this.defaultCondition_

--- a/src/ol/interaction/keyboardzoominteraction.js
+++ b/src/ol/interaction/keyboardzoominteraction.js
@@ -33,7 +33,7 @@ ol.interaction.KeyboardZoom = function(opt_options) {
 
   /**
    * @private
-   * @type {ol.events.ConditionType}
+   * @type {ol.EventsConditionType}
    */
   this.condition_ = options.condition ? options.condition :
           ol.events.condition.targetNotEditable;

--- a/src/ol/interaction/modifyinteraction.js
+++ b/src/ol/interaction/modifyinteraction.js
@@ -103,7 +103,7 @@ ol.interaction.Modify = function(options) {
 
   /**
    * @private
-   * @type {ol.events.ConditionType}
+   * @type {ol.EventsConditionType}
    */
   this.condition_ = options.condition ?
       options.condition : ol.events.condition.primaryAction;
@@ -120,7 +120,7 @@ ol.interaction.Modify = function(options) {
   }
 
   /**
-   * @type {ol.events.ConditionType}
+   * @type {ol.EventsConditionType}
    * @private
    */
   this.deleteCondition_ = options.deleteCondition ?
@@ -162,7 +162,7 @@ ol.interaction.Modify = function(options) {
 
   /**
    * Segment RTree for each layer
-   * @type {ol.structs.RBush.<ol.interaction.SegmentDataType>}
+   * @type {ol.structs.RBush.<ol.ModifySegmentDataType>}
    * @private
    */
   this.rBush_ = new ol.structs.RBush();
@@ -302,10 +302,10 @@ ol.interaction.Modify.prototype.removeFeature_ = function(feature) {
  */
 ol.interaction.Modify.prototype.removeFeatureSegmentData_ = function(feature) {
   var rBush = this.rBush_;
-  var /** @type {Array.<ol.interaction.SegmentDataType>} */ nodesToRemove = [];
+  var /** @type {Array.<ol.ModifySegmentDataType>} */ nodesToRemove = [];
   rBush.forEach(
       /**
-       * @param {ol.interaction.SegmentDataType} node RTree node.
+       * @param {ol.ModifySegmentDataType} node RTree node.
        */
       function(node) {
         if (feature === node.feature) {
@@ -369,7 +369,7 @@ ol.interaction.Modify.prototype.handleFeatureRemove_ = function(evt) {
  */
 ol.interaction.Modify.prototype.writePointGeometry_ = function(feature, geometry) {
   var coordinates = geometry.getCoordinates();
-  var segmentData = /** @type {ol.interaction.SegmentDataType} */ ({
+  var segmentData = /** @type {ol.ModifySegmentDataType} */ ({
     feature: feature,
     geometry: geometry,
     segment: [coordinates, coordinates]
@@ -388,7 +388,7 @@ ol.interaction.Modify.prototype.writeMultiPointGeometry_ = function(feature, geo
   var coordinates, i, ii, segmentData;
   for (i = 0, ii = points.length; i < ii; ++i) {
     coordinates = points[i];
-    segmentData = /** @type {ol.interaction.SegmentDataType} */ ({
+    segmentData = /** @type {ol.ModifySegmentDataType} */ ({
       feature: feature,
       geometry: geometry,
       depth: [i],
@@ -410,7 +410,7 @@ ol.interaction.Modify.prototype.writeLineStringGeometry_ = function(feature, geo
   var i, ii, segment, segmentData;
   for (i = 0, ii = coordinates.length - 1; i < ii; ++i) {
     segment = coordinates.slice(i, i + 2);
-    segmentData = /** @type {ol.interaction.SegmentDataType} */ ({
+    segmentData = /** @type {ol.ModifySegmentDataType} */ ({
       feature: feature,
       geometry: geometry,
       index: i,
@@ -433,7 +433,7 @@ ol.interaction.Modify.prototype.writeMultiLineStringGeometry_ = function(feature
     coordinates = lines[j];
     for (i = 0, ii = coordinates.length - 1; i < ii; ++i) {
       segment = coordinates.slice(i, i + 2);
-      segmentData = /** @type {ol.interaction.SegmentDataType} */ ({
+      segmentData = /** @type {ol.ModifySegmentDataType} */ ({
         feature: feature,
         geometry: geometry,
         depth: [j],
@@ -458,7 +458,7 @@ ol.interaction.Modify.prototype.writePolygonGeometry_ = function(feature, geomet
     coordinates = rings[j];
     for (i = 0, ii = coordinates.length - 1; i < ii; ++i) {
       segment = coordinates.slice(i, i + 2);
-      segmentData = /** @type {ol.interaction.SegmentDataType} */ ({
+      segmentData = /** @type {ol.ModifySegmentDataType} */ ({
         feature: feature,
         geometry: geometry,
         depth: [j],
@@ -485,7 +485,7 @@ ol.interaction.Modify.prototype.writeMultiPolygonGeometry_ = function(feature, g
       coordinates = rings[j];
       for (i = 0, ii = coordinates.length - 1; i < ii; ++i) {
         segment = coordinates.slice(i, i + 2);
-        segmentData = /** @type {ol.interaction.SegmentDataType} */ ({
+        segmentData = /** @type {ol.ModifySegmentDataType} */ ({
           feature: feature,
           geometry: geometry,
           depth: [j, k],
@@ -533,8 +533,8 @@ ol.interaction.Modify.prototype.createOrUpdateVertexFeature_ = function(coordina
 
 
 /**
- * @param {ol.interaction.SegmentDataType} a The first segment data.
- * @param {ol.interaction.SegmentDataType} b The second segment data.
+ * @param {ol.ModifySegmentDataType} a The first segment data.
+ * @param {ol.ModifySegmentDataType} b The second segment data.
  * @return {number} The difference in indexes.
  * @private
  */
@@ -808,7 +808,7 @@ ol.interaction.Modify.prototype.handlePointerAtPixel_ = function(pixel, map) {
 
 
 /**
- * @param {ol.interaction.SegmentDataType} segmentData Segment data.
+ * @param {ol.ModifySegmentDataType} segmentData Segment data.
  * @param {ol.Coordinate} vertex Vertex.
  * @private
  */
@@ -859,7 +859,7 @@ ol.interaction.Modify.prototype.insertVertex_ = function(segmentData, vertex) {
   rTree.remove(segmentData);
   goog.asserts.assert(index !== undefined, 'index should be defined');
   this.updateSegmentIndices_(geometry, index, depth, 1);
-  var newSegmentData = /** @type {ol.interaction.SegmentDataType} */ ({
+  var newSegmentData = /** @type {ol.ModifySegmentDataType} */ ({
     segment: [segment[0], vertex],
     feature: feature,
     geometry: geometry,
@@ -870,7 +870,7 @@ ol.interaction.Modify.prototype.insertVertex_ = function(segmentData, vertex) {
       newSegmentData);
   this.dragSegments_.push([newSegmentData, 1]);
 
-  var newSegmentData2 = /** @type {ol.interaction.SegmentDataType} */ ({
+  var newSegmentData2 = /** @type {ol.ModifySegmentDataType} */ ({
     segment: [vertex, segment[1]],
     feature: feature,
     geometry: geometry,
@@ -998,7 +998,7 @@ ol.interaction.Modify.prototype.removeVertex_ = function() {
       if (left !== undefined && right !== undefined) {
         goog.asserts.assert(newIndex >= 0, 'newIndex should be larger than 0');
 
-        var newSegmentData = /** @type {ol.interaction.SegmentDataType} */ ({
+        var newSegmentData = /** @type {ol.ModifySegmentDataType} */ ({
           depth: segmentData.depth,
           feature: segmentData.feature,
           geometry: segmentData.geometry,
@@ -1053,7 +1053,7 @@ ol.interaction.Modify.prototype.updateSegmentIndices_ = function(
 
 
 /**
- * @return {ol.style.StyleFunction} Styles.
+ * @return {ol.StyleFunction} Styles.
  */
 ol.interaction.Modify.getDefaultStyleFunction = function() {
   var style = ol.style.createDefaultEditingStyles();

--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -99,28 +99,28 @@ ol.interaction.Select = function(opt_options) {
 
   /**
    * @private
-   * @type {ol.events.ConditionType}
+   * @type {ol.EventsConditionType}
    */
   this.condition_ = options.condition ?
       options.condition : ol.events.condition.singleClick;
 
   /**
    * @private
-   * @type {ol.events.ConditionType}
+   * @type {ol.EventsConditionType}
    */
   this.addCondition_ = options.addCondition ?
       options.addCondition : ol.events.condition.never;
 
   /**
    * @private
-   * @type {ol.events.ConditionType}
+   * @type {ol.EventsConditionType}
    */
   this.removeCondition_ = options.removeCondition ?
       options.removeCondition : ol.events.condition.never;
 
   /**
    * @private
-   * @type {ol.events.ConditionType}
+   * @type {ol.EventsConditionType}
    */
   this.toggleCondition_ = options.toggleCondition ?
       options.toggleCondition : ol.events.condition.shiftKeyOnly;
@@ -133,7 +133,7 @@ ol.interaction.Select = function(opt_options) {
 
   /**
    * @private
-   * @type {ol.interaction.SelectFilterFunction}
+   * @type {ol.SelectFilterFunction}
    */
   this.filter_ = options.filter ? options.filter :
       ol.functions.TRUE;
@@ -355,7 +355,7 @@ ol.interaction.Select.prototype.setMap = function(map) {
 
 
 /**
- * @return {ol.style.StyleFunction} Styles.
+ * @return {ol.StyleFunction} Styles.
  */
 ol.interaction.Select.getDefaultStyleFunction = function() {
   var styles = ol.style.createDefaultEditingStyles();

--- a/src/ol/interaction/snapinteraction.js
+++ b/src/ol/interaction/snapinteraction.js
@@ -80,19 +80,19 @@ ol.interaction.Snap = function(opt_options) {
   this.features_ = options.features ? options.features : null;
 
   /**
-   * @type {Array.<ol.events.Key>}
+   * @type {Array.<ol.EventsKey>}
    * @private
    */
   this.featuresListenerKeys_ = [];
 
   /**
-   * @type {Object.<number, ol.events.Key>}
+   * @type {Object.<number, ol.EventsKey>}
    * @private
    */
   this.geometryChangeListenerKeys_ = {};
 
   /**
-   * @type {Object.<number, ol.events.Key>}
+   * @type {Object.<number, ol.EventsKey>}
    * @private
    */
   this.geometryModifyListenerKeys_ = {};
@@ -129,7 +129,7 @@ ol.interaction.Snap = function(opt_options) {
       options.pixelTolerance : 10;
 
   /**
-   * @type {function(ol.interaction.SnapSegmentDataType, ol.interaction.SnapSegmentDataType): number}
+   * @type {function(ol.SnapSegmentDataType, ol.SnapSegmentDataType): number}
    * @private
    */
   this.sortByDistance_ = ol.interaction.Snap.sortByDistance.bind(this);
@@ -137,7 +137,7 @@ ol.interaction.Snap = function(opt_options) {
 
   /**
   * Segment RTree for each layer
-  * @type {ol.structs.RBush.<ol.interaction.SnapSegmentDataType>}
+  * @type {ol.structs.RBush.<ol.SnapSegmentDataType>}
   * @private
   */
   this.rBush_ = new ol.structs.RBush();
@@ -377,7 +377,7 @@ ol.interaction.Snap.prototype.shouldStopEvent = ol.functions.FALSE;
  * @param {ol.Pixel} pixel Pixel
  * @param {ol.Coordinate} pixelCoordinate Coordinate
  * @param {ol.Map} map Map.
- * @return {ol.interaction.SnapResultType} Snap result
+ * @return {ol.SnapResultType} Snap result
  */
 ol.interaction.Snap.prototype.snapTo = function(pixel, pixelCoordinate, map) {
 
@@ -436,7 +436,7 @@ ol.interaction.Snap.prototype.snapTo = function(pixel, pixelCoordinate, map) {
       vertexPixel = [Math.round(vertexPixel[0]), Math.round(vertexPixel[1])];
     }
   }
-  return /** @type {ol.interaction.SnapResultType} */ ({
+  return /** @type {ol.SnapResultType} */ ({
     snapped: snapped,
     vertex: vertex,
     vertexPixel: vertexPixel
@@ -478,7 +478,7 @@ ol.interaction.Snap.prototype.writeLineStringGeometry_ = function(feature, geome
   var i, ii, segment, segmentData;
   for (i = 0, ii = coordinates.length - 1; i < ii; ++i) {
     segment = coordinates.slice(i, i + 2);
-    segmentData = /** @type {ol.interaction.SnapSegmentDataType} */ ({
+    segmentData = /** @type {ol.SnapSegmentDataType} */ ({
       feature: feature,
       segment: segment
     });
@@ -499,7 +499,7 @@ ol.interaction.Snap.prototype.writeMultiLineStringGeometry_ = function(feature, 
     coordinates = lines[j];
     for (i = 0, ii = coordinates.length - 1; i < ii; ++i) {
       segment = coordinates.slice(i, i + 2);
-      segmentData = /** @type {ol.interaction.SnapSegmentDataType} */ ({
+      segmentData = /** @type {ol.SnapSegmentDataType} */ ({
         feature: feature,
         segment: segment
       });
@@ -519,7 +519,7 @@ ol.interaction.Snap.prototype.writeMultiPointGeometry_ = function(feature, geome
   var coordinates, i, ii, segmentData;
   for (i = 0, ii = points.length; i < ii; ++i) {
     coordinates = points[i];
-    segmentData = /** @type {ol.interaction.SnapSegmentDataType} */ ({
+    segmentData = /** @type {ol.SnapSegmentDataType} */ ({
       feature: feature,
       segment: [coordinates, coordinates]
     });
@@ -542,7 +542,7 @@ ol.interaction.Snap.prototype.writeMultiPolygonGeometry_ = function(feature, geo
       coordinates = rings[j];
       for (i = 0, ii = coordinates.length - 1; i < ii; ++i) {
         segment = coordinates.slice(i, i + 2);
-        segmentData = /** @type {ol.interaction.SnapSegmentDataType} */ ({
+        segmentData = /** @type {ol.SnapSegmentDataType} */ ({
           feature: feature,
           segment: segment
         });
@@ -560,7 +560,7 @@ ol.interaction.Snap.prototype.writeMultiPolygonGeometry_ = function(feature, geo
  */
 ol.interaction.Snap.prototype.writePointGeometry_ = function(feature, geometry) {
   var coordinates = geometry.getCoordinates();
-  var segmentData = /** @type {ol.interaction.SnapSegmentDataType} */ ({
+  var segmentData = /** @type {ol.SnapSegmentDataType} */ ({
     feature: feature,
     segment: [coordinates, coordinates]
   });
@@ -580,7 +580,7 @@ ol.interaction.Snap.prototype.writePolygonGeometry_ = function(feature, geometry
     coordinates = rings[j];
     for (i = 0, ii = coordinates.length - 1; i < ii; ++i) {
       segment = coordinates.slice(i, i + 2);
-      segmentData = /** @type {ol.interaction.SnapSegmentDataType} */ ({
+      segmentData = /** @type {ol.SnapSegmentDataType} */ ({
         feature: feature,
         segment: segment
       });
@@ -625,8 +625,8 @@ ol.interaction.Snap.handleUpEvent_ = function(evt) {
 
 /**
  * Sort segments by distance, helper function
- * @param {ol.interaction.SnapSegmentDataType} a The first segment data.
- * @param {ol.interaction.SnapSegmentDataType} b The second segment data.
+ * @param {ol.SnapSegmentDataType} a The first segment data.
+ * @param {ol.SnapSegmentDataType} b The second segment data.
  * @return {number} The difference in distance.
  * @this {ol.interaction.Snap}
  */

--- a/src/ol/layer/layer.js
+++ b/src/ol/layer/layer.js
@@ -41,19 +41,19 @@ ol.layer.Layer = function(options) {
 
   /**
    * @private
-   * @type {?ol.events.Key}
+   * @type {?ol.EventsKey}
    */
   this.mapPrecomposeKey_ = null;
 
   /**
    * @private
-   * @type {?ol.events.Key}
+   * @type {?ol.EventsKey}
    */
   this.mapRenderKey_ = null;
 
   /**
    * @private
-   * @type {?ol.events.Key}
+   * @type {?ol.EventsKey}
    */
   this.sourceChangeKey_ = null;
 

--- a/src/ol/layer/layergroup.js
+++ b/src/ol/layer/layergroup.js
@@ -46,13 +46,13 @@ ol.layer.Group = function(opt_options) {
 
   /**
    * @private
-   * @type {Array.<ol.events.Key>}
+   * @type {Array.<ol.EventsKey>}
    */
   this.layersListenerKeys_ = [];
 
   /**
    * @private
-   * @type {Object.<string, Array.<ol.events.Key>>}
+   * @type {Object.<string, Array.<ol.EventsKey>>}
    */
   this.listenerKeys_ = {};
 

--- a/src/ol/layer/vectorlayer.js
+++ b/src/ol/layer/vectorlayer.js
@@ -55,14 +55,14 @@ ol.layer.Vector = function(opt_options) {
 
   /**
    * User provided style.
-   * @type {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction}
+   * @type {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction}
    * @private
    */
   this.style_ = null;
 
   /**
    * Style function for use within the library.
-   * @type {ol.style.StyleFunction|undefined}
+   * @type {ol.StyleFunction|undefined}
    * @private
    */
   this.styleFunction_ = undefined;
@@ -117,7 +117,7 @@ ol.layer.Vector.prototype.getSource;
 /**
  * Get the style for features.  This returns whatever was passed to the `style`
  * option at construction or to the `setStyle` method.
- * @return {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction}
+ * @return {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction}
  *     Layer style.
  * @api stable
  */
@@ -128,7 +128,7 @@ ol.layer.Vector.prototype.getStyle = function() {
 
 /**
  * Get the style function.
- * @return {ol.style.StyleFunction|undefined} Layer style function.
+ * @return {ol.StyleFunction|undefined} Layer style function.
  * @api stable
  */
 ol.layer.Vector.prototype.getStyleFunction = function() {
@@ -174,7 +174,7 @@ ol.layer.Vector.prototype.setRenderOrder = function(renderOrder) {
  * it is `null` the layer has no style (a `null` style), so only features
  * that have their own styles will be rendered in the layer. See
  * {@link ol.style} for information on the default style.
- * @param {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|null|undefined}
+ * @param {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|null|undefined}
  *     style Layer style.
  * @api stable
  */

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -235,13 +235,13 @@ ol.Map = function(options) {
 
   /**
    * @private
-   * @type {?ol.events.Key}
+   * @type {?ol.EventsKey}
    */
   this.viewPropertyListenerKey_ = null;
 
   /**
    * @private
-   * @type {Array.<ol.events.Key>}
+   * @type {Array.<ol.EventsKey>}
    */
   this.layerGroupPropertyListenerKeys_ = null;
 
@@ -307,7 +307,7 @@ ol.Map = function(options) {
 
   /**
    * @private
-   * @type {Array.<ol.events.Key>}
+   * @type {Array.<ol.EventsKey>}
    */
   this.keyHandlerKeys_ = null;
 

--- a/src/ol/mapbrowserevent.js
+++ b/src/ol/mapbrowserevent.js
@@ -145,7 +145,7 @@ ol.MapBrowserEventHandler = function(map) {
   this.dragging_ = false;
 
   /**
-   * @type {!Array.<ol.events.Key>}
+   * @type {!Array.<ol.EventsKey>}
    * @private
    */
   this.dragListenerKeys_ = [];
@@ -191,7 +191,7 @@ ol.MapBrowserEventHandler = function(map) {
   this.documentPointerEventHandler_ = null;
 
   /**
-   * @type {?ol.events.Key}
+   * @type {?ol.EventsKey}
    * @private
    */
   this.pointerdownListenerKey_ = ol.events.listen(this.pointerEventHandler_,
@@ -199,7 +199,7 @@ ol.MapBrowserEventHandler = function(map) {
       this.handlePointerDown_, this);
 
   /**
-   * @type {?ol.events.Key}
+   * @type {?ol.EventsKey}
    * @private
    */
   this.relayedListenerKey_ = ol.events.listen(this.pointerEventHandler_,

--- a/src/ol/observable.js
+++ b/src/ol/observable.js
@@ -35,7 +35,7 @@ ol.inherits(ol.Observable, ol.events.EventTarget);
 
 /**
  * Removes an event listener using the key returned by `on()` or `once()`.
- * @param {ol.events.Key|Array.<ol.events.Key>} key The key returned by `on()`
+ * @param {ol.EventsKey|Array.<ol.EventsKey>} key The key returned by `on()`
  *     or `once()` (or an array of keys).
  * @api stable
  */
@@ -45,7 +45,7 @@ ol.Observable.unByKey = function(key) {
       ol.events.unlistenByKey(key[i]);
     }
   } else {
-    ol.events.unlistenByKey(/** @type {ol.events.Key} */ (key));
+    ol.events.unlistenByKey(/** @type {ol.EventsKey} */ (key));
   }
 };
 
@@ -97,7 +97,7 @@ ol.Observable.prototype.getRevision = function() {
  * @param {string|Array.<string>} type The event type or array of event types.
  * @param {function(?): ?} listener The listener function.
  * @param {Object=} opt_this The object to use as `this` in `listener`.
- * @return {ol.events.Key|Array.<ol.events.Key>} Unique key for the listener. If
+ * @return {ol.EventsKey|Array.<ol.EventsKey>} Unique key for the listener. If
  *     called with an array of event types as the first argument, the return
  *     will be an array of keys.
  * @api stable
@@ -122,7 +122,7 @@ ol.Observable.prototype.on = function(type, listener, opt_this) {
  * @param {string|Array.<string>} type The event type or array of event types.
  * @param {function(?): ?} listener The listener function.
  * @param {Object=} opt_this The object to use as `this` in `listener`.
- * @return {ol.events.Key|Array.<ol.events.Key>} Unique key for the listener. If
+ * @return {ol.EventsKey|Array.<ol.EventsKey>} Unique key for the listener. If
  *     called with an array of event types as the first argument, the return
  *     will be an array of keys.
  * @api stable
@@ -166,7 +166,7 @@ ol.Observable.prototype.un = function(type, listener, opt_this) {
  * Removes an event listener using the key returned by `on()` or `once()`.
  * Note that using the {@link ol.Observable.unByKey} static function is to
  * be preferred.
- * @param {ol.events.Key|Array.<ol.events.Key>} key The key returned by `on()`
+ * @param {ol.EventsKey|Array.<ol.EventsKey>} key The key returned by `on()`
  *     or `once()` (or an array of keys).
  * @function
  * @api stable

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -135,7 +135,7 @@ ol.Overlay = function(options) {
 
   /**
    * @private
-   * @type {?ol.events.Key}
+   * @type {?ol.EventsKey}
    */
   this.mapPostrenderListenerKey_ = null;
 

--- a/src/ol/proj/proj.js
+++ b/src/ol/proj/proj.js
@@ -44,7 +44,7 @@ ol.proj.METERS_PER_UNIT[ol.proj.Units.USFEET] = 1200 / 3937;
  * Projection definition class. One of these is created for each projection
  * supported in the application and stored in the {@link ol.proj} namespace.
  * You can use these in applications, but this is not required, as API params
- * and options use {@link ol.proj.ProjectionLike} which means the simple string
+ * and options use {@link ol.ProjectionLike} which means the simple string
  * code will suffice.
  *
  * You can use {@link ol.proj.get} to retrieve the object for a particular
@@ -543,8 +543,8 @@ ol.proj.addTransform = function(source, destination, transformFn) {
  * converts these into the functions used internally which also handle
  * extents and coordinate arrays.
  *
- * @param {ol.proj.ProjectionLike} source Source projection.
- * @param {ol.proj.ProjectionLike} destination Destination projection.
+ * @param {ol.ProjectionLike} source Source projection.
+ * @param {ol.ProjectionLike} destination Destination projection.
  * @param {function(ol.Coordinate): ol.Coordinate} forward The forward transform
  *     function (that is, from the source projection to the destination
  *     projection) that takes a {@link ol.Coordinate} as argument and returns
@@ -628,7 +628,7 @@ ol.proj.removeTransform = function(source, destination) {
  * Transforms a coordinate from longitude/latitude to a different projection.
  * @param {ol.Coordinate} coordinate Coordinate as longitude and latitude, i.e.
  *     an array with longitude as 1st and latitude as 2nd element.
- * @param {ol.proj.ProjectionLike=} opt_projection Target projection. The
+ * @param {ol.ProjectionLike=} opt_projection Target projection. The
  *     default is Web Mercator, i.e. 'EPSG:3857'.
  * @return {ol.Coordinate} Coordinate projected to the target projection.
  * @api stable
@@ -642,7 +642,7 @@ ol.proj.fromLonLat = function(coordinate, opt_projection) {
 /**
  * Transforms a coordinate to longitude/latitude.
  * @param {ol.Coordinate} coordinate Projected coordinate.
- * @param {ol.proj.ProjectionLike=} opt_projection Projection of the coordinate.
+ * @param {ol.ProjectionLike=} opt_projection Projection of the coordinate.
  *     The default is Web Mercator, i.e. 'EPSG:3857'.
  * @return {ol.Coordinate} Coordinate as longitude and latitude, i.e. an array
  *     with longitude as 1st and latitude as 2nd element.
@@ -657,7 +657,7 @@ ol.proj.toLonLat = function(coordinate, opt_projection) {
 /**
  * Fetches a Projection object for the code specified.
  *
- * @param {ol.proj.ProjectionLike} projectionLike Either a code string which is
+ * @param {ol.ProjectionLike} projectionLike Either a code string which is
  *     a combination of authority and identifier such as "EPSG:4326", or an
  *     existing projection object, or undefined.
  * @return {ol.proj.Projection} Projection object, or null if not in list.
@@ -715,8 +715,8 @@ ol.proj.equivalent = function(projection1, projection2) {
  * function to convert a coordinates array from the source projection to the
  * destination projection.
  *
- * @param {ol.proj.ProjectionLike} source Source.
- * @param {ol.proj.ProjectionLike} destination Destination.
+ * @param {ol.ProjectionLike} source Source.
+ * @param {ol.ProjectionLike} destination Destination.
  * @return {ol.TransformFunction} Transform function.
  * @api stable
  */
@@ -802,8 +802,8 @@ ol.proj.cloneTransform = function(input, opt_output, opt_dimension) {
  * geometry transforms.
  *
  * @param {ol.Coordinate} coordinate Coordinate.
- * @param {ol.proj.ProjectionLike} source Source projection-like.
- * @param {ol.proj.ProjectionLike} destination Destination projection-like.
+ * @param {ol.ProjectionLike} source Source projection-like.
+ * @param {ol.ProjectionLike} destination Destination projection-like.
  * @return {ol.Coordinate} Coordinate.
  * @api stable
  */
@@ -818,8 +818,8 @@ ol.proj.transform = function(coordinate, source, destination) {
  * returns a new extent (and does not modify the original).
  *
  * @param {ol.Extent} extent The extent to transform.
- * @param {ol.proj.ProjectionLike} source Source projection-like.
- * @param {ol.proj.ProjectionLike} destination Destination projection-like.
+ * @param {ol.ProjectionLike} source Source projection-like.
+ * @param {ol.ProjectionLike} destination Destination projection-like.
  * @return {ol.Extent} The transformed extent.
  * @api stable
  */

--- a/src/ol/renderer/maprenderer.js
+++ b/src/ol/renderer/maprenderer.js
@@ -52,7 +52,7 @@ ol.renderer.Map = function(container, map) {
 
   /**
    * @private
-   * @type {Object.<string, ol.events.Key>}
+   * @type {Object.<string, ol.EventsKey>}
    */
   this.layerRendererListeners_ = {};
 

--- a/src/ol/reproj/image.js
+++ b/src/ol/reproj/image.js
@@ -95,7 +95,7 @@ ol.reproj.Image = function(sourceProj, targetProj,
 
   /**
    * @private
-   * @type {?ol.events.Key}
+   * @type {?ol.EventsKey}
    */
   this.sourceListenerKey_ = null;
 

--- a/src/ol/reproj/tile.js
+++ b/src/ol/reproj/tile.js
@@ -96,7 +96,7 @@ ol.reproj.Tile = function(sourceProj, sourceTileGrid,
 
   /**
    * @private
-   * @type {Array.<ol.events.Key>}
+   * @type {Array.<ol.EventsKey>}
    */
   this.sourcesListenerKeys_ = null;
 

--- a/src/ol/source/imagevectorsource.js
+++ b/src/ol/source/imagevectorsource.js
@@ -75,14 +75,14 @@ ol.source.ImageVector = function(options) {
 
   /**
    * User provided style.
-   * @type {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction}
+   * @type {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction}
    * @private
    */
   this.style_ = null;
 
   /**
    * Style function for use within the library.
-   * @type {ol.style.StyleFunction|undefined}
+   * @type {ol.StyleFunction|undefined}
    * @private
    */
   this.styleFunction_ = undefined;
@@ -188,7 +188,7 @@ ol.source.ImageVector.prototype.getSource = function() {
 /**
  * Get the style for features.  This returns whatever was passed to the `style`
  * option at construction or to the `setStyle` method.
- * @return {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction}
+ * @return {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction}
  *     Layer style.
  * @api stable
  */
@@ -199,7 +199,7 @@ ol.source.ImageVector.prototype.getStyle = function() {
 
 /**
  * Get the style function.
- * @return {ol.style.StyleFunction|undefined} Layer style function.
+ * @return {ol.StyleFunction|undefined} Layer style function.
  * @api stable
  */
 ol.source.ImageVector.prototype.getStyleFunction = function() {
@@ -284,7 +284,7 @@ ol.source.ImageVector.prototype.renderFeature_ = function(feature, resolution, p
  * it is `null` the layer has no style (a `null` style), so only features
  * that have their own styles will be rendered in the layer. See
  * {@link ol.style} for information on the default style.
- * @param {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined}
+ * @param {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined}
  *     style Layer style.
  * @api stable
  */

--- a/src/ol/source/imagewmssource.js
+++ b/src/ol/source/imagewmssource.js
@@ -126,7 +126,7 @@ ol.source.ImageWMS.GETFEATUREINFO_IMAGE_SIZE_ = [101, 101];
  * constructed.
  * @param {ol.Coordinate} coordinate Coordinate.
  * @param {number} resolution Resolution.
- * @param {ol.proj.ProjectionLike} projection Projection.
+ * @param {ol.ProjectionLike} projection Projection.
  * @param {!Object} params GetFeatureInfo params. `INFO_FORMAT` at least should
  *     be provided. If `QUERY_LAYERS` is not provided then the layers specified
  *     in the `LAYERS` parameter will be used. `VERSION` should not be

--- a/src/ol/source/tileimagesource.js
+++ b/src/ol/source/tileimagesource.js
@@ -345,7 +345,7 @@ ol.source.TileImage.prototype.setRenderReprojectionEdges = function(render) {
  * (e.g. projection has no extent defined) or
  * for optimization reasons (custom tile size, resolutions, ...).
  *
- * @param {ol.proj.ProjectionLike} projection Projection.
+ * @param {ol.ProjectionLike} projection Projection.
  * @param {ol.tilegrid.TileGrid} tilegrid Tile grid to use for the projection.
  * @api
  */

--- a/src/ol/source/tilewmssource.js
+++ b/src/ol/source/tilewmssource.js
@@ -108,7 +108,7 @@ ol.inherits(ol.source.TileWMS, ol.source.TileImage);
  * constructed.
  * @param {ol.Coordinate} coordinate Coordinate.
  * @param {number} resolution Resolution.
- * @param {ol.proj.ProjectionLike} projection Projection.
+ * @param {ol.ProjectionLike} projection Projection.
  * @param {!Object} params GetFeatureInfo params. `INFO_FORMAT` at least should
  *     be provided. If `QUERY_LAYERS` is not provided then the layers specified
  *     in the `LAYERS` parameter will be used. `VERSION` should not be

--- a/src/ol/source/vectorsource.js
+++ b/src/ol/source/vectorsource.js
@@ -155,7 +155,7 @@ ol.source.Vector = function(opt_options) {
 
   /**
    * @private
-   * @type {Object.<string, Array.<ol.events.Key>>}
+   * @type {Object.<string, Array.<ol.EventsKey>>}
    */
   this.featureChangeKeys_ = {};
 

--- a/src/ol/structs/lrucache.js
+++ b/src/ol/structs/lrucache.js
@@ -133,7 +133,7 @@ ol.structs.LRUCache.prototype.get = function(key) {
   if (entry === this.newest_) {
     return entry.value_;
   } else if (entry === this.oldest_) {
-    this.oldest_ = this.oldest_.newer;
+    this.oldest_ = /** @type {ol.LRUCacheEntry} */ (this.oldest_.newer);
     this.oldest_.older = null;
   } else {
     entry.newer.older = entry.older;
@@ -216,7 +216,7 @@ ol.structs.LRUCache.prototype.pop = function() {
   if (entry.newer) {
     entry.newer.older = null;
   }
-  this.oldest_ = entry.newer;
+  this.oldest_ = /** @type {ol.LRUCacheEntry} */ (entry.newer);
   if (!this.oldest_) {
     this.newest_ = null;
   }
@@ -244,12 +244,12 @@ ol.structs.LRUCache.prototype.set = function(key, value) {
       'key is not a standard property of objects (e.g. "__proto__")');
   goog.asserts.assert(!(key in this.entries_),
       'key is not used already');
-  var entry = {
+  var entry = /** @type {ol.LRUCacheEntry} */ ({
     key_: key,
     newer: null,
     older: this.newest_,
     value_: value
-  };
+  });
   if (!this.newest_) {
     this.oldest_ = entry;
   } else {

--- a/src/ol/style/atlasmanager.js
+++ b/src/ol/style/atlasmanager.js
@@ -75,17 +75,17 @@ ol.style.AtlasManager = function(opt_options) {
 
 /**
  * @param {string} id The identifier of the entry to check.
- * @return {?ol.style.AtlasManagerInfo} The position and atlas image for the
+ * @return {?ol.AtlasManagerInfo} The position and atlas image for the
  *    entry, or `null` if the entry is not part of the atlas manager.
  */
 ol.style.AtlasManager.prototype.getInfo = function(id) {
-  /** @type {?ol.style.AtlasInfo} */
+  /** @type {?ol.AtlasInfo} */
   var info = this.getInfo_(this.atlases_, id);
 
   if (!info) {
     return null;
   }
-  /** @type {?ol.style.AtlasInfo} */
+  /** @type {?ol.AtlasInfo} */
   var hitInfo = this.getInfo_(this.hitAtlases_, id);
   goog.asserts.assert(hitInfo, 'hitInfo must not be null');
 
@@ -97,7 +97,7 @@ ol.style.AtlasManager.prototype.getInfo = function(id) {
  * @private
  * @param {Array.<ol.style.Atlas>} atlases The atlases to search.
  * @param {string} id The identifier of the entry to check.
- * @return {?ol.style.AtlasInfo} The position and atlas image for the entry,
+ * @return {?ol.AtlasInfo} The position and atlas image for the entry,
  *    or `null` if the entry is not part of the atlases.
  */
 ol.style.AtlasManager.prototype.getInfo_ = function(atlases, id) {
@@ -115,10 +115,10 @@ ol.style.AtlasManager.prototype.getInfo_ = function(atlases, id) {
 
 /**
  * @private
- * @param {ol.style.AtlasInfo} info The info for the real image.
- * @param {ol.style.AtlasInfo} hitInfo The info for the hit-detection
+ * @param {ol.AtlasInfo} info The info for the real image.
+ * @param {ol.AtlasInfo} hitInfo The info for the hit-detection
  *    image.
- * @return {?ol.style.AtlasManagerInfo} The position and atlas image for the
+ * @return {?ol.AtlasManagerInfo} The position and atlas image for the
  *    entry, or `null` if the entry is not part of the atlases.
  */
 ol.style.AtlasManager.prototype.mergeInfos_ = function(info, hitInfo) {
@@ -126,7 +126,7 @@ ol.style.AtlasManager.prototype.mergeInfos_ = function(info, hitInfo) {
       'in order to merge, offsetX of info and hitInfo must be equal');
   goog.asserts.assert(info.offsetY === hitInfo.offsetY,
       'in order to merge, offsetY of info and hitInfo must be equal');
-  return /** @type {ol.style.AtlasManagerInfo} */ ({
+  return /** @type {ol.AtlasManagerInfo} */ ({
     offsetX: info.offsetX,
     offsetY: info.offsetY,
     image: info.image,
@@ -154,7 +154,7 @@ ol.style.AtlasManager.prototype.mergeInfos_ = function(info, hitInfo) {
  *    detection atlas image.
  * @param {Object=} opt_this Value to use as `this` when executing
  *    `renderCallback` and `renderHitCallback`.
- * @return {?ol.style.AtlasManagerInfo}  The position and atlas image for the
+ * @return {?ol.AtlasManagerInfo}  The position and atlas image for the
  *    entry, or `null` if the image is too big.
  */
 ol.style.AtlasManager.prototype.add = function(id, width, height,
@@ -164,7 +164,7 @@ ol.style.AtlasManager.prototype.add = function(id, width, height,
     return null;
   }
 
-  /** @type {?ol.style.AtlasInfo} */
+  /** @type {?ol.AtlasInfo} */
   var info = this.add_(false,
       id, width, height, renderCallback, opt_this);
   if (!info) {
@@ -177,7 +177,7 @@ ol.style.AtlasManager.prototype.add = function(id, width, height,
   var renderHitCallback = opt_renderHitCallback !== undefined ?
       opt_renderHitCallback : ol.nullFunction
 
-  /** @type {?ol.style.AtlasInfo} */
+  /** @type {?ol.AtlasInfo} */
   var hitInfo = this.add_(true,
       id, width, height, renderHitCallback, opt_this);
   goog.asserts.assert(hitInfo, 'hitInfo must not be null');
@@ -196,7 +196,7 @@ ol.style.AtlasManager.prototype.add = function(id, width, height,
  *    Called to render the new image onto an atlas image.
  * @param {Object=} opt_this Value to use as `this` when executing
  *    `renderCallback` and `renderHitCallback`.
- * @return {?ol.style.AtlasInfo}  The position and atlas image for the entry,
+ * @return {?ol.AtlasInfo}  The position and atlas image for the entry,
  *    or `null` if the image is too big.
  */
 ol.style.AtlasManager.prototype.add_ = function(isHitAtlas, id, width, height,
@@ -256,13 +256,13 @@ ol.style.Atlas = function(size, space) {
 
   /**
    * @private
-   * @type {Array.<ol.style.AtlasBlock>}
+   * @type {Array.<ol.AtlasBlock>}
    */
   this.emptyBlocks_ = [{x: 0, y: 0, width: size, height: size}];
 
   /**
    * @private
-   * @type {Object.<string, ol.style.AtlasInfo>}
+   * @type {Object.<string, ol.AtlasInfo>}
    */
   this.entries_ = {};
 
@@ -282,7 +282,7 @@ ol.style.Atlas = function(size, space) {
 
 /**
  * @param {string} id The identifier of the entry to check.
- * @return {?ol.style.AtlasInfo} The atlas info.
+ * @return {?ol.AtlasInfo} The atlas info.
  */
 ol.style.Atlas.prototype.get = function(id) {
   return this.entries_[id] || null;
@@ -297,7 +297,7 @@ ol.style.Atlas.prototype.get = function(id) {
  *    Called to render the new image onto an atlas image.
  * @param {Object=} opt_this Value to use as `this` when executing
  *    `renderCallback`.
- * @return {?ol.style.AtlasInfo} The position and atlas image for the entry.
+ * @return {?ol.AtlasInfo} The position and atlas image for the entry.
  */
 ol.style.Atlas.prototype.add = function(id, width, height, renderCallback, opt_this) {
   var block, i, ii;
@@ -332,7 +332,7 @@ ol.style.Atlas.prototype.add = function(id, width, height, renderCallback, opt_t
 /**
  * @private
  * @param {number} index The index of the block.
- * @param {ol.style.AtlasBlock} block The block to split.
+ * @param {ol.AtlasBlock} block The block to split.
  * @param {number} width The width of the entry to insert.
  * @param {number} height The height of the entry to insert.
  */
@@ -340,9 +340,9 @@ ol.style.Atlas.prototype.split_ = function(index, block, width, height) {
   var deltaWidth = block.width - width;
   var deltaHeight = block.height - height;
 
-  /** @type {ol.style.AtlasBlock} */
+  /** @type {ol.AtlasBlock} */
   var newBlock1;
-  /** @type {ol.style.AtlasBlock} */
+  /** @type {ol.AtlasBlock} */
   var newBlock2;
 
   if (deltaWidth > deltaHeight) {
@@ -391,8 +391,8 @@ ol.style.Atlas.prototype.split_ = function(index, block, width, height) {
  * blocks (that are potentially smaller) are filled first.
  * @private
  * @param {number} index The index of the block to remove.
- * @param {ol.style.AtlasBlock} newBlock1 The 1st block to add.
- * @param {ol.style.AtlasBlock} newBlock2 The 2nd block to add.
+ * @param {ol.AtlasBlock} newBlock1 The 1st block to add.
+ * @param {ol.AtlasBlock} newBlock2 The 2nd block to add.
  */
 ol.style.Atlas.prototype.updateBlocks_ = function(index, newBlock1, newBlock2) {
   var args = [index, 1];

--- a/src/ol/style/circlestyle.js
+++ b/src/ol/style/circlestyle.js
@@ -252,7 +252,7 @@ ol.style.Circle.prototype.render_ = function(atlasManager) {
 
   var size = 2 * (this.radius_ + strokeWidth) + 1;
 
-  /** @type {ol.style.CircleRenderOptions} */
+  /** @type {ol.CircleRenderOptions} */
   var renderOptions = {
     strokeStyle: strokeStyle,
     strokeWidth: strokeWidth,
@@ -313,7 +313,7 @@ ol.style.Circle.prototype.render_ = function(atlasManager) {
 
 /**
  * @private
- * @param {ol.style.CircleRenderOptions} renderOptions Render options.
+ * @param {ol.CircleRenderOptions} renderOptions Render options.
  * @param {CanvasRenderingContext2D} context The rendering context.
  * @param {number} x The origin for the symbol (x).
  * @param {number} y The origin for the symbol (y).
@@ -348,7 +348,7 @@ ol.style.Circle.prototype.draw_ = function(renderOptions, context, x, y) {
 
 /**
  * @private
- * @param {ol.style.CircleRenderOptions} renderOptions Render options.
+ * @param {ol.CircleRenderOptions} renderOptions Render options.
  */
 ol.style.Circle.prototype.createHitDetectionCanvas_ = function(renderOptions) {
   this.hitDetectionImageSize_ = [renderOptions.size, renderOptions.size];
@@ -368,7 +368,7 @@ ol.style.Circle.prototype.createHitDetectionCanvas_ = function(renderOptions) {
 
 /**
  * @private
- * @param {ol.style.CircleRenderOptions} renderOptions Render options.
+ * @param {ol.CircleRenderOptions} renderOptions Render options.
  * @param {CanvasRenderingContext2D} context The context.
  * @param {number} x The origin for the symbol (x).
  * @param {number} y The origin for the symbol (y).

--- a/src/ol/style/iconstyle.js
+++ b/src/ol/style/iconstyle.js
@@ -414,7 +414,7 @@ ol.style.IconImage_ = function(image, src, size, crossOrigin, imageState,
 
   /**
    * @private
-   * @type {Array.<ol.events.Key>}
+   * @type {Array.<ol.EventsKey>}
    */
   this.imageListenerKeys_ = null;
 

--- a/src/ol/style/imagestyle.js
+++ b/src/ol/style/imagestyle.js
@@ -20,7 +20,7 @@ ol.style.ImageState = {
  * {@link ol.style.RegularShape}.
  *
  * @constructor
- * @param {ol.style.ImageOptions} options Options.
+ * @param {ol.StyleImageOptions} options Options.
  * @api
  */
 ol.style.Image = function(options) {
@@ -223,7 +223,7 @@ ol.style.Image.prototype.setSnapToPixel = function(snapToPixel) {
 /**
  * @param {function(this: T, ol.events.Event)} listener Listener function.
  * @param {T} thisArg Value to use as `this` when executing `listener`.
- * @return {ol.events.Key|undefined} Listener key.
+ * @return {ol.EventsKey|undefined} Listener key.
  * @template T
  */
 ol.style.Image.prototype.listenImageChange = goog.abstractMethod;

--- a/src/ol/style/regularshapestyle.js
+++ b/src/ol/style/regularshapestyle.js
@@ -328,7 +328,7 @@ ol.style.RegularShape.prototype.render_ = function(atlasManager) {
 
   var size = 2 * (this.radius_ + strokeWidth) + 1;
 
-  /** @type {ol.style.RegularShapeRenderOptions} */
+  /** @type {ol.RegularShapeRenderOptions} */
   var renderOptions = {
     strokeStyle: strokeStyle,
     strokeWidth: strokeWidth,
@@ -391,7 +391,7 @@ ol.style.RegularShape.prototype.render_ = function(atlasManager) {
 
 /**
  * @private
- * @param {ol.style.RegularShapeRenderOptions} renderOptions Render options.
+ * @param {ol.RegularShapeRenderOptions} renderOptions Render options.
  * @param {CanvasRenderingContext2D} context The rendering context.
  * @param {number} x The origin for the symbol (x).
  * @param {number} y The origin for the symbol (y).
@@ -436,7 +436,7 @@ ol.style.RegularShape.prototype.draw_ = function(renderOptions, context, x, y) {
 
 /**
  * @private
- * @param {ol.style.RegularShapeRenderOptions} renderOptions Render options.
+ * @param {ol.RegularShapeRenderOptions} renderOptions Render options.
  */
 ol.style.RegularShape.prototype.createHitDetectionCanvas_ = function(renderOptions) {
   this.hitDetectionImageSize_ = [renderOptions.size, renderOptions.size];
@@ -456,7 +456,7 @@ ol.style.RegularShape.prototype.createHitDetectionCanvas_ = function(renderOptio
 
 /**
  * @private
- * @param {ol.style.RegularShapeRenderOptions} renderOptions Render options.
+ * @param {ol.RegularShapeRenderOptions} renderOptions Render options.
  * @param {CanvasRenderingContext2D} context The context.
  * @param {number} x The origin for the symbol (x).
  * @param {number} y The origin for the symbol (y).

--- a/src/ol/style/style.js
+++ b/src/ol/style/style.js
@@ -27,13 +27,13 @@ ol.style.Style = function(opt_options) {
 
   /**
    * @private
-   * @type {string|ol.geom.Geometry|ol.style.GeometryFunction}
+   * @type {string|ol.geom.Geometry|ol.StyleGeometryFunction}
    */
   this.geometry_ = null;
 
   /**
    * @private
-   * @type {!ol.style.GeometryFunction}
+   * @type {!ol.StyleGeometryFunction}
    */
   this.geometryFunction_ = ol.style.defaultGeometryFunction;
 
@@ -76,7 +76,7 @@ ol.style.Style = function(opt_options) {
 
 /**
  * Get the geometry to be rendered.
- * @return {string|ol.geom.Geometry|ol.style.GeometryFunction}
+ * @return {string|ol.geom.Geometry|ol.StyleGeometryFunction}
  * Feature property or geometry or function that returns the geometry that will
  * be rendered with this style.
  * @api
@@ -88,7 +88,7 @@ ol.style.Style.prototype.getGeometry = function() {
 
 /**
  * Get the function used to generate a geometry for rendering.
- * @return {!ol.style.GeometryFunction} Function that is called with a feature
+ * @return {!ol.StyleGeometryFunction} Function that is called with a feature
  * and returns the geometry to render instead of the feature's geometry.
  * @api
  */
@@ -150,7 +150,7 @@ ol.style.Style.prototype.getZIndex = function() {
 /**
  * Set a geometry that is rendered instead of the feature's geometry.
  *
- * @param {string|ol.geom.Geometry|ol.style.GeometryFunction} geometry
+ * @param {string|ol.geom.Geometry|ol.StyleGeometryFunction} geometry
  *     Feature property or geometry or function returning a geometry to render
  *     for this style.
  * @api
@@ -195,9 +195,9 @@ ol.style.Style.prototype.setZIndex = function(zIndex) {
  * Convert the provided object into a style function.  Functions passed through
  * unchanged.  Arrays of ol.style.Style or single style objects wrapped in a
  * new style function.
- * @param {ol.style.StyleFunction|Array.<ol.style.Style>|ol.style.Style} obj
+ * @param {ol.StyleFunction|Array.<ol.style.Style>|ol.style.Style} obj
  *     A style function, a single style, or an array of styles.
- * @return {ol.style.StyleFunction} A style function.
+ * @return {ol.StyleFunction} A style function.
  */
 ol.style.createStyleFunction = function(obj) {
   var styleFunction;

--- a/src/ol/tilegrid/tilegrid.js
+++ b/src/ol/tilegrid/tilegrid.js
@@ -589,7 +589,7 @@ ol.tilegrid.resolutionsFromExtent = function(extent, opt_maxZoom, opt_tileSize) 
 
 
 /**
- * @param {ol.proj.ProjectionLike} projection Projection.
+ * @param {ol.ProjectionLike} projection Projection.
  * @param {number=} opt_maxZoom Maximum zoom level (default is
  *     ol.DEFAULT_MAX_ZOOM).
  * @param {ol.Size=} opt_tileSize Tile size (default uses ol.DEFAULT_TILE_SIZE).
@@ -607,7 +607,7 @@ ol.tilegrid.createForProjection = function(projection, opt_maxZoom, opt_tileSize
 /**
  * Generate a tile grid extent from a projection.  If the projection has an
  * extent, it is used.  If not, a global extent is assumed.
- * @param {ol.proj.ProjectionLike} projection Projection.
+ * @param {ol.ProjectionLike} projection Projection.
  * @return {ol.Extent} Extent.
  */
 ol.tilegrid.extentFromProjection = function(projection) {

--- a/src/ol/typedefs.js
+++ b/src/ol/typedefs.js
@@ -11,13 +11,7 @@
  * appear in module code.
  *
  * They are now all in the `ol` namespace.
- *
- * In principle, typedefs should not have a `goog.provide` nor should files which
- * refer to a typedef in comments need a `goog.require`. However, goog.provides
- * are needed for 2 cases, both to prevent compiler errors/warnings.
  */
-goog.provide('ol.Extent');
-goog.provide('ol.EventTargetLike');
 
 
 /**
@@ -126,7 +120,7 @@ ol.ColorLike;
 
 /**
  * An array of numbers representing an xy coordinate. Example: `[16, 48]`.
- * @typedef {Array.<number>} ol.Coordinate
+ * @typedef {Array.<number>}
  */
 ol.Coordinate;
 
@@ -162,15 +156,6 @@ ol.DrawGeometryFunctionType;
 
 
 /**
- * @typedef {EventTarget|ol.events.EventTarget|
- *     {addEventListener: function(string, Function, boolean=),
- *     removeEventListener: function(string, Function, boolean=),
- *     dispatchEvent: function(string)}}
- */
-ol.EventTargetLike;
-
-
-/**
  * A function that takes an {@link ol.MapBrowserEvent} and returns a
  * `{boolean}`. If the condition is met, true should be returned.
  *
@@ -200,6 +185,12 @@ ol.EventsKey;
  * @typedef {function(ol.events.Event)|function(ol.events.Event): boolean}
  */
 ol.EventsListenerFunctionType;
+
+
+/**
+ * @typedef {EventTarget|ol.events.EventTarget}
+ */
+ol.EventTargetLike;
 
 
 /**
@@ -318,8 +309,8 @@ ol.LoadingStrategy;
 
 /**
  * @typedef {{key_: string,
- *            newer: ol.LRUCacheEntry,
- *            older: ol.LRUCacheEntry,
+ *            newer: Object,
+ *            older: Object,
  *            value_: *}}
  */
 ol.LRUCacheEntry;

--- a/src/ol/typedefs.js
+++ b/src/ol/typedefs.js
@@ -10,23 +10,40 @@
  * in type-defining comments used by the Closure compiler, and so should not
  * appear in module code.
  *
- * When the code is converted to ES6 modules, the namespace structure will
- * disappear, and these typedefs will have to be renamed accordingly, but the
- * namespace structure is maintained for the present for backwards compatibility.
+ * They are now all in the `ol` namespace.
  *
  * In principle, typedefs should not have a `goog.provide` nor should files which
  * refer to a typedef in comments need a `goog.require`. However, goog.provides
- * are needed for 2 cases, both to prevent compiler errors/warnings:
- * - the 1st two for specific errors
- * - each sub-namespace needs at least one so the namespace is created when not
- *   used in the code, as when application code is compiled with the library.
+ * are needed for 2 cases, both to prevent compiler errors/warnings.
  */
 goog.provide('ol.Extent');
-goog.provide('ol.events.EventTargetLike');
+goog.provide('ol.EventTargetLike');
 
-goog.provide('ol.interaction.DragBoxEndConditionType');
-goog.provide('ol.proj.ProjectionLike');
-goog.provide('ol.style.AtlasBlock');
+
+/**
+ * @typedef {{x: number, y: number, width: number, height: number}}
+ */
+ol.AtlasBlock;
+
+
+/**
+ * Provides information for an image inside an atlas.
+ * `offsetX` and `offsetY` are the position of the image inside
+ * the atlas image `image`.
+ * @typedef {{offsetX: number, offsetY: number, image: HTMLCanvasElement}}
+ */
+ol.AtlasInfo;
+
+
+/**
+ * Provides information for an image inside an atlas manager.
+ * `offsetX` and `offsetY` is the position of the image inside
+ * the atlas image `image` and the position of the hit-detection image
+ * inside the hit-detection atlas image `hitImage`.
+ * @typedef {{offsetX: number, offsetY: number, image: HTMLCanvasElement,
+ *    hitImage: HTMLCanvasElement}}
+ */
+ol.AtlasManagerInfo;
 
 
 /**
@@ -82,6 +99,13 @@ ol.CenterConstraintType;
 
 
 /**
+ * @typedef {{strokeStyle: (string|undefined), strokeWidth: number,
+ *   size: number, lineDash: Array.<number>}}
+ */
+ol.CircleRenderOptions;
+
+
+/**
  * A color represented as a short array [red, green, blue, alpha].
  * red, green, and blue should be integers in the range 0..255 inclusive.
  * alpha should be a float in the range 0..1 inclusive. If no alpha value is
@@ -114,6 +138,68 @@ ol.Coordinate;
  * @typedef {function((ol.Coordinate|undefined)): string}
  */
 ol.CoordinateFormatType;
+
+
+/**
+ * A function that takes a {@link ol.MapBrowserEvent} and two
+ * {@link ol.Pixel}s and returns a `{boolean}`. If the condition is met,
+ * true should be returned.
+ * @typedef {function(ol.MapBrowserEvent, ol.Pixel, ol.Pixel):boolean}
+ */
+ol.DragBoxEndConditionType;
+
+
+/**
+ * Function that takes coordinates and an optional existing geometry as
+ * arguments, and returns a geometry. The optional existing geometry is the
+ * geometry that is returned when the function is called without a second
+ * argument.
+ * @typedef {function(!(ol.Coordinate|Array.<ol.Coordinate>|
+ *     Array.<Array.<ol.Coordinate>>), ol.geom.SimpleGeometry=):
+ *     ol.geom.SimpleGeometry}
+ */
+ol.DrawGeometryFunctionType;
+
+
+/**
+ * @typedef {EventTarget|ol.events.EventTarget|
+ *     {addEventListener: function(string, Function, boolean=),
+ *     removeEventListener: function(string, Function, boolean=),
+ *     dispatchEvent: function(string)}}
+ */
+ol.EventTargetLike;
+
+
+/**
+ * A function that takes an {@link ol.MapBrowserEvent} and returns a
+ * `{boolean}`. If the condition is met, true should be returned.
+ *
+ * @typedef {function(ol.MapBrowserEvent): boolean}
+ */
+ol.EventsConditionType;
+
+
+/**
+ * Key to use with {@link ol.Observable#unByKey}.
+ *
+ * @typedef {{bindTo: (Object|undefined),
+ *     boundListener: (ol.EventsListenerFunctionType|undefined),
+ *     callOnce: boolean,
+ *     deleteIndex: (number|undefined),
+ *     listener: ol.EventsListenerFunctionType,
+ *     target: (EventTarget|ol.events.EventTarget),
+ *     type: string}}
+ */
+ol.EventsKey;
+
+
+/**
+ * Listener function. This function is called with an event object as argument.
+ * When the function returns `false`, event propagation will stop.
+ *
+ * @typedef {function(ol.events.Event)|function(ol.events.Event): boolean}
+ */
+ol.EventsListenerFunctionType;
 
 
 /**
@@ -253,6 +339,16 @@ ol.MapOptionsInternal;
 
 
 /**
+ * @typedef {{depth: (Array.<number>|undefined),
+ *            feature: ol.Feature,
+ *            geometry: ol.geom.SimpleGeometry,
+ *            index: (number|undefined),
+ *            segment: Array.<ol.Extent>}}
+ */
+ol.ModifySegmentDataType;
+
+
+/**
  * An array with two elements, representing a pixel. The first element is the
  * x-coordinate, the second the y-coordinate of the pixel.
  * @typedef {Array.<number>}
@@ -277,6 +373,14 @@ ol.PreRenderFunction;
 
 
 /**
+ * A projection as {@link ol.proj.Projection}, SRS identifier string or
+ * undefined.
+ * @typedef {ol.proj.Projection|string|undefined} ol.ProjectionLike
+ */
+ol.ProjectionLike;
+
+
+/**
  * A function that takes an array of input data, performs some operation, and
  * returns an array of ouput data.
  * For `pixel` type operations, the function will be called with an array of
@@ -294,6 +398,20 @@ ol.PreRenderFunction;
  *     (Array.<number>|ImageData)}
  */
 ol.RasterOperation;
+
+
+/**
+ * @typedef {{
+ *   strokeStyle: (string|undefined),
+ *   strokeWidth: number,
+ *   size: number,
+ *   lineCap: string,
+ *   lineDash: Array.<number>,
+ *   lineJoin: string,
+ *   miterLimit: number
+ * }}
+ */
+ol.RegularShapeRenderOptions;
 
 
 /**
@@ -330,6 +448,16 @@ ol.RotationConstraintType;
 
 
 /**
+ * A function that takes an {@link ol.Feature} or {@link ol.render.Feature} and
+ * an {@link ol.layer.Layer} and returns `true` if the feature may be selected
+ * or `false` otherwise.
+ * @typedef {function((ol.Feature|ol.render.Feature), ol.layer.Layer):
+ *     boolean}
+ */
+ol.SelectFilterFunction;
+
+
+/**
  * An array of numbers representing a size: `[width, height]`.
  * @typedef {Array.<number>}
  */
@@ -337,10 +465,29 @@ ol.Size;
 
 
 /**
+ * @typedef {{
+ *     snapped: {boolean},
+ *     vertex: (ol.Coordinate|null),
+ *     vertexPixel: (ol.Pixel|null)
+ * }}
+ */
+ol.SnapResultType;
+
+
+/**
+ * @typedef {{
+ *     feature: ol.Feature,
+ *     segment: Array.<ol.Coordinate>
+ * }}
+ */
+ol.SnapSegmentDataType;
+
+
+/**
  * @typedef {{attributions: (ol.AttributionLike|undefined),
  *            extent: (null|ol.Extent|undefined),
  *            logo: (string|olx.LogoOptions|undefined),
- *            projection: ol.proj.ProjectionLike,
+ *            projection: ol.ProjectionLike,
  *            resolutions: (Array.<number>|undefined),
  *            state: (ol.source.State|undefined)}}
  */
@@ -358,7 +505,7 @@ ol.SourceRasterRenderedState;
 /**
  * @typedef {{attributions: (ol.AttributionLike|undefined),
  *            logo: (string|olx.LogoOptions|undefined),
- *            projection: ol.proj.ProjectionLike,
+ *            projection: ol.ProjectionLike,
  *            state: (ol.source.State|undefined),
  *            wrapX: (boolean|undefined)}}
  */
@@ -372,7 +519,7 @@ ol.SourceSourceOptions;
  *            logo: (string|olx.LogoOptions|undefined),
  *            opaque: (boolean|undefined),
  *            tilePixelRatio: (number|undefined),
- *            projection: ol.proj.ProjectionLike,
+ *            projection: ol.ProjectionLike,
  *            state: (ol.source.State|undefined),
  *            tileGrid: (ol.tilegrid.TileGrid|undefined),
  *            wrapX: (boolean|undefined)}}
@@ -386,7 +533,7 @@ ol.SourceTileOptions;
  *            extent: (ol.Extent|undefined),
  *            logo: (string|olx.LogoOptions|undefined),
  *            opaque: (boolean|undefined),
- *            projection: ol.proj.ProjectionLike,
+ *            projection: ol.ProjectionLike,
  *            state: (ol.source.State|undefined),
  *            tileGrid: (ol.tilegrid.TileGrid|undefined),
  *            tileLoadFunction: ol.TileLoadFunctionType,
@@ -397,6 +544,37 @@ ol.SourceTileOptions;
  *            wrapX: (boolean|undefined)}}
  */
 ol.SourceUrlTileOptions;
+
+
+/**
+ * A function that takes an {@link ol.Feature} and a `{number}` representing
+ * the view's resolution. The function should return a {@link ol.style.Style}
+ * or an array of them. This way e.g. a vector layer can be styled.
+ *
+ * @typedef {function((ol.Feature|ol.render.Feature), number):
+ *     (ol.style.Style|Array.<ol.style.Style>)}
+ */
+ol.StyleFunction;
+
+
+/**
+ * A function that takes an {@link ol.Feature} as argument and returns an
+ * {@link ol.geom.Geometry} that will be rendered and styled for the feature.
+ *
+ * @typedef {function((ol.Feature|ol.render.Feature)):
+ *     (ol.geom.Geometry|ol.render.Feature|undefined)}
+ */
+ol.StyleGeometryFunction;
+
+
+/**
+ * @typedef {{opacity: number,
+ *            rotateWithView: boolean,
+ *            rotation: number,
+ *            scale: number,
+ *            snapToPixel: boolean}}
+ */
+ol.StyleImageOptions;
 
 
 /**
@@ -517,190 +695,3 @@ ol.XmlParser;
  * @typedef {function(Node, *, Array.<*>)}
  */
 ol.XmlSerializer;
-
-
-/**
- * A function that takes an {@link ol.MapBrowserEvent} and returns a
- * `{boolean}`. If the condition is met, true should be returned.
- *
- * @typedef {function(ol.MapBrowserEvent): boolean}
- */
-ol.events.ConditionType;
-
-
-/**
- * @typedef {EventTarget|ol.events.EventTarget|
- *     {addEventListener: function(string, Function, boolean=),
- *     removeEventListener: function(string, Function, boolean=),
- *     dispatchEvent: function(string)}}
- */
-ol.events.EventTargetLike;
-
-
-/**
- * Key to use with {@link ol.Observable#unByKey}.
- *
- * @typedef {{bindTo: (Object|undefined),
- *     boundListener: (ol.events.ListenerFunctionType|undefined),
- *     callOnce: boolean,
- *     deleteIndex: (number|undefined),
- *     listener: ol.events.ListenerFunctionType,
- *     target: (EventTarget|ol.events.EventTarget),
- *     type: string}}
- */
-ol.events.Key;
-
-
-/**
- * Listener function. This function is called with an event object as argument.
- * When the function returns `false`, event propagation will stop.
- *
- * @typedef {function(ol.events.Event)|function(ol.events.Event): boolean}
- */
-ol.events.ListenerFunctionType;
-
-
-/**
- * A function that takes a {@link ol.MapBrowserEvent} and two
- * {@link ol.Pixel}s and returns a `{boolean}`. If the condition is met,
- * true should be returned.
- * @typedef {function(ol.MapBrowserEvent, ol.Pixel, ol.Pixel):boolean}
- */
-ol.interaction.DragBoxEndConditionType;
-
-
-/**
- * Function that takes coordinates and an optional existing geometry as
- * arguments, and returns a geometry. The optional existing geometry is the
- * geometry that is returned when the function is called without a second
- * argument.
- * @typedef {function(!(ol.Coordinate|Array.<ol.Coordinate>|
- *     Array.<Array.<ol.Coordinate>>), ol.geom.SimpleGeometry=):
- *     ol.geom.SimpleGeometry}
- */
-ol.interaction.DrawGeometryFunctionType;
-
-
-/**
- * @typedef {{depth: (Array.<number>|undefined),
- *            feature: ol.Feature,
- *            geometry: ol.geom.SimpleGeometry,
- *            index: (number|undefined),
- *            segment: Array.<ol.Extent>}}
- */
-ol.interaction.SegmentDataType;
-
-
-/**
- * A function that takes an {@link ol.Feature} or {@link ol.render.Feature} and
- * an {@link ol.layer.Layer} and returns `true` if the feature may be selected
- * or `false` otherwise.
- * @typedef {function((ol.Feature|ol.render.Feature), ol.layer.Layer):
- *     boolean}
- */
-ol.interaction.SelectFilterFunction;
-
-
-/**
- * @typedef {{
- *     snapped: {boolean},
- *     vertex: (ol.Coordinate|null),
- *     vertexPixel: (ol.Pixel|null)
- * }}
- */
-ol.interaction.SnapResultType;
-
-
-/**
- * @typedef {{
- *     feature: ol.Feature,
- *     segment: Array.<ol.Coordinate>
- * }}
- */
-ol.interaction.SnapSegmentDataType;
-
-
-/**
- * A projection as {@link ol.proj.Projection}, SRS identifier string or
- * undefined.
- * @typedef {ol.proj.Projection|string|undefined} ol.proj.ProjectionLike
- */
-ol.proj.ProjectionLike;
-
-
-/**
- * @typedef {{x: number, y: number, width: number, height: number}}
- */
-ol.style.AtlasBlock;
-
-
-/**
- * Provides information for an image inside an atlas.
- * `offsetX` and `offsetY` are the position of the image inside
- * the atlas image `image`.
- * @typedef {{offsetX: number, offsetY: number, image: HTMLCanvasElement}}
- */
-ol.style.AtlasInfo;
-
-
-/**
- * Provides information for an image inside an atlas manager.
- * `offsetX` and `offsetY` is the position of the image inside
- * the atlas image `image` and the position of the hit-detection image
- * inside the hit-detection atlas image `hitImage`.
- * @typedef {{offsetX: number, offsetY: number, image: HTMLCanvasElement,
- *    hitImage: HTMLCanvasElement}}
- */
-ol.style.AtlasManagerInfo;
-
-
-/**
- * @typedef {{strokeStyle: (string|undefined), strokeWidth: number,
- *   size: number, lineDash: Array.<number>}}
- */
-ol.style.CircleRenderOptions;
-
-
-/**
- * @typedef {{opacity: number,
- *            rotateWithView: boolean,
- *            rotation: number,
- *            scale: number,
- *            snapToPixel: boolean}}
- */
-ol.style.ImageOptions;
-
-
-/**
- * A function that takes an {@link ol.Feature} as argument and returns an
- * {@link ol.geom.Geometry} that will be rendered and styled for the feature.
- *
- * @typedef {function((ol.Feature|ol.render.Feature)):
- *     (ol.geom.Geometry|ol.render.Feature|undefined)}
- */
-ol.style.GeometryFunction;
-
-
-/**
- * @typedef {{
- *   strokeStyle: (string|undefined),
- *   strokeWidth: number,
- *   size: number,
- *   lineCap: string,
- *   lineDash: Array.<number>,
- *   lineJoin: string,
- *   miterLimit: number
- * }}
- */
-ol.style.RegularShapeRenderOptions;
-
-
-/**
- * A function that takes an {@link ol.Feature} and a `{number}` representing
- * the view's resolution. The function should return a {@link ol.style.Style}
- * or an array of them. This way e.g. a vector layer can be styled.
- *
- * @typedef {function((ol.Feature|ol.render.Feature), number):
- *     (ol.style.Style|Array.<ol.style.Style>)}
- */
-ol.style.StyleFunction;

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -206,6 +206,7 @@ function build(config, paths, callback) {
     concatenate(paths, callback);
   } else {
     log.info('ol', 'Compiling ' + paths.length + ' sources');
+    paths = paths.concat('src/ol/typedefs.js');
     options.compile.js = paths.concat(options.compile.js || []);
     closure.compile(options, callback);
   }


### PR DESCRIPTION
My final work on typedefs, which removes the need for all `goog.provide`s in `typedefs.js` except for the 2 strange problem cases. As before, I've kept the sub-namespace in the new name where I thought there was ambiguity, but otherwise removed it. This highlighted one unneeded require in `geom/circle` which I've removed. As there is no longer an api distinction for typedefs, I've listed all the renamed ones in the release notes file, even though I doubt whether most of them are used.