### PR TITLE
Added image data value to 'forEachLayerAtPixel' method callback

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -619,10 +619,11 @@ ol.Map.prototype.forEachFeatureAtPixel = function(pixel, callback, opt_this, opt
  * execute a callback with each matching layer. Layers included in the
  * detection can be configured through `opt_layerFilter`.
  * @param {ol.Pixel} pixel Pixel.
- * @param {function(this: S, ol.layer.Layer): T} callback Layer
- *     callback. Will receive one argument, the {@link ol.layer.Layer layer}
- *     that contains the color pixel. To stop detection, callback functions can
- *     return a truthy value.
+ * @param {function(this: S, ol.layer.Layer, ol.Color): T} callback Layer
+ *     callback. This callback will recieve two arguments: first is the
+ *     {@link ol.layer.Layer layer}, second argument is {@link ol.Color}
+ *     and will be null for layer types that do not currently support this
+ *     argument. To stop detection callback functions can return a truthy value.
  * @param {S=} opt_this Value to use as `this` when executing `callback`.
  * @param {(function(this: U, ol.layer.Layer): boolean)=} opt_layerFilter Layer
  *     filter function. The filter function will receive one argument, the

--- a/src/ol/renderer/canvas/imagelayer.js
+++ b/src/ol/renderer/canvas/imagelayer.js
@@ -69,7 +69,13 @@ ol.renderer.canvas.ImageLayer.prototype.forEachFeatureAtCoordinate = function(co
 
 
 /**
- * @inheritDoc
+ * @param {ol.Pixel} pixel Pixel.
+ * @param {olx.FrameState} frameState FrameState.
+ * @param {function(this: S, ol.layer.Layer, ol.Color): T} callback Layer
+ *     callback.
+ * @param {S} thisArg Value to use as `this` when executing `callback`.
+ * @return {T|undefined} Callback result.
+ * @template S,T,U
  */
 ol.renderer.canvas.ImageLayer.prototype.forEachLayerAtPixel = function(pixel, frameState, callback, thisArg) {
   if (!this.getImage()) {
@@ -85,7 +91,7 @@ ol.renderer.canvas.ImageLayer.prototype.forEachLayerAtPixel = function(pixel, fr
         coordinate, frameState, ol.functions.TRUE, this);
 
     if (hasFeature) {
-      return callback.call(thisArg, this.getLayer());
+      return callback.call(thisArg, this.getLayer(), null);
     } else {
       return undefined;
     }
@@ -108,7 +114,7 @@ ol.renderer.canvas.ImageLayer.prototype.forEachLayerAtPixel = function(pixel, fr
 
     var imageData = this.hitCanvasContext_.getImageData(0, 0, 1, 1).data;
     if (imageData[3] > 0) {
-      return callback.call(thisArg, this.getLayer());
+      return callback.call(thisArg, this.getLayer(),  imageData);
     } else {
       return undefined;
     }

--- a/src/ol/renderer/canvas/tilelayer.js
+++ b/src/ol/renderer/canvas/tilelayer.js
@@ -186,7 +186,13 @@ ol.renderer.canvas.TileLayer.prototype.prepareFrame = function(
 
 
 /**
- * @inheritDoc
+ * @param {ol.Pixel} pixel Pixel.
+ * @param {olx.FrameState} frameState FrameState.
+ * @param {function(this: S, ol.layer.Layer, ol.Color): T} callback Layer
+ *     callback.
+ * @param {S} thisArg Value to use as `this` when executing `callback`.
+ * @return {T|undefined} Callback result.
+ * @template S,T,U
  */
 ol.renderer.canvas.TileLayer.prototype.forEachLayerAtPixel = function(
     pixel, frameState, callback, thisArg) {
@@ -200,7 +206,7 @@ ol.renderer.canvas.TileLayer.prototype.forEachLayerAtPixel = function(
       pixel[0], pixel[1], 1, 1).data;
 
   if (imageData[3] > 0) {
-    return callback.call(thisArg, this.getLayer());
+    return callback.call(thisArg, this.getLayer(),  imageData);
   } else {
     return undefined;
   }

--- a/src/ol/renderer/layer.js
+++ b/src/ol/renderer/layer.js
@@ -47,7 +47,7 @@ ol.renderer.Layer.prototype.forEachFeatureAtCoordinate = ol.nullFunction;
 /**
  * @param {ol.Pixel} pixel Pixel.
  * @param {olx.FrameState} frameState Frame state.
- * @param {function(this: S, ol.layer.Layer): T} callback Layer callback.
+ * @param {function(this: S, ol.layer.Layer, ol.Color): T} callback Layer callback.
  * @param {S} thisArg Value to use as `this` when executing `callback`.
  * @return {T|undefined} Callback result.
  * @template S,T
@@ -60,7 +60,7 @@ ol.renderer.Layer.prototype.forEachLayerAtPixel = function(pixel, frameState, ca
       coordinate, frameState, ol.functions.TRUE, this);
 
   if (hasFeature) {
-    return callback.call(thisArg, this.layer_);
+    return callback.call(thisArg, this.layer_, null);
   } else {
     return undefined;
   }

--- a/src/ol/renderer/map.js
+++ b/src/ol/renderer/map.js
@@ -180,7 +180,7 @@ ol.renderer.Map.prototype.forEachFeatureAtCoordinate = function(coordinate, fram
 /**
  * @param {ol.Pixel} pixel Pixel.
  * @param {olx.FrameState} frameState FrameState.
- * @param {function(this: S, ol.layer.Layer): T} callback Layer
+ * @param {function(this: S, ol.layer.Layer, ol.Color): T} callback Layer
  *     callback.
  * @param {S} thisArg Value to use as `this` when executing `callback`.
  * @param {function(this: U, ol.layer.Layer): boolean} layerFilter Layer filter

--- a/src/ol/renderer/webgl/imagelayer.js
+++ b/src/ol/renderer/webgl/imagelayer.js
@@ -218,7 +218,13 @@ ol.renderer.webgl.ImageLayer.prototype.hasFeatureAtCoordinate = function(coordin
 
 
 /**
- * @inheritDoc
+ * @param {ol.Pixel} pixel Pixel.
+ * @param {olx.FrameState} frameState FrameState.
+ * @param {function(this: S, ol.layer.Layer, ol.Color): T} callback Layer
+ *     callback.
+ * @param {S} thisArg Value to use as `this` when executing `callback`.
+ * @return {T|undefined} Callback result.
+ * @template S,T,U
  */
 ol.renderer.webgl.ImageLayer.prototype.forEachLayerAtPixel = function(pixel, frameState, callback, thisArg) {
   if (!this.image_ || !this.image_.getImage()) {
@@ -234,7 +240,7 @@ ol.renderer.webgl.ImageLayer.prototype.forEachLayerAtPixel = function(pixel, fra
         coordinate, frameState, ol.functions.TRUE, this);
 
     if (hasFeature) {
-      return callback.call(thisArg, this.getLayer());
+      return callback.call(thisArg, this.getLayer(), null);
     } else {
       return undefined;
     }
@@ -266,7 +272,7 @@ ol.renderer.webgl.ImageLayer.prototype.forEachLayerAtPixel = function(pixel, fra
 
     var imageData = this.hitCanvasContext_.getImageData(0, 0, 1, 1).data;
     if (imageData[3] > 0) {
-      return callback.call(thisArg, this.getLayer());
+      return callback.call(thisArg, this.getLayer(),  imageData);
     } else {
       return undefined;
     }

--- a/src/ol/renderer/webgl/tilelayer.js
+++ b/src/ol/renderer/webgl/tilelayer.js
@@ -364,7 +364,13 @@ ol.renderer.webgl.TileLayer.prototype.prepareFrame = function(frameState, layerS
 
 
 /**
- * @inheritDoc
+ * @param {ol.Pixel} pixel Pixel.
+ * @param {olx.FrameState} frameState FrameState.
+ * @param {function(this: S, ol.layer.Layer, ol.Color): T} callback Layer
+ *     callback.
+ * @param {S} thisArg Value to use as `this` when executing `callback`.
+ * @return {T|undefined} Callback result.
+ * @template S,T,U
  */
 ol.renderer.webgl.TileLayer.prototype.forEachLayerAtPixel = function(pixel, frameState, callback, thisArg) {
   if (!this.framebuffer) {
@@ -388,7 +394,7 @@ ol.renderer.webgl.TileLayer.prototype.forEachLayerAtPixel = function(pixel, fram
       gl.RGBA, gl.UNSIGNED_BYTE, imageData);
 
   if (imageData[3] > 0) {
-    return callback.call(thisArg, this.getLayer());
+    return callback.call(thisArg, this.getLayer(),  imageData);
   } else {
     return undefined;
   }

--- a/src/ol/renderer/webgl/vectorlayer.js
+++ b/src/ol/renderer/webgl/vectorlayer.js
@@ -147,7 +147,13 @@ ol.renderer.webgl.VectorLayer.prototype.hasFeatureAtCoordinate = function(coordi
 
 
 /**
- * @inheritDoc
+ * @param {ol.Pixel} pixel Pixel.
+ * @param {olx.FrameState} frameState FrameState.
+ * @param {function(this: S, ol.layer.Layer, ol.Color): T} callback Layer
+ *     callback.
+ * @param {S} thisArg Value to use as `this` when executing `callback`.
+ * @return {T|undefined} Callback result.
+ * @template S,T,U
  */
 ol.renderer.webgl.VectorLayer.prototype.forEachLayerAtPixel = function(pixel, frameState, callback, thisArg) {
   var coordinate = ol.transform.apply(
@@ -155,7 +161,7 @@ ol.renderer.webgl.VectorLayer.prototype.forEachLayerAtPixel = function(pixel, fr
   var hasFeature = this.hasFeatureAtCoordinate(coordinate, frameState);
 
   if (hasFeature) {
-    return callback.call(thisArg, this.getLayer());
+    return callback.call(thisArg, this.getLayer(), null);
   } else {
     return undefined;
   }

--- a/src/ol/typedefs.js
+++ b/src/ol/typedefs.js
@@ -104,7 +104,7 @@ ol.CircleRenderOptions;
  * red, green, and blue should be integers in the range 0..255 inclusive.
  * alpha should be a float in the range 0..1 inclusive. If no alpha value is
  * given then `1` will be used.
- * @typedef {Array.<number>}
+ * @typedef {Array.<number>|Uint8Array|Uint8ClampedArray}
  */
 ol.Color;
 


### PR DESCRIPTION
The update has been added to the docs for all 'forEachLayerAtPixel' prototypes
and currently returns null for non-supporting definitions. #5586 

@tsauerwein @ahocevar @fredj closed [Pull request #5650](https://github.com/openlayers/ol3/pull/5650#issuecomment-236831740) when trying to reference the issue.

@fredj `Array.from()` has been replaced by  `Array.prototype.slice.call()`