### PR TITLE
Remove goog.global

### DIFF
--- a/src/ol/reproj/reproj.js
+++ b/src/ol/reproj/reproj.js
@@ -27,7 +27,7 @@ ol.reproj.browserAntialiasesClip_ = (function(winNav, winChrome) {
     isOpera == false && // Not Opera
     isIEedge == false // Not Edge
   );
-})(goog.global.navigator, goog.global.chrome);
+})(ol.global.navigator, ol.global.chrome);
 
 
 /**


### PR DESCRIPTION
This one seems to have slipped through the previous effort to remove goog.global.