### PR TITLE
Replace goog.webgl

### DIFF
--- a/src/ol/render/webgl/webglreplay.js
+++ b/src/ol/render/webgl/webglreplay.js
@@ -12,6 +12,7 @@ goog.require('ol.render.webgl.imagereplay.shader.Default.Locations');
 goog.require('ol.render.webgl.imagereplay.shader.DefaultFragment');
 goog.require('ol.render.webgl.imagereplay.shader.DefaultVertex');
 goog.require('ol.vec.Mat4');
+goog.require('ol.webgl');
 goog.require('ol.webgl.Buffer');
 goog.require('ol.webgl.Context');
 
@@ -408,7 +409,7 @@ ol.render.webgl.ImageReplay.prototype.finish = function(context) {
 
   // create, bind, and populate the vertices buffer
   this.verticesBuffer_ = new ol.webgl.Buffer(this.vertices_);
-  context.bindBuffer(goog.webgl.ARRAY_BUFFER, this.verticesBuffer_);
+  context.bindBuffer(ol.webgl.ARRAY_BUFFER, this.verticesBuffer_);
 
   var indices = this.indices_;
   var bits = context.hasOESElementIndexUint ? 32 : 16;
@@ -418,7 +419,7 @@ ol.render.webgl.ImageReplay.prototype.finish = function(context) {
 
   // create, bind, and populate the indices buffer
   this.indicesBuffer_ = new ol.webgl.Buffer(indices);
-  context.bindBuffer(goog.webgl.ELEMENT_ARRAY_BUFFER, this.indicesBuffer_);
+  context.bindBuffer(ol.webgl.ELEMENT_ARRAY_BUFFER, this.indicesBuffer_);
 
   // create textures
   /** @type {Object.<string, WebGLTexture>} */
@@ -475,7 +476,7 @@ ol.render.webgl.ImageReplay.prototype.createTextures_ = function(textures, image
       texture = texturePerImage[uid];
     } else {
       texture = ol.webgl.Context.createTexture(
-          gl, image, goog.webgl.CLAMP_TO_EDGE, goog.webgl.CLAMP_TO_EDGE);
+          gl, image, ol.webgl.CLAMP_TO_EDGE, ol.webgl.CLAMP_TO_EDGE);
       texturePerImage[uid] = texture;
     }
     textures[i] = texture;
@@ -509,12 +510,12 @@ ol.render.webgl.ImageReplay.prototype.replay = function(context,
   // bind the vertices buffer
   goog.asserts.assert(this.verticesBuffer_,
       'verticesBuffer must not be null');
-  context.bindBuffer(goog.webgl.ARRAY_BUFFER, this.verticesBuffer_);
+  context.bindBuffer(ol.webgl.ARRAY_BUFFER, this.verticesBuffer_);
 
   // bind the indices buffer
   goog.asserts.assert(this.indicesBuffer_,
       'indecesBuffer must not be null');
-  context.bindBuffer(goog.webgl.ELEMENT_ARRAY_BUFFER, this.indicesBuffer_);
+  context.bindBuffer(ol.webgl.ELEMENT_ARRAY_BUFFER, this.indicesBuffer_);
 
   // get the program
   var fragmentShader =
@@ -538,23 +539,23 @@ ol.render.webgl.ImageReplay.prototype.replay = function(context,
 
   // enable the vertex attrib arrays
   gl.enableVertexAttribArray(locations.a_position);
-  gl.vertexAttribPointer(locations.a_position, 2, goog.webgl.FLOAT,
+  gl.vertexAttribPointer(locations.a_position, 2, ol.webgl.FLOAT,
       false, 32, 0);
 
   gl.enableVertexAttribArray(locations.a_offsets);
-  gl.vertexAttribPointer(locations.a_offsets, 2, goog.webgl.FLOAT,
+  gl.vertexAttribPointer(locations.a_offsets, 2, ol.webgl.FLOAT,
       false, 32, 8);
 
   gl.enableVertexAttribArray(locations.a_texCoord);
-  gl.vertexAttribPointer(locations.a_texCoord, 2, goog.webgl.FLOAT,
+  gl.vertexAttribPointer(locations.a_texCoord, 2, ol.webgl.FLOAT,
       false, 32, 16);
 
   gl.enableVertexAttribArray(locations.a_opacity);
-  gl.vertexAttribPointer(locations.a_opacity, 1, goog.webgl.FLOAT,
+  gl.vertexAttribPointer(locations.a_opacity, 1, ol.webgl.FLOAT,
       false, 32, 24);
 
   gl.enableVertexAttribArray(locations.a_rotateWithView);
-  gl.vertexAttribPointer(locations.a_rotateWithView, 1, goog.webgl.FLOAT,
+  gl.vertexAttribPointer(locations.a_rotateWithView, 1, ol.webgl.FLOAT,
       false, 32, 28);
 
   // set the "uniform" values
@@ -614,7 +615,7 @@ ol.render.webgl.ImageReplay.prototype.drawReplay_ = function(gl, context, skippe
   goog.asserts.assert(textures.length === groupIndices.length,
       'number of textures and groupIndeces match');
   var elementType = context.hasOESElementIndexUint ?
-      goog.webgl.UNSIGNED_INT : goog.webgl.UNSIGNED_SHORT;
+      ol.webgl.UNSIGNED_INT : ol.webgl.UNSIGNED_SHORT;
   var elementSize = context.hasOESElementIndexUint ? 4 : 2;
 
   if (!ol.object.isEmpty(skippedFeaturesHash)) {
@@ -624,7 +625,7 @@ ol.render.webgl.ImageReplay.prototype.drawReplay_ = function(gl, context, skippe
   } else {
     var i, ii, start;
     for (i = 0, ii = textures.length, start = 0; i < ii; ++i) {
-      gl.bindTexture(goog.webgl.TEXTURE_2D, textures[i]);
+      gl.bindTexture(ol.webgl.TEXTURE_2D, textures[i]);
       var end = groupIndices[i];
       this.drawElements_(gl, start, end, elementType, elementSize);
       start = end;
@@ -666,7 +667,7 @@ ol.render.webgl.ImageReplay.prototype.drawReplaySkipping_ = function(gl, skipped
 
   var i, ii;
   for (i = 0, ii = textures.length; i < ii; ++i) {
-    gl.bindTexture(goog.webgl.TEXTURE_2D, textures[i]);
+    gl.bindTexture(ol.webgl.TEXTURE_2D, textures[i]);
     var groupStart = (i > 0) ? groupIndices[i - 1] : 0;
     var groupEnd = groupIndices[i];
 
@@ -716,7 +717,7 @@ ol.render.webgl.ImageReplay.prototype.drawElements_ = function(
     gl, start, end, elementType, elementSize) {
   var numItems = end - start;
   var offsetInBytes = start * elementSize;
-  gl.drawElements(goog.webgl.TRIANGLES, numItems, elementType, offsetInBytes);
+  gl.drawElements(ol.webgl.TRIANGLES, numItems, elementType, offsetInBytes);
 };
 
 
@@ -789,13 +790,13 @@ ol.render.webgl.ImageReplay.prototype.drawHitDetectionReplayOneByOne_ = function
       this.hitDetectionGroupIndices_.length,
       'number of hitDetectionTextures and hitDetectionGroupIndices match');
   var elementType = context.hasOESElementIndexUint ?
-      goog.webgl.UNSIGNED_INT : goog.webgl.UNSIGNED_SHORT;
+      ol.webgl.UNSIGNED_INT : ol.webgl.UNSIGNED_SHORT;
   var elementSize = context.hasOESElementIndexUint ? 4 : 2;
 
   var i, groupStart, start, end, feature, featureUid;
   var featureIndex = this.startIndices_.length - 1;
   for (i = this.hitDetectionTextures_.length - 1; i >= 0; --i) {
-    gl.bindTexture(goog.webgl.TEXTURE_2D, this.hitDetectionTextures_[i]);
+    gl.bindTexture(ol.webgl.TEXTURE_2D, this.hitDetectionTextures_[i]);
     groupStart = (i > 0) ? this.hitDetectionGroupIndices_[i - 1] : 0;
     end = this.hitDetectionGroupIndices_[i];
 

--- a/src/ol/renderer/webgl/webglimagelayerrenderer.js
+++ b/src/ol/renderer/webgl/webglimagelayerrenderer.js
@@ -2,7 +2,6 @@ goog.provide('ol.renderer.webgl.ImageLayer');
 
 goog.require('goog.asserts');
 goog.require('ol.transform');
-goog.require('goog.webgl');
 goog.require('ol.ImageBase');
 goog.require('ol.ViewHint');
 goog.require('ol.dom');
@@ -12,6 +11,7 @@ goog.require('ol.layer.Image');
 goog.require('ol.proj');
 goog.require('ol.renderer.webgl.Layer');
 goog.require('ol.source.ImageVector');
+goog.require('ol.webgl');
 goog.require('ol.webgl.Context');
 
 
@@ -63,7 +63,7 @@ ol.renderer.webgl.ImageLayer.prototype.createTexture_ = function(image) {
   var gl = this.mapRenderer.getGL();
 
   return ol.webgl.Context.createTexture(
-      gl, imageElement, goog.webgl.CLAMP_TO_EDGE, goog.webgl.CLAMP_TO_EDGE);
+      gl, imageElement, ol.webgl.CLAMP_TO_EDGE, ol.webgl.CLAMP_TO_EDGE);
 };
 
 

--- a/src/ol/renderer/webgl/webgllayerrenderer.js
+++ b/src/ol/renderer/webgl/webgllayerrenderer.js
@@ -1,6 +1,5 @@
 goog.provide('ol.renderer.webgl.Layer');
 
-goog.require('goog.webgl');
 goog.require('ol.layer.Layer');
 goog.require('ol.transform');
 goog.require('ol.render.Event');
@@ -12,6 +11,7 @@ goog.require('ol.renderer.webgl.map.shader.Default.Locations');
 goog.require('ol.renderer.webgl.map.shader.DefaultFragment');
 goog.require('ol.renderer.webgl.map.shader.DefaultVertex');
 goog.require('ol.vec.Mat4');
+goog.require('ol.webgl');
 goog.require('ol.webgl.Buffer');
 goog.require('ol.webgl.Context');
 
@@ -120,16 +120,16 @@ ol.renderer.webgl.Layer.prototype.bindFramebuffer = function(frameState, framebu
         gl, framebufferDimension, framebufferDimension);
 
     var framebuffer = gl.createFramebuffer();
-    gl.bindFramebuffer(goog.webgl.FRAMEBUFFER, framebuffer);
-    gl.framebufferTexture2D(goog.webgl.FRAMEBUFFER,
-        goog.webgl.COLOR_ATTACHMENT0, goog.webgl.TEXTURE_2D, texture, 0);
+    gl.bindFramebuffer(ol.webgl.FRAMEBUFFER, framebuffer);
+    gl.framebufferTexture2D(ol.webgl.FRAMEBUFFER,
+        ol.webgl.COLOR_ATTACHMENT0, ol.webgl.TEXTURE_2D, texture, 0);
 
     this.texture = texture;
     this.framebuffer = framebuffer;
     this.framebufferDimension = framebufferDimension;
 
   } else {
-    gl.bindFramebuffer(goog.webgl.FRAMEBUFFER, this.framebuffer);
+    gl.bindFramebuffer(ol.webgl.FRAMEBUFFER, this.framebuffer);
   }
 
 };
@@ -145,7 +145,7 @@ ol.renderer.webgl.Layer.prototype.composeFrame = function(frameState, layerState
   this.dispatchComposeEvent_(
       ol.render.EventType.PRECOMPOSE, context, frameState);
 
-  context.bindBuffer(goog.webgl.ARRAY_BUFFER, this.arrayBuffer_);
+  context.bindBuffer(ol.webgl.ARRAY_BUFFER, this.arrayBuffer_);
 
   var gl = context.getGL();
 
@@ -167,10 +167,10 @@ ol.renderer.webgl.Layer.prototype.composeFrame = function(frameState, layerState
   if (context.useProgram(program)) {
     gl.enableVertexAttribArray(locations.a_position);
     gl.vertexAttribPointer(
-        locations.a_position, 2, goog.webgl.FLOAT, false, 16, 0);
+        locations.a_position, 2, ol.webgl.FLOAT, false, 16, 0);
     gl.enableVertexAttribArray(locations.a_texCoord);
     gl.vertexAttribPointer(
-        locations.a_texCoord, 2, goog.webgl.FLOAT, false, 16, 8);
+        locations.a_texCoord, 2, ol.webgl.FLOAT, false, 16, 8);
     gl.uniform1i(locations.u_texture, 0);
   }
 
@@ -179,8 +179,8 @@ ol.renderer.webgl.Layer.prototype.composeFrame = function(frameState, layerState
   gl.uniformMatrix4fv(locations.u_projectionMatrix, false,
       ol.vec.Mat4.fromTransform(this.tmpMat4_, this.getProjectionMatrix()));
   gl.uniform1f(locations.u_opacity, layerState.opacity);
-  gl.bindTexture(goog.webgl.TEXTURE_2D, this.getTexture());
-  gl.drawArrays(goog.webgl.TRIANGLE_STRIP, 0, 4);
+  gl.bindTexture(ol.webgl.TEXTURE_2D, this.getTexture());
+  gl.drawArrays(ol.webgl.TRIANGLE_STRIP, 0, 4);
 
   this.dispatchComposeEvent_(
       ol.render.EventType.POSTCOMPOSE, context, frameState);

--- a/src/ol/renderer/webgl/webglmaprenderer.js
+++ b/src/ol/renderer/webgl/webglmaprenderer.js
@@ -3,7 +3,6 @@
 goog.provide('ol.renderer.webgl.Map');
 
 goog.require('goog.asserts');
-goog.require('goog.webgl');
 goog.require('ol');
 goog.require('ol.RendererType');
 goog.require('ol.array');
@@ -154,7 +153,7 @@ ol.renderer.webgl.Map = function(container, map) {
           var tileSize = /** @type {ol.Size} */ (element[3]);
           var tileGutter = /** @type {number} */ (element[4]);
           this.bindTileTexture(
-              tile, tileSize, tileGutter, goog.webgl.LINEAR, goog.webgl.LINEAR);
+              tile, tileSize, tileGutter, ol.webgl.LINEAR, ol.webgl.LINEAR);
         }
         return false;
       }.bind(this);
@@ -186,20 +185,20 @@ ol.renderer.webgl.Map.prototype.bindTileTexture = function(tile, tileSize, tileG
     var textureCacheEntry = this.textureCache_.get(tileKey);
     goog.asserts.assert(textureCacheEntry,
         'a texture cache entry exists for key %s', tileKey);
-    gl.bindTexture(goog.webgl.TEXTURE_2D, textureCacheEntry.texture);
+    gl.bindTexture(ol.webgl.TEXTURE_2D, textureCacheEntry.texture);
     if (textureCacheEntry.magFilter != magFilter) {
       gl.texParameteri(
-          goog.webgl.TEXTURE_2D, goog.webgl.TEXTURE_MAG_FILTER, magFilter);
+          ol.webgl.TEXTURE_2D, ol.webgl.TEXTURE_MAG_FILTER, magFilter);
       textureCacheEntry.magFilter = magFilter;
     }
     if (textureCacheEntry.minFilter != minFilter) {
       gl.texParameteri(
-          goog.webgl.TEXTURE_2D, goog.webgl.TEXTURE_MIN_FILTER, minFilter);
+          ol.webgl.TEXTURE_2D, ol.webgl.TEXTURE_MIN_FILTER, minFilter);
       textureCacheEntry.minFilter = minFilter;
     }
   } else {
     var texture = gl.createTexture();
-    gl.bindTexture(goog.webgl.TEXTURE_2D, texture);
+    gl.bindTexture(ol.webgl.TEXTURE_2D, texture);
     if (tileGutter > 0) {
       var clipTileCanvas = this.clipTileContext_.canvas;
       var clipTileContext = this.clipTileContext_;
@@ -214,22 +213,22 @@ ol.renderer.webgl.Map.prototype.bindTileTexture = function(tile, tileSize, tileG
       }
       clipTileContext.drawImage(tile.getImage(), tileGutter, tileGutter,
           tileSize[0], tileSize[1], 0, 0, tileSize[0], tileSize[1]);
-      gl.texImage2D(goog.webgl.TEXTURE_2D, 0,
-          goog.webgl.RGBA, goog.webgl.RGBA,
-          goog.webgl.UNSIGNED_BYTE, clipTileCanvas);
+      gl.texImage2D(ol.webgl.TEXTURE_2D, 0,
+          ol.webgl.RGBA, ol.webgl.RGBA,
+          ol.webgl.UNSIGNED_BYTE, clipTileCanvas);
     } else {
-      gl.texImage2D(goog.webgl.TEXTURE_2D, 0,
-          goog.webgl.RGBA, goog.webgl.RGBA,
-          goog.webgl.UNSIGNED_BYTE, tile.getImage());
+      gl.texImage2D(ol.webgl.TEXTURE_2D, 0,
+          ol.webgl.RGBA, ol.webgl.RGBA,
+          ol.webgl.UNSIGNED_BYTE, tile.getImage());
     }
     gl.texParameteri(
-        goog.webgl.TEXTURE_2D, goog.webgl.TEXTURE_MAG_FILTER, magFilter);
+        ol.webgl.TEXTURE_2D, ol.webgl.TEXTURE_MAG_FILTER, magFilter);
     gl.texParameteri(
-        goog.webgl.TEXTURE_2D, goog.webgl.TEXTURE_MIN_FILTER, minFilter);
-    gl.texParameteri(goog.webgl.TEXTURE_2D, goog.webgl.TEXTURE_WRAP_S,
-        goog.webgl.CLAMP_TO_EDGE);
-    gl.texParameteri(goog.webgl.TEXTURE_2D, goog.webgl.TEXTURE_WRAP_T,
-        goog.webgl.CLAMP_TO_EDGE);
+        ol.webgl.TEXTURE_2D, ol.webgl.TEXTURE_MIN_FILTER, minFilter);
+    gl.texParameteri(ol.webgl.TEXTURE_2D, ol.webgl.TEXTURE_WRAP_S,
+        ol.webgl.CLAMP_TO_EDGE);
+    gl.texParameteri(ol.webgl.TEXTURE_2D, ol.webgl.TEXTURE_WRAP_T,
+        ol.webgl.CLAMP_TO_EDGE);
     this.textureCache_.set(tileKey, {
       texture: texture,
       magFilter: magFilter,
@@ -394,14 +393,14 @@ ol.renderer.webgl.Map.prototype.handleWebGLContextRestored = function() {
  */
 ol.renderer.webgl.Map.prototype.initializeGL_ = function() {
   var gl = this.gl_;
-  gl.activeTexture(goog.webgl.TEXTURE0);
+  gl.activeTexture(ol.webgl.TEXTURE0);
   gl.blendFuncSeparate(
-      goog.webgl.SRC_ALPHA, goog.webgl.ONE_MINUS_SRC_ALPHA,
-      goog.webgl.ONE, goog.webgl.ONE_MINUS_SRC_ALPHA);
-  gl.disable(goog.webgl.CULL_FACE);
-  gl.disable(goog.webgl.DEPTH_TEST);
-  gl.disable(goog.webgl.SCISSOR_TEST);
-  gl.disable(goog.webgl.STENCIL_TEST);
+      ol.webgl.SRC_ALPHA, ol.webgl.ONE_MINUS_SRC_ALPHA,
+      ol.webgl.ONE, ol.webgl.ONE_MINUS_SRC_ALPHA);
+  gl.disable(ol.webgl.CULL_FACE);
+  gl.disable(ol.webgl.DEPTH_TEST);
+  gl.disable(ol.webgl.SCISSOR_TEST);
+  gl.disable(ol.webgl.STENCIL_TEST);
 };
 
 
@@ -468,11 +467,11 @@ ol.renderer.webgl.Map.prototype.renderFrame = function(frameState) {
     this.canvas_.height = height;
   }
 
-  gl.bindFramebuffer(goog.webgl.FRAMEBUFFER, null);
+  gl.bindFramebuffer(ol.webgl.FRAMEBUFFER, null);
 
   gl.clearColor(0, 0, 0, 0);
-  gl.clear(goog.webgl.COLOR_BUFFER_BIT);
-  gl.enable(goog.webgl.BLEND);
+  gl.clear(ol.webgl.COLOR_BUFFER_BIT);
+  gl.enable(ol.webgl.BLEND);
   gl.viewport(0, 0, this.canvas_.width, this.canvas_.height);
 
   for (i = 0, ii = layerStatesToDraw.length; i < ii; ++i) {

--- a/src/ol/renderer/webgl/webgltilelayerrenderer.js
+++ b/src/ol/renderer/webgl/webgltilelayerrenderer.js
@@ -5,7 +5,6 @@ goog.provide('ol.renderer.webgl.TileLayer');
 
 goog.require('goog.asserts');
 goog.require('ol.transform');
-goog.require('goog.webgl');
 goog.require('ol.TileRange');
 goog.require('ol.TileState');
 goog.require('ol.array');
@@ -17,6 +16,7 @@ goog.require('ol.renderer.webgl.tilelayer.shader.Fragment');
 goog.require('ol.renderer.webgl.tilelayer.shader.Locations');
 goog.require('ol.renderer.webgl.tilelayer.shader.Vertex');
 goog.require('ol.size');
+goog.require('ol.webgl');
 goog.require('ol.webgl.Buffer');
 
 
@@ -209,8 +209,8 @@ ol.renderer.webgl.TileLayer.prototype.prepareFrame = function(frameState, layerS
     gl.viewport(0, 0, framebufferDimension, framebufferDimension);
 
     gl.clearColor(0, 0, 0, 0);
-    gl.clear(goog.webgl.COLOR_BUFFER_BIT);
-    gl.disable(goog.webgl.BLEND);
+    gl.clear(ol.webgl.COLOR_BUFFER_BIT);
+    gl.disable(ol.webgl.BLEND);
 
     var program = context.getProgram(this.fragmentShader_, this.vertexShader_);
     context.useProgram(program);
@@ -219,13 +219,13 @@ ol.renderer.webgl.TileLayer.prototype.prepareFrame = function(frameState, layerS
           new ol.renderer.webgl.tilelayer.shader.Locations(gl, program);
     }
 
-    context.bindBuffer(goog.webgl.ARRAY_BUFFER, this.renderArrayBuffer_);
+    context.bindBuffer(ol.webgl.ARRAY_BUFFER, this.renderArrayBuffer_);
     gl.enableVertexAttribArray(this.locations_.a_position);
     gl.vertexAttribPointer(
-        this.locations_.a_position, 2, goog.webgl.FLOAT, false, 16, 0);
+        this.locations_.a_position, 2, ol.webgl.FLOAT, false, 16, 0);
     gl.enableVertexAttribArray(this.locations_.a_texCoord);
     gl.vertexAttribPointer(
-        this.locations_.a_texCoord, 2, goog.webgl.FLOAT, false, 16, 8);
+        this.locations_.a_texCoord, 2, ol.webgl.FLOAT, false, 16, 8);
     gl.uniform1i(this.locations_.u_texture, 0);
 
     /**
@@ -309,8 +309,8 @@ ol.renderer.webgl.TileLayer.prototype.prepareFrame = function(frameState, layerS
             framebufferExtentDimension - 1;
         gl.uniform4fv(this.locations_.u_tileOffset, u_tileOffset);
         mapRenderer.bindTileTexture(tile, tilePixelSize,
-            tileGutter * pixelRatio, goog.webgl.LINEAR, goog.webgl.LINEAR);
-        gl.drawArrays(goog.webgl.TRIANGLE_STRIP, 0, 4);
+            tileGutter * pixelRatio, ol.webgl.LINEAR, ol.webgl.LINEAR);
+        gl.drawArrays(ol.webgl.TRIANGLE_STRIP, 0, 4);
       }
     }
 

--- a/src/ol/webgl/buffer.js
+++ b/src/ol/webgl/buffer.js
@@ -1,16 +1,16 @@
 goog.provide('ol.webgl.Buffer');
 
-goog.require('goog.webgl');
 goog.require('ol');
+goog.require('ol.webgl');
 
 
 /**
  * @enum {number}
  */
 ol.webgl.BufferUsage = {
-  STATIC_DRAW: goog.webgl.STATIC_DRAW,
-  STREAM_DRAW: goog.webgl.STREAM_DRAW,
-  DYNAMIC_DRAW: goog.webgl.DYNAMIC_DRAW
+  STATIC_DRAW: ol.webgl.STATIC_DRAW,
+  STREAM_DRAW: ol.webgl.STREAM_DRAW,
+  DYNAMIC_DRAW: ol.webgl.DYNAMIC_DRAW
 };
 
 

--- a/src/ol/webgl/context.js
+++ b/src/ol/webgl/context.js
@@ -6,6 +6,7 @@ goog.require('ol.Disposable');
 goog.require('ol.array');
 goog.require('ol.events');
 goog.require('ol.object');
+goog.require('ol.webgl');
 goog.require('ol.webgl.Buffer');
 goog.require('ol.webgl.WebGLContextEventType');
 
@@ -114,13 +115,13 @@ ol.webgl.Context.prototype.bindBuffer = function(target, buf) {
   } else {
     var buffer = gl.createBuffer();
     gl.bindBuffer(target, buffer);
-    goog.asserts.assert(target == goog.webgl.ARRAY_BUFFER ||
-        target == goog.webgl.ELEMENT_ARRAY_BUFFER,
+    goog.asserts.assert(target == ol.webgl.ARRAY_BUFFER ||
+        target == ol.webgl.ELEMENT_ARRAY_BUFFER,
         'target is supposed to be an ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER');
     var /** @type {ArrayBufferView} */ arrayBuffer;
-    if (target == goog.webgl.ARRAY_BUFFER) {
+    if (target == ol.webgl.ARRAY_BUFFER) {
       arrayBuffer = new Float32Array(arr);
-    } else if (target == goog.webgl.ELEMENT_ARRAY_BUFFER) {
+    } else if (target == ol.webgl.ELEMENT_ARRAY_BUFFER) {
       arrayBuffer = this.hasOESElementIndexUint ?
           new Uint32Array(arr) : new Uint16Array(arr);
     } else {
@@ -222,7 +223,7 @@ ol.webgl.Context.prototype.getShader = function(shaderObject) {
     gl.shaderSource(shader, shaderObject.getSource());
     gl.compileShader(shader);
     goog.asserts.assert(
-        gl.getShaderParameter(shader, goog.webgl.COMPILE_STATUS) ||
+        gl.getShaderParameter(shader, ol.webgl.COMPILE_STATUS) ||
         gl.isContextLost(),
         gl.getShaderInfoLog(shader) || 'illegal state, shader not compiled or context lost');
     this.shaderCache_[shaderKey] = shader;
@@ -252,7 +253,7 @@ ol.webgl.Context.prototype.getProgram = function(
     gl.attachShader(program, this.getShader(vertexShaderObject));
     gl.linkProgram(program);
     goog.asserts.assert(
-        gl.getProgramParameter(program, goog.webgl.LINK_STATUS) ||
+        gl.getProgramParameter(program, ol.webgl.LINK_STATUS) ||
         gl.isContextLost(),
         gl.getProgramInfoLog(program) || 'illegal state, shader not linked or context lost');
     this.programCache_[programKey] = program;
@@ -343,11 +344,11 @@ ol.webgl.Context.createTexture_ = function(gl, opt_wrapS, opt_wrapT) {
 
   if (opt_wrapS !== undefined) {
     gl.texParameteri(
-        goog.webgl.TEXTURE_2D, goog.webgl.TEXTURE_WRAP_S, opt_wrapS);
+        ol.webgl.TEXTURE_2D, ol.webgl.TEXTURE_WRAP_S, opt_wrapS);
   }
   if (opt_wrapT !== undefined) {
     gl.texParameteri(
-        goog.webgl.TEXTURE_2D, goog.webgl.TEXTURE_WRAP_T, opt_wrapT);
+        ol.webgl.TEXTURE_2D, ol.webgl.TEXTURE_WRAP_T, opt_wrapT);
   }
 
   return texture;

--- a/src/ol/webgl/shader.js
+++ b/src/ol/webgl/shader.js
@@ -3,7 +3,6 @@ goog.provide('ol.webgl.Shader');
 goog.provide('ol.webgl.Vertex');
 goog.provide('ol.webgl.shader');
 
-goog.require('goog.webgl');
 goog.require('ol.functions');
 goog.require('ol.webgl');
 
@@ -60,7 +59,7 @@ ol.inherits(ol.webgl.shader.Fragment, ol.webgl.Shader);
  * @inheritDoc
  */
 ol.webgl.shader.Fragment.prototype.getType = function() {
-  return goog.webgl.FRAGMENT_SHADER;
+  return ol.webgl.FRAGMENT_SHADER;
 };
 
 
@@ -80,5 +79,5 @@ ol.inherits(ol.webgl.shader.Vertex, ol.webgl.Shader);
  * @inheritDoc
  */
 ol.webgl.shader.Vertex.prototype.getType = function() {
-  return goog.webgl.VERTEX_SHADER;
+  return ol.webgl.VERTEX_SHADER;
 };

--- a/src/ol/webgl/webgl.js
+++ b/src/ol/webgl/webgl.js
@@ -2,6 +2,259 @@ goog.provide('ol.webgl');
 goog.provide('ol.webgl.WebGLContextEventType');
 
 
+/** Constants taken from goog.webgl
+ */
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.ONE = 1;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.SRC_ALPHA = 0x0302;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.COLOR_ATTACHMENT0 = 0x8CE0;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.COLOR_BUFFER_BIT = 0x00004000;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.TRIANGLES = 0x0004;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.TRIANGLE_STRIP = 0x0005;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.ONE_MINUS_SRC_ALPHA = 0x0303;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.ARRAY_BUFFER = 0x8892;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.ELEMENT_ARRAY_BUFFER = 0x8893;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.STREAM_DRAW = 0x88E0;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.STATIC_DRAW = 0x88E4;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.DYNAMIC_DRAW = 0x88E8;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.CULL_FACE = 0x0B44;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.BLEND = 0x0BE2;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.STENCIL_TEST = 0x0B90;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.DEPTH_TEST = 0x0B71;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.SCISSOR_TEST = 0x0C11;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.UNSIGNED_BYTE = 0x1401;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.UNSIGNED_SHORT = 0x1403;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.UNSIGNED_INT = 0x1405;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.FLOAT = 0x1406;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.RGBA = 0x1908;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.FRAGMENT_SHADER = 0x8B30;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.VERTEX_SHADER = 0x8B31;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.LINK_STATUS = 0x8B82;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.LINEAR = 0x2601;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.TEXTURE_MAG_FILTER = 0x2800;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.TEXTURE_MIN_FILTER = 0x2801;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.TEXTURE_WRAP_S = 0x2802;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.TEXTURE_WRAP_T = 0x2803;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.TEXTURE_2D = 0x0DE1;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.TEXTURE0 = 0x84C0;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.CLAMP_TO_EDGE = 0x812F;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.COMPILE_STATUS = 0x8B81;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+ol.webgl.FRAMEBUFFER = 0x8D40;
+
+
+/** end of goog.webgl constants
+ */
+
+
 /**
  * @const
  * @private


### PR DESCRIPTION
[`goog.webgl`](https://github.com/google/closure-library/blob/master/closure/goog/webgl/webgl.js) consists entirely of constants, mainly hex numbers. There are a large number of these, most of which OL does not use, so I have copied all those currently used into `webgl/webgl.js` and renamed to the `ol.webgl` namespace. If any others are needed in the future, they can be similarly added.