### PR TITLE
Make sure reprojected tiles are recreated on updateParams

### DIFF
--- a/src/ol/source/tileimagesource.js
+++ b/src/ol/source/tileimagesource.js
@@ -241,16 +241,21 @@ ol.source.TileImage.prototype.getTile = function(z, x, y, pixelRatio, projection
   } else {
     var cache = this.getTileCacheForProjection(projection);
     var tileCoord = [z, x, y];
+    var tile;
     var tileCoordKey = this.getKeyZXY.apply(this, tileCoord);
     if (cache.containsKey(tileCoordKey)) {
-      return /** @type {!ol.Tile} */ (cache.get(tileCoordKey));
+      tile = /** @type {!ol.Tile} */ (cache.get(tileCoordKey));
+    }
+    var key = this.getKey();
+    if (tile && tile.key == key) {
+      return tile;
     } else {
       var sourceProjection = this.getProjection();
       var sourceTileGrid = this.getTileGridForProjection(sourceProjection);
       var targetTileGrid = this.getTileGridForProjection(projection);
       var wrappedTileCoord =
           this.getTileCoordForTileUrlFunction(tileCoord, projection);
-      var tile = new ol.reproj.Tile(
+      var newTile = new ol.reproj.Tile(
           sourceProjection, sourceTileGrid,
           projection, targetTileGrid,
           tileCoord, wrappedTileCoord, this.getTilePixelRatio(pixelRatio),
@@ -259,9 +264,15 @@ ol.source.TileImage.prototype.getTile = function(z, x, y, pixelRatio, projection
             return this.getTileInternal(z, x, y, pixelRatio, sourceProjection);
           }.bind(this), this.reprojectionErrorThreshold_,
           this.renderReprojectionEdges_);
+      newTile.key = key;
 
-      cache.set(tileCoordKey, tile);
-      return tile;
+      if (tile) {
+        newTile.interimTile = tile;
+        cache.replace(tileCoordKey, newTile);
+      } else {
+        cache.set(tileCoordKey, newTile);
+      }
+      return newTile;
     }
   }
 };


### PR DESCRIPTION
Because we are very smart when it comes to re-fetching tiles after calling `updateParams`, tile caches in other projections need some smart tile invalidation handling too.