### PR TITLE
Fix GPX write of xsi ns

### DIFF
--- a/src/ol/format/gpxformat.js
+++ b/src/ol/format/gpxformat.js
@@ -57,6 +57,15 @@ ol.format.GPX.NAMESPACE_URIS_ = [
 
 
 /**
+ * @const
+ * @type {string}
+ * @private
+ */
+ol.format.GPX.SCHEMA_LOCATION_ = 'http://www.topografix.com/GPX/1/1 ' +
+    'http://www.topografix.com/GPX/1/1/gpx.xsd';
+
+
+/**
  * @param {Array.<number>} flatCoordinates Flat coordinates.
  * @param {Node} node Node.
  * @param {Object} values Values.
@@ -911,6 +920,13 @@ ol.format.GPX.prototype.writeFeaturesNode = function(features, opt_options) {
   opt_options = this.adaptOptions(opt_options);
   //FIXME Serialize metadata
   var gpx = ol.xml.createElementNS('http://www.topografix.com/GPX/1/1', 'gpx');
+  var xmlnsUri = 'http://www.w3.org/2000/xmlns/';
+  var xmlSchemaInstanceUri = 'http://www.w3.org/2001/XMLSchema-instance';
+  ol.xml.setAttributeNS(gpx, xmlnsUri, 'xmlns:xsi', xmlSchemaInstanceUri);
+  ol.xml.setAttributeNS(gpx, xmlSchemaInstanceUri, 'xsi:schemaLocation',
+      ol.format.GPX.SCHEMA_LOCATION_);
+  gpx.setAttribute('version', '1.1');
+  gpx.setAttribute('creator', 'OpenLayers 3');
 
   ol.xml.pushSerializeAndPop(/** @type {ol.XmlNodeStackItem} */
       ({node: gpx}), ol.format.GPX.GPX_SERIALIZERS_,

--- a/test/spec/ol/format/gpxformat.test.js
+++ b/test/spec/ol/format/gpxformat.test.js
@@ -38,7 +38,10 @@ describe('ol.format.GPX', function() {
 
     it('can read and write various rte attributes', function() {
       var text =
-          '<gpx xmlns="http://www.topografix.com/GPX/1/1">' +
+          '<gpx xmlns="http://www.topografix.com/GPX/1/1" ' +
+          'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+          'xsi:schemaLocation="http://www.topografix.com/GPX/1/1 ' +
+          'http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1" creator="OpenLayers 3">' +
           '  <rte>' +
           '    <name>Name</name>' +
           '    <cmt>Comment</cmt>' +
@@ -71,7 +74,10 @@ describe('ol.format.GPX', function() {
 
     it('can read and write a rte with multiple rtepts', function() {
       var text =
-          '<gpx xmlns="http://www.topografix.com/GPX/1/1">' +
+          '<gpx xmlns="http://www.topografix.com/GPX/1/1" ' +
+          'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+          'xsi:schemaLocation="http://www.topografix.com/GPX/1/1 ' +
+          'http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1" creator="OpenLayers 3">' +
           '  <rte>' +
           '    <rtept lat="1" lon="2"/>' +
           '    <rtept lat="3" lon="4"/>' +
@@ -91,7 +97,10 @@ describe('ol.format.GPX', function() {
 
     it('can transform, read and write a rte', function() {
       var text =
-          '<gpx xmlns="http://www.topografix.com/GPX/1/1">' +
+          '<gpx xmlns="http://www.topografix.com/GPX/1/1" ' +
+          'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+          'xsi:schemaLocation="http://www.topografix.com/GPX/1/1 ' +
+          'http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1" creator="OpenLayers 3">' +
           '  <rte>' +
           '    <rtept lat="1" lon="2"/>' +
           '    <rtept lat="5" lon="6"/>' +
@@ -119,7 +128,10 @@ describe('ol.format.GPX', function() {
 
     it('does not write rte attributes in rtepts', function() {
       var text =
-          '<gpx xmlns="http://www.topografix.com/GPX/1/1">' +
+          '<gpx xmlns="http://www.topografix.com/GPX/1/1" ' +
+          'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+          'xsi:schemaLocation="http://www.topografix.com/GPX/1/1 ' +
+          'http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1" creator="OpenLayers 3">' +
           '  <rte>' +
           '    <name>Name</name>' +
           '    <rtept lat="1" lon="2"/>' +
@@ -152,7 +164,10 @@ describe('ol.format.GPX', function() {
 
     it('can read and write various trk attributes', function() {
       var text =
-          '<gpx xmlns="http://www.topografix.com/GPX/1/1">' +
+          '<gpx xmlns="http://www.topografix.com/GPX/1/1" ' +
+          'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+          'xsi:schemaLocation="http://www.topografix.com/GPX/1/1 ' +
+          'http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1" creator="OpenLayers 3">' +
           '  <trk>' +
           '    <name>Name</name>' +
           '    <cmt>Comment</cmt>' +
@@ -185,7 +200,10 @@ describe('ol.format.GPX', function() {
 
     it('can read and write a trk with an empty trkseg', function() {
       var text =
-          '<gpx xmlns="http://www.topografix.com/GPX/1/1">' +
+          '<gpx xmlns="http://www.topografix.com/GPX/1/1" ' +
+          'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+          'xsi:schemaLocation="http://www.topografix.com/GPX/1/1 ' +
+          'http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1" creator="OpenLayers 3">' +
           '  <trk>' +
           '    <trkseg/>' +
           '  </trk>' +
@@ -204,7 +222,10 @@ describe('ol.format.GPX', function() {
 
     it('can read/write a trk with a trkseg with multiple trkpts', function() {
       var text =
-          '<gpx xmlns="http://www.topografix.com/GPX/1/1">' +
+          '<gpx xmlns="http://www.topografix.com/GPX/1/1" ' +
+          'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+          'xsi:schemaLocation="http://www.topografix.com/GPX/1/1 ' +
+          'http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1" creator="OpenLayers 3">' +
           '  <trk>' +
           '    <trkseg>' +
           '      <trkpt lat="1" lon="2">' +
@@ -234,7 +255,10 @@ describe('ol.format.GPX', function() {
 
     it('can transform, read and write a trk with a trkseg', function() {
       var text =
-          '<gpx xmlns="http://www.topografix.com/GPX/1/1">' +
+          '<gpx xmlns="http://www.topografix.com/GPX/1/1" ' +
+          'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+          'xsi:schemaLocation="http://www.topografix.com/GPX/1/1 ' +
+          'http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1" creator="OpenLayers 3">' +
           '  <trk>' +
           '    <trkseg>' +
           '      <trkpt lat="1" lon="2">' +
@@ -270,7 +294,10 @@ describe('ol.format.GPX', function() {
 
     it('can read and write a trk with multiple trksegs', function() {
       var text =
-          '<gpx xmlns="http://www.topografix.com/GPX/1/1">' +
+          '<gpx xmlns="http://www.topografix.com/GPX/1/1" ' +
+          'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+          'xsi:schemaLocation="http://www.topografix.com/GPX/1/1 ' +
+          'http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1" creator="OpenLayers 3">' +
           '  <trk>' +
           '    <trkseg>' +
           '      <trkpt lat="1" lon="2">' +
@@ -311,7 +338,10 @@ describe('ol.format.GPX', function() {
 
     it('does not write trk attributes in trkpts', function() {
       var text =
-          '<gpx xmlns="http://www.topografix.com/GPX/1/1">' +
+          '<gpx xmlns="http://www.topografix.com/GPX/1/1" ' +
+          'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+          'xsi:schemaLocation="http://www.topografix.com/GPX/1/1 ' +
+          'http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1" creator="OpenLayers 3">' +
           '  <trk>' +
           '    <name>Name</name>' +
           '    <trkseg>' +
@@ -347,7 +377,10 @@ describe('ol.format.GPX', function() {
 
     it('can read and write a wpt', function() {
       var text =
-          '<gpx xmlns="http://www.topografix.com/GPX/1/1">' +
+          '<gpx xmlns="http://www.topografix.com/GPX/1/1" ' +
+          'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+          'xsi:schemaLocation="http://www.topografix.com/GPX/1/1 ' +
+          'http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1" creator="OpenLayers 3">' +
           '  <wpt lat="1" lon="2"/>' +
           '</gpx>';
       var fs = format.readFeatures(text);
@@ -364,7 +397,10 @@ describe('ol.format.GPX', function() {
 
     it('can transform, read and write a wpt', function() {
       var text =
-          '<gpx xmlns="http://www.topografix.com/GPX/1/1">' +
+          '<gpx xmlns="http://www.topografix.com/GPX/1/1" ' +
+          'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+          'xsi:schemaLocation="http://www.topografix.com/GPX/1/1 ' +
+          'http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1" creator="OpenLayers 3">' +
           '  <wpt lat="1" lon="2"/>' +
           '</gpx>';
       var fs = format.readFeatures(text, {
@@ -387,7 +423,10 @@ describe('ol.format.GPX', function() {
 
     it('can read and write a wpt with ele', function() {
       var text =
-          '<gpx xmlns="http://www.topografix.com/GPX/1/1">' +
+          '<gpx xmlns="http://www.topografix.com/GPX/1/1" ' +
+          'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+          'xsi:schemaLocation="http://www.topografix.com/GPX/1/1 ' +
+          'http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1" creator="OpenLayers 3">' +
           '  <wpt lat="1" lon="2">' +
           '    <ele>3</ele>' +
           '  </wpt>' +
@@ -406,7 +445,10 @@ describe('ol.format.GPX', function() {
 
     it('can read and write a wpt with time', function() {
       var text =
-          '<gpx xmlns="http://www.topografix.com/GPX/1/1">' +
+          '<gpx xmlns="http://www.topografix.com/GPX/1/1" ' +
+          'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+          'xsi:schemaLocation="http://www.topografix.com/GPX/1/1 ' +
+          'http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1" creator="OpenLayers 3">' +
           '  <wpt lat="1" lon="2">' +
           '    <time>2010-01-10T09:29:12Z</time>' +
           '  </wpt>' +
@@ -425,7 +467,10 @@ describe('ol.format.GPX', function() {
 
     it('can read and write a wpt with ele and time', function() {
       var text =
-          '<gpx xmlns="http://www.topografix.com/GPX/1/1">' +
+          '<gpx xmlns="http://www.topografix.com/GPX/1/1" ' +
+          'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+          'xsi:schemaLocation="http://www.topografix.com/GPX/1/1 ' +
+          'http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1" creator="OpenLayers 3">' +
           '  <wpt lat="1" lon="2">' +
           '    <ele>3</ele>' +
           '    <time>2010-01-10T09:29:12Z</time>' +
@@ -445,7 +490,10 @@ describe('ol.format.GPX', function() {
 
     it('can read and write various wpt attributes', function() {
       var text =
-          '<gpx xmlns="http://www.topografix.com/GPX/1/1">' +
+          '<gpx xmlns="http://www.topografix.com/GPX/1/1" ' +
+          'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+          'xsi:schemaLocation="http://www.topografix.com/GPX/1/1 ' +
+          'http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1" creator="OpenLayers 3">' +
           '  <wpt lat="1" lon="2">' +
           '    <magvar>11</magvar>' +
           '    <geoidheight>4</geoidheight>' +
@@ -615,7 +663,11 @@ describe('ol.format.GPX', function() {
       var features = [feature];
       var gpx = format.writeFeaturesNode(features);
       var expected =
-          '<gpx xmlns="http://www.topografix.com/GPX/1/1"/>';
+          '<gpx xmlns="http://www.topografix.com/GPX/1/1" ' +
+          'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+          'xsi:schemaLocation="http://www.topografix.com/GPX/1/1 ' +
+          'http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1" ' +
+          'creator="OpenLayers 3"></gpx>';
       expect(gpx).to.xmleql(ol.xml.parse(expected));
     });
   });


### PR DESCRIPTION
Fixes #4699

As this changes the `<gpx>` element itself, I had to change all the tests that compare output with input so that the input matches the new output - a bit of a pain, but it does at least test that the new attributes are being output correctly :-)