### PR TITLE
Replace goog.getUid with ol.getUid

### DIFF
--- a/src/ol/control/attributioncontrol.js
+++ b/src/ol/control/attributioncontrol.js
@@ -167,14 +167,14 @@ ol.control.Attribution.prototype.getSourceAttributions = function(frameState) {
     if (!source) {
       continue;
     }
-    sourceKey = goog.getUid(source).toString();
+    sourceKey = ol.getUid(source).toString();
     sourceAttributions = source.getAttributions();
     if (!sourceAttributions) {
       continue;
     }
     for (j = 0, jj = sourceAttributions.length; j < jj; j++) {
       sourceAttribution = sourceAttributions[j];
-      sourceAttributionKey = goog.getUid(sourceAttribution).toString();
+      sourceAttributionKey = ol.getUid(sourceAttribution).toString();
       if (sourceAttributionKey in attributions) {
         continue;
       }

--- a/src/ol/image.js
+++ b/src/ol/image.js
@@ -78,7 +78,7 @@ ol.inherits(ol.Image, ol.ImageBase);
 ol.Image.prototype.getImage = function(opt_context) {
   if (opt_context !== undefined) {
     var image;
-    var key = goog.getUid(opt_context);
+    var key = ol.getUid(opt_context);
     if (key in this.imageByContext_) {
       return this.imageByContext_[key];
     } else if (ol.object.isEmpty(this.imageByContext_)) {

--- a/src/ol/imagetile.js
+++ b/src/ol/imagetile.js
@@ -84,7 +84,7 @@ ol.ImageTile.prototype.disposeInternal = function() {
 ol.ImageTile.prototype.getImage = function(opt_context) {
   if (opt_context !== undefined) {
     var image;
-    var key = goog.getUid(opt_context);
+    var key = ol.getUid(opt_context);
     if (key in this.imageByContext_) {
       return this.imageByContext_[key];
     } else if (ol.object.isEmpty(this.imageByContext_)) {

--- a/src/ol/interaction/modifyinteraction.js
+++ b/src/ol/interaction/modifyinteraction.js
@@ -568,7 +568,7 @@ ol.interaction.Modify.handleDownEvent_ = function(evt) {
     for (var i = 0, ii = segmentDataMatches.length; i < ii; ++i) {
       var segmentDataMatch = segmentDataMatches[i];
       var segment = segmentDataMatch.segment;
-      var uid = goog.getUid(segmentDataMatch.feature);
+      var uid = ol.getUid(segmentDataMatch.feature);
       var depth = segmentDataMatch.depth;
       if (depth) {
         uid += '-' + depth.join('-'); // separate feature components
@@ -595,7 +595,7 @@ ol.interaction.Modify.handleDownEvent_ = function(evt) {
 
         this.dragSegments_.push([segmentDataMatch, 1]);
         componentSegments[uid][1] = segmentDataMatch;
-      } else if (goog.getUid(segment) in this.vertexSegments_ &&
+      } else if (ol.getUid(segment) in this.vertexSegments_ &&
           (!componentSegments[uid][0] && !componentSegments[uid][1])) {
         insertVertices.push([segmentDataMatch, vertex]);
       }
@@ -783,7 +783,7 @@ ol.interaction.Modify.prototype.handlePointerAtPixel_ = function(pixel, map) {
       }
       this.createOrUpdateVertexFeature_(vertex);
       var vertexSegments = {};
-      vertexSegments[goog.getUid(closestSegment)] = true;
+      vertexSegments[ol.getUid(closestSegment)] = true;
       var segment;
       for (var i = 1, ii = nodes.length; i < ii; ++i) {
         segment = nodes[i].segment;
@@ -791,7 +791,7 @@ ol.interaction.Modify.prototype.handlePointerAtPixel_ = function(pixel, map) {
             ol.coordinate.equals(closestSegment[1], segment[1]) ||
             (ol.coordinate.equals(closestSegment[0], segment[1]) &&
             ol.coordinate.equals(closestSegment[1], segment[0])))) {
-          vertexSegments[goog.getUid(segment)] = true;
+          vertexSegments[ol.getUid(segment)] = true;
         } else {
           break;
         }
@@ -915,7 +915,7 @@ ol.interaction.Modify.prototype.removeVertex_ = function() {
   for (i = dragSegments.length - 1; i >= 0; --i) {
     dragSegment = dragSegments[i];
     segmentData = dragSegment[0];
-    uid = goog.getUid(segmentData.feature);
+    uid = ol.getUid(segmentData.feature);
     if (segmentData.depth) {
       // separate feature components
       uid += '-' + segmentData.depth.join('-');

--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -211,7 +211,7 @@ ol.inherits(ol.interaction.Select, ol.interaction.Interaction);
  * @private
  */
 ol.interaction.Select.prototype.addFeatureLayerAssociation_ = function(feature, layer) {
-  var key = goog.getUid(feature);
+  var key = ol.getUid(feature);
   this.featureLayerAssociation_[key] = layer;
 };
 
@@ -238,7 +238,7 @@ ol.interaction.Select.prototype.getFeatures = function() {
 ol.interaction.Select.prototype.getLayer = function(feature) {
   goog.asserts.assertInstanceof(feature, ol.Feature,
       'feature should be an ol.Feature');
-  var key = goog.getUid(feature);
+  var key = ol.getUid(feature);
   return /** @type {ol.layer.Vector} */ (this.featureLayerAssociation_[key]);
 };
 
@@ -400,6 +400,6 @@ ol.interaction.Select.prototype.removeFeature_ = function(evt) {
  * @private
  */
 ol.interaction.Select.prototype.removeFeatureLayerAssociation_ = function(feature) {
-  var key = goog.getUid(feature);
+  var key = ol.getUid(feature);
   delete this.featureLayerAssociation_[key];
 };

--- a/src/ol/interaction/snapinteraction.js
+++ b/src/ol/interaction/snapinteraction.js
@@ -171,7 +171,7 @@ ol.inherits(ol.interaction.Snap, ol.interaction.Pointer);
  */
 ol.interaction.Snap.prototype.addFeature = function(feature, opt_listen) {
   var listen = opt_listen !== undefined ? opt_listen : true;
-  var feature_uid = goog.getUid(feature);
+  var feature_uid = ol.getUid(feature);
   var geometry = feature.getGeometry();
   if (geometry) {
     var segmentWriter = this.SEGMENT_WRITERS_[geometry.getType()];
@@ -286,7 +286,7 @@ ol.interaction.Snap.prototype.handleGeometryChange_ = function(evt) {
  */
 ol.interaction.Snap.prototype.handleGeometryModify_ = function(feature, evt) {
   if (this.handlingDownUpSequence) {
-    var uid = goog.getUid(feature);
+    var uid = ol.getUid(feature);
     if (!(uid in this.pendingFeatures_)) {
       this.pendingFeatures_[uid] = feature;
     }
@@ -305,7 +305,7 @@ ol.interaction.Snap.prototype.handleGeometryModify_ = function(feature, evt) {
  */
 ol.interaction.Snap.prototype.removeFeature = function(feature, opt_unlisten) {
   var unlisten = opt_unlisten !== undefined ? opt_unlisten : true;
-  var feature_uid = goog.getUid(feature);
+  var feature_uid = ol.getUid(feature);
   var extent = this.indexedFeaturesExtents_[feature_uid];
   if (extent) {
     var rBush = this.rBush_;

--- a/src/ol/layer/layer.js
+++ b/src/ol/layer/layer.js
@@ -182,7 +182,7 @@ ol.layer.Layer.prototype.setMap = function(map) {
           layerState.managed = false;
           layerState.zIndex = Infinity;
           evt.frameState.layerStatesArray.push(layerState);
-          evt.frameState.layerStates[goog.getUid(this)] = layerState;
+          evt.frameState.layerStates[ol.getUid(this)] = layerState;
         }, this);
     this.mapRenderKey_ = ol.events.listen(
         this, ol.events.EventType.CHANGE, map.render, map);

--- a/src/ol/layer/layergroup.js
+++ b/src/ol/layer/layergroup.js
@@ -112,7 +112,7 @@ ol.layer.Group.prototype.handleLayersChanged_ = function(event) {
   var i, ii, layer;
   for (i = 0, ii = layersArray.length; i < ii; i++) {
     layer = layersArray[i];
-    this.listenerKeys_[goog.getUid(layer).toString()] = [
+    this.listenerKeys_[ol.getUid(layer).toString()] = [
       ol.events.listen(layer, ol.ObjectEventType.PROPERTYCHANGE,
           this.handleLayerChange_, this),
       ol.events.listen(layer, ol.events.EventType.CHANGE,
@@ -130,7 +130,7 @@ ol.layer.Group.prototype.handleLayersChanged_ = function(event) {
  */
 ol.layer.Group.prototype.handleLayersAdd_ = function(collectionEvent) {
   var layer = /** @type {ol.layer.Base} */ (collectionEvent.element);
-  var key = goog.getUid(layer).toString();
+  var key = ol.getUid(layer).toString();
   goog.asserts.assert(!(key in this.listenerKeys_),
       'listeners already registered');
   this.listenerKeys_[key] = [
@@ -149,7 +149,7 @@ ol.layer.Group.prototype.handleLayersAdd_ = function(collectionEvent) {
  */
 ol.layer.Group.prototype.handleLayersRemove_ = function(collectionEvent) {
   var layer = /** @type {ol.layer.Base} */ (collectionEvent.element);
-  var key = goog.getUid(layer).toString();
+  var key = ol.getUid(layer).toString();
   goog.asserts.assert(key in this.listenerKeys_, 'no listeners to unregister');
   this.listenerKeys_[key].forEach(ol.events.unlistenByKey);
   delete this.listenerKeys_[key];

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -1289,7 +1289,7 @@ ol.Map.prototype.renderFrame_ = function(time) {
     var layerStatesArray = this.getLayerGroup().getLayerStatesArray();
     var layerStates = {};
     for (i = 0, ii = layerStatesArray.length; i < ii; ++i) {
-      layerStates[goog.getUid(layerStatesArray[i].layer)] = layerStatesArray[i];
+      layerStates[ol.getUid(layerStatesArray[i].layer)] = layerStatesArray[i];
     }
     viewState = view.getState();
     frameState = /** @type {olx.FrameState} */ ({
@@ -1411,7 +1411,7 @@ ol.Map.prototype.setView = function(view) {
  * @param {ol.Feature} feature Feature.
  */
 ol.Map.prototype.skipFeature = function(feature) {
-  var featureUid = goog.getUid(feature).toString();
+  var featureUid = ol.getUid(feature).toString();
   this.skippedFeatureUids_[featureUid] = true;
   this.render();
 };
@@ -1449,7 +1449,7 @@ ol.Map.prototype.updateSize = function() {
  * @param {ol.Feature} feature Feature.
  */
 ol.Map.prototype.unskipFeature = function(feature) {
-  var featureUid = goog.getUid(feature).toString();
+  var featureUid = ol.getUid(feature).toString();
   delete this.skippedFeatureUids_[featureUid];
   this.render();
 };
@@ -1485,7 +1485,7 @@ ol.Map.createOptionsInternal = function(options) {
     if (typeof logo === 'string') {
       logos[logo] = '';
     } else if (logo instanceof HTMLElement) {
-      logos[goog.getUid(logo).toString()] = logo;
+      logos[ol.getUid(logo).toString()] = logo;
     } else if (logo !== null) {
       goog.asserts.assertString(logo.href, 'logo.href should be a string');
       goog.asserts.assertString(logo.src, 'logo.src should be a string');

--- a/src/ol/net.js
+++ b/src/ol/net.js
@@ -14,7 +14,7 @@ goog.provide('ol.net');
  */
 ol.net.jsonp = function(url, callback, opt_errback, opt_callbackParam) {
   var script = ol.global.document.createElement('script');
-  var key = 'olc_' + goog.getUid(callback);
+  var key = 'olc_' + ol.getUid(callback);
   function cleanup() {
     delete ol.global[key];
     script.parentNode.removeChild(script);

--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -102,11 +102,11 @@ ol.inherits(ol.ObjectEvent, ol.events.Event);
 ol.Object = function(opt_values) {
   ol.Observable.call(this);
 
-  // Call goog.getUid to ensure that the order of objects' ids is the same as
+  // Call ol.getUid to ensure that the order of objects' ids is the same as
   // the order in which they were created.  This also helps to ensure that
   // object properties are always added in the same order, which helps many
   // JavaScript engines generate faster code.
-  goog.getUid(this);
+  ol.getUid(this);
 
   /**
    * @private

--- a/src/ol/ol.js
+++ b/src/ol/ol.js
@@ -266,6 +266,28 @@ ol.nullFunction = function() {};
 
 
 /**
+ * Gets a unique ID for an object. This mutates the object so that further calls
+ * with the same object as a parameter returns the same value. Adapted from
+ * goog.getUid.
+ *
+ * @param {Object} obj The object to get the unique ID for.
+ * @return {number} The unique ID for the object.
+ */
+ol.getUid = function(obj) {
+  return obj.ol_uid ||
+      (obj.ol_uid = ++ol.uidCounter_);
+};
+
+
+/**
+ * Counter for getUid.
+ * @type {number}
+ * @private
+ */
+ol.uidCounter_ = 0;
+
+
+/**
  * @see https://github.com/tc39/proposal-global
  */
 if (typeof window !== 'undefined') {

--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -265,7 +265,7 @@ ol.render.canvas.Replay.prototype.replay_ = function(
       case ol.render.canvas.Instruction.BEGIN_GEOMETRY:
         feature = /** @type {ol.Feature|ol.render.Feature} */ (instruction[1]);
         if ((skipFeatures &&
-            skippedFeaturesHash[goog.getUid(feature).toString()]) ||
+            skippedFeaturesHash[ol.getUid(feature).toString()]) ||
             !feature.getGeometry()) {
           i = /** @type {number} */ (instruction[2]);
         } else if (opt_hitExtent !== undefined && !ol.extent.intersects(

--- a/src/ol/render/vector.js
+++ b/src/ol/render/vector.js
@@ -13,7 +13,7 @@ goog.require('ol.style.Style');
  * @return {number} Order.
  */
 ol.renderer.vector.defaultOrder = function(feature1, feature2) {
-  return goog.getUid(feature1) - goog.getUid(feature2);
+  return ol.getUid(feature1) - ol.getUid(feature2);
 };
 
 

--- a/src/ol/render/webgl/webglreplay.js
+++ b/src/ol/render/webgl/webglreplay.js
@@ -471,7 +471,7 @@ ol.render.webgl.ImageReplay.prototype.createTextures_ = function(textures, image
   for (i = 0; i < ii; ++i) {
     image = images[i];
 
-    uid = goog.getUid(image).toString();
+    uid = ol.getUid(image).toString();
     if (uid in texturePerImage) {
       texture = texturePerImage[uid];
     } else {
@@ -677,7 +677,7 @@ ol.render.webgl.ImageReplay.prototype.drawReplaySkipping_ = function(gl, skipped
         this.startIndices_[featureIndex] <= groupEnd) {
       var feature = this.startIndicesFeature_[featureIndex];
 
-      var featureUid = goog.getUid(feature).toString();
+      var featureUid = ol.getUid(feature).toString();
       if (skippedFeaturesHash[featureUid] !== undefined) {
         // feature should be skipped
         if (start !== end) {
@@ -805,7 +805,7 @@ ol.render.webgl.ImageReplay.prototype.drawHitDetectionReplayOneByOne_ = function
         this.startIndices_[featureIndex] >= groupStart) {
       start = this.startIndices_[featureIndex];
       feature = this.startIndicesFeature_[featureIndex];
-      featureUid = goog.getUid(feature).toString();
+      featureUid = ol.getUid(feature).toString();
 
       if (skippedFeaturesHash[featureUid] === undefined &&
           feature.getGeometry() &&
@@ -872,7 +872,7 @@ ol.render.webgl.ImageReplay.prototype.setImageStyle = function(imageStyle) {
     this.images_.push(image);
   } else {
     currentImage = this.images_[this.images_.length - 1];
-    if (goog.getUid(currentImage) != goog.getUid(image)) {
+    if (ol.getUid(currentImage) != ol.getUid(image)) {
       this.groupIndices_.push(this.indices_.length);
       goog.asserts.assert(this.groupIndices_.length === this.images_.length,
           'number of groupIndices and images match');
@@ -885,7 +885,7 @@ ol.render.webgl.ImageReplay.prototype.setImageStyle = function(imageStyle) {
   } else {
     currentImage =
         this.hitDetectionImages_[this.hitDetectionImages_.length - 1];
-    if (goog.getUid(currentImage) != goog.getUid(hitDetectionImage)) {
+    if (ol.getUid(currentImage) != ol.getUid(hitDetectionImage)) {
       this.hitDetectionGroupIndices_.push(this.indices_.length);
       goog.asserts.assert(this.hitDetectionGroupIndices_.length ===
           this.hitDetectionImages_.length,

--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -175,7 +175,7 @@ ol.renderer.canvas.VectorLayer.prototype.forEachFeatureAtCoordinate = function(c
          */
         function(feature) {
           goog.asserts.assert(feature !== undefined, 'received a feature');
-          var key = goog.getUid(feature).toString();
+          var key = ol.getUid(feature).toString();
           if (!(key in features)) {
             features[key] = true;
             return callback.call(thisArg, feature, layer);

--- a/src/ol/renderer/canvas/canvasvectortilelayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectortilelayerrenderer.js
@@ -315,7 +315,7 @@ ol.renderer.canvas.VectorTileLayer.prototype.forEachFeatureAtCoordinate = functi
          */
         function(feature) {
           goog.asserts.assert(feature, 'received a feature');
-          var key = goog.getUid(feature).toString();
+          var key = ol.getUid(feature).toString();
           if (!(key in features)) {
             features[key] = true;
             return callback.call(thisArg, feature, layer);

--- a/src/ol/renderer/dom/domvectorlayerrenderer.js
+++ b/src/ol/renderer/dom/domvectorlayerrenderer.js
@@ -194,7 +194,7 @@ ol.renderer.dom.VectorLayer.prototype.forEachFeatureAtCoordinate = function(coor
          */
         function(feature) {
           goog.asserts.assert(feature !== undefined, 'received a feature');
-          var key = goog.getUid(feature).toString();
+          var key = ol.getUid(feature).toString();
           if (!(key in features)) {
             features[key] = true;
             return callback.call(thisArg, feature, layer);

--- a/src/ol/renderer/layerrenderer.js
+++ b/src/ol/renderer/layerrenderer.js
@@ -185,7 +185,7 @@ ol.renderer.Layer.prototype.scheduleExpireCache = function(frameState, tileSourc
      * @param {olx.FrameState} frameState Frame state.
      */
     var postRenderFunction = function(tileSource, map, frameState) {
-      var tileSourceKey = goog.getUid(tileSource).toString();
+      var tileSourceKey = ol.getUid(tileSource).toString();
       tileSource.expireCache(frameState.viewState.projection,
                              frameState.usedTiles[tileSourceKey]);
     }.bind(null, tileSource);
@@ -208,7 +208,7 @@ ol.renderer.Layer.prototype.updateAttributions = function(attributionsSet, attri
     var attribution, i, ii;
     for (i = 0, ii = attributions.length; i < ii; ++i) {
       attribution = attributions[i];
-      attributionsSet[goog.getUid(attribution).toString()] = attribution;
+      attributionsSet[ol.getUid(attribution).toString()] = attribution;
     }
   }
 };
@@ -242,7 +242,7 @@ ol.renderer.Layer.prototype.updateLogos = function(frameState, source) {
  */
 ol.renderer.Layer.prototype.updateUsedTiles = function(usedTiles, tileSource, z, tileRange) {
   // FIXME should we use tilesToDrawByZ instead?
-  var tileSourceKey = goog.getUid(tileSource).toString();
+  var tileSourceKey = ol.getUid(tileSource).toString();
   var zKey = z.toString();
   if (tileSourceKey in usedTiles) {
     if (zKey in usedTiles[tileSourceKey]) {
@@ -295,7 +295,7 @@ ol.renderer.Layer.prototype.snapCenterToPixel = function(center, resolution, siz
 ol.renderer.Layer.prototype.manageTilePyramid = function(
     frameState, tileSource, tileGrid, pixelRatio, projection, extent,
     currentZ, preload, opt_tileCallback, opt_this) {
-  var tileSourceKey = goog.getUid(tileSource).toString();
+  var tileSourceKey = ol.getUid(tileSource).toString();
   if (!(tileSourceKey in frameState.wantedTiles)) {
     frameState.wantedTiles[tileSourceKey] = {};
   }

--- a/src/ol/renderer/maprenderer.js
+++ b/src/ol/renderer/maprenderer.js
@@ -137,8 +137,8 @@ ol.renderer.Map.prototype.forEachFeatureAtCoordinate = function(coordinate, fram
    */
   function forEachFeatureAtCoordinate(feature, layer) {
     goog.asserts.assert(feature !== undefined, 'received a feature');
-    var key = goog.getUid(feature).toString();
-    var managed = frameState.layerStates[goog.getUid(layer)].managed;
+    var key = ol.getUid(feature).toString();
+    var managed = frameState.layerStates[ol.getUid(layer)].managed;
     if (!(key in frameState.skippedFeatureUids && !managed)) {
       return callback.call(thisArg, feature, managed ? layer : null);
     }
@@ -245,7 +245,7 @@ ol.renderer.Map.prototype.hasFeatureAtCoordinate = function(coordinate, frameSta
  * @return {ol.renderer.Layer} Layer renderer.
  */
 ol.renderer.Map.prototype.getLayerRenderer = function(layer) {
-  var layerKey = goog.getUid(layer).toString();
+  var layerKey = ol.getUid(layer).toString();
   if (layerKey in this.layerRenderers_) {
     return this.layerRenderers_[layerKey];
   } else {

--- a/src/ol/renderer/webgl/webglvectorlayerrenderer.js
+++ b/src/ol/renderer/webgl/webglvectorlayerrenderer.js
@@ -122,7 +122,7 @@ ol.renderer.webgl.VectorLayer.prototype.forEachFeatureAtCoordinate = function(co
          */
         function(feature) {
           goog.asserts.assert(feature !== undefined, 'received a feature');
-          var key = goog.getUid(feature).toString();
+          var key = ol.getUid(feature).toString();
           if (!(key in features)) {
             features[key] = true;
             return callback.call(thisArg, feature, layer);

--- a/src/ol/reproj/tile.js
+++ b/src/ol/reproj/tile.js
@@ -222,7 +222,7 @@ ol.reproj.Tile.prototype.disposeInternal = function() {
 ol.reproj.Tile.prototype.getImage = function(opt_context) {
   if (opt_context !== undefined) {
     var image;
-    var key = goog.getUid(opt_context);
+    var key = ol.getUid(opt_context);
     if (key in this.canvasByContext_) {
       return this.canvasByContext_[key];
     } else if (ol.object.isEmpty(this.canvasByContext_)) {

--- a/src/ol/source/clustersource.js
+++ b/src/ol/source/clustersource.js
@@ -129,7 +129,7 @@ ol.source.Cluster.prototype.cluster_ = function() {
 
   for (var i = 0, ii = features.length; i < ii; i++) {
     var feature = features[i];
-    if (!(goog.getUid(feature).toString() in clustered)) {
+    if (!(ol.getUid(feature).toString() in clustered)) {
       var geometry = this.geometryFunction_(feature);
       if (geometry) {
         var coordinates = geometry.getCoordinates();
@@ -139,7 +139,7 @@ ol.source.Cluster.prototype.cluster_ = function() {
         var neighbors = this.source_.getFeaturesInExtent(extent);
         goog.asserts.assert(neighbors.length >= 1, 'at least one neighbor found');
         neighbors = neighbors.filter(function(neighbor) {
-          var uid = goog.getUid(neighbor).toString();
+          var uid = ol.getUid(neighbor).toString();
           if (!(uid in clustered)) {
             clustered[uid] = true;
             return true;

--- a/src/ol/source/imagevectorsource.js
+++ b/src/ol/source/imagevectorsource.js
@@ -170,7 +170,7 @@ ol.source.ImageVector.prototype.forEachFeatureAtCoordinate = function(
          */
         function(feature) {
           goog.asserts.assert(feature !== undefined, 'passed a feature');
-          var key = goog.getUid(feature).toString();
+          var key = ol.getUid(feature).toString();
           if (!(key in features)) {
             features[key] = true;
             return callback(feature);

--- a/src/ol/source/rastersource.js
+++ b/src/ol/source/rastersource.js
@@ -96,7 +96,7 @@ ol.source.Raster = function(options) {
   var layerStatesArray = ol.source.Raster.getLayerStatesArray_(this.renderers_);
   var layerStates = {};
   for (var i = 0, ii = layerStatesArray.length; i < ii; ++i) {
-    layerStates[goog.getUid(layerStatesArray[i].layer)] = layerStatesArray[i];
+    layerStates[ol.getUid(layerStatesArray[i].layer)] = layerStatesArray[i];
   }
 
   /**

--- a/src/ol/source/tiledebugsource.js
+++ b/src/ol/source/tiledebugsource.js
@@ -48,7 +48,7 @@ ol.inherits(ol.DebugTile_, ol.Tile);
  * @return {HTMLCanvasElement} Image.
  */
 ol.DebugTile_.prototype.getImage = function(opt_context) {
-  var key = opt_context !== undefined ? goog.getUid(opt_context) : -1;
+  var key = opt_context !== undefined ? ol.getUid(opt_context) : -1;
   if (key in this.canvasByContext_) {
     return this.canvasByContext_[key];
   } else {

--- a/src/ol/source/tileimagesource.js
+++ b/src/ol/source/tileimagesource.js
@@ -170,7 +170,7 @@ ol.source.TileImage.prototype.getTileGridForProjection = function(projection) {
       (!thisProj || ol.proj.equivalent(thisProj, projection))) {
     return this.tileGrid;
   } else {
-    var projKey = goog.getUid(projection).toString();
+    var projKey = ol.getUid(projection).toString();
     if (!(projKey in this.tileGridForProjection)) {
       this.tileGridForProjection[projKey] =
           ol.tilegrid.getForProjection(projection);
@@ -191,7 +191,7 @@ ol.source.TileImage.prototype.getTileCacheForProjection = function(projection) {
   if (!thisProj || ol.proj.equivalent(thisProj, projection)) {
     return this.tileCache;
   } else {
-    var projKey = goog.getUid(projection).toString();
+    var projKey = ol.getUid(projection).toString();
     if (!(projKey in this.tileCacheForProjection)) {
       this.tileCacheForProjection[projKey] = new ol.TileCache();
     }
@@ -364,7 +364,7 @@ ol.source.TileImage.prototype.setTileGridForProjection = function(projection, ti
   if (ol.ENABLE_RASTER_REPROJECTION) {
     var proj = ol.proj.get(projection);
     if (proj) {
-      var projKey = goog.getUid(proj).toString();
+      var projKey = ol.getUid(proj).toString();
       if (!(projKey in this.tileGridForProjection)) {
         this.tileGridForProjection[projKey] = tilegrid;
       }

--- a/src/ol/source/vectorsource.js
+++ b/src/ol/source/vectorsource.js
@@ -147,7 +147,7 @@ ol.source.Vector = function(opt_options) {
   this.idIndex_ = {};
 
   /**
-   * A lookup of features without id (keyed by goog.getUid(feature)).
+   * A lookup of features without id (keyed by ol.getUid(feature)).
    * @private
    * @type {Object.<string, ol.Feature>}
    */
@@ -205,7 +205,7 @@ ol.source.Vector.prototype.addFeature = function(feature) {
  * @protected
  */
 ol.source.Vector.prototype.addFeatureInternal = function(feature) {
-  var featureKey = goog.getUid(feature).toString();
+  var featureKey = ol.getUid(feature).toString();
 
   if (!this.addToIndex_(featureKey, feature)) {
     return;
@@ -295,7 +295,7 @@ ol.source.Vector.prototype.addFeaturesInternal = function(features) {
 
   for (i = 0, length = features.length; i < length; i++) {
     feature = features[i];
-    featureKey = goog.getUid(feature).toString();
+    featureKey = ol.getUid(feature).toString();
     if (this.addToIndex_(featureKey, feature)) {
       newFeatures.push(feature);
     }
@@ -303,7 +303,7 @@ ol.source.Vector.prototype.addFeaturesInternal = function(features) {
 
   for (i = 0, length = newFeatures.length; i < length; i++) {
     feature = newFeatures[i];
-    featureKey = goog.getUid(feature).toString();
+    featureKey = ol.getUid(feature).toString();
     this.setupChangeEvents_(featureKey, feature);
 
     var geometry = feature.getGeometry();
@@ -721,7 +721,7 @@ ol.source.Vector.prototype.getUrl = function() {
  */
 ol.source.Vector.prototype.handleFeatureChange_ = function(event) {
   var feature = /** @type {ol.Feature} */ (event.target);
-  var featureKey = goog.getUid(feature).toString();
+  var featureKey = ol.getUid(feature).toString();
   var geometry = feature.getGeometry();
   if (!geometry) {
     if (!(featureKey in this.nullGeometryFeatures_)) {
@@ -820,7 +820,7 @@ ol.source.Vector.prototype.loadFeatures = function(
  * @api stable
  */
 ol.source.Vector.prototype.removeFeature = function(feature) {
-  var featureKey = goog.getUid(feature).toString();
+  var featureKey = ol.getUid(feature).toString();
   if (featureKey in this.nullGeometryFeatures_) {
     delete this.nullGeometryFeatures_[featureKey];
   } else {
@@ -839,7 +839,7 @@ ol.source.Vector.prototype.removeFeature = function(feature) {
  * @protected
  */
 ol.source.Vector.prototype.removeFeatureInternal = function(feature) {
-  var featureKey = goog.getUid(feature).toString();
+  var featureKey = ol.getUid(feature).toString();
   goog.asserts.assert(featureKey in this.featureChangeKeys_,
       'featureKey exists in featureChangeKeys');
   this.featureChangeKeys_[featureKey].forEach(ol.events.unlistenByKey);

--- a/src/ol/source/zoomifysource.js
+++ b/src/ol/source/zoomifysource.js
@@ -165,7 +165,7 @@ ol.inherits(ol.source.ZoomifyTile_, ol.ImageTile);
 ol.source.ZoomifyTile_.prototype.getImage = function(opt_context) {
   var tileSize = ol.DEFAULT_TILE_SIZE;
   var key = opt_context !== undefined ?
-      goog.getUid(opt_context).toString() : '';
+      ol.getUid(opt_context).toString() : '';
   if (key in this.zoomifyImageByContext_) {
     return this.zoomifyImageByContext_[key];
   } else {

--- a/src/ol/structs/rbush.js
+++ b/src/ol/structs/rbush.js
@@ -60,9 +60,9 @@ ol.structs.RBush.prototype.insert = function(extent, value) {
 
   this.rbush_.insert(item);
   // remember the object that was added to the internal rbush
-  goog.asserts.assert(!(goog.getUid(value) in this.items_),
-      'uid (%s) of value (%s) already exists', goog.getUid(value), value);
-  this.items_[goog.getUid(value)] = item;
+  goog.asserts.assert(!(ol.getUid(value) in this.items_),
+      'uid (%s) of value (%s) already exists', ol.getUid(value), value);
+  this.items_[ol.getUid(value)] = item;
 };
 
 
@@ -93,9 +93,9 @@ ol.structs.RBush.prototype.load = function(extents, values) {
       value: value
     };
     items[i] = item;
-    goog.asserts.assert(!(goog.getUid(value) in this.items_),
-        'uid (%s) of value (%s) already exists', goog.getUid(value), value);
-    this.items_[goog.getUid(value)] = item;
+    goog.asserts.assert(!(ol.getUid(value) in this.items_),
+        'uid (%s) of value (%s) already exists', ol.getUid(value), value);
+    this.items_[ol.getUid(value)] = item;
   }
   this.rbush_.load(items);
 };
@@ -110,7 +110,7 @@ ol.structs.RBush.prototype.remove = function(value) {
   if (goog.DEBUG && this.readers_) {
     throw new Error('Can not remove value while reading');
   }
-  var uid = goog.getUid(value);
+  var uid = ol.getUid(value);
   goog.asserts.assert(uid in this.items_,
       'uid (%s) of value (%s) does not exist', uid, value);
 
@@ -128,7 +128,7 @@ ol.structs.RBush.prototype.remove = function(value) {
  * @param {T} value Value.
  */
 ol.structs.RBush.prototype.update = function(extent, value) {
-  var uid = goog.getUid(value);
+  var uid = ol.getUid(value);
   goog.asserts.assert(uid in this.items_,
       'uid (%s) of value (%s) does not exist', uid, value);
 

--- a/src/ol/style/fillstyle.js
+++ b/src/ol/style/fillstyle.js
@@ -60,7 +60,7 @@ ol.style.Fill.prototype.getChecksum = function() {
         this.color_ instanceof CanvasPattern ||
         this.color_ instanceof CanvasGradient
     ) {
-      this.checksum_ = goog.getUid(this.color_).toString();
+      this.checksum_ = ol.getUid(this.color_).toString();
     } else {
       this.checksum_ = 'f' + (this.color_ ?
           ol.color.asString(this.color_) : '-');

--- a/src/ol/style/iconstyle.js
+++ b/src/ol/style/iconstyle.js
@@ -109,7 +109,7 @@ ol.style.Icon = function(opt_options) {
       'imgSize must be set when image is provided');
 
   if ((src === undefined || src.length === 0) && image) {
-    src = image.src || goog.getUid(image).toString();
+    src = image.src || ol.getUid(image).toString();
   }
   goog.asserts.assert(src !== undefined && src.length > 0,
       'must provide a defined and non-empty src or image');

--- a/src/ol/webgl/context.js
+++ b/src/ol/webgl/context.js
@@ -108,7 +108,7 @@ ol.inherits(ol.webgl.Context, ol.Disposable);
 ol.webgl.Context.prototype.bindBuffer = function(target, buf) {
   var gl = this.getGL();
   var arr = buf.getArray();
-  var bufferKey = String(goog.getUid(buf));
+  var bufferKey = String(ol.getUid(buf));
   if (bufferKey in this.bufferCache_) {
     var bufferCacheEntry = this.bufferCache_[bufferKey];
     gl.bindBuffer(target, bufferCacheEntry.buffer);
@@ -141,7 +141,7 @@ ol.webgl.Context.prototype.bindBuffer = function(target, buf) {
  */
 ol.webgl.Context.prototype.deleteBuffer = function(buf) {
   var gl = this.getGL();
-  var bufferKey = String(goog.getUid(buf));
+  var bufferKey = String(ol.getUid(buf));
   goog.asserts.assert(bufferKey in this.bufferCache_,
       'attempted to delete uncached buffer');
   var bufferCacheEntry = this.bufferCache_[bufferKey];
@@ -214,7 +214,7 @@ ol.webgl.Context.prototype.getHitDetectionFramebuffer = function() {
  * @return {WebGLShader} Shader.
  */
 ol.webgl.Context.prototype.getShader = function(shaderObject) {
-  var shaderKey = String(goog.getUid(shaderObject));
+  var shaderKey = String(ol.getUid(shaderObject));
   if (shaderKey in this.shaderCache_) {
     return this.shaderCache_[shaderKey];
   } else {
@@ -243,7 +243,7 @@ ol.webgl.Context.prototype.getShader = function(shaderObject) {
 ol.webgl.Context.prototype.getProgram = function(
     fragmentShaderObject, vertexShaderObject) {
   var programKey =
-      goog.getUid(fragmentShaderObject) + '/' + goog.getUid(vertexShaderObject);
+      ol.getUid(fragmentShaderObject) + '/' + ol.getUid(vertexShaderObject);
   if (programKey in this.programCache_) {
     return this.programCache_[programKey];
   } else {

--- a/test/spec/ol/layer/layer.test.js
+++ b/test/spec/ol/layer/layer.test.js
@@ -398,7 +398,7 @@ describe('ol.layer.Layer', function() {
         expect(frameState.layerStatesArray.length).to.be(1);
         var layerState = frameState.layerStatesArray[0];
         expect(layerState.layer).to.equal(layer);
-        expect(frameState.layerStates[goog.getUid(layer)]).to.equal(layerState);
+        expect(frameState.layerStates[ol.getUid(layer)]).to.equal(layerState);
       });
     });
 

--- a/test/spec/ol/layer/layergroup.test.js
+++ b/test/spec/ol/layer/layergroup.test.js
@@ -284,7 +284,7 @@ describe('ol.layer.Group', function() {
       layers.push(layer);
       expect(Object.keys(layerGroup.listenerKeys_).length).to.eql(1);
 
-      var listeners = layerGroup.listenerKeys_[goog.getUid(layer)];
+      var listeners = layerGroup.listenerKeys_[ol.getUid(layer)];
       expect(listeners.length).to.eql(2);
       expect(typeof listeners[0]).to.be('object');
       expect(typeof listeners[1]).to.be('object');

--- a/test/spec/ol/net.test.js
+++ b/test/spec/ol/net.test.js
@@ -17,7 +17,7 @@ describe('ol.net', function() {
         expect(removeChild.called).to.be(true);
         done();
       };
-      key = 'olc_' + goog.getUid(callback);
+      key = 'olc_' + ol.getUid(callback);
       return callback;
     }
 

--- a/test/spec/ol/renderer/canvas/canvasmaprenderer.test.js
+++ b/test/spec/ol/renderer/canvas/canvasmaprenderer.test.js
@@ -121,7 +121,7 @@ describe('ol.renderer.canvas.Map', function() {
       layerRenderer.getImage = function() {
         return null;
       };
-      renderer.layerRenderers_[goog.getUid(layer)] = layerRenderer;
+      renderer.layerRenderers_[ol.getUid(layer)] = layerRenderer;
     });
 
   });

--- a/test/spec/ol/renderer/canvas/canvasvectorlayerrenderer.test.js
+++ b/test/spec/ol/renderer/canvas/canvasvectorlayerrenderer.test.js
@@ -83,7 +83,7 @@ describe('ol.renderer.canvas.VectorLayer', function() {
           rotation: 0
         }
       };
-      frameState.layerStates[goog.getUid(layer)] = {};
+      frameState.layerStates[ol.getUid(layer)] = {};
       renderer.forEachFeatureAtCoordinate(
           coordinate, frameState, spy, undefined);
       expect(spy.callCount).to.be(1);

--- a/test/spec/ol/renderer/canvas/canvasvectortilelayerrenderer.test.js
+++ b/test/spec/ol/renderer/canvas/canvasvectortilelayerrenderer.test.js
@@ -170,7 +170,7 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
           rotation: 0
         }
       };
-      frameState.layerStates[goog.getUid(layer)] = {};
+      frameState.layerStates[ol.getUid(layer)] = {};
       renderer.renderedTiles = [new TileClass([0, 0, -1])];
       renderer.forEachFeatureAtCoordinate(
           coordinate, frameState, spy, undefined);

--- a/test/spec/ol/style/iconstyle.test.js
+++ b/test/spec/ol/style/iconstyle.test.js
@@ -18,7 +18,7 @@ describe('ol.style.Icon', function() {
         imgSize: size
       });
       expect(ol.style.IconImage_.get(
-          canvas, goog.getUid(canvas), size, '').getImage()).to.eql(canvas);
+          canvas, ol.getUid(canvas), size, '').getImage()).to.eql(canvas);
     });
 
     it('imgSize overrides img.width and img.height', function(done) {


### PR DESCRIPTION
As discussed in #5615. Fixes #5615.

A simplified version of the goog function, as I don't think there's any need to cater for 2 OLs in one page. So the uid property is simply called 'ol_uid'.