### PR TITLE
Avoid unnecessary getImageData calls in hit detection

### DIFF
--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -270,7 +270,7 @@ ol.render.canvas.Replay.prototype.replay_ = function(
           i = /** @type {number} */ (instruction[2]);
         } else if (opt_hitExtent !== undefined && !ol.extent.intersects(
             opt_hitExtent, feature.getGeometry().getExtent())) {
-          i = /** @type {number} */ (instruction[2]);
+          i = /** @type {number} */ (instruction[2]) + 1;
         } else {
           ++i;
         }


### PR DESCRIPTION
If a feature is skipped or outside the hit extent, don't execute the end geometry instruction that calls getImageData. Partially resolves #5527.