### PR TITLE
Update TileWMS.coordKeyPrefix_ on setUrls

### DIFF
--- a/src/ol/source/tilewmssource.js
+++ b/src/ol/source/tilewmssource.js
@@ -355,6 +355,14 @@ ol.source.TileWMS.prototype.fixedTileUrlFunction = function(tileCoord, pixelRati
       pixelRatio, projection, baseParams);
 };
 
+/**
+ * @inheritDoc
+ */
+ol.source.TileWMS.prototype.setUrls = function(urls) {
+  ol.source.TileImage.prototype.setUrls.call(this, urls);
+  this.resetCoordKeyPrefix_();
+};
+
 
 /**
  * Update the user-provided params.

--- a/test/spec/ol/source/tilewmssource.test.js
+++ b/test/spec/ol/source/tilewmssource.test.js
@@ -265,6 +265,19 @@ describe('ol.source.TileWMS', function() {
     var tileUrl = source.tileUrlFunction([0, 0, 0], 1, ol.proj.get('EPSG:4326'));
     expect(tileUrl.indexOf(url)).to.be(0);
   });
+
+  describe('#setUrls()', function() {
+    it ('resets coordKeyPrefix_', function() {
+      var urls = ['u1', 'u2'];
+      var source1 = new ol.source.TileWMS({
+        urls: urls
+      });
+      var source2 = new ol.source.TileWMS({});
+      expect(source2.coordKeyPrefix_).to.be.empty();
+      source2.setUrls(urls);
+      expect(source2.coordKeyPrefix_).to.equal(source1.coordKeyPrefix_);
+    });
+  });
 });
 
 


### PR DESCRIPTION
Outdated coordKeyPrefix_ causes the TileWMS layer to flicker
on the first updateParams call.

Fixes #5617.