### PR TITLE
Fix assert namespace

### DIFF
--- a/src/ol/events/condition.js
+++ b/src/ol/events/condition.js
@@ -1,5 +1,6 @@
 goog.provide('ol.events.condition');
 
+goog.require('ol.asserts');
 goog.require('ol.functions');
 goog.require('ol.MapBrowserEvent.EventType');
 
@@ -203,7 +204,7 @@ ol.events.condition.targetNotEditable = function(mapBrowserEvent) {
  * @api stable
  */
 ol.events.condition.mouseOnly = function(mapBrowserEvent) {
-  ol.assert(mapBrowserEvent.pointerEvent, 56); // mapBrowserEvent must originate from a pointer event
+  ol.asserts.assert(mapBrowserEvent.pointerEvent, 56); // mapBrowserEvent must originate from a pointer event
   // see http://www.w3.org/TR/pointerevents/#widl-PointerEvent-pointerType
   return /** @type {ol.MapBrowserEvent} */ (mapBrowserEvent).pointerEvent.pointerType == 'mouse';
 };


### PR DESCRIPTION
This is a follow-up pull request to #5616. `ol.assert` has moved to `ol.asserts.assert`.