### PR TITLE
Use HTTPS to access tiles at tileserver.maptiler.com in examples

### DIFF
--- a/examples/reprojection.js
+++ b/examples/reprojection.js
@@ -57,7 +57,7 @@ var layers = {};
 layers['bng'] = new ol.layer.Tile({
   source: new ol.source.XYZ({
     projection: 'EPSG:27700',
-    url: 'http://tileserver.maptiler.com/miniscale/{z}/{x}/{y}.png',
+    url: 'https://tileserver.maptiler.com/miniscale/{z}/{x}/{y}.png',
     crossOrigin: '',
     maxZoom: 6
   })
@@ -111,7 +111,7 @@ fetch(url).then(function(response) {
 
 layers['grandcanyon'] = new ol.layer.Tile({
   source: new ol.source.XYZ({
-    url: 'http://tileserver.maptiler.com/grandcanyon@2x/{z}/{x}/{y}.png',
+    url: 'https://tileserver.maptiler.com/grandcanyon@2x/{z}/{x}/{y}.png',
     crossOrigin: '',
     tilePixelRatio: 2,
     maxZoom: 15,

--- a/examples/xyz-retina.js
+++ b/examples/xyz-retina.js
@@ -20,7 +20,7 @@ var map = new ol.Map({
       source: new ol.source.XYZ({
         attributions: 'Tiles © USGS, rendered with ' +
             '<a href="http://www.maptiler.com/">MapTiler</a>',
-        url: 'http://tileserver.maptiler.com/grandcanyon@2x/{z}/{x}/{y}.png',
+        url: 'https://tileserver.maptiler.com/grandcanyon@2x/{z}/{x}/{y}.png',
         tilePixelRatio: 2, // THIS IS IMPORTANT
         minZoom: mapMinZoom,
         maxZoom: mapMaxZoom


### PR DESCRIPTION
The server at tileserver.maptiler.com now uses HTTPS.

This PR avoids unnecessary redirect for every tile.