### PR TITLE
Add getters for min and max resolution of the view

### DIFF
--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -298,6 +298,26 @@ ol.View.prototype.calculateExtent = function(size) {
 
 
 /**
+ * Get the maximum resolution of the view.
+ * @return {number} The maximum resolution of the view.
+ * @api
+ */
+ol.View.prototype.getMaxResolution = function() {
+  return this.maxResolution_;
+};
+
+
+/**
+ * Get the minimum resolution of the view.
+ * @return {number} The minimum resolution of the view.
+ * @api
+ */
+ol.View.prototype.getMinResolution = function() {
+  return this.minResolution_;
+};
+
+
+/**
  * Get the view projection.
  * @return {ol.proj.Projection} The projection of the view.
  * @api stable


### PR DESCRIPTION
In order to support external sliders, it would make sense to have getters for min and max resolution of the view.