### PR TITLE
Reinsert goog.provide for enums in olx.js

### DIFF
--- a/src/ol/control/scalelinecontrol.js
+++ b/src/ol/control/scalelinecontrol.js
@@ -1,4 +1,5 @@
 goog.provide('ol.control.ScaleLine');
+goog.provide('ol.control.ScaleLineUnits');
 
 goog.require('goog.asserts');
 goog.require('ol.events');

--- a/src/ol/format/igcformat.js
+++ b/src/ol/format/igcformat.js
@@ -1,4 +1,5 @@
 goog.provide('ol.format.IGC');
+goog.provide('ol.format.IGCZ');
 
 goog.require('goog.asserts');
 goog.require('ol.Feature');

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -1,4 +1,5 @@
 goog.provide('ol.source.WMTS');
+goog.provide('ol.source.WMTSRequestEncoding');
 
 goog.require('goog.asserts');
 goog.require('ol.TileUrlFunction');


### PR DESCRIPTION
A partial revert of #5475 to fix #5564. I don't understand why this should be ok for some custom builds and not for others, but the safest is to put these `goog.provide`s back again. I tried removing `manage_closure_dependencies` but then I get other errors to do with CartoDB source - sigh.