### PR TITLE
Add interface for ol.MapBrowserPointerEvent

### DIFF
--- a/externs/oli.js
+++ b/externs/oli.js
@@ -148,6 +148,18 @@ oli.MapBrowserEvent.prototype.dragging;
 /**
  * @interface
  */
+oli.MapBrowserPointerEvent = function() {};
+
+
+/**
+ * @type {ol.pointer.PointerEvent}
+ */
+oli.MapBrowserPointerEvent.prototype.pointerEvent;
+
+
+/**
+ * @interface
+ */
 oli.MapEvent = function() {};
 
 

--- a/src/ol/mapbrowserevent.js
+++ b/src/ol/mapbrowserevent.js
@@ -94,6 +94,7 @@ ol.MapBrowserEvent.prototype.stopPropagation = function() {
 /**
  * @constructor
  * @extends {ol.MapBrowserEvent}
+ * @implements {oli.MapBrowserPointerEvent}
  * @param {string} type Event type.
  * @param {ol.Map} map Map.
  * @param {ol.pointer.PointerEvent} pointerEvent Pointer event.


### PR DESCRIPTION
All in the title. Without this we can't export the `pointerEvent` property in a custom build.