### PR TITLE
Remove unneeded requires from featureloader

### DIFF
--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -1,10 +1,7 @@
 goog.provide('ol.featureloader');
 
 goog.require('ol.TileState');
-goog.require('ol.VectorTile');
 goog.require('ol.format.FormatType');
-goog.require('ol.proj');
-goog.require('ol.proj.Projection');
 goog.require('ol.xml');
 
 


### PR DESCRIPTION
more requires only used in JSDoc comments. There seem to be quite a few of these; if I find time, I'll go through the library more systematically.