### PR TITLE
Re-enable ESLint config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "extend": "openlayers",
-  "rules": {
-    "no-console": [2, {"allow": ["assert"]}]
-  }
-}

--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ build/timestamps/eslint-timestamp: $(SRC_JS) $(SPEC_JS) $(SPEC_RENDERING_JS) \
                                    build/timestamps/node-modules-timestamp
 	@mkdir -p $(@D)
 	@echo "Running eslint..."
-	@./node_modules/.bin/eslint $?
+	@./node_modules/.bin/eslint tasks test test_rendering src examples
 	@touch $@
 
 build/timestamps/node-modules-timestamp: package.json

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
       "proj4": false
     },
     "rules": {
+      "no-console": [2, {"allow": ["assert"]}],
       "no-constant-condition": 0
     }
   },

--- a/src/ol/control/overviewmap.js
+++ b/src/ol/control/overviewmap.js
@@ -371,8 +371,6 @@ ol.control.OverviewMap.prototype.updateBox_ = function() {
 
   var ovview = ovmap.getView();
 
-  var ovmapSize = ovmap.getSize();
-
   var rotation = view.getRotation();
 
   var overlay = this.boxOverlay_;

--- a/src/ol/format/esrijson.js
+++ b/src/ol/format/esrijson.js
@@ -315,7 +315,9 @@ ol.format.EsriJSON.writeLineStringGeometry_ = function(geometry, opt_options) {
   return /** @type {EsriJSONPolyline} */ ({
     hasZ: hasZM.hasZ,
     hasM: hasZM.hasM,
-    paths: [/** @type {ol.geom.LineString} */ (geometry).getCoordinates()]
+    paths: [
+      /** @type {ol.geom.LineString} */ (geometry).getCoordinates()
+    ]
   });
 };
 

--- a/src/ol/format/gml3.js
+++ b/src/ol/format/gml3.js
@@ -911,7 +911,6 @@ ol.format.GML3.prototype.writeRing_ = function(node, ring, objectStack) {
  * @private
  */
 ol.format.GML3.prototype.writeSurfaceOrPolygonMember_ = function(node, polygon, objectStack) {
-  var context = objectStack[objectStack.length - 1];
   var child = this.GEOMETRY_NODE_FACTORY_(
       polygon, objectStack);
   if (child) {
@@ -941,7 +940,6 @@ ol.format.GML3.prototype.writePointMember_ = function(node, point, objectStack) 
  * @private
  */
 ol.format.GML3.prototype.writeLineStringOrCurveMember_ = function(node, line, objectStack) {
-  var context = objectStack[objectStack.length - 1];
   var child = this.GEOMETRY_NODE_FACTORY_(line, objectStack);
   if (child) {
     node.appendChild(child);

--- a/src/ol/interaction/modify.js
+++ b/src/ol/interaction/modify.js
@@ -709,7 +709,6 @@ ol.interaction.Modify.handleEvent = function(mapBrowserEvent) {
   if (this.vertexFeature_ && this.deleteCondition_(mapBrowserEvent)) {
     if (mapBrowserEvent.type != ol.MapBrowserEvent.EventType.SINGLECLICK ||
         !this.ignoreNextSingleClick_) {
-      var geometry = /** @type {ol.geom.Point} */ (this.vertexFeature_.getGeometry());
       handled = this.removePoint();
     } else {
       handled = true;

--- a/src/ol/math.js
+++ b/src/ol/math.js
@@ -1,7 +1,6 @@
 goog.provide('ol.math');
 
 
-
 /**
  * Takes a number and clamps it to within the provided bounds.
  * @param {number} value The input number.

--- a/src/ol/renderer/dom/vectorlayer.js
+++ b/src/ol/renderer/dom/vectorlayer.js
@@ -103,9 +103,6 @@ ol.renderer.dom.VectorLayer.prototype.clearFrame = function() {
  * @inheritDoc
  */
 ol.renderer.dom.VectorLayer.prototype.composeFrame = function(frameState, layerState) {
-
-  var vectorLayer = /** @type {ol.layer.Vector} */ (this.getLayer());
-
   var viewState = frameState.viewState;
   var viewCenter = viewState.center;
   var viewRotation = viewState.rotation;

--- a/test/node/.eslintrc
+++ b/test/node/.eslintrc
@@ -1,5 +1,6 @@
 {
   "env": {
-    "es6": true
+    "es6": true,
+    "mocha": true
   }
 }

--- a/test/node/one-provide.js
+++ b/test/node/one-provide.js
@@ -5,7 +5,7 @@ const path = require('path');
 
 const src = path.join(__dirname, '..', '..', 'src');
 
-const PROVIDE_RE = /^goog.provide\('(.*)'\);/
+const PROVIDE_RE = /^goog.provide\('(.*)'\);/;
 
 describe('each file', () => {
 

--- a/test/spec/ol/format/wfs.test.js
+++ b/test/spec/ol/format/wfs.test.js
@@ -672,7 +672,7 @@ describe('ol.format.WFS', function() {
         [-12240318, 6507071],
         [-12416429, 6604910]
       ]]));
-      var error = false;
+
       expect(function() {
         format.writeTransaction(null, [updateFeature], null, {
           featureNS: 'http://foo',

--- a/test/spec/ol/ol.test.js
+++ b/test/spec/ol/ol.test.js
@@ -29,7 +29,7 @@ describe('ol', function() {
     it('has a name', function() {
       var error = new ol.AssertionError(42);
       expect(error.name).to.be('AssertionError');
-    })
+    });
   });
 
 });

--- a/test/spec/ol/structs/priorityqueue.test.js
+++ b/test/spec/ol/structs/priorityqueue.test.js
@@ -16,7 +16,7 @@ describe('ol.structs.PriorityQueue', function() {
         if (!assertion) {
           throw new Error(message);
         }
-      }
+      };
       pq = new ol.structs.PriorityQueue(
           identity, identity);
     });


### PR DESCRIPTION
The `.eslintrc` added in #5619 takes precedence over the `eslintConfig` already defined in our `package.json`.  The `"extend": "openlayers"` [in that file](https://github.com/ahocevar/ol3/blob/bf275b0740aa518974d7744f173ab8db023724d6/.eslintrc#L2) should have been spelled `"extends": "openlayers"`.  So there were a number of changes in #5619 that introduced linter errors.  This branch addresses those.  In addition, the `make lint` target is overly optimized - if our `package.json` (or linter config) changes, we don't re-run all files with the new rules (instead we only run changed files).  This changes the `Makefile` so it does the same thing as `npm run pretest`.

When we again enable the linter, `make lint` generates this:
```
Running eslint...

/Users/tschaub/projects/ol3/test/node/one-provide.js
   8:46  error  Missing semicolon          semi
  10:1   error  'describe' is not defined  no-undef
  14:3   error  'before' is not defined    no-undef
  44:3   error  'it' is not defined        no-undef
  50:3   error  'it' is not defined        no-undef

/Users/tschaub/projects/ol3/test/spec/ol/format/wfs.test.js
  675:11  error  'error' is defined but never used  no-unused-vars

/Users/tschaub/projects/ol3/test/spec/ol/ol.test.js
  32:7  error  Missing semicolon  semi

/Users/tschaub/projects/ol3/test/spec/ol/structs/priorityqueue.test.js
  19:8  error  Missing semicolon  semi

/Users/tschaub/projects/ol3/src/ol/control/overviewmap.js
  374:7  error  'ovmapSize' is defined but never used  no-unused-vars

/Users/tschaub/projects/ol3/src/ol/format/esrijson.js
  318:12  error  There should be no space after '['  array-bracket-spacing

/Users/tschaub/projects/ol3/src/ol/format/gml3.js
  914:7  error  'context' is defined but never used  no-unused-vars
  944:7  error  'context' is defined but never used  no-unused-vars

/Users/tschaub/projects/ol3/src/ol/interaction/modify.js
  712:11  error  'geometry' is defined but never used  no-unused-vars

/Users/tschaub/projects/ol3/src/ol/math.js
  4:2  error  More than 2 blank lines not allowed  no-multiple-empty-lines

/Users/tschaub/projects/ol3/src/ol/renderer/dom/vectorlayer.js
  107:7  error  'vectorLayer' is defined but never used  no-unused-vars

✖ 15 problems (15 errors, 0 warnings)
```