### PR TITLE
Remove useless target argument from ol.Event and subclass constructors

### DIFF
--- a/src/ol/collection.js
+++ b/src/ol/collection.js
@@ -40,11 +40,10 @@ ol.CollectionEventType = {
  * @implements {oli.CollectionEvent}
  * @param {ol.CollectionEventType} type Type.
  * @param {*=} opt_element Element.
- * @param {Object=} opt_target Target.
  */
-ol.CollectionEvent = function(type, opt_element, opt_target) {
+ol.CollectionEvent = function(type, opt_element) {
 
-  ol.events.Event.call(this, type, opt_target);
+  ol.events.Event.call(this, type);
 
   /**
    * The element that is added to or removed from the collection.
@@ -182,7 +181,7 @@ ol.Collection.prototype.insertAt = function(index, elem) {
   this.array_.splice(index, 0, elem);
   this.updateLength_();
   this.dispatchEvent(
-      new ol.CollectionEvent(ol.CollectionEventType.ADD, elem, this));
+      new ol.CollectionEvent(ol.CollectionEventType.ADD, elem));
 };
 
 
@@ -240,7 +239,7 @@ ol.Collection.prototype.removeAt = function(index) {
   this.array_.splice(index, 1);
   this.updateLength_();
   this.dispatchEvent(
-      new ol.CollectionEvent(ol.CollectionEventType.REMOVE, prev, this));
+      new ol.CollectionEvent(ol.CollectionEventType.REMOVE, prev));
   return prev;
 };
 
@@ -257,9 +256,9 @@ ol.Collection.prototype.setAt = function(index, elem) {
     var prev = this.array_[index];
     this.array_[index] = elem;
     this.dispatchEvent(
-        new ol.CollectionEvent(ol.CollectionEventType.REMOVE, prev, this));
+        new ol.CollectionEvent(ol.CollectionEventType.REMOVE, prev));
     this.dispatchEvent(
-        new ol.CollectionEvent(ol.CollectionEventType.ADD, elem, this));
+        new ol.CollectionEvent(ol.CollectionEventType.ADD, elem));
   } else {
     var j;
     for (j = n; j < index; ++j) {

--- a/src/ol/events/event.js
+++ b/src/ol/events/event.js
@@ -14,9 +14,8 @@ goog.provide('ol.events.Event');
  * @constructor
  * @implements {oli.events.Event}
  * @param {string} type Type.
- * @param {Object=} opt_target Target.
  */
-ol.events.Event = function(type, opt_target) {
+ol.events.Event = function(type) {
 
   /**
    * @type {boolean}
@@ -35,7 +34,7 @@ ol.events.Event = function(type, opt_target) {
    * @type {Object}
    * @api stable
    */
-  this.target = opt_target || null;
+  this.target = null;
 
 };
 

--- a/src/ol/interaction/draganddropinteraction.js
+++ b/src/ol/interaction/draganddropinteraction.js
@@ -121,7 +121,7 @@ ol.interaction.DragAndDrop.prototype.handleResult_ = function(file, event) {
   }
   this.dispatchEvent(
       new ol.interaction.DragAndDropEvent(
-          ol.interaction.DragAndDropEventType.ADD_FEATURES, this, file,
+          ol.interaction.DragAndDropEventType.ADD_FEATURES, file,
           features, projection));
 };
 
@@ -200,14 +200,13 @@ ol.interaction.DragAndDropEventType = {
  * @extends {ol.events.Event}
  * @implements {oli.interaction.DragAndDropEvent}
  * @param {ol.interaction.DragAndDropEventType} type Type.
- * @param {Object} target Target.
  * @param {File} file File.
  * @param {Array.<ol.Feature>=} opt_features Features.
  * @param {ol.proj.Projection=} opt_projection Projection.
  */
-ol.interaction.DragAndDropEvent = function(type, target, file, opt_features, opt_projection) {
+ol.interaction.DragAndDropEvent = function(type, file, opt_features, opt_projection) {
 
-  ol.events.Event.call(this, type, target);
+  ol.events.Event.call(this, type);
 
   /**
    * The features parsed from dropped data.

--- a/src/ol/render/renderevent.js
+++ b/src/ol/render/renderevent.js
@@ -32,17 +32,16 @@ ol.render.EventType = {
  * @extends {ol.events.Event}
  * @implements {oli.render.Event}
  * @param {ol.render.EventType} type Type.
- * @param {Object=} opt_target Target.
  * @param {ol.render.VectorContext=} opt_vectorContext Vector context.
  * @param {olx.FrameState=} opt_frameState Frame state.
  * @param {?CanvasRenderingContext2D=} opt_context Context.
  * @param {?ol.webgl.Context=} opt_glContext WebGL Context.
  */
 ol.render.Event = function(
-    type, opt_target, opt_vectorContext, opt_frameState, opt_context,
+    type, opt_vectorContext, opt_frameState, opt_context,
     opt_glContext) {
 
-  ol.events.Event.call(this, type, opt_target);
+  ol.events.Event.call(this, type);
 
   /**
    * For canvas, this is an instance of {@link ol.render.canvas.Immediate}.

--- a/src/ol/renderer/canvas/canvaslayerrenderer.js
+++ b/src/ol/renderer/canvas/canvaslayerrenderer.js
@@ -119,7 +119,7 @@ ol.renderer.canvas.Layer.prototype.dispatchComposeEvent_ = function(type, contex
     var render = new ol.render.canvas.Immediate(
         context, frameState.pixelRatio, frameState.extent, transform,
         frameState.viewState.rotation);
-    var composeEvent = new ol.render.Event(type, layer, render, frameState,
+    var composeEvent = new ol.render.Event(type, render, frameState,
         context, null);
     layer.dispatchEvent(composeEvent);
     ol.render.canvas.rotateAtOffset(context, rotation, width / 2, height / 2);

--- a/src/ol/renderer/canvas/canvasmaprenderer.js
+++ b/src/ol/renderer/canvas/canvasmaprenderer.js
@@ -107,7 +107,7 @@ ol.renderer.canvas.Map.prototype.dispatchComposeEvent_ = function(type, frameSta
 
     var vectorContext = new ol.render.canvas.Immediate(context, pixelRatio,
         extent, transform, rotation);
-    var composeEvent = new ol.render.Event(type, map, vectorContext,
+    var composeEvent = new ol.render.Event(type, vectorContext,
         frameState, context, null);
     map.dispatchEvent(composeEvent);
   }

--- a/src/ol/renderer/dom/dommaprenderer.js
+++ b/src/ol/renderer/dom/dommaprenderer.js
@@ -131,7 +131,7 @@ ol.renderer.dom.Map.prototype.dispatchComposeEvent_ = function(type, frameState)
 
     var vectorContext = new ol.render.canvas.Immediate(context, pixelRatio,
         extent, transform, rotation);
-    var composeEvent = new ol.render.Event(type, map, vectorContext,
+    var composeEvent = new ol.render.Event(type, vectorContext,
         frameState, context, null);
     map.dispatchEvent(composeEvent);
   }

--- a/src/ol/renderer/dom/domvectorlayerrenderer.js
+++ b/src/ol/renderer/dom/domvectorlayerrenderer.js
@@ -168,8 +168,7 @@ ol.renderer.dom.VectorLayer.prototype.dispatchEvent_ = function(type, frameState
     var render = new ol.render.canvas.Immediate(
         context, frameState.pixelRatio, frameState.extent, transform,
         frameState.viewState.rotation);
-    var event = new ol.render.Event(type, layer, render, frameState,
-        context, null);
+    var event = new ol.render.Event(type, render, frameState, context, null);
     layer.dispatchEvent(event);
   }
 };

--- a/src/ol/renderer/webgl/webgllayerrenderer.js
+++ b/src/ol/renderer/webgl/webgllayerrenderer.js
@@ -208,7 +208,7 @@ ol.renderer.webgl.Layer.prototype.dispatchComposeEvent_ = function(type, context
     var render = new ol.render.webgl.Immediate(
         context, center, resolution, rotation, size, extent, pixelRatio);
     var composeEvent = new ol.render.Event(
-        type, layer, render, frameState, null, context);
+        type, render, frameState, null, context);
     layer.dispatchEvent(composeEvent);
   }
 };

--- a/src/ol/renderer/webgl/webglmaprenderer.js
+++ b/src/ol/renderer/webgl/webglmaprenderer.js
@@ -276,7 +276,7 @@ ol.renderer.webgl.Map.prototype.dispatchComposeEvent_ = function(type, frameStat
 
     var vectorContext = new ol.render.webgl.Immediate(context,
         center, resolution, rotation, size, extent, pixelRatio);
-    var composeEvent = new ol.render.Event(type, map, vectorContext,
+    var composeEvent = new ol.render.Event(type, vectorContext,
         frameState, null, context);
     map.dispatchEvent(composeEvent);
   }

--- a/test/spec/ol/events/event.test.js
+++ b/test/spec/ol/events/event.test.js
@@ -8,11 +8,6 @@ describe('ol.events.Event', function() {
       var event = new ol.events.Event('foo');
       expect(event.type).to.be('foo');
     });
-    it('can be constructed with an optional 2nd target arg', function() {
-      var target = {id: 1};
-      var event = new ol.events.Event('foo', target);
-      expect(event.target).to.equal(target);
-    });
     it('does not set the propagationStopped flag', function() {
       var event = new ol.events.Event('foo');
       expect(event.propagationStopped).to.be(undefined);

--- a/test/spec/ol/layer/layer.test.js
+++ b/test/spec/ol/layer/layer.test.js
@@ -393,7 +393,7 @@ describe('ol.layer.Layer', function() {
           layerStatesArray: [],
           layerStates: {}
         };
-        map.dispatchEvent(new ol.render.Event('precompose', map, null,
+        map.dispatchEvent(new ol.render.Event('precompose', null,
             frameState, null, null));
         expect(frameState.layerStatesArray.length).to.be(1);
         var layerState = frameState.layerStatesArray[0];


### PR DESCRIPTION
This is an alternative to #5545, and simplifies the code base quite a bit.

Closes #5545.