### PR TITLE
Fix DateTime parsing with non-Zulu times

### DIFF
--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -1360,28 +1360,8 @@ ol.format.KML.whenParser_ = function(node, objectStack) {
       'gxTrackObject should be an Object');
   var whens = gxTrackObject.whens;
   var s = ol.xml.getAllTextContent(node, false);
-  var re =
-      /^\s*(\d{4})($|-(\d{2})($|-(\d{2})($|T(\d{2}):(\d{2}):(\d{2})(Z|(?:([+\-])(\d{2})(?::(\d{2}))?)))))\s*$/;
-  var m = re.exec(s);
-  if (m) {
-    var year = parseInt(m[1], 10);
-    var month = m[3] ? parseInt(m[3], 10) - 1 : 0;
-    var day = m[5] ? parseInt(m[5], 10) : 1;
-    var hour = m[7] ? parseInt(m[7], 10) : 0;
-    var minute = m[8] ? parseInt(m[8], 10) : 0;
-    var second = m[9] ? parseInt(m[9], 10) : 0;
-    var when = Date.UTC(year, month, day, hour, minute, second);
-    if (m[10] && m[10] != 'Z') {
-      var sign = m[11] == '-' ? -1 : 1;
-      when += sign * 60 * parseInt(m[12], 10);
-      if (m[13]) {
-        when += sign * 60 * 60 * parseInt(m[13], 10);
-      }
-    }
-    whens.push(when);
-  } else {
-    whens.push(0);
-  }
+  var when = Date.parse(s);
+  whens.push(isNaN(when) ? 0 : when);
 };
 
 

--- a/src/ol/format/xsdformat.js
+++ b/src/ol/format/xsdformat.js
@@ -43,28 +43,8 @@ ol.format.XSD.readBooleanString = function(string) {
  */
 ol.format.XSD.readDateTime = function(node) {
   var s = ol.xml.getAllTextContent(node, false);
-  var re =
-      /^\s*(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(Z|(?:([+\-])(\d{2})(?::(\d{2}))?))\s*$/;
-  var m = re.exec(s);
-  if (m) {
-    var year = parseInt(m[1], 10);
-    var month = parseInt(m[2], 10) - 1;
-    var day = parseInt(m[3], 10);
-    var hour = parseInt(m[4], 10);
-    var minute = parseInt(m[5], 10);
-    var second = parseInt(m[6], 10);
-    var dateTime = Date.UTC(year, month, day, hour, minute, second) / 1000;
-    if (m[7] != 'Z') {
-      var sign = m[8] == '-' ? 1 : -1;
-      dateTime += sign * 60 * 60 * parseInt(m[9], 10);
-      if (m[10] !== undefined) {
-        dateTime += sign * 60 * parseInt(m[10], 10);
-      }
-    }
-    return dateTime;
-  } else {
-    return undefined;
-  }
+  var dateTime = Date.parse(s);
+  return isNaN(dateTime) ? undefined : dateTime / 1000;
 };
 
 

--- a/src/ol/format/xsdformat.js
+++ b/src/ol/format/xsdformat.js
@@ -55,10 +55,10 @@ ol.format.XSD.readDateTime = function(node) {
     var second = parseInt(m[6], 10);
     var dateTime = Date.UTC(year, month, day, hour, minute, second) / 1000;
     if (m[7] != 'Z') {
-      var sign = m[8] == '-' ? -1 : 1;
-      dateTime += sign * 60 * parseInt(m[9], 10);
+      var sign = m[8] == '-' ? 1 : -1;
+      dateTime += sign * 60 * 60 * parseInt(m[9], 10);
       if (m[10] !== undefined) {
-        dateTime += sign * 60 * 60 * parseInt(m[10], 10);
+        dateTime += sign * 60 * parseInt(m[10], 10);
       }
     }
     return dateTime;

--- a/test/spec/ol/format/kmlformat.test.js
+++ b/test/spec/ol/format/kmlformat.test.js
@@ -1138,7 +1138,7 @@ describe('ol.format.KML', function() {
         expect(flatCoordinates[11]).to.be.eql(Date.UTC(2014, 1, 6, 0, 0, 0));
         expect(flatCoordinates[15]).to.be.eql(Date.UTC(2014, 1, 6, 19, 39, 3));
         expect(flatCoordinates[19]).to.be.eql(
-            Date.UTC(2014, 1, 6, 19, 39, 10) + 3 * 60
+            Date.UTC(2014, 1, 6, 16, 39, 10)
         );
       });
 

--- a/test/spec/ol/format/xsdformat.test.js
+++ b/test/spec/ol/format/xsdformat.test.js
@@ -1,0 +1,16 @@
+goog.provide('ol.test.XSD');
+
+describe('ol.format.XSD', function() {
+
+  describe('readDateTime', function() {
+    it('can handle non-Zulu time zones', function() {
+      var node = document.createElement('time');
+      node.textContent = '2016-07-12T15:00:00+03:00';
+      expect(new Date(ol.format.XSD.readDateTime(node) * 1000).toISOString()).to.eql('2016-07-12T12:00:00.000Z');
+    });
+
+  });
+
+});
+
+goog.require('ol.format.XSD');


### PR DESCRIPTION
Instead of just fixing our parser, we can now use `Date.parse()`, which is supported by all our supported browsers.

Fixes #5643.