### PR TITLE
Improve docs for the ol.LoadingStrategy type

### DIFF
--- a/src/ol/typedefs.js
+++ b/src/ol/typedefs.js
@@ -300,7 +300,9 @@ ol.LayerState;
 
 
 /**
- * One of `all`, `bbox`, `tile`.
+ * A function that takes an {@link ol.Extent} and a resolution as arguments, and
+ * returns an array of {@link ol.Extent} with the extents to load. Usually this
+ * is one of the standard {@link ol.loadingstrategy} strategies.
  *
  * @typedef {function(ol.Extent, number): Array.<ol.Extent>}
  */


### PR DESCRIPTION
The docs for `ol.LoadingStrategy` are misleading, and omit the fact that a user provided function will also work.