### PR TITLE
Remove goog.provide from enums only used internally or in olx.js

### DIFF
--- a/src/ol/control/scalelinecontrol.js
+++ b/src/ol/control/scalelinecontrol.js
@@ -1,5 +1,4 @@
 goog.provide('ol.control.ScaleLine');
-goog.provide('ol.control.ScaleLineProperty');
 goog.provide('ol.control.ScaleLineUnits');
 
 goog.require('goog.asserts');

--- a/src/ol/control/scalelinecontrol.js
+++ b/src/ol/control/scalelinecontrol.js
@@ -1,5 +1,4 @@
 goog.provide('ol.control.ScaleLine');
-goog.provide('ol.control.ScaleLineUnits');
 
 goog.require('goog.asserts');
 goog.require('ol.events');

--- a/src/ol/deviceorientation.js
+++ b/src/ol/deviceorientation.js
@@ -1,5 +1,4 @@
 goog.provide('ol.DeviceOrientation');
-goog.provide('ol.DeviceOrientationProperty');
 
 goog.require('ol.events');
 goog.require('ol');

--- a/src/ol/format/igcformat.js
+++ b/src/ol/format/igcformat.js
@@ -1,5 +1,4 @@
 goog.provide('ol.format.IGC');
-goog.provide('ol.format.IGCZ');
 
 goog.require('goog.asserts');
 goog.require('ol.Feature');

--- a/src/ol/geolocation.js
+++ b/src/ol/geolocation.js
@@ -1,7 +1,6 @@
 // FIXME handle geolocation not supported
 
 goog.provide('ol.Geolocation');
-goog.provide('ol.GeolocationProperty');
 
 goog.require('ol.events');
 goog.require('ol.events.EventType');

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -1,6 +1,5 @@
 goog.provide('ol.Overlay');
 goog.provide('ol.OverlayPositioning');
-goog.provide('ol.OverlayProperty');
 
 goog.require('goog.asserts');
 goog.require('goog.dom');

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -1,5 +1,4 @@
 goog.provide('ol.source.WMTS');
-goog.provide('ol.source.WMTSRequestEncoding');
 
 goog.require('goog.asserts');
 goog.require('ol.TileUrlFunction');


### PR DESCRIPTION
Another minor tidy of `goog.provide`. As mentioned in #5463, these are not needed.