### PR TITLE
Wmts tilematrixlimits

### DIFF
--- a/src/ol/format/wmtscapabilities.js
+++ b/src/ol/format/wmtscapabilities.js
@@ -252,6 +252,32 @@ ol.format.WMTSCapabilities.readTileMatrix_ = function(node, objectStack) {
 
 
 /**
+ * @private
+ * @param {Node} node Node.
+ * @param {Array.<*>} objectStack Object stack.
+ * @return {Object|undefined} TileMatrixSetLimits Object.
+ */
+ol.format.WMTSCapabilities.readTileMatrixLimitsList_ = function(node,
+    objectStack) {
+  return ol.xml.pushParseAndPop([],
+      ol.format.WMTSCapabilities.TMS_LIMITS_LIST_PARSERS_, node,
+      objectStack);
+};
+
+
+/**
+ * @private
+ * @param {Node} node Node.
+ * @param {Array.<*>} objectStack Object stack.
+ * @return {Object|undefined} TileMatrixLimits Array.
+ */
+ol.format.WMTSCapabilities.readTileMatrixLimits_ = function(node, objectStack) {
+  return ol.xml.pushParseAndPop({},
+      ol.format.WMTSCapabilities.TMS_LIMITS_PARSERS_, node, objectStack);
+};
+
+
+/**
  * @const
  * @private
  * @type {Array.<string>}
@@ -353,7 +379,40 @@ ol.format.WMTSCapabilities.STYLE_PARSERS_ = ol.xml.makeStructureNS(
 ol.format.WMTSCapabilities.TMS_LINKS_PARSERS_ = ol.xml.makeStructureNS(
     ol.format.WMTSCapabilities.NAMESPACE_URIS_, {
       'TileMatrixSet': ol.xml.makeObjectPropertySetter(
-          ol.format.XSD.readString)
+          ol.format.XSD.readString),
+      'TileMatrixSetLimits': ol.xml.makeObjectPropertySetter(
+          ol.format.WMTSCapabilities.readTileMatrixLimitsList_)
+    });
+
+/**
+ * @const
+ * @type {Object.<string, Object.<string, ol.XmlParser>>}
+ * @private
+ */
+ol.format.WMTSCapabilities.TMS_LIMITS_LIST_PARSERS_ = ol.xml.makeStructureNS(
+    ol.format.WMTSCapabilities.NAMESPACE_URIS_, {
+      'TileMatrixLimits': ol.xml.makeArrayPusher(
+          ol.format.WMTSCapabilities.readTileMatrixLimits_)
+    });
+
+
+/**
+ * @const
+ * @type {Object.<string, Object.<string, ol.XmlParser>>}
+ * @private
+ */
+ol.format.WMTSCapabilities.TMS_LIMITS_PARSERS_ = ol.xml.makeStructureNS(
+    ol.format.WMTSCapabilities.NAMESPACE_URIS_, {
+      'TileMatrix': ol.xml.makeObjectPropertySetter(
+          ol.format.XSD.readString),
+      'MinTileRow': ol.xml.makeObjectPropertySetter(
+          ol.format.XSD.readNonNegativeInteger),
+      'MaxTileRow': ol.xml.makeObjectPropertySetter(
+          ol.format.XSD.readNonNegativeInteger),
+      'MinTileCol': ol.xml.makeObjectPropertySetter(
+          ol.format.XSD.readNonNegativeInteger),
+      'MaxTileCol': ol.xml.makeObjectPropertySetter(
+          ol.format.XSD.readNonNegativeInteger)
     });
 
 

--- a/src/ol/source/wmts.js
+++ b/src/ol/source/wmts.js
@@ -309,7 +309,7 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
   ol.DEBUG && console.assert(l['TileMatrixSetLink'].length > 0,
       'layer has TileMatrixSetLink');
   var tileMatrixSets = wmtsCap['Contents']['TileMatrixSet'];
-  var idx, matrixSet;
+  var idx, matrixSet, matrixLimits;
   if (l['TileMatrixSetLink'].length > 1) {
     if ('projection' in config) {
       idx = ol.array.findIndex(l['TileMatrixSetLink'],
@@ -340,6 +340,8 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
   }
   matrixSet = /** @type {string} */
       (l['TileMatrixSetLink'][idx]['TileMatrixSet']);
+  matrixLimits = /** @type {Array.<Object>} */
+      (l['TileMatrixSetLink'][idx]['TileMatrixSetLimits']);
 
   ol.DEBUG && console.assert(matrixSet, 'TileMatrixSet must not be null');
 
@@ -409,7 +411,7 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
   }
 
   var tileGrid = ol.tilegrid.WMTS.createFromCapabilitiesMatrixSet(
-      matrixSetObj, extent);
+      matrixSetObj, extent, matrixLimits);
 
   /** @type {!Array.<string>} */
   var urls = [];

--- a/src/ol/tilegrid/wmts.js
+++ b/src/ol/tilegrid/wmts.js
@@ -65,15 +65,19 @@ ol.tilegrid.WMTS.prototype.getMatrixIds = function() {
 
 
 /**
- * Create a tile grid from a WMTS capabilities matrix set.
+ * Create a tile grid from a WMTS capabilities matrix set and an
+ * optional TileMatrixSetLimits.
  * @param {Object} matrixSet An object representing a matrixSet in the
  *     capabilities document.
  * @param {ol.Extent=} opt_extent An optional extent to restrict the tile
  *     ranges the server provides.
+ * @param {Array.<Object>=} opt_matrixLimits An optional object representing
+ *     the available matrices for tileGrid.
  * @return {ol.tilegrid.WMTS} WMTS tileGrid instance.
  * @api
  */
-ol.tilegrid.WMTS.createFromCapabilitiesMatrixSet = function(matrixSet, opt_extent) {
+ol.tilegrid.WMTS.createFromCapabilitiesMatrixSet = function(matrixSet, opt_extent,
+ opt_matrixLimits) {
 
   /** @type {!Array.<number>} */
   var resolutions = [];
@@ -85,6 +89,8 @@ ol.tilegrid.WMTS.createFromCapabilitiesMatrixSet = function(matrixSet, opt_exten
   var tileSizes = [];
   /** @type {!Array.<ol.Size>} */
   var sizes = [];
+
+  var matrixLimits = opt_matrixLimits !== undefined ? opt_matrixLimits : [];
 
   var supportedCRSPropName = 'SupportedCRS';
   var matrixIdsPropName = 'TileMatrix';
@@ -106,21 +112,36 @@ ol.tilegrid.WMTS.createFromCapabilitiesMatrixSet = function(matrixSet, opt_exten
   });
 
   matrixSet[matrixIdsPropName].forEach(function(elt, index, array) {
-    matrixIds.push(elt[identifierPropName]);
-    var resolution = elt[scaleDenominatorPropName] * 0.28E-3 / metersPerUnit;
-    var tileWidth = elt[tileWidthPropName];
-    var tileHeight = elt[tileHeightPropName];
-    if (switchOriginXY) {
-      origins.push([elt[topLeftCornerPropName][1],
-        elt[topLeftCornerPropName][0]]);
+
+    var matrixAvailable;
+    // use of matrixLimits to filter TileMatrices from GetCapabilities
+    // TileMatrixSet from unavailable matrix levels.
+    if (matrixLimits.length > 0) {
+      matrixAvailable = ol.array.find(matrixLimits,
+          function(elt_ml, index_ml, array_ml) {
+            return elt[identifierPropName] == elt_ml[matrixIdsPropName];
+          });
     } else {
-      origins.push(elt[topLeftCornerPropName]);
+      matrixAvailable = true;
     }
-    resolutions.push(resolution);
-    tileSizes.push(tileWidth == tileHeight ?
-        tileWidth : [tileWidth, tileHeight]);
-    // top-left origin, so height is negative
-    sizes.push([elt['MatrixWidth'], -elt['MatrixHeight']]);
+
+    if (matrixAvailable) {
+      matrixIds.push(elt[identifierPropName]);
+      var resolution = elt[scaleDenominatorPropName] * 0.28E-3 / metersPerUnit;
+      var tileWidth = elt[tileWidthPropName];
+      var tileHeight = elt[tileHeightPropName];
+      if (switchOriginXY) {
+        origins.push([elt[topLeftCornerPropName][1],
+          elt[topLeftCornerPropName][0]]);
+      } else {
+        origins.push(elt[topLeftCornerPropName]);
+      }
+      resolutions.push(resolution);
+      tileSizes.push(tileWidth == tileHeight ?
+          tileWidth : [tileWidth, tileHeight]);
+      // top-left origin, so height is negative
+      sizes.push([elt['MatrixWidth'], -elt['MatrixHeight']]);
+    }
   });
 
   return new ol.tilegrid.WMTS({

--- a/test/spec/ol/format/wmts/ign.xml
+++ b/test/spec/ol/format/wmts/ign.xml
@@ -1,0 +1,455 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Capabilities xmlns="http://www.opengis.net/wmts/1.0" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/wmts/1.0 http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd">
+  <ows:ServiceIdentification>
+    <ows:Title>Service de visualisation WMTS</ows:Title>
+    <ows:Abstract>
+Ce service permet la visualisation de couches de données raster IGN au travers d'un flux WMTS
+</ows:Abstract>
+    <ows:Keywords>
+      <ows:Keyword>Unités administratives</ows:Keyword>
+      <ows:Keyword>Limites administratives</ows:Keyword>
+      <ows:Keyword>Surfaces bâties</ows:Keyword>
+      <ows:Keyword>Réseaux de transport</ows:Keyword>
+      <ows:Keyword>Routes</ows:Keyword>
+      <ows:Keyword>Réseaux ferroviaires</ows:Keyword>
+      <ows:Keyword>Aérodromes</ows:Keyword>
+      <ows:Keyword>Réseau hydrographique</ows:Keyword>
+      <ows:Keyword>Parcelles cadastrales</ows:Keyword>
+      <ows:Keyword>Bâtiments</ows:Keyword>
+      <ows:Keyword>Services d'utilité publique et services publics</ows:Keyword>
+      <ows:Keyword>Réseaux de transport</ows:Keyword>
+      <ows:Keyword>Hydrographie</ows:Keyword>
+      <ows:Keyword>Photographies aériennes</ows:Keyword>
+      <ows:Keyword>Cartes</ows:Keyword>
+      <ows:Keyword>Cartes historiques</ows:Keyword>
+      <ows:Keyword>Altitude</ows:Keyword>
+    </ows:Keywords>
+    <ows:ServiceType>OGC WMTS</ows:ServiceType>
+    <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
+    <ows:Fees>licences</ows:Fees>
+    <ows:AccessConstraints>
+Conditions Générales d'Utilisation disponibles ici : http://professionnels.ign.fr/doc/Conditions_d_utilisation_des_licences_et_des_services_en_ligne.pdf
+</ows:AccessConstraints>
+  </ows:ServiceIdentification>
+  <ows:ServiceProvider>
+    <ows:ProviderName>IGN</ows:ProviderName>
+    <ows:ProviderSite xlink:href=""/>
+    <ows:ServiceContact>
+      <ows:IndividualName>Géoportail SAV</ows:IndividualName>
+      <ows:PositionName>custodian</ows:PositionName>
+      <ows:ContactInfo>
+        <ows:Phone>
+          <ows:Voice/>
+          <ows:Facsimile/>
+        </ows:Phone>
+        <ows:Address>
+          <ows:DeliveryPoint>73 avenue de Paris</ows:DeliveryPoint>
+          <ows:City>Saint Mandé</ows:City>
+          <ows:AdministrativeArea/>
+          <ows:PostalCode>94160</ows:PostalCode>
+          <ows:Country>France</ows:Country>
+          <ows:ElectronicMailAddress>geop_services@geoportail.fr</ows:ElectronicMailAddress>
+        </ows:Address>
+      </ows:ContactInfo>
+    </ows:ServiceContact>
+  </ows:ServiceProvider>
+  <ows:OperationsMetadata>
+    <ows:Operation name="GetCapabilities">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="http://wxs.ign.fr/geoportail/wmts?">
+            <ows:Constraint name="GetEncoding">
+              <ows:AllowedValues>
+                <ows:Value>KVP</ows:Value>
+              </ows:AllowedValues>
+            </ows:Constraint>
+          </ows:Get>
+        </ows:HTTP>
+      </ows:DCP>
+    </ows:Operation>
+    <ows:Operation name="GetTile">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="http://wxs.ign.fr/geoportail/wmts?">
+            <ows:Constraint name="GetEncoding">
+              <ows:AllowedValues>
+                <ows:Value>KVP</ows:Value>
+              </ows:AllowedValues>
+            </ows:Constraint>
+          </ows:Get>
+        </ows:HTTP>
+      </ows:DCP>
+    </ows:Operation>
+  </ows:OperationsMetadata>
+  <Contents>
+    <Layer>
+      <ows:Title>Photographies aériennes</ows:Title>
+      <ows:Abstract>Photographies aériennes</ows:Abstract>
+      <ows:Keywords>
+        <ows:Keyword>Photographies</ows:Keyword>
+      </ows:Keywords>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-180 -86</ows:LowerCorner>
+        <ows:UpperCorner>180 84</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <ows:Identifier>ORTHOIMAGERY.ORTHOPHOTOS</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Title>Données Brutes</ows:Title>
+        <ows:Abstract>Données brutes sans changement de palette</ows:Abstract>
+        <ows:Keywords>
+          <ows:Keyword>Défaut</ows:Keyword>
+        </ows:Keywords>
+        <ows:Identifier>normal</ows:Identifier>
+        <LegendURL format="image/jpeg" height="200" maxScaleDenominator="100000000" minScaleDenominator="200" width="200" xlink:href="http://www.geoportail.gouv.fr/depot/LEGEND.jpg"/>
+      </Style>
+      <Format>image/jpeg</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>PM</TileMatrixSet>
+        <TileMatrixSetLimits>
+          <TileMatrixLimits>
+            <TileMatrix>0</TileMatrix>
+            <MinTileRow>0</MinTileRow>
+            <MaxTileRow>1</MaxTileRow>
+            <MinTileCol>0</MinTileCol>
+            <MaxTileCol>1</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>1</TileMatrix>
+            <MinTileRow>0</MinTileRow>
+            <MaxTileRow>2</MaxTileRow>
+            <MinTileCol>0</MinTileCol>
+            <MaxTileCol>2</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>10</TileMatrix>
+            <MinTileRow>31</MinTileRow>
+            <MaxTileRow>1024</MaxTileRow>
+            <MinTileCol>0</MinTileCol>
+            <MaxTileCol>1024</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>11</TileMatrix>
+            <MinTileRow>62</MinTileRow>
+            <MaxTileRow>2048</MaxTileRow>
+            <MinTileCol>0</MinTileCol>
+            <MaxTileCol>2048</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>12</TileMatrix>
+            <MinTileRow>125</MinTileRow>
+            <MaxTileRow>4096</MaxTileRow>
+            <MinTileCol>0</MinTileCol>
+            <MaxTileCol>4096</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>13</TileMatrix>
+            <MinTileRow>2739</MinTileRow>
+            <MaxTileRow>4628</MaxTileRow>
+            <MinTileCol>41</MinTileCol>
+            <MaxTileCol>7917</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>14</TileMatrix>
+            <MinTileRow>5478</MinTileRow>
+            <MaxTileRow>9256</MaxTileRow>
+            <MinTileCol>82</MinTileCol>
+            <MaxTileCol>15835</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>15</TileMatrix>
+            <MinTileRow>10956</MinTileRow>
+            <MaxTileRow>18513</MaxTileRow>
+            <MinTileCol>165</MinTileCol>
+            <MaxTileCol>31670</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>16</TileMatrix>
+            <MinTileRow>21912</MinTileRow>
+            <MaxTileRow>37026</MaxTileRow>
+            <MinTileCol>330</MinTileCol>
+            <MaxTileCol>63341</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>17</TileMatrix>
+            <MinTileRow>43825</MinTileRow>
+            <MaxTileRow>74052</MaxTileRow>
+            <MinTileCol>660</MinTileCol>
+            <MaxTileCol>126683</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>18</TileMatrix>
+            <MinTileRow>87651</MinTileRow>
+            <MaxTileRow>148105</MaxTileRow>
+            <MinTileCol>1320</MinTileCol>
+            <MaxTileCol>253366</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>19</TileMatrix>
+            <MinTileRow>175302</MinTileRow>
+            <MaxTileRow>294060</MaxTileRow>
+            <MinTileCol>170159</MinTileCol>
+            <MaxTileCol>343473</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>2</TileMatrix>
+            <MinTileRow>0</MinTileRow>
+            <MaxTileRow>4</MaxTileRow>
+            <MinTileCol>0</MinTileCol>
+            <MaxTileCol>4</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>3</TileMatrix>
+            <MinTileRow>0</MinTileRow>
+            <MaxTileRow>8</MaxTileRow>
+            <MinTileCol>0</MinTileCol>
+            <MaxTileCol>8</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>4</TileMatrix>
+            <MinTileRow>0</MinTileRow>
+            <MaxTileRow>16</MaxTileRow>
+            <MinTileCol>0</MinTileCol>
+            <MaxTileCol>16</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>5</TileMatrix>
+            <MinTileRow>0</MinTileRow>
+            <MaxTileRow>32</MaxTileRow>
+            <MinTileCol>0</MinTileCol>
+            <MaxTileCol>32</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>6</TileMatrix>
+            <MinTileRow>1</MinTileRow>
+            <MaxTileRow>64</MaxTileRow>
+            <MinTileCol>0</MinTileCol>
+            <MaxTileCol>64</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>7</TileMatrix>
+            <MinTileRow>3</MinTileRow>
+            <MaxTileRow>128</MaxTileRow>
+            <MinTileCol>0</MinTileCol>
+            <MaxTileCol>128</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>8</TileMatrix>
+            <MinTileRow>7</MinTileRow>
+            <MaxTileRow>256</MaxTileRow>
+            <MinTileCol>0</MinTileCol>
+            <MaxTileCol>256</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>9</TileMatrix>
+            <MinTileRow>15</MinTileRow>
+            <MaxTileRow>512</MaxTileRow>
+            <MinTileCol>0</MinTileCol>
+            <MaxTileCol>512</MaxTileCol>
+          </TileMatrixLimits>
+        </TileMatrixSetLimits>
+      </TileMatrixSetLink>
+    </Layer>
+    <TileMatrixSet>
+      <ows:Identifier>PM</ows:Identifier>
+      <ows:SupportedCRS>EPSG:3857</ows:SupportedCRS>
+      <TileMatrix>
+        <ows:Identifier>0</ows:Identifier>
+        <ScaleDenominator>559082264.0287178958533332</ScaleDenominator>
+        <TopLeftCorner>-20037508 20037508</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>1</MatrixWidth>
+        <MatrixHeight>1</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>1</ows:Identifier>
+        <ScaleDenominator>279541132.0143588959472254</ScaleDenominator>
+        <TopLeftCorner>-20037508 20037508</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>2</MatrixWidth>
+        <MatrixHeight>2</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>10</ows:Identifier>
+        <ScaleDenominator>545978.7734655447186469</ScaleDenominator>
+        <TopLeftCorner>-20037508 20037508</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>1024</MatrixWidth>
+        <MatrixHeight>1024</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>11</ows:Identifier>
+        <ScaleDenominator>272989.3867327723085907</ScaleDenominator>
+        <TopLeftCorner>-20037508 20037508</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>2048</MatrixWidth>
+        <MatrixHeight>2048</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>12</ows:Identifier>
+        <ScaleDenominator>136494.6933663861796617</ScaleDenominator>
+        <TopLeftCorner>-20037508 20037508</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>4096</MatrixWidth>
+        <MatrixHeight>4096</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>13</ows:Identifier>
+        <ScaleDenominator>68247.3466831930771477</ScaleDenominator>
+        <TopLeftCorner>-20037508 20037508</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>8192</MatrixWidth>
+        <MatrixHeight>8192</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>14</ows:Identifier>
+        <ScaleDenominator>34123.6733415965449154</ScaleDenominator>
+        <TopLeftCorner>-20037508 20037508</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>16384</MatrixWidth>
+        <MatrixHeight>16384</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>15</ows:Identifier>
+        <ScaleDenominator>17061.8366707982724577</ScaleDenominator>
+        <TopLeftCorner>-20037508 20037508</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>32768</MatrixWidth>
+        <MatrixHeight>32768</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>16</ows:Identifier>
+        <ScaleDenominator>8530.9183353991362289</ScaleDenominator>
+        <TopLeftCorner>-20037508 20037508</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>65536</MatrixWidth>
+        <MatrixHeight>65536</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>17</ows:Identifier>
+        <ScaleDenominator>4265.4591676995681144</ScaleDenominator>
+        <TopLeftCorner>-20037508 20037508</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>131072</MatrixWidth>
+        <MatrixHeight>131072</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>18</ows:Identifier>
+        <ScaleDenominator>2132.7295838497840572</ScaleDenominator>
+        <TopLeftCorner>-20037508 20037508</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>262144</MatrixWidth>
+        <MatrixHeight>262144</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>19</ows:Identifier>
+        <ScaleDenominator>1066.3647919248918304</ScaleDenominator>
+        <TopLeftCorner>-20037508 20037508</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>524288</MatrixWidth>
+        <MatrixHeight>524288</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>2</ows:Identifier>
+        <ScaleDenominator>139770566.0071793960087234</ScaleDenominator>
+        <TopLeftCorner>-20037508 20037508</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>4</MatrixWidth>
+        <MatrixHeight>4</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>20</ows:Identifier>
+        <ScaleDenominator>533.1823959624461134</ScaleDenominator>
+        <TopLeftCorner>-20037508 20037508</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>1048576</MatrixWidth>
+        <MatrixHeight>1048576</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>21</ows:Identifier>
+        <ScaleDenominator>266.5911979812228585</ScaleDenominator>
+        <TopLeftCorner>-20037508 20037508</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>2097152</MatrixWidth>
+        <MatrixHeight>2097152</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>3</ows:Identifier>
+        <ScaleDenominator>69885283.0035897239868063</ScaleDenominator>
+        <TopLeftCorner>-20037508 20037508</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>8</MatrixWidth>
+        <MatrixHeight>8</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>4</ows:Identifier>
+        <ScaleDenominator>34942641.5017948619934032</ScaleDenominator>
+        <TopLeftCorner>-20037508 20037508</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>16</MatrixWidth>
+        <MatrixHeight>16</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>5</ows:Identifier>
+        <ScaleDenominator>17471320.7508974309967016</ScaleDenominator>
+        <TopLeftCorner>-20037508 20037508</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>32</MatrixWidth>
+        <MatrixHeight>32</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>6</ows:Identifier>
+        <ScaleDenominator>8735660.3754487154983508</ScaleDenominator>
+        <TopLeftCorner>-20037508 20037508</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>64</MatrixWidth>
+        <MatrixHeight>64</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>7</ows:Identifier>
+        <ScaleDenominator>4367830.1877243577491754</ScaleDenominator>
+        <TopLeftCorner>-20037508 20037508</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>128</MatrixWidth>
+        <MatrixHeight>128</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>8</ows:Identifier>
+        <ScaleDenominator>2183915.0938621788745877</ScaleDenominator>
+        <TopLeftCorner>-20037508 20037508</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>256</MatrixWidth>
+        <MatrixHeight>256</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>9</ows:Identifier>
+        <ScaleDenominator>1091957.5469310886252288</ScaleDenominator>
+        <TopLeftCorner>-20037508 20037508</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>512</MatrixWidth>
+        <MatrixHeight>512</MatrixHeight>
+      </TileMatrix>
+    </TileMatrixSet>
+  </Contents>
+</Capabilities>

--- a/test/spec/ol/format/wmtscapabilities.test.js
+++ b/test/spec/ol/format/wmtscapabilities.test.js
@@ -115,4 +115,78 @@ describe('ol.format.WMTSCapabilities', function() {
     });
 
   });
+
+  describe('when parsing ign.xml', function() {
+
+    var parser = new ol.format.WMTSCapabilities();
+    var capabilities;
+    before(function(done) {
+      afterLoadText('spec/ol/format/wmts/ign.xml', function(xml) {
+        try {
+          capabilities = parser.read(xml);
+        } catch (e) {
+          done(e);
+        }
+        done();
+      });
+    });
+
+    it('can read Capability.Contents.Layer', function() {
+      expect(capabilities.Contents.Layer).to.be.an('array');
+      expect(capabilities.Contents.Layer).to.have.length(1);
+
+
+      var layer = capabilities.Contents.Layer[0];
+      expect(layer.TileMatrixSetLink).to.be.an('array');
+      expect(layer.TileMatrixSetLink).to.have.length(1);
+      expect(layer.TileMatrixSetLink[0].TileMatrixSet).to.be
+        .eql('PM');
+      expect(layer.TileMatrixSetLink[0].TileMatrixSetLimits).to.be.an('array');
+      expect(layer.TileMatrixSetLink[0].TileMatrixSetLimits).to.have.length(20);
+      expect(layer.TileMatrixSetLink[0].TileMatrixSetLimits[0].TileMatrix)
+        .to.be.eql('0');
+      expect(layer.TileMatrixSetLink[0].TileMatrixSetLimits[0].MinTileRow)
+        .to.be.eql(0);
+      expect(layer.TileMatrixSetLink[0].TileMatrixSetLimits[0].MaxTileRow)
+        .to.be.eql(1);
+      expect(layer.TileMatrixSetLink[0].TileMatrixSetLimits[0].MinTileCol)
+        .to.be.eql(0);
+      expect(layer.TileMatrixSetLink[0].TileMatrixSetLimits[0].MaxTileCol)
+        .to.be.eql(1);
+
+    });
+
+    it('Can read Capabilities.Content.TileMatrixSet', function() {
+      expect(capabilities.Contents.TileMatrixSet).to.be.ok();
+
+      var pm = capabilities.Contents.TileMatrixSet[0];
+      expect(pm).to.be.ok();
+      expect(pm.Identifier).to.be.eql('PM');
+      expect(pm.SupportedCRS).to.be.eql('EPSG:3857');
+      expect(pm.TileMatrix).to.have.length(22);
+      expect(pm.TileMatrix[0].Identifier).to.be.eql('0');
+      expect(pm.TileMatrix[0].MatrixHeight).to.be.eql(1);
+      expect(pm.TileMatrix[0].MatrixWidth).to.be.eql(1);
+      expect(pm.TileMatrix[0].ScaleDenominator)
+        .to.be.eql(559082264.0287178958533332);
+      expect(pm.TileMatrix[0].TileWidth).to.be.eql(256);
+      expect(pm.TileMatrix[0].TileHeight).to.be.eql(256);
+      expect(pm.TileMatrix[0].TopLeftCorner).to.be.a('array');
+      expect(pm.TileMatrix[0].TopLeftCorner[0]).to.be.eql(-20037508);
+      expect(pm.TileMatrix[0].TopLeftCorner[1]).to.be.eql(20037508);
+      expect(pm.TileMatrix[1].Identifier).to.be.eql('1');
+      expect(pm.TileMatrix[1].MatrixHeight).to.be.eql(2);
+      expect(pm.TileMatrix[1].MatrixWidth).to.be.eql(2);
+      expect(pm.TileMatrix[1].ScaleDenominator)
+        .to.be.eql(279541132.0143588959472254);
+      expect(pm.TileMatrix[1].TileWidth).to.be.eql(256);
+      expect(pm.TileMatrix[1].TileHeight).to.be.eql(256);
+      expect(pm.TileMatrix[1].TopLeftCorner).to.be.a('array');
+      expect(pm.TileMatrix[1].TopLeftCorner[0]).to.be.eql(-20037508);
+      expect(pm.TileMatrix[1].TopLeftCorner[1]).to.be.eql(20037508);
+
+
+    });
+
+  });
 });

--- a/test/spec/ol/tilegrid/wmts.test.js
+++ b/test/spec/ol/tilegrid/wmts.test.js
@@ -58,4 +58,100 @@ describe('ol.tilegrid.WMTS', function() {
 
         });
   });
+
+
+  describe('when creating tileGrid from capabilities with and without TileMatrixSetLimits',
+    function() {
+      var parser = new ol.format.WMTSCapabilities();
+      var capabilities;
+      before(function(done) {
+        afterLoadText('spec/ol/format/wmts/ign.xml', function(xml) {
+          try {
+            capabilities = parser.read(xml);
+          } catch (e) {
+            done(e);
+          }
+          done();
+        });
+      });
+
+      it('can create tileGrid for EPSG:3857 without matrixLimits',
+        function() {
+          var matrixSetObj = capabilities.Contents.TileMatrixSet[0];
+          var tileGrid;
+          tileGrid = ol.tilegrid.WMTS.createFromCapabilitiesMatrixSet(
+              matrixSetObj);
+          expect(tileGrid.matrixIds_).to.be.an('array');
+          expect(tileGrid.matrixIds_).to.have.length(22);
+          expect(tileGrid.matrixIds_).to.eql([
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11',
+            '12', '13', '14', '15', '16', '17', '18', '19', '20', '21'
+          ]);
+
+          expect(tileGrid.resolutions_).to.be.an('array');
+          expect(tileGrid.resolutions_).to.have.length(22);
+          expect(tileGrid.resolutions_).to.eql([
+            156543.033928041, 78271.51696402048, 39135.758482010235,
+            19567.87924100512, 9783.93962050256, 4891.96981025128,
+            2445.98490512564, 1222.99245256282, 611.49622628141,
+            305.7481131407048, 152.8740565703525, 76.43702828517624,
+            38.21851414258813, 19.10925707129406, 9.554628535647032,
+            4.777314267823516, 2.388657133911758, 1.194328566955879,
+            0.5971642834779395, 0.2985821417389697, 0.1492910708694849,
+            0.0746455354347424
+          ]);
+
+          expect(tileGrid.origins_).to.be.an('array');
+          expect(tileGrid.origins_).to.have.length(22);
+          expect(tileGrid.origins_).to.eql(
+              Array.apply(null, Array(22)).map(Array.prototype.valueOf,
+                  [-20037508, 20037508]));
+
+          expect(tileGrid.tileSizes_).to.be.an('array');
+          expect(tileGrid.tileSizes_).to.have.length(22);
+          expect(tileGrid.tileSizes_).to.eql(
+              Array.apply(null, Array(22)).map(Number.prototype.valueOf, 256));
+
+        });
+
+      it('can create tileGrid for EPSG:3857 with matrixLimits',
+        function() {
+          var matrixSetObj = capabilities.Contents.TileMatrixSet[0];
+          var matrixLimitArray = capabilities.Contents.Layer[0]
+            .TileMatrixSetLink[0].TileMatrixSetLimits;
+          var tileGrid;
+          tileGrid = ol.tilegrid.WMTS.createFromCapabilitiesMatrixSet(
+              matrixSetObj, undefined, matrixLimitArray);
+          expect(tileGrid.matrixIds_).to.be.an('array');
+          expect(tileGrid.matrixIds_).to.have.length(20);
+          expect(tileGrid.matrixIds_).to.eql([
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11',
+            '12', '13', '14', '15', '16', '17', '18', '19'
+          ]);
+
+          expect(tileGrid.resolutions_).to.be.an('array');
+          expect(tileGrid.resolutions_).to.have.length(20);
+          expect(tileGrid.resolutions_).to.eql([
+            156543.033928041, 78271.51696402048, 39135.758482010235,
+            19567.87924100512, 9783.93962050256, 4891.96981025128,
+            2445.98490512564, 1222.99245256282, 611.49622628141,
+            305.7481131407048, 152.8740565703525, 76.43702828517624,
+            38.21851414258813, 19.10925707129406, 9.554628535647032,
+            4.777314267823516, 2.388657133911758, 1.194328566955879,
+            0.5971642834779395, 0.2985821417389697
+          ]);
+
+          expect(tileGrid.origins_).to.be.an('array');
+          expect(tileGrid.origins_).to.have.length(20);
+          expect(tileGrid.origins_).to.eql(
+              Array.apply(null, Array(20)).map(Array.prototype.valueOf,
+                  [-20037508, 20037508]));
+
+          expect(tileGrid.tileSizes_).to.be.an('array');
+          expect(tileGrid.tileSizes_).to.have.length(20);
+          expect(tileGrid.tileSizes_).to.eql(
+              Array.apply(null, Array(20)).map(Number.prototype.valueOf, 256));
+
+        });
+    });
 });


### PR DESCRIPTION
TileMatrixSetLimits, optional information described in WMTS GetCapabilities precise the TileMatrixSet levels available for a layer. By default, for a layer, the tilegrid is built using the whole TileMatrixSet description. For some layers where all TimeMatrixSet levels are not available, this could create 404 error requests.
This pull request adds:
- the reading of such information in WMTSCapabilities format,
- the use of such information in ol.source.WMTS.optionsFromCapabilities function to build the tilegrid It includes tests and a new example coming from french IGN® services.
