### PR TITLE
Do not set evt.target attribute, if it's not defined yet

### DIFF
--- a/src/ol/events/eventtarget.js
+++ b/src/ol/events/eventtarget.js
@@ -75,7 +75,7 @@ ol.events.EventTarget.prototype.addEventListener = function(type, listener) {
 ol.events.EventTarget.prototype.dispatchEvent = function(event) {
   var evt = typeof event === 'string' ? new ol.events.Event(event) : event;
   var type = evt.type;
-  evt.target = this;
+  evt.target = evt.target || this;
   var listeners = this.listeners_[type];
   var propagate;
   if (listeners) {

--- a/test/spec/ol/events/eventtarget.test.js
+++ b/test/spec/ol/events/eventtarget.test.js
@@ -106,6 +106,14 @@ describe('ol.events.EventTarget', function() {
       expect(events[0].type).to.be('foo');
       expect(events[0].target).to.equal(eventTarget);
     });
+    it('passes a ol.events.Event object but with defined target', function() {
+      eventTarget.addEventListener('foo', spy1);
+      var evt = new ol.events.Event('foo', {'myvalue': 'mytarget'});
+      eventTarget.dispatchEvent(evt);
+      expect(events[0]).to.be.a(ol.events.Event);
+      expect(events[0].target).not.to.equal(eventTarget);
+      expect(events[0].target['myvalue']).to.equal('mytarget');
+    });
     it('passes a custom event object with target to listeners', function() {
       eventTarget.addEventListener('foo', spy1);
       var event = {


### PR DESCRIPTION
ol.events.EventTarget.dispatchEvent(event) sets `event.target` attribute in the headless way - the target can be already set in ol.events.Event https://github.com/openlayers/ol3/blob/master/src/ol/events/event.js#L38 and here it is overwritten without checking - it does not make sense IMHO.

This PR tries to solve the issue and make openlayers to behave more predictable.