### PR TITLE
Fix cursor change in translate interaction

### DIFF
--- a/src/ol/interaction/translate.js
+++ b/src/ol/interaction/translate.js
@@ -215,30 +215,18 @@ ol.interaction.Translate.handleDragEvent_ = function(event) {
  */
 ol.interaction.Translate.handleMoveEvent_ = function(event) {
   var elem = event.map.getTargetElement();
-  var intersectingFeature = event.map.forEachFeatureAtPixel(event.pixel,
-      function(feature) {
-        return feature;
-      });
 
-  if (intersectingFeature) {
-    var isSelected = false;
-
-    if (this.features_ &&
-        ol.array.includes(this.features_.getArray(), intersectingFeature)) {
-      isSelected = true;
-    }
-
+  // Change the cursor to grab/grabbing if hovering any of the features managed
+  // by the interaction
+  if (this.featuresAtPixel_(event.pixel, event.map)) {
     this.previousCursor_ = elem.style.cursor;
-
     // WebKit browsers don't support the grab icons without a prefix
     elem.style.cursor = this.lastCoordinate_ ?
-        '-webkit-grabbing' : (isSelected ? '-webkit-grab' : 'pointer');
+        '-webkit-grabbing' : '-webkit-grab';
 
     // Thankfully, attempting to set the standard ones will silently fail,
     // keeping the prefixed icons
-    elem.style.cursor = !this.lastCoordinate_ ?
-        'grabbing' : (isSelected ? 'grab' : 'pointer');
-
+    elem.style.cursor = this.lastCoordinate_ ?  'grabbing' : 'grab';
   } else {
     elem.style.cursor = this.previousCursor_ !== undefined ?
         this.previousCursor_ : '';


### PR DESCRIPTION
This pull request aims to fix the following issues:

 - in webkit and non webkit browsers, the cursor change behaves differently. The cursor is "grab" when not dragging and "grabbing" when dragging on Chrome, which is correct. It's the opposite on FF.
The test on `this.lastCoordinate_` is different between the two cases.
https://github.com/openlayers/ol3/blob/master/src/ol/interaction/translateinteraction.js#L235 vs. https://github.com/openlayers/ol3/blob/master/src/ol/interaction/translateinteraction.js#L240

 - it's in my opinion not translate interaction's job to change the cursor to "pointer" for other features. It should only manage its own features and change the cursor from `grab` to `grabbing`. In other words if the translate interaction is combined with a select interaction, only the selected features should be taken into account for the cursor change.

The code gets simplified by using `featuresAtPixel_` and fixes #5457 at the same time.

Please review.

