### PR TITLE
Fix broken link to Google JavaScript Style Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ include:
 ### Follow OpenLayers 3's coding style
 
 OpenLayers 3 follows [Google's JavaScript Style
-Guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml).
+Guide](https://google.github.io/styleguide/javascriptguide.xml).
 This is checked using [ESLint](http://eslint.org/), you
 can run the linter locally on your machine before committing using the `lint`
 target:


### PR DESCRIPTION
This pull request only fixes a broken link in the CONTRIBUTING.md

My contribution is covered by CCLA (employee of the company "Klaus Benndorf", see https://github.com/openlayers/cla/pull/6).