### PR TITLE
Add polyfills to copy/paste code

### DIFF
--- a/config/examples/example.html
+++ b/config/examples/example.html
@@ -73,6 +73,8 @@
   &lt;head&gt;
     &lt;title&gt;{{ title }}&lt;/title&gt;
     &lt;link rel="stylesheet" href="http://openlayers.org/en/v{{ olVersion }}/css/ol.css" type="text/css"&gt;
+    &lt;!-- The line below is only needed for old environments like Internet Explorer and Android 4.x --&gt;
+    &lt;script src="http://cdn.polyfill.io/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList"&gt;&lt;/script&gt;
     &lt;script src="http://openlayers.org/en/v{{ olVersion }}/build/ol.js"&gt;&lt;/script&gt;{{#if extraHead.remote}}
 {{ indent extraHead.remote spaces=4 }}{{/if}}{{#if css.source}}
     &lt;style&gt;


### PR DESCRIPTION
This makes copy/paste examples work out of the box in old environments.