### PR TITLE
Added a pixelRatio adjust to the canvasTileLayer 'forEachLayerAtPixel…

### DIFF
--- a/src/ol/renderer/canvas/tilelayer.js
+++ b/src/ol/renderer/canvas/tilelayer.js
@@ -198,8 +198,9 @@ ol.renderer.canvas.TileLayer.prototype.forEachLayerAtPixel = function(
     pixel, frameState, callback, thisArg) {
   var canvas = this.context.canvas;
   var size = frameState.size;
-  canvas.width = size[0];
-  canvas.height = size[1];
+  var pixelRatio = frameState.pixelRatio;
+  canvas.width = size[0] * pixelRatio;
+  canvas.height = size[1] * pixelRatio;
   this.composeFrame(frameState, this.getLayer().getLayerState(), this.context);
 
   var imageData = this.context.getImageData(


### PR DESCRIPTION
…' method

This method was composing a frame that was only accurate for devices
with a pixelRatio of 1. Now the canvas widths and heights are
multiplied beforehand by the pixelRatio. #5601