### PR TITLE
Parse MVT id property

### DIFF
--- a/src/ol/format/mvtformat.js
+++ b/src/ol/format/mvtformat.js
@@ -95,6 +95,7 @@ ol.format.MVT.prototype.getType = function() {
 ol.format.MVT.prototype.readFeature_ = function(
     rawFeature, layer, opt_options) {
   var feature = new this.featureClass_();
+  var id = rawFeature.id;
   var values = rawFeature.properties;
   values[this.layerName_] = layer;
   var geometry = ol.format.Feature.transformWithOptions(
@@ -104,6 +105,7 @@ ol.format.MVT.prototype.readFeature_ = function(
     goog.asserts.assertInstanceof(geometry, ol.geom.Geometry);
     values[this.geometryName_] = geometry;
   }
+  feature.setId(id);
   feature.setProperties(values);
   feature.setGeometryName(this.geometryName_);
   return feature;

--- a/test/spec/ol/format/mvtformat.test.js
+++ b/test/spec/ol/format/mvtformat.test.js
@@ -65,6 +65,15 @@ where('ArrayBuffer').describe('ol.format.MVT', function() {
           .to.eql([rawGeometry[1][0].x, rawGeometry[1][0].y]);
     });
 
+    it('parses id property', function() {
+      var format = new ol.format.MVT({
+        featureClass: ol.Feature,
+        layers: ['building']
+      });
+      var features = format.readFeatures(data);
+      expect(features[0].getId()).to.be(2);
+    });
+
   });
 
 });


### PR DESCRIPTION
Fix issue #5366. It requires `"vector-tile": "1.3.0"` (PR #5612).