### PR TITLE
Moved <script> tag for ol.js into body

### DIFF
--- a/doc/quickstart.hbs
+++ b/doc/quickstart.hbs
@@ -20,12 +20,12 @@ Below you'll find a complete working example.  Create a new file, copy in the co
         width: 100%;
       }
     </style>
-    <script src="http://openlayers.org/en/{{ latest }}/build/ol.js" type="text/javascript"></script>
     <title>OpenLayers 3 example</title>
   </head>
   <body>
     <h2>My Map</h2>
     <div id="map" class="map"></div>
+    <script src="http://openlayers.org/en/{{ latest }}/build/ol.js" type="text/javascript"></script>
     <script type="text/javascript">
       var map = new ol.Map({
         target: 'map',


### PR DESCRIPTION
In Firefox 47.0 using this example doesn't work, as the ol.js script references the document.body, and this element doesn't necessarily exist when parsing the <head> tag. Moving it to the end of the body (as is typical for scripts these days) resolves the issue and makes this example work when copy/pasted.

Also tested in Google Chrome 51