### PR TITLE
Make XHR work for file:// urls

### DIFF
--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -41,7 +41,8 @@ ol.featureloader.loadFeaturesXhr = function(url, format, success, failure) {
          * @private
          */
         xhr.onload = function(event) {
-          if (xhr.status >= 200 && xhr.status < 300) {
+          // status will be 0 for file:// urls
+          if (!xhr.status || xhr.status >= 200 && xhr.status < 300) {
             var type = format.getType();
             /** @type {Document|Node|Object|string|undefined} */
             var source;

--- a/src/ol/source/cartodb.js
+++ b/src/ol/source/cartodb.js
@@ -125,7 +125,8 @@ ol.source.CartoDB.prototype.initializeMap_ = function() {
  */
 ol.source.CartoDB.prototype.handleInitResponse_ = function(paramHash, event) {
   var client = /** @type {XMLHttpRequest} */ (event.target);
-  if (client.status >= 200 && client.status < 300) {
+  // status will be 0 for file:// urls
+  if (!client.status || client.status >= 200 && client.status < 300) {
     var response;
     try {
       response = /** @type {CartoDBLayerInfo} */(JSON.parse(client.responseText));

--- a/src/ol/source/tilejsonsource.js
+++ b/src/ol/source/tilejsonsource.js
@@ -67,7 +67,8 @@ ol.inherits(ol.source.TileJSON, ol.source.TileImage);
  */
 ol.source.TileJSON.prototype.onXHRLoad_ = function(event) {
   var client = /** @type {XMLHttpRequest} */ (event.target);
-  if (client.status >= 200 && client.status < 300) {
+  // status will be 0 for file:// urls
+  if (!client.status || client.status >= 200 && client.status < 300) {
     var response;
     try {
       response = /** @type {TileJSON} */(JSON.parse(client.responseText));

--- a/src/ol/source/tileutfgridsource.js
+++ b/src/ol/source/tileutfgridsource.js
@@ -81,7 +81,8 @@ ol.inherits(ol.source.TileUTFGrid, ol.source.Tile);
  */
 ol.source.TileUTFGrid.prototype.onXHRLoad_ = function(event) {
   var client = /** @type {XMLHttpRequest} */ (event.target);
-  if (client.status >= 200 && client.status < 300) {
+  // status will be 0 for file:// urls
+  if (!client.status || client.status >= 200 && client.status < 300) {
     var response;
     try {
       response = /** @type {TileJSON} */(JSON.parse(client.responseText));
@@ -457,7 +458,8 @@ ol.source.TileUTFGridTile_.prototype.loadInternal_ = function() {
  */
 ol.source.TileUTFGridTile_.prototype.onXHRLoad_ = function(event) {
   var client = /** @type {XMLHttpRequest} */ (event.target);
-  if (client.status >= 200 && client.status < 300) {
+  // status will be 0 for file:// urls
+  if (!client.status || client.status >= 200 && client.status < 300) {
     var response;
     try {
       response = /** @type {!UTFGridJSON} */(JSON.parse(client.responseText));


### PR DESCRIPTION
The response status will be 0 instead of a HTTP status code for file urls, so we need to consider a status of 0 as success too.

Fixes #5647.