### PR TITLE
Add script to check custom builds w/ configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "start": "node tasks/serve.js",
     "pretest": "eslint tasks test test_rendering src examples",
     "test": "node tasks/test.js",
+    "check:compile-standalone": "node test_compilation/run.js",
     "debug-server": "node tasks/serve-lib.js"
   },
   "main": "dist/ol.js",

--- a/test_compilation/expected-ok/official-workshop.json
+++ b/test_compilation/expected-ok/official-workshop.json
@@ -1,0 +1,55 @@
+{
+  "exports": [
+    "ol.Map",
+    "ol.View",
+    "ol.format.KML",
+    "ol.layer.Tile",
+    "ol.layer.Vector",
+    "ol.proj.fromLonLat",
+    "ol.source.OSM",
+    "ol.source.Vector",
+    "ol.style.Fill",
+    "ol.style.Stroke",
+    "ol.style.Style",
+    "ol.style.Text"
+  ],
+  "jvm": [],
+  "umd": true,
+  "compile": {
+    "externs": [
+      "externs/bingmaps.js",
+      "externs/closure-compiler.js",
+      "externs/esrijson.js",
+      "externs/geojson.js",
+      "externs/oli.js",
+      "externs/olx.js",
+      "externs/proj4js.js",
+      "externs/tilejson.js",
+      "externs/topojson.js"
+    ],
+    "define": [
+      "goog.dom.ASSUME_STANDARDS_MODE=true",
+      "goog.DEBUG=false",
+      "ol.ENABLE_DOM=false",
+      "ol.ENABLE_WEBGL=false",
+      "ol.ENABLE_PROJ4JS=false",
+      "ol.ENABLE_IMAGE=false"
+    ],
+    "jscomp_error": [
+      "*"
+    ],
+    "jscomp_off": [
+      "analyzerChecks",
+      "lintChecks",
+      "unnecessaryCasts",
+      "useOfGoogBase"
+    ],
+    "extra_annotation_name": [
+      "api", "observable"
+    ],
+    "compilation_level": "ADVANCED",
+    "warning_level": "VERBOSE",
+    "use_types_for_optimization": true,
+    "manage_closure_dependencies": true
+  }
+}

--- a/test_compilation/run.js
+++ b/test_compilation/run.js
@@ -1,0 +1,59 @@
+var fs = require('fs-extra');
+var glob = require('glob');
+var log = require('closure-util').log;
+var path = require('path');
+
+var build = require('../tasks/build');
+
+/**
+ * Called as callback for the glob call, will receive an array of filenames to
+ * JSON-files in this directory.
+ *
+ * @param {Error} globErr An error or null if the glob call succeeded.
+ * @param {Array.<string>} jsonFiles An array of `*.json`-files.
+ */
+function foundJsonConfigs(globErr, jsonFiles) {
+  if (globErr) {
+    log.error('compile-check', 'Trouble finding configurations: ' + globErr);
+    process.exit(1);
+  }
+  jsonFiles.forEach(buildWithConfigFile);
+}
+
+/**
+ * Creates a custom build of OpenLayers with the configuration in the specified
+ * file.
+ *
+ * @param {String} jsonFile The file with the JSON configuration
+ */
+function buildWithConfigFile(jsonFile) {
+  var fileName = path.basename(jsonFile);
+  log.info('compile-check', 'Checking compilation config "' + fileName + '"');
+  fs.readFile(jsonFile, 'utf8', function(readErr, json) {
+    if (readErr) {
+      log.error('compile-check', 'Trouble reading configuration: ' + readErr);
+      process.exit(1);
+    }
+    var jsonObj = JSON.parse(json);
+    build(jsonObj, compileCallback);
+  });
+}
+
+/**
+ * Called once the build call finishes, this function checks if we had an error
+ * and bails out in that case.
+ *
+ * @param {compileErr} compileErr An error or null if the compile call
+ *   succeeded.
+ */
+function compileCallback(compileErr) {
+  if (compileErr) {
+    log.error('compile-check', 'Trouble compiling sources: ' + compileErr);
+    process.exit(1);
+  }
+  log.info('compile-check', '…OK');
+}
+
+// Find all JSON files in the 'expected-ok'-directory and try to use these as
+// build configurations
+glob(path.join(__dirname, 'expected-ok', '/*.json'), {}, foundJsonConfigs);


### PR DESCRIPTION
This PR adds the script `test_compilation/run.js` (also available via `npm run check:compile-standalone`) to test if custom builds can be generated.

See also https://github.com/openlayers/workshop/pull/58

Please review.

/cc @bartvde, @tsauerwein 

