### PR TITLE
Replace goog.abstractMethod

### DIFF
--- a/src/ol/format/featureformat.js
+++ b/src/ol/format/featureformat.js
@@ -28,9 +28,10 @@ ol.format.Feature = function() {
 
 
 /**
+ * @abstract
  * @return {Array.<string>} Extensions.
  */
-ol.format.Feature.prototype.getExtensions = goog.abstractMethod;
+ol.format.Feature.prototype.getExtensions = function() {};
 
 
 /**
@@ -80,78 +81,86 @@ ol.format.Feature.prototype.adaptOptions = function(options) {
 
 
 /**
+ * @abstract
  * @return {ol.format.FormatType} Format.
  */
-ol.format.Feature.prototype.getType = goog.abstractMethod;
+ol.format.Feature.prototype.getType = function() {};
 
 
 /**
  * Read a single feature from a source.
  *
+ * @abstract
  * @param {Document|Node|Object|string} source Source.
  * @param {olx.format.ReadOptions=} opt_options Read options.
  * @return {ol.Feature} Feature.
  */
-ol.format.Feature.prototype.readFeature = goog.abstractMethod;
+ol.format.Feature.prototype.readFeature = function(source, opt_options) {};
 
 
 /**
  * Read all features from a source.
  *
+ * @abstract
  * @param {Document|Node|ArrayBuffer|Object|string} source Source.
  * @param {olx.format.ReadOptions=} opt_options Read options.
  * @return {Array.<ol.Feature>} Features.
  */
-ol.format.Feature.prototype.readFeatures = goog.abstractMethod;
+ol.format.Feature.prototype.readFeatures = function(source, opt_options) {};
 
 
 /**
  * Read a single geometry from a source.
  *
+ * @abstract
  * @param {Document|Node|Object|string} source Source.
  * @param {olx.format.ReadOptions=} opt_options Read options.
  * @return {ol.geom.Geometry} Geometry.
  */
-ol.format.Feature.prototype.readGeometry = goog.abstractMethod;
+ol.format.Feature.prototype.readGeometry = function(source, opt_options) {};
 
 
 /**
  * Read the projection from a source.
  *
+ * @abstract
  * @param {Document|Node|Object|string} source Source.
  * @return {ol.proj.Projection} Projection.
  */
-ol.format.Feature.prototype.readProjection = goog.abstractMethod;
+ol.format.Feature.prototype.readProjection = function(source) {};
 
 
 /**
  * Encode a feature in this format.
  *
+ * @abstract
  * @param {ol.Feature} feature Feature.
  * @param {olx.format.WriteOptions=} opt_options Write options.
  * @return {string} Result.
  */
-ol.format.Feature.prototype.writeFeature = goog.abstractMethod;
+ol.format.Feature.prototype.writeFeature = function(feature, opt_options) {};
 
 
 /**
  * Encode an array of features in this format.
  *
+ * @abstract
  * @param {Array.<ol.Feature>} features Features.
  * @param {olx.format.WriteOptions=} opt_options Write options.
  * @return {string} Result.
  */
-ol.format.Feature.prototype.writeFeatures = goog.abstractMethod;
+ol.format.Feature.prototype.writeFeatures = function(features, opt_options) {};
 
 
 /**
  * Write a single geometry in this format.
  *
+ * @abstract
  * @param {ol.geom.Geometry} geometry Geometry.
  * @param {olx.format.WriteOptions=} opt_options Write options.
  * @return {string} Result.
  */
-ol.format.Feature.prototype.writeGeometry = goog.abstractMethod;
+ol.format.Feature.prototype.writeGeometry = function(geometry, opt_options) {};
 
 
 /**

--- a/src/ol/format/jsonfeatureformat.js
+++ b/src/ol/format/jsonfeatureformat.js
@@ -65,21 +65,23 @@ ol.format.JSONFeature.prototype.readFeatures = function(source, opt_options) {
 
 
 /**
+ * @abstract
  * @param {Object} object Object.
  * @param {olx.format.ReadOptions=} opt_options Read options.
  * @protected
  * @return {ol.Feature} Feature.
  */
-ol.format.JSONFeature.prototype.readFeatureFromObject = goog.abstractMethod;
+ol.format.JSONFeature.prototype.readFeatureFromObject = function(object, opt_options) {};
 
 
 /**
+ * @abstract
  * @param {Object} object Object.
  * @param {olx.format.ReadOptions=} opt_options Read options.
  * @protected
  * @return {Array.<ol.Feature>} Features.
  */
-ol.format.JSONFeature.prototype.readFeaturesFromObject = goog.abstractMethod;
+ol.format.JSONFeature.prototype.readFeaturesFromObject = function(object, opt_options) {};
 
 
 /**
@@ -92,12 +94,13 @@ ol.format.JSONFeature.prototype.readGeometry = function(source, opt_options) {
 
 
 /**
+ * @abstract
  * @param {Object} object Object.
  * @param {olx.format.ReadOptions=} opt_options Read options.
  * @protected
  * @return {ol.geom.Geometry} Geometry.
  */
-ol.format.JSONFeature.prototype.readGeometryFromObject = goog.abstractMethod;
+ol.format.JSONFeature.prototype.readGeometryFromObject = function(object, opt_options) {};
 
 
 /**
@@ -109,11 +112,12 @@ ol.format.JSONFeature.prototype.readProjection = function(source) {
 
 
 /**
+ * @abstract
  * @param {Object} object Object.
  * @protected
  * @return {ol.proj.Projection} Projection.
  */
-ol.format.JSONFeature.prototype.readProjectionFromObject = goog.abstractMethod;
+ol.format.JSONFeature.prototype.readProjectionFromObject = function(object) {};
 
 
 /**
@@ -125,11 +129,12 @@ ol.format.JSONFeature.prototype.writeFeature = function(feature, opt_options) {
 
 
 /**
+ * @abstract
  * @param {ol.Feature} feature Feature.
  * @param {olx.format.WriteOptions=} opt_options Write options.
  * @return {Object} Object.
  */
-ol.format.JSONFeature.prototype.writeFeatureObject = goog.abstractMethod;
+ol.format.JSONFeature.prototype.writeFeatureObject = function(feature, opt_options) {};
 
 
 /**
@@ -141,11 +146,12 @@ ol.format.JSONFeature.prototype.writeFeatures = function(features, opt_options) 
 
 
 /**
+ * @abstract
  * @param {Array.<ol.Feature>} features Features.
  * @param {olx.format.WriteOptions=} opt_options Write options.
  * @return {Object} Object.
  */
-ol.format.JSONFeature.prototype.writeFeaturesObject = goog.abstractMethod;
+ol.format.JSONFeature.prototype.writeFeaturesObject = function(features, opt_options) {};
 
 
 /**
@@ -157,8 +163,9 @@ ol.format.JSONFeature.prototype.writeGeometry = function(geometry, opt_options) 
 
 
 /**
+ * @abstract
  * @param {ol.geom.Geometry} geometry Geometry.
  * @param {olx.format.WriteOptions=} opt_options Write options.
  * @return {Object} Object.
  */
-ol.format.JSONFeature.prototype.writeGeometryObject = goog.abstractMethod;
+ol.format.JSONFeature.prototype.writeGeometryObject = function(geometry, opt_options) {};

--- a/src/ol/format/textfeatureformat.js
+++ b/src/ol/format/textfeatureformat.js
@@ -53,12 +53,13 @@ ol.format.TextFeature.prototype.readFeature = function(source, opt_options) {
 
 
 /**
+ * @abstract
  * @param {string} text Text.
  * @param {olx.format.ReadOptions=} opt_options Read options.
  * @protected
  * @return {ol.Feature} Feature.
  */
-ol.format.TextFeature.prototype.readFeatureFromText = goog.abstractMethod;
+ol.format.TextFeature.prototype.readFeatureFromText = function(text, opt_options) {};
 
 
 /**
@@ -71,12 +72,13 @@ ol.format.TextFeature.prototype.readFeatures = function(source, opt_options) {
 
 
 /**
+ * @abstract
  * @param {string} text Text.
  * @param {olx.format.ReadOptions=} opt_options Read options.
  * @protected
  * @return {Array.<ol.Feature>} Features.
  */
-ol.format.TextFeature.prototype.readFeaturesFromText = goog.abstractMethod;
+ol.format.TextFeature.prototype.readFeaturesFromText = function(text, opt_options) {};
 
 
 /**
@@ -89,12 +91,13 @@ ol.format.TextFeature.prototype.readGeometry = function(source, opt_options) {
 
 
 /**
+ * @abstract
  * @param {string} text Text.
  * @param {olx.format.ReadOptions=} opt_options Read options.
  * @protected
  * @return {ol.geom.Geometry} Geometry.
  */
-ol.format.TextFeature.prototype.readGeometryFromText = goog.abstractMethod;
+ol.format.TextFeature.prototype.readGeometryFromText = function(text, opt_options) {};
 
 
 /**
@@ -124,12 +127,13 @@ ol.format.TextFeature.prototype.writeFeature = function(feature, opt_options) {
 
 
 /**
+ * @abstract
  * @param {ol.Feature} feature Features.
  * @param {olx.format.WriteOptions=} opt_options Write options.
  * @protected
  * @return {string} Text.
  */
-ol.format.TextFeature.prototype.writeFeatureText = goog.abstractMethod;
+ol.format.TextFeature.prototype.writeFeatureText = function(feature, opt_options) {};
 
 
 /**
@@ -142,12 +146,13 @@ ol.format.TextFeature.prototype.writeFeatures = function(
 
 
 /**
+ * @abstract
  * @param {Array.<ol.Feature>} features Features.
  * @param {olx.format.WriteOptions=} opt_options Write options.
  * @protected
  * @return {string} Text.
  */
-ol.format.TextFeature.prototype.writeFeaturesText = goog.abstractMethod;
+ol.format.TextFeature.prototype.writeFeaturesText = function(features, opt_options) {};
 
 
 /**
@@ -160,9 +165,10 @@ ol.format.TextFeature.prototype.writeGeometry = function(
 
 
 /**
+ * @abstract
  * @param {ol.geom.Geometry} geometry Geometry.
  * @param {olx.format.WriteOptions=} opt_options Write options.
  * @protected
  * @return {string} Text.
  */
-ol.format.TextFeature.prototype.writeGeometryText = goog.abstractMethod;
+ol.format.TextFeature.prototype.writeGeometryText = function(geometry, opt_options) {};

--- a/src/ol/format/xmlfeatureformat.js
+++ b/src/ol/format/xmlfeatureformat.js
@@ -74,11 +74,12 @@ ol.format.XMLFeature.prototype.readFeatureFromDocument = function(
 
 
 /**
+ * @abstract
  * @param {Node} node Node.
  * @param {olx.format.ReadOptions=} opt_options Options.
  * @return {ol.Feature} Feature.
  */
-ol.format.XMLFeature.prototype.readFeatureFromNode = goog.abstractMethod;
+ol.format.XMLFeature.prototype.readFeatureFromNode = function(node, opt_options) {};
 
 
 /**
@@ -121,12 +122,13 @@ ol.format.XMLFeature.prototype.readFeaturesFromDocument = function(
 
 
 /**
+ * @abstract
  * @param {Node} node Node.
  * @param {olx.format.ReadOptions=} opt_options Options.
  * @protected
  * @return {Array.<ol.Feature>} Features.
  */
-ol.format.XMLFeature.prototype.readFeaturesFromNode = goog.abstractMethod;
+ol.format.XMLFeature.prototype.readFeaturesFromNode = function(node, opt_options) {};
 
 
 /**
@@ -149,21 +151,23 @@ ol.format.XMLFeature.prototype.readGeometry = function(source, opt_options) {
 
 
 /**
+ * @abstract
  * @param {Document} doc Document.
  * @param {olx.format.ReadOptions=} opt_options Options.
  * @protected
  * @return {ol.geom.Geometry} Geometry.
  */
-ol.format.XMLFeature.prototype.readGeometryFromDocument = goog.abstractMethod;
+ol.format.XMLFeature.prototype.readGeometryFromDocument = function(doc, opt_options) {};
 
 
 /**
+ * @abstract
  * @param {Node} node Node.
  * @param {olx.format.ReadOptions=} opt_options Options.
  * @protected
  * @return {ol.geom.Geometry} Geometry.
  */
-ol.format.XMLFeature.prototype.readGeometryFromNode = goog.abstractMethod;
+ol.format.XMLFeature.prototype.readGeometryFromNode = function(node, opt_options) {};
 
 
 /**
@@ -216,12 +220,13 @@ ol.format.XMLFeature.prototype.writeFeature = function(feature, opt_options) {
 
 
 /**
+ * @abstract
  * @param {ol.Feature} feature Feature.
  * @param {olx.format.WriteOptions=} opt_options Options.
  * @protected
  * @return {Node} Node.
  */
-ol.format.XMLFeature.prototype.writeFeatureNode = goog.abstractMethod;
+ol.format.XMLFeature.prototype.writeFeatureNode = function(feature, opt_options) {};
 
 
 /**
@@ -236,11 +241,12 @@ ol.format.XMLFeature.prototype.writeFeatures = function(features, opt_options) {
 
 
 /**
+ * @abstract
  * @param {Array.<ol.Feature>} features Features.
  * @param {olx.format.WriteOptions=} opt_options Options.
  * @return {Node} Node.
  */
-ol.format.XMLFeature.prototype.writeFeaturesNode = goog.abstractMethod;
+ol.format.XMLFeature.prototype.writeFeaturesNode = function(features, opt_options) {};
 
 
 /**
@@ -255,8 +261,9 @@ ol.format.XMLFeature.prototype.writeGeometry = function(geometry, opt_options) {
 
 
 /**
+ * @abstract
  * @param {ol.geom.Geometry} geometry Geometry.
  * @param {olx.format.WriteOptions=} opt_options Options.
  * @return {Node} Node.
  */
-ol.format.XMLFeature.prototype.writeGeometryNode = goog.abstractMethod;
+ol.format.XMLFeature.prototype.writeGeometryNode = function(geometry, opt_options) {};

--- a/src/ol/format/xmlformat.js
+++ b/src/ol/format/xmlformat.js
@@ -35,14 +35,16 @@ ol.format.XML.prototype.read = function(source) {
 
 
 /**
+ * @abstract
  * @param {Document} doc Document.
- * @return {Object}
+ * @return {Object} Object
  */
-ol.format.XML.prototype.readFromDocument = goog.abstractMethod;
+ol.format.XML.prototype.readFromDocument = function(doc) {};
 
 
 /**
+ * @abstract
  * @param {Node} node Node.
- * @return {Object}
+ * @return {Object} Object
  */
-ol.format.XML.prototype.readFromNode = goog.abstractMethod;
+ol.format.XML.prototype.readFromNode = function(node) {};

--- a/src/ol/geom/geometry.js
+++ b/src/ol/geom/geometry.js
@@ -96,20 +96,21 @@ ol.inherits(ol.geom.Geometry, ol.Object);
 
 /**
  * Make a complete copy of the geometry.
- * @function
+ * @abstract
  * @return {!ol.geom.Geometry} Clone.
  */
-ol.geom.Geometry.prototype.clone = goog.abstractMethod;
+ol.geom.Geometry.prototype.clone = function() {};
 
 
 /**
+ * @abstract
  * @param {number} x X.
  * @param {number} y Y.
  * @param {ol.Coordinate} closestPoint Closest point.
  * @param {number} minSquaredDistance Minimum squared distance.
  * @return {number} Minimum squared distance.
  */
-ol.geom.Geometry.prototype.closestPointXY = goog.abstractMethod;
+ol.geom.Geometry.prototype.closestPointXY = function(x, y, closestPoint, minSquaredDistance) {};
 
 
 /**
@@ -137,11 +138,12 @@ ol.geom.Geometry.prototype.containsCoordinate = function(coordinate) {
 
 
 /**
+ * @abstract
  * @param {ol.Extent} extent Extent.
  * @protected
  * @return {ol.Extent} extent Extent.
  */
-ol.geom.Geometry.prototype.computeExtent = goog.abstractMethod;
+ol.geom.Geometry.prototype.computeExtent = function(extent) {};
 
 
 /**
@@ -170,12 +172,12 @@ ol.geom.Geometry.prototype.getExtent = function(opt_extent) {
 /**
  * Rotate the geometry around a given coordinate. This modifies the geometry
  * coordinates in place.
+ * @abstract
  * @param {number} angle Rotation angle in radians.
  * @param {ol.Coordinate} anchor The rotation center.
  * @api
- * @function
  */
-ol.geom.Geometry.prototype.rotate = goog.abstractMethod;
+ol.geom.Geometry.prototype.rotate = function(angle, anchor) {};
 
 
 /**
@@ -199,19 +201,19 @@ ol.geom.Geometry.prototype.simplify = function(tolerance) {
  * Create a simplified version of this geometry using the Douglas Peucker
  * algorithm.
  * @see https://en.wikipedia.org/wiki/Ramer-Douglas-Peucker_algorithm
- * @function
+ * @abstract
  * @param {number} squaredTolerance Squared tolerance.
  * @return {ol.geom.Geometry} Simplified geometry.
  */
-ol.geom.Geometry.prototype.getSimplifiedGeometry = goog.abstractMethod;
+ol.geom.Geometry.prototype.getSimplifiedGeometry = function(squaredTolerance) {};
 
 
 /**
  * Get the type of this geometry.
- * @function
+ * @abstract
  * @return {ol.geom.GeometryType} Geometry type.
  */
-ol.geom.Geometry.prototype.getType = goog.abstractMethod;
+ol.geom.Geometry.prototype.getType = function() {};
 
 
 /**
@@ -219,29 +221,29 @@ ol.geom.Geometry.prototype.getType = goog.abstractMethod;
  * The geometry is modified in place.
  * If you do not want the geometry modified in place, first `clone()` it and
  * then use this function on the clone.
- * @function
+ * @abstract
  * @param {ol.TransformFunction} transformFn Transform.
  */
-ol.geom.Geometry.prototype.applyTransform = goog.abstractMethod;
+ol.geom.Geometry.prototype.applyTransform = function(transformFn) {};
 
 
 /**
  * Test if the geometry and the passed extent intersect.
+ * @abstract
  * @param {ol.Extent} extent Extent.
  * @return {boolean} `true` if the geometry and the extent intersect.
- * @function
  */
-ol.geom.Geometry.prototype.intersectsExtent = goog.abstractMethod;
+ol.geom.Geometry.prototype.intersectsExtent = function(extent) {};
 
 
 /**
  * Translate the geometry.  This modifies the geometry coordinates in place.  If
  * instead you want a new geometry, first `clone()` this geometry.
+ * @abstract
  * @param {number} deltaX Delta X.
  * @param {number} deltaY Delta Y.
- * @function
  */
-ol.geom.Geometry.prototype.translate = goog.abstractMethod;
+ol.geom.Geometry.prototype.translate = function(deltaX, deltaY) {};
 
 
 /**

--- a/src/ol/geom/simplegeometry.js
+++ b/src/ol/geom/simplegeometry.js
@@ -98,9 +98,10 @@ ol.geom.SimpleGeometry.prototype.computeExtent = function(extent) {
 
 
 /**
+ * @abstract
  * @return {Array} Coordinates.
  */
-ol.geom.SimpleGeometry.prototype.getCoordinates = goog.abstractMethod;
+ol.geom.SimpleGeometry.prototype.getCoordinates = function() {};
 
 
 /**
@@ -212,10 +213,11 @@ ol.geom.SimpleGeometry.prototype.setFlatCoordinatesInternal = function(layout, f
 
 
 /**
+ * @abstract
  * @param {Array} coordinates Coordinates.
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
  */
-ol.geom.SimpleGeometry.prototype.setCoordinates = goog.abstractMethod;
+ol.geom.SimpleGeometry.prototype.setCoordinates = function(coordinates, opt_layout) {};
 
 
 /**

--- a/src/ol/imagebase.js
+++ b/src/ol/imagebase.js
@@ -90,10 +90,11 @@ ol.ImageBase.prototype.getExtent = function() {
 
 
 /**
+ * @abstract
  * @param {Object=} opt_context Object.
  * @return {HTMLCanvasElement|Image|HTMLVideoElement} Image.
  */
-ol.ImageBase.prototype.getImage = goog.abstractMethod;
+ol.ImageBase.prototype.getImage = function(opt_context) {};
 
 
 /**
@@ -123,5 +124,6 @@ ol.ImageBase.prototype.getState = function() {
 
 /**
  * Load not yet loaded URI.
+ * @abstract
  */
-ol.ImageBase.prototype.load = goog.abstractMethod;
+ol.ImageBase.prototype.load = function() {};

--- a/src/ol/layer/layerbase.js
+++ b/src/ol/layer/layerbase.js
@@ -85,19 +85,21 @@ ol.layer.Base.prototype.getLayerState = function() {
 
 
 /**
+ * @abstract
  * @param {Array.<ol.layer.Layer>=} opt_array Array of layers (to be
  *     modified in place).
  * @return {Array.<ol.layer.Layer>} Array of layers.
  */
-ol.layer.Base.prototype.getLayersArray = goog.abstractMethod;
+ol.layer.Base.prototype.getLayersArray = function(opt_array) {};
 
 
 /**
+ * @abstract
  * @param {Array.<ol.LayerState>=} opt_states Optional list of layer
  *     states (to be modified in place).
  * @return {Array.<ol.LayerState>} List of layer states.
  */
-ol.layer.Base.prototype.getLayerStatesArray = goog.abstractMethod;
+ol.layer.Base.prototype.getLayerStatesArray = function(opt_states) {};
 
 
 /**
@@ -149,9 +151,10 @@ ol.layer.Base.prototype.getOpacity = function() {
 
 
 /**
+ * @abstract
  * @return {ol.source.State} Source state.
  */
-ol.layer.Base.prototype.getSourceState = goog.abstractMethod;
+ol.layer.Base.prototype.getSourceState = function() {};
 
 
 /**

--- a/src/ol/render/vectorcontext.js
+++ b/src/ol/render/vectorcontext.js
@@ -15,88 +15,100 @@ ol.render.VectorContext = function() {
 /**
  * Render a geometry.
  *
+ * @abstract
  * @param {ol.geom.Geometry} geometry The geometry to render.
  */
-ol.render.VectorContext.prototype.drawGeometry = goog.abstractMethod;
+ol.render.VectorContext.prototype.drawGeometry = function(geometry) {};
 
 
 /**
  * Set the rendering style.
  *
+ * @abstract
  * @param {ol.style.Style} style The rendering style.
  */
-ol.render.VectorContext.prototype.setStyle = goog.abstractMethod;
+ol.render.VectorContext.prototype.setStyle = function(style) {};
 
 
 /**
+ * @abstract
  * @param {ol.geom.Circle} circleGeometry Circle geometry.
  * @param {ol.Feature} feature Feature,
  */
-ol.render.VectorContext.prototype.drawCircle = goog.abstractMethod;
+ol.render.VectorContext.prototype.drawCircle = function(circleGeometry, feature) {};
 
 
 /**
+ * @abstract
  * @param {ol.Feature} feature Feature.
  * @param {ol.style.Style} style Style.
  */
-ol.render.VectorContext.prototype.drawFeature = goog.abstractMethod;
+ol.render.VectorContext.prototype.drawFeature = function(feature, style) {};
 
 
 /**
+ * @abstract
  * @param {ol.geom.GeometryCollection} geometryCollectionGeometry Geometry
  *     collection.
  * @param {ol.Feature} feature Feature.
  */
-ol.render.VectorContext.prototype.drawGeometryCollection = goog.abstractMethod;
+ol.render.VectorContext.prototype.drawGeometryCollection = function(geometryCollectionGeometry, feature) {};
 
 
 /**
+ * @abstract
  * @param {ol.geom.LineString|ol.render.Feature} lineStringGeometry Line
  *     string geometry.
  * @param {ol.Feature|ol.render.Feature} feature Feature.
  */
-ol.render.VectorContext.prototype.drawLineString = goog.abstractMethod;
+ol.render.VectorContext.prototype.drawLineString = function(lineStringGeometry, feature) {};
 
 
 /**
+ * @abstract
  * @param {ol.geom.MultiLineString|ol.render.Feature} multiLineStringGeometry
  *     MultiLineString geometry.
  * @param {ol.Feature|ol.render.Feature} feature Feature.
  */
-ol.render.VectorContext.prototype.drawMultiLineString = goog.abstractMethod;
+ol.render.VectorContext.prototype.drawMultiLineString = function(multiLineStringGeometry, feature) {};
 
 
 /**
+ * @abstract
  * @param {ol.geom.MultiPoint|ol.render.Feature} multiPointGeometry MultiPoint
  *     geometry.
  * @param {ol.Feature|ol.render.Feature} feature Feature.
  */
-ol.render.VectorContext.prototype.drawMultiPoint = goog.abstractMethod;
+ol.render.VectorContext.prototype.drawMultiPoint = function(multiPointGeometry, feature) {};
 
 
 /**
+ * @abstract
  * @param {ol.geom.MultiPolygon} multiPolygonGeometry MultiPolygon geometry.
  * @param {ol.Feature} feature Feature.
  */
-ol.render.VectorContext.prototype.drawMultiPolygon = goog.abstractMethod;
+ol.render.VectorContext.prototype.drawMultiPolygon = function(multiPolygonGeometry, feature) {};
 
 
 /**
+ * @abstract
  * @param {ol.geom.Point|ol.render.Feature} pointGeometry Point geometry.
  * @param {ol.Feature|ol.render.Feature} feature Feature.
  */
-ol.render.VectorContext.prototype.drawPoint = goog.abstractMethod;
+ol.render.VectorContext.prototype.drawPoint = function(pointGeometry, feature) {};
 
 
 /**
+ * @abstract
  * @param {ol.geom.Polygon|ol.render.Feature} polygonGeometry Polygon
  *     geometry.
  * @param {ol.Feature|ol.render.Feature} feature Feature.
  */
-ol.render.VectorContext.prototype.drawPolygon = goog.abstractMethod;
+ol.render.VectorContext.prototype.drawPolygon = function(polygonGeometry, feature) {};
 
 
 /**
+ * @abstract
  * @param {Array.<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
@@ -104,23 +116,26 @@ ol.render.VectorContext.prototype.drawPolygon = goog.abstractMethod;
  * @param {ol.geom.Geometry|ol.render.Feature} geometry Geometry.
  * @param {ol.Feature|ol.render.Feature} feature Feature.
  */
-ol.render.VectorContext.prototype.drawText = goog.abstractMethod;
+ol.render.VectorContext.prototype.drawText = function(flatCoordinates, offset, end, stride, geometry, feature) {};
 
 
 /**
+ * @abstract
  * @param {ol.style.Fill} fillStyle Fill style.
  * @param {ol.style.Stroke} strokeStyle Stroke style.
  */
-ol.render.VectorContext.prototype.setFillStrokeStyle = goog.abstractMethod;
+ol.render.VectorContext.prototype.setFillStrokeStyle = function(fillStyle, strokeStyle) {};
 
 
 /**
+ * @abstract
  * @param {ol.style.Image} imageStyle Image style.
  */
-ol.render.VectorContext.prototype.setImageStyle = goog.abstractMethod;
+ol.render.VectorContext.prototype.setImageStyle = function(imageStyle) {};
 
 
 /**
+ * @abstract
  * @param {ol.style.Text} textStyle Text style.
  */
-ol.render.VectorContext.prototype.setTextStyle = goog.abstractMethod;
+ol.render.VectorContext.prototype.setTextStyle = function(textStyle) {};

--- a/src/ol/render/webgl/webglreplay.js
+++ b/src/ol/render/webgl/webglreplay.js
@@ -831,8 +831,9 @@ ol.render.webgl.ImageReplay.prototype.drawHitDetectionReplayOneByOne_ = function
 
 /**
  * @inheritDoc
+ * @abstract
  */
-ol.render.webgl.ImageReplay.prototype.setFillStrokeStyle = goog.abstractMethod;
+ol.render.webgl.ImageReplay.prototype.setFillStrokeStyle = function() {};
 
 
 /**

--- a/src/ol/renderer/canvas/canvaslayerrenderer.js
+++ b/src/ol/renderer/canvas/canvaslayerrenderer.js
@@ -164,15 +164,17 @@ ol.renderer.canvas.Layer.prototype.dispatchRenderEvent = function(context, frame
 
 
 /**
+ * @abstract
  * @return {HTMLCanvasElement|HTMLVideoElement|Image} Canvas.
  */
-ol.renderer.canvas.Layer.prototype.getImage = goog.abstractMethod;
+ol.renderer.canvas.Layer.prototype.getImage = function() {};
 
 
 /**
+ * @abstract
  * @return {!ol.Transform} Image transform.
  */
-ol.renderer.canvas.Layer.prototype.getImageTransform = goog.abstractMethod;
+ol.renderer.canvas.Layer.prototype.getImageTransform = function() {};
 
 
 /**
@@ -196,11 +198,12 @@ ol.renderer.canvas.Layer.prototype.getTransform = function(frameState, offsetX) 
 
 
 /**
+ * @abstract
  * @param {olx.FrameState} frameState Frame state.
  * @param {ol.LayerState} layerState Layer state.
  * @return {boolean} whether composeFrame should be called.
  */
-ol.renderer.canvas.Layer.prototype.prepareFrame = goog.abstractMethod;
+ol.renderer.canvas.Layer.prototype.prepareFrame = function(frameState, layerState) {};
 
 
 /**

--- a/src/ol/renderer/dom/domlayerrenderer.js
+++ b/src/ol/renderer/dom/domlayerrenderer.js
@@ -47,8 +47,9 @@ ol.renderer.dom.Layer.prototype.getTarget = function() {
 
 
 /**
+ * @abstract
  * @param {olx.FrameState} frameState Frame state.
  * @param {ol.LayerState} layerState Layer state.
  * @return {boolean} whether composeFrame should be called.
  */
-ol.renderer.dom.Layer.prototype.prepareFrame = goog.abstractMethod;
+ol.renderer.dom.Layer.prototype.prepareFrame = function(frameState, layerState) {};

--- a/src/ol/renderer/maprenderer.js
+++ b/src/ol/renderer/maprenderer.js
@@ -82,11 +82,12 @@ ol.renderer.Map.prototype.calculateMatrices2D = function(frameState) {
 
 
 /**
+ * @abstract
  * @param {ol.layer.Layer} layer Layer.
  * @protected
  * @return {ol.renderer.Layer} layerRenderer Layer renderer.
  */
-ol.renderer.Map.prototype.createLayerRenderer = goog.abstractMethod;
+ol.renderer.Map.prototype.createLayerRenderer = function(layer) {};
 
 
 /**
@@ -288,9 +289,10 @@ ol.renderer.Map.prototype.getMap = function() {
 
 
 /**
+ * @abstract
  * @return {string} Type
  */
-ol.renderer.Map.prototype.getType = goog.abstractMethod;
+ol.renderer.Map.prototype.getType = function() {};
 
 
 /**

--- a/src/ol/renderer/webgl/webgllayerrenderer.js
+++ b/src/ol/renderer/webgl/webgllayerrenderer.js
@@ -249,9 +249,10 @@ ol.renderer.webgl.Layer.prototype.handleWebGLContextLost = function() {
 
 
 /**
+ * @abstract
  * @param {olx.FrameState} frameState Frame state.
  * @param {ol.LayerState} layerState Layer state.
  * @param {ol.webgl.Context} context Context.
  * @return {boolean} whether composeFrame should be called.
  */
-ol.renderer.webgl.Layer.prototype.prepareFrame = goog.abstractMethod;
+ol.renderer.webgl.Layer.prototype.prepareFrame = function(frameState, layerState, context) {};

--- a/src/ol/source/imagesource.js
+++ b/src/ol/source/imagesource.js
@@ -129,6 +129,7 @@ ol.source.Image.prototype.getImage = function(extent, resolution, pixelRatio, pr
 
 
 /**
+ * @abstract
  * @param {ol.Extent} extent Extent.
  * @param {number} resolution Resolution.
  * @param {number} pixelRatio Pixel ratio.
@@ -136,7 +137,7 @@ ol.source.Image.prototype.getImage = function(extent, resolution, pixelRatio, pr
  * @return {ol.ImageBase} Single image.
  * @protected
  */
-ol.source.Image.prototype.getImageInternal = goog.abstractMethod;
+ol.source.Image.prototype.getImageInternal = function(extent, resolution, pixelRatio, projection) {};
 
 
 /**

--- a/src/ol/source/source.js
+++ b/src/ol/source/source.js
@@ -146,9 +146,10 @@ ol.source.Source.prototype.getProjection = function() {
 
 
 /**
+ * @abstract
  * @return {Array.<number>|undefined} Resolutions.
  */
-ol.source.Source.prototype.getResolutions = goog.abstractMethod;
+ol.source.Source.prototype.getResolutions = function() {};
 
 
 /**

--- a/src/ol/source/tilesource.js
+++ b/src/ol/source/tilesource.js
@@ -194,6 +194,7 @@ ol.source.Tile.prototype.getResolutions = function() {
 
 
 /**
+ * @abstract
  * @param {number} z Tile coordinate z.
  * @param {number} x Tile coordinate x.
  * @param {number} y Tile coordinate y.
@@ -201,7 +202,7 @@ ol.source.Tile.prototype.getResolutions = function() {
  * @param {ol.proj.Projection} projection Projection.
  * @return {!ol.Tile} Tile.
  */
-ol.source.Tile.prototype.getTile = goog.abstractMethod;
+ol.source.Tile.prototype.getTile = function(z, x, y, pixelRatio, projection) {};
 
 
 /**

--- a/src/ol/style/imagestyle.js
+++ b/src/ol/style/imagestyle.js
@@ -111,60 +111,64 @@ ol.style.Image.prototype.getSnapToPixel = function() {
 /**
  * Get the anchor point in pixels. The anchor determines the center point for the
  * symbolizer.
- * @function
+ * @abstract
  * @return {Array.<number>} Anchor.
  */
-ol.style.Image.prototype.getAnchor = goog.abstractMethod;
+ol.style.Image.prototype.getAnchor = function() {};
 
 
 /**
  * Get the image element for the symbolizer.
- * @function
+ * @abstract
  * @param {number} pixelRatio Pixel ratio.
  * @return {HTMLCanvasElement|HTMLVideoElement|Image} Image element.
  */
-ol.style.Image.prototype.getImage = goog.abstractMethod;
+ol.style.Image.prototype.getImage = function(pixelRatio) {};
 
 
 /**
+ * @abstract
  * @param {number} pixelRatio Pixel ratio.
  * @return {HTMLCanvasElement|HTMLVideoElement|Image} Image element.
  */
-ol.style.Image.prototype.getHitDetectionImage = goog.abstractMethod;
+ol.style.Image.prototype.getHitDetectionImage = function(pixelRatio) {};
 
 
 /**
+ * @abstract
  * @return {ol.style.ImageState} Image state.
  */
-ol.style.Image.prototype.getImageState = goog.abstractMethod;
+ol.style.Image.prototype.getImageState = function() {};
 
 
 /**
+ * @abstract
  * @return {ol.Size} Image size.
  */
-ol.style.Image.prototype.getImageSize = goog.abstractMethod;
+ol.style.Image.prototype.getImageSize = function() {};
 
 
 /**
+ * @abstract
  * @return {ol.Size} Size of the hit-detection image.
  */
-ol.style.Image.prototype.getHitDetectionImageSize = goog.abstractMethod;
+ol.style.Image.prototype.getHitDetectionImageSize = function() {};
 
 
 /**
  * Get the origin of the symbolizer.
- * @function
+ * @abstract
  * @return {Array.<number>} Origin.
  */
-ol.style.Image.prototype.getOrigin = goog.abstractMethod;
+ol.style.Image.prototype.getOrigin = function() {};
 
 
 /**
  * Get the size of the symbolizer (in pixels).
- * @function
+ * @abstract
  * @return {ol.Size} Size.
  */
-ol.style.Image.prototype.getSize = goog.abstractMethod;
+ol.style.Image.prototype.getSize = function() {};
 
 
 /**
@@ -221,23 +225,26 @@ ol.style.Image.prototype.setSnapToPixel = function(snapToPixel) {
 
 
 /**
+ * @abstract
  * @param {function(this: T, ol.events.Event)} listener Listener function.
  * @param {T} thisArg Value to use as `this` when executing `listener`.
  * @return {ol.EventsKey|undefined} Listener key.
  * @template T
  */
-ol.style.Image.prototype.listenImageChange = goog.abstractMethod;
+ol.style.Image.prototype.listenImageChange = function(listener, thisArg) {};
 
 
 /**
  * Load not yet loaded URI.
+ * @abstract
  */
-ol.style.Image.prototype.load = goog.abstractMethod;
+ol.style.Image.prototype.load = function() {};
 
 
 /**
+ * @abstract
  * @param {function(this: T, ol.events.Event)} listener Listener function.
  * @param {T} thisArg Value to use as `this` when executing `listener`.
  * @template T
  */
-ol.style.Image.prototype.unlistenImageChange = goog.abstractMethod;
+ol.style.Image.prototype.unlistenImageChange = function(listener, thisArg) {};

--- a/src/ol/tile.js
+++ b/src/ol/tile.js
@@ -73,11 +73,11 @@ ol.Tile.prototype.changed = function() {
 
 /**
  * Get the HTML image element for this tile (may be a Canvas, Image, or Video).
- * @function
+ * @abstract
  * @param {Object=} opt_context Object.
  * @return {HTMLCanvasElement|HTMLImageElement|HTMLVideoElement} Image.
  */
-ol.Tile.prototype.getImage = goog.abstractMethod;
+ol.Tile.prototype.getImage = function(opt_context) {};
 
 
 /**
@@ -110,6 +110,7 @@ ol.Tile.prototype.getState = function() {
  * Load the image or retry if loading previously failed.
  * Loading is taken care of by the tile queue, and calling this method is
  * only needed for preloading or for reloading in case of an error.
+ * @abstract
  * @api
  */
-ol.Tile.prototype.load = goog.abstractMethod;
+ol.Tile.prototype.load = function() {};

--- a/src/ol/webgl/shader.js
+++ b/src/ol/webgl/shader.js
@@ -24,9 +24,10 @@ ol.webgl.Shader = function(source) {
 
 
 /**
+ * @abstract
  * @return {number} Type.
  */
-ol.webgl.Shader.prototype.getType = goog.abstractMethod;
+ol.webgl.Shader.prototype.getType = function() {};
 
 
 /**


### PR DESCRIPTION
With very convenient timing, the [June compiler release](https://github.com/google/closure-compiler/wiki/Releases) "Added support for `@abstract` on methods as an ES6-compatible alternative to goog.abstractMethod" - see also https://developers.google.com/closure/compiler/docs/js-for-compiler#tags

So I've replaced all `goog.abstractMethod` with empty functions and an `@abstract` annotation (plus a couple of small docs changes to keep the linter happy).