### PR TITLE
Replace goog.isNumber

### DIFF
--- a/src/ol/deviceorientation.js
+++ b/src/ol/deviceorientation.js
@@ -117,7 +117,7 @@ ol.DeviceOrientation.prototype.orientationChange_ = function(originalEvent) {
     // event.absolute is undefined in iOS.
     if (typeof event.absolute === 'boolean' && event.absolute) {
       this.set(ol.DeviceOrientationProperty.HEADING, alpha);
-    } else if (goog.isNumber(event.webkitCompassHeading) &&
+    } else if (typeof event.webkitCompassHeading === 'number' &&
                event.webkitCompassAccuracy != -1) {
       var heading = ol.math.toRadians(event.webkitCompassHeading);
       this.set(ol.DeviceOrientationProperty.HEADING, heading);

--- a/src/ol/format/esrijsonformat.js
+++ b/src/ol/format/esrijsonformat.js
@@ -57,7 +57,7 @@ ol.format.EsriJSON.readGeometry_ = function(object, opt_options) {
     return null;
   }
   var type;
-  if (goog.isNumber(object.x) && goog.isNumber(object.y)) {
+  if (typeof object.x === 'number' && typeof object.y === 'number') {
     type = ol.geom.GeometryType.POINT;
   } else if (object.points) {
     type = ol.geom.GeometryType.MULTI_POINT;
@@ -145,8 +145,8 @@ ol.format.EsriJSON.convertRings_ = function(rings, layout) {
  * @return {ol.geom.Geometry} Point.
  */
 ol.format.EsriJSON.readPointGeometry_ = function(object) {
-  goog.asserts.assert(goog.isNumber(object.x), 'object.x should be number');
-  goog.asserts.assert(goog.isNumber(object.y), 'object.y should be number');
+  goog.asserts.assert(typeof object.x === 'number', 'object.x should be number');
+  goog.asserts.assert(typeof object.y === 'number', 'object.y should be number');
   var point;
   if (object.m !== undefined && object.z !== undefined) {
     point = new ol.geom.Point([object.x, object.y, object.z, object.m],
@@ -493,7 +493,7 @@ ol.format.EsriJSON.prototype.readFeatureFromObject = function(
   if (opt_options && opt_options.idField &&
       esriJSONFeature.attributes[opt_options.idField]) {
     goog.asserts.assert(
-        goog.isNumber(esriJSONFeature.attributes[opt_options.idField]),
+        typeof esriJSONFeature.attributes[opt_options.idField] === 'number',
         'objectIdFieldName value should be a number');
     feature.setId(/** @type {number} */(
         esriJSONFeature.attributes[opt_options.idField]));

--- a/src/ol/pointer/mssource.js
+++ b/src/ol/pointer/mssource.js
@@ -82,7 +82,7 @@ ol.inherits(ol.pointer.MsSource, ol.pointer.EventSource);
  */
 ol.pointer.MsSource.prototype.prepareEvent_ = function(inEvent) {
   var e = inEvent;
-  if (goog.isNumber(inEvent.pointerType)) {
+  if (typeof inEvent.pointerType === 'number') {
     e = this.dispatcher.cloneEvent(inEvent, inEvent);
     e.pointerType = this.POINTER_TYPES[inEvent.pointerType];
   }

--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -281,7 +281,7 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         ++i;
         break;
       case ol.render.canvas.Instruction.CIRCLE:
-        goog.asserts.assert(goog.isNumber(instruction[1]),
+        goog.asserts.assert(typeof instruction[1] === 'number',
             'second instruction should be a number');
         d = /** @type {number} */ (instruction[1]);
         var x1 = pixelCoordinates[d];
@@ -299,10 +299,10 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         ++i;
         break;
       case ol.render.canvas.Instruction.DRAW_IMAGE:
-        goog.asserts.assert(goog.isNumber(instruction[1]),
+        goog.asserts.assert(typeof instruction[1] === 'number',
             'second instruction should be a number');
         d = /** @type {number} */ (instruction[1]);
-        goog.asserts.assert(goog.isNumber(instruction[2]),
+        goog.asserts.assert(typeof instruction[2] === 'number',
             'third instruction should be a number');
         dd = /** @type {number} */ (instruction[2]);
         var image =  /** @type {HTMLCanvasElement|HTMLVideoElement|Image} */
@@ -371,25 +371,25 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         ++i;
         break;
       case ol.render.canvas.Instruction.DRAW_TEXT:
-        goog.asserts.assert(goog.isNumber(instruction[1]),
+        goog.asserts.assert(typeof instruction[1] === 'number',
             '2nd instruction should be a number');
         d = /** @type {number} */ (instruction[1]);
-        goog.asserts.assert(goog.isNumber(instruction[2]),
+        goog.asserts.assert(typeof instruction[2] === 'number',
             '3rd instruction should be a number');
         dd = /** @type {number} */ (instruction[2]);
         goog.asserts.assert(typeof instruction[3] === 'string',
             '4th instruction should be a string');
         text = /** @type {string} */ (instruction[3]);
-        goog.asserts.assert(goog.isNumber(instruction[4]),
+        goog.asserts.assert(typeof instruction[4] === 'number',
             '5th instruction should be a number');
         var offsetX = /** @type {number} */ (instruction[4]) * pixelRatio;
-        goog.asserts.assert(goog.isNumber(instruction[5]),
+        goog.asserts.assert(typeof instruction[5] === 'number',
             '6th instruction should be a number');
         var offsetY = /** @type {number} */ (instruction[5]) * pixelRatio;
-        goog.asserts.assert(goog.isNumber(instruction[6]),
+        goog.asserts.assert(typeof instruction[6] === 'number',
             '7th instruction should be a number');
         rotation = /** @type {number} */ (instruction[6]);
-        goog.asserts.assert(goog.isNumber(instruction[7]),
+        goog.asserts.assert(typeof instruction[7] === 'number',
             '8th instruction should be a number');
         scale = /** @type {number} */ (instruction[7]) * pixelRatio;
         goog.asserts.assert(typeof instruction[8] === 'boolean',
@@ -469,10 +469,10 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         ++i;
         break;
       case ol.render.canvas.Instruction.MOVE_TO_LINE_TO:
-        goog.asserts.assert(goog.isNumber(instruction[1]),
+        goog.asserts.assert(typeof instruction[1] === 'number',
             '2nd instruction should be a number');
         d = /** @type {number} */ (instruction[1]);
-        goog.asserts.assert(goog.isNumber(instruction[2]),
+        goog.asserts.assert(typeof instruction[2] === 'number',
             '3rd instruction should be a number');
         dd = /** @type {number} */ (instruction[2]);
         x = pixelCoordinates[d];
@@ -508,13 +508,13 @@ ol.render.canvas.Replay.prototype.replay_ = function(
       case ol.render.canvas.Instruction.SET_STROKE_STYLE:
         goog.asserts.assert(typeof instruction[1] === 'string',
             '2nd instruction should be a string');
-        goog.asserts.assert(goog.isNumber(instruction[2]),
+        goog.asserts.assert(typeof instruction[2] === 'number',
             '3rd instruction should be a number');
         goog.asserts.assert(typeof instruction[3] === 'string',
             '4rd instruction should be a string');
         goog.asserts.assert(typeof instruction[4] === 'string',
             '5th instruction should be a string');
-        goog.asserts.assert(goog.isNumber(instruction[5]),
+        goog.asserts.assert(typeof instruction[5] === 'number',
             '6th instruction should be a number');
         goog.asserts.assert(instruction[6],
             '7th instruction should not be null');

--- a/src/ol/reproj/tile.js
+++ b/src/ol/reproj/tile.js
@@ -258,8 +258,8 @@ ol.reproj.Tile.prototype.reproject_ = function() {
   } else {
     var z = this.wrappedTileCoord_[0];
     var size = this.targetTileGrid_.getTileSize(z);
-    var width = goog.isNumber(size) ? size : size[0];
-    var height = goog.isNumber(size) ? size : size[1];
+    var width = typeof size === 'number' ? size : size[0];
+    var height = typeof size === 'number' ? size : size[1];
     var targetResolution = this.targetTileGrid_.getResolution(z);
     var sourceResolution = this.sourceTileGrid_.getResolution(this.sourceZ_);
 

--- a/src/ol/size.js
+++ b/src/ol/size.js
@@ -72,7 +72,7 @@ ol.size.toSize = function(size, opt_size) {
   if (Array.isArray(size)) {
     return size;
   } else {
-    goog.asserts.assert(goog.isNumber(size));
+    goog.asserts.assert(typeof size === 'number');
     if (opt_size === undefined) {
       opt_size = [size, size];
     } else {

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -781,7 +781,7 @@ ol.View.createRotationConstraint_ = function(options) {
       return ol.RotationConstraint.createSnapToZero();
     } else if (constrainRotation === false) {
       return ol.RotationConstraint.none;
-    } else if (goog.isNumber(constrainRotation)) {
+    } else if (typeof constrainRotation === 'number') {
       return ol.RotationConstraint.createSnapToN(constrainRotation);
     } else {
       goog.asserts.fail(


### PR DESCRIPTION
`goog.isNumber` just does `== 'number'` but I use `===` to be consistent with string