### PR TITLE
Fix Github links to specific lines on jsdoc pages

### DIFF
--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -88,7 +88,7 @@ $(function () {
       var link = 'https://github.com/openlayers/ol3/blob/v' + currentVersion + '/' +
           textParts[0];
       el.innerHTML = '<a href="' + link + '">' + textParts[0] + '</a>, ' +
-          '<a href="' + link + textParts[1].replace('line ', '#l') + '">' +
+          '<a href="' + link + textParts[1].replace('line ', '#L') + '">' +
           textParts[1] + '</a>';
     });
 


### PR DESCRIPTION
It seems that Github line links only work with a capital `L`. I _think_ this is all that has to change.