### PR TITLE
Add renderBuffer option for ol.source.ImageVector

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -4970,6 +4970,7 @@ olx.source.ImageCanvasOptions.prototype.state;
  *     logo: (string|olx.LogoOptions|undefined),
  *     projection: ol.ProjectionLike,
  *     ratio: (number|undefined),
+ *     renderBuffer: (number|undefined),
  *     resolutions: (Array.<number>|undefined),
  *     source: ol.source.Vector,
  *     style: (ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined)}}
@@ -5009,6 +5010,17 @@ olx.source.ImageVectorOptions.prototype.projection;
  * @api
  */
 olx.source.ImageVectorOptions.prototype.ratio;
+
+
+/**
+ * The buffer around the viewport extent used by the renderer when getting
+ * features from the vector source for the rendering or hit-detection.
+ * Recommended value: the size of the largest symbol, line width or label.
+ * Default is 100 pixels.
+ * @type {number|undefined}
+ * @api
+ */
+olx.source.ImageVectorOptions.prototype.renderBuffer;
 
 
 /**

--- a/src/ol/source/imagevectorsource.js
+++ b/src/ol/source/imagevectorsource.js
@@ -58,6 +58,12 @@ ol.source.ImageVector = function(options) {
 
   /**
    * @private
+   * @type {number}
+   */
+  this.renderBuffer_ = options.renderBuffer == undefined ? 100 : options.renderBuffer;
+
+  /**
+   * @private
    * @type {ol.render.canvas.ReplayGroup}
    */
   this.replayGroup_ = null;
@@ -108,7 +114,7 @@ ol.source.ImageVector.prototype.canvasFunctionInternal_ = function(extent, resol
 
   var replayGroup = new ol.render.canvas.ReplayGroup(
       ol.renderer.vector.getTolerance(resolution, pixelRatio), extent,
-      resolution);
+      resolution, this.renderBuffer_);
 
   this.source_.loadFeatures(extent, resolution, projection);
 


### PR DESCRIPTION
Currently, when doing hit detection on an `ol.layer.Image` with an `ol.source.ImageVector`, the hit detection replay group will replay all features, instead of only those in proximity to the pixel of interest. `ol.layer.Vector` uses a `renderBuffer` option to limit the extent of interest. This pull request introduces the same for `ol.source.ImageVector`.

This pull request brings a huge improvement for hit detection performance when using `ol.source.ImageVector`. See #4232.