### PR TITLE
Use tile keys instead of coord keys

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -937,8 +937,7 @@ ol.Map.prototype.getTilePriority = function(tile, tileSourceKey, tileCenter, til
   if (!frameState || !(tileSourceKey in frameState.wantedTiles)) {
     return ol.structs.PriorityQueue.DROP;
   }
-  var coordKey = tile.tileCoord.toString();
-  if (!frameState.wantedTiles[tileSourceKey][coordKey]) {
+  if (!frameState.wantedTiles[tileSourceKey][tile.getKey()]) {
     return ol.structs.PriorityQueue.DROP;
   }
   // Prioritize the highest zoom level tiles closest to the focus.

--- a/src/ol/renderer/layerrenderer.js
+++ b/src/ol/renderer/layerrenderer.js
@@ -311,7 +311,7 @@ ol.renderer.Layer.prototype.manageTilePyramid = function(
         if (currentZ - z <= preload) {
           tile = tileSource.getTile(z, x, y, pixelRatio, projection);
           if (tile.getState() == ol.TileState.IDLE) {
-            wantedTiles[tile.tileCoord.toString()] = true;
+            wantedTiles[tile.getKey()] = true;
             if (!tileQueue.isKeyQueued(tile.getKey())) {
               tileQueue.enqueue([tile, tileSourceKey,
                 tileGrid.getTileCoordCenter(tile.tileCoord), tileResolution]);

--- a/src/ol/tile.js
+++ b/src/ol/tile.js
@@ -84,7 +84,7 @@ ol.Tile.prototype.getImage = goog.abstractMethod;
  * @return {string} Key.
  */
 ol.Tile.prototype.getKey = function() {
-  return goog.getUid(this).toString();
+  return this.key + '/' + this.tileCoord;
 };
 
 


### PR DESCRIPTION
This change ensures that tiles with old params or dimensions are discarded.

Fixes #4455.