### PR TITLE
chore(build): guard against unterminated scripts

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -15,7 +15,7 @@ var generateExports = require('./generate-exports');
 var log = closure.log;
 var root = path.join(__dirname, '..');
 
-var umdWrapper = '(function (root, factory) {\n' +
+var umdWrapper = ';(function (root, factory) {\n' +
     '  if (typeof exports === "object") {\n' +
     '    module.exports = factory();\n' +
     '  } else if (typeof define === "function" && define.amd) {\n' +


### PR DESCRIPTION
If ol3 is included as part of a concatenated build and the script before it does
not end in a semi-colon, the IIFE is interpreted incorrectly (often resulting in
`TypeError: (intermediate value)`).