### PR TITLE
Point to the English workshop

### DIFF
--- a/doc/index.hbs
+++ b/doc/index.hbs
@@ -9,7 +9,7 @@ If you're eager to get your first OpenLayers 3 map on a page, dive into the [qui
 
 For a more in-depth overview of OpenLayers 3 core concepts, check out the [tutorials](tutorials/).
 
-Make sure to also check out the [OpenLayers 3 workshop](/workshop/).
+Make sure to also check out the [OpenLayers 3 workshop](/workshop/en/).
 
 Find additional reference material in the [API docs](../apidoc).
 


### PR DESCRIPTION
We should probably point directly to the English workshop on the main page