### PR TITLE
Fix #5730 - Ignore null/undef. values in uri.appendParams

### DIFF
--- a/src/ol/uri.js
+++ b/src/ol/uri.js
@@ -10,9 +10,14 @@ goog.provide('ol.uri');
  * @return {string} The new URI.
  */
 ol.uri.appendParams = function(uri, params) {
-  var qs = Object.keys(params).map(function(k) {
-    return k + '=' + encodeURIComponent(params[k]);
-  }).join('&');
+  var keyParams = [];
+  // Skip any null or undefined parameter values
+  Object.keys(params).forEach(function(k) {
+    if (params[k] !== null && params[k] !== undefined) {
+      keyParams.push(k + '=' + encodeURIComponent(params[k]));
+    }
+  });
+  var qs = keyParams.join('&');
   // remove any trailing ? or &
   uri = uri.replace(/[?&]$/, '');
   // append ? or & depending on whether uri has existing parameters

--- a/test/spec/ol/uri.test.js
+++ b/test/spec/ol/uri.test.js
@@ -62,4 +62,13 @@ describe('ol.uri.appendParams()', function() {
     expect(url).to.equal('http://example.com/foo?bar=bam&baz=bat&bop=&k=v');
   });
 
+  it('should not append null or undefined parameters to the url', function() {
+    var url = ol.uri.appendParams('http://example.com/foo', {
+      a: '1',
+      b: null,
+      c: undefined
+    });
+    expect(url).to.equal('http://example.com/foo?a=1');
+  });
+
 });


### PR DESCRIPTION
Fixes #5730 

This PR makes the `null` and `undefined` parameters are ignored in the `ol.uri.appendParams` method.