### PR TITLE
Remove unneeded requires in renderers

### DIFF
--- a/src/ol/renderer/canvas/canvaslayerrenderer.js
+++ b/src/ol/renderer/canvas/canvaslayerrenderer.js
@@ -2,7 +2,6 @@ goog.provide('ol.renderer.canvas.Layer');
 
 goog.require('ol.transform');
 goog.require('ol.extent');
-goog.require('ol.layer.Layer');
 goog.require('ol.render.Event');
 goog.require('ol.render.EventType');
 goog.require('ol.render.canvas');

--- a/src/ol/renderer/dom/domlayerrenderer.js
+++ b/src/ol/renderer/dom/domlayerrenderer.js
@@ -1,7 +1,6 @@
 goog.provide('ol.renderer.dom.Layer');
 
 goog.require('ol');
-goog.require('ol.layer.Layer');
 goog.require('ol.renderer.Layer');
 
 

--- a/src/ol/renderer/layerrenderer.js
+++ b/src/ol/renderer/layerrenderer.js
@@ -8,7 +8,6 @@ goog.require('ol.ImageState');
 goog.require('ol.Observable');
 goog.require('ol.TileRange');
 goog.require('ol.TileState');
-goog.require('ol.layer.Layer');
 goog.require('ol.transform');
 goog.require('ol.source.State');
 goog.require('ol.source.Tile');

--- a/src/ol/renderer/maprenderer.js
+++ b/src/ol/renderer/maprenderer.js
@@ -9,7 +9,6 @@ goog.require('ol.events.EventType');
 goog.require('ol.extent');
 goog.require('ol.functions');
 goog.require('ol.layer.Layer');
-goog.require('ol.renderer.Layer');
 goog.require('ol.style.IconImageCache');
 
 

--- a/src/ol/renderer/webgl/webgllayerrenderer.js
+++ b/src/ol/renderer/webgl/webgllayerrenderer.js
@@ -1,6 +1,5 @@
 goog.provide('ol.renderer.webgl.Layer');
 
-goog.require('ol.layer.Layer');
 goog.require('ol.transform');
 goog.require('ol.render.Event');
 goog.require('ol.render.EventType');


### PR DESCRIPTION
a couple more requires that are only used in type comments and so not required