### PR TITLE
Reference ol.MapBrowserEvent instead of ol.MapBrowserPointerEvent

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -1,5 +1,9 @@
 ## Upgrade notes
 
+#### `ol.interaction.ModifyEvent` changes
+
+The event object previously had a `mapBrowserPointerEvent` property, which has been renamed to `mapBrowserEvent`.
+
 #### Removal of ol.raster namespace
 
 Users compiling their code with the library and using types in the `ol.raster` namespace should note that this has now been removed. `ol.raster.Pixel` has been deleted, and the other types have been renamed as follows, and your code may need changing if you use these:

--- a/externs/oli.js
+++ b/externs/oli.js
@@ -92,9 +92,9 @@ oli.ModifyEvent.prototype.features;
 
 
 /**
- * @type {ol.MapBrowserPointerEvent}
+ * @type {ol.MapBrowserEvent}
  */
-oli.ModifyEvent.prototype.mapBrowserPointerEvent;
+oli.ModifyEvent.prototype.mapBrowserEvent;
 
 
 /**

--- a/src/ol/events/condition.js
+++ b/src/ol/events/condition.js
@@ -202,12 +202,14 @@ ol.events.condition.targetNotEditable = function(mapBrowserEvent) {
 /**
  * Return `true` if the event originates from a mouse device.
  *
- * @param {ol.MapBrowserPointerEvent} mapBrowserEvent Map browser event.
+ * @param {ol.MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} True if the event originates from a mouse device.
  * @api stable
  */
 ol.events.condition.mouseOnly = function(mapBrowserEvent) {
   // see http://www.w3.org/TR/pointerevents/#widl-PointerEvent-pointerType
+  goog.asserts.assertInstanceof(mapBrowserEvent, ol.MapBrowserPointerEvent,
+      'Requires an ol.MapBrowserPointerEvent to work.');
   return mapBrowserEvent.pointerEvent.pointerType == 'mouse';
 };
 

--- a/src/ol/interaction/modifyinteraction.js
+++ b/src/ol/interaction/modifyinteraction.js
@@ -73,11 +73,11 @@ ol.interaction.ModifyEvent = function(type, features, mapBrowserPointerEvent) {
   this.features = features;
 
   /**
-   * Associated {@link ol.MapBrowserPointerEvent}.
-   * @type {ol.MapBrowserPointerEvent}
+   * Associated {@link ol.MapBrowserEvent}.
+   * @type {ol.MapBrowserEvent}
    * @api
    */
-  this.mapBrowserPointerEvent = mapBrowserPointerEvent;
+  this.mapBrowserEvent = mapBrowserPointerEvent;
 };
 ol.inherits(ol.interaction.ModifyEvent, ol.events.Event);
 


### PR DESCRIPTION
There is nothing exportable in ol.MapBrowserEvent in addition to what is exportable in ol.MapBrowserEvent.

Fixes #5414.