### PR TITLE
Closure bye bye

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -1,5 +1,9 @@
 ## Upgrade notes
 
+#### ´goog.DEBUG´ define was renamed to ´ol.DEBUG´
+
+As last step in the removal of the dependency on Google Closure Library, the `goog.DEBUG` compiler define was renamed to `ol.DEBUG`. Please change accordingly in your custom build configuration json files.
+
 ### v3.18.0
 
 #### Changes in the way assertions are handled

--- a/config/example.json
+++ b/config/example.json
@@ -24,7 +24,7 @@
       "externs/topojson.js"
     ],
     "define": [
-      "goog.DEBUG=false"
+      "ol.DEBUG=false"
     ],
     "jscomp_error": [
       "*"

--- a/config/examples-all.json
+++ b/config/examples-all.json
@@ -24,7 +24,7 @@
       "externs/topojson.js"
     ],
     "define": [
-      "goog.DEBUG=false"
+      "ol.DEBUG=false"
     ],
     "jscomp_error": [
       "*"

--- a/config/ol.json
+++ b/config/ol.json
@@ -15,7 +15,7 @@
       "externs/topojson.js"
     ],
     "define": [
-      "goog.DEBUG=false"
+      "ol.DEBUG=false"
     ],
     "jscomp_error": [
       "*"

--- a/doc/tutorials/closure.md
+++ b/doc/tutorials/closure.md
@@ -169,7 +169,7 @@ The minimum config file looks like this:
       "node_modules/openlayers/externs/topojson.js"
     ],
     "define": [
-      "goog.DEBUG=false",
+      "ol.DEBUG=false",
       "ol.ENABLE_DOM=false",
       "ol.ENABLE_WEBGL=false"
     ],
@@ -221,7 +221,7 @@ Here is a version of `config.json` with more compilation checks enabled:
       "node_modules/openlayers/externs/topojson.js"
     ],
     "define": [
-      "goog.DEBUG=false",
+      "ol.DEBUG=false",
       "ol.ENABLE_DOM=false",
       "ol.ENABLE_WEBGL=false"
     ],

--- a/doc/tutorials/custom-builds.md
+++ b/doc/tutorials/custom-builds.md
@@ -60,7 +60,7 @@ Creating a custom build requires writing a build configuration file. The format 
       "externs/topojson.js"
     ],
     "define": [
-      "goog.DEBUG=false"
+      "ol.DEBUG=false"
     ],
     "extra_annotation_name": [
       "api", "observable"
@@ -211,7 +211,7 @@ Now let's try a more complicated example: [`heatmaps-earthquakes`](http://openla
       "ol.ENABLE_WEBGL=false",
       "ol.ENABLE_PROJ4JS=false",
       "ol.ENABLE_IMAGE=false",
-      "goog.DEBUG=false"
+      "ol.DEBUG=false"
     ],
     "compilation_level": "ADVANCED",
     "manage_closure_dependencies": true

--- a/src/ol/array.js
+++ b/src/ol/array.js
@@ -144,9 +144,9 @@ ol.array.linearFindNearest = function(arr, target, direction) {
  * @param {number} end End index.
  */
 ol.array.reverseSubArray = function(arr, begin, end) {
-  goog.DEBUG && console.assert(begin >= 0,
+  ol.DEBUG && console.assert(begin >= 0,
       'Array begin index should be equal to or greater than 0');
-  goog.DEBUG && console.assert(end < arr.length,
+  ol.DEBUG && console.assert(end < arr.length,
       'Array end index should be less than the array length');
   while (begin < end) {
     var tmp = arr[begin];

--- a/src/ol/dom.js
+++ b/src/ol/dom.js
@@ -1,7 +1,7 @@
 goog.provide('ol.dom');
 
-goog.require('goog.userAgent');
 goog.require('ol');
+goog.require('ol.has');
 goog.require('ol.vec.Mat4');
 
 
@@ -115,7 +115,7 @@ ol.dom.setTransform = function(element, value) {
   style.transform = value;
 
   // IE 9+ seems to assume transform-origin: 100% 100%; for some unknown reason
-  if (goog.userAgent.IE && goog.userAgent.isVersionOrHigher('9.0')) {
+  if (ol.has.IE) {
     element.style.transformOrigin = '0 0';
   }
 };

--- a/src/ol/events/condition.js
+++ b/src/ol/events/condition.js
@@ -1,6 +1,7 @@
 goog.provide('ol.events.condition');
 
 goog.require('ol.asserts');
+goog.require('ol.has');
 goog.require('ol.functions');
 goog.require('ol.MapBrowserEvent.EventType');
 
@@ -74,7 +75,7 @@ ol.events.condition.click = function(mapBrowserEvent) {
 ol.events.condition.mouseActionButton = function(mapBrowserEvent) {
   var originalEvent = mapBrowserEvent.originalEvent;
   return originalEvent.button == 0 &&
-      !(goog.userAgent.WEBKIT && ol.has.MAC && originalEvent.ctrlKey);
+      !(ol.has.WEBKIT && ol.has.MAC && originalEvent.ctrlKey);
 };
 
 

--- a/src/ol/events/eventtarget.js
+++ b/src/ol/events/eventtarget.js
@@ -144,7 +144,7 @@ ol.events.EventTarget.prototype.removeEventListener = function(type, listener) {
   var listeners = this.listeners_[type];
   if (listeners) {
     var index = listeners.indexOf(listener);
-    goog.DEBUG && console.assert(index != -1, 'listener not found');
+    ol.DEBUG && console.assert(index != -1, 'listener not found');
     if (type in this.pendingRemovals_) {
       // make listener a no-op, and remove later in #dispatchEvent()
       listeners[index] = ol.nullFunction;

--- a/src/ol/extent.js
+++ b/src/ol/extent.js
@@ -55,8 +55,8 @@ ol.extent.boundingExtent = function(coordinates) {
  * @return {ol.Extent} Extent.
  */
 ol.extent.boundingExtentXYs_ = function(xs, ys, opt_extent) {
-  goog.DEBUG && console.assert(xs.length > 0, 'xs length should be larger than 0');
-  goog.DEBUG && console.assert(ys.length > 0, 'ys length should be larger than 0');
+  ol.DEBUG && console.assert(xs.length > 0, 'xs length should be larger than 0');
+  ol.DEBUG && console.assert(ys.length > 0, 'ys length should be larger than 0');
   var minX = Math.min.apply(null, xs);
   var minY = Math.min.apply(null, ys);
   var maxX = Math.max.apply(null, xs);

--- a/src/ol/format/esrijson.js
+++ b/src/ol/format/esrijson.js
@@ -144,8 +144,8 @@ ol.format.EsriJSON.convertRings_ = function(rings, layout) {
  * @return {ol.geom.Geometry} Point.
  */
 ol.format.EsriJSON.readPointGeometry_ = function(object) {
-  goog.DEBUG && console.assert(typeof object.x === 'number', 'object.x should be number');
-  goog.DEBUG && console.assert(typeof object.y === 'number', 'object.y should be number');
+  ol.DEBUG && console.assert(typeof object.x === 'number', 'object.x should be number');
+  ol.DEBUG && console.assert(typeof object.y === 'number', 'object.y should be number');
   var point;
   if (object.m !== undefined && object.z !== undefined) {
     point = new ol.geom.Point([object.x, object.y, object.z, object.m],
@@ -169,9 +169,9 @@ ol.format.EsriJSON.readPointGeometry_ = function(object) {
  * @return {ol.geom.Geometry} LineString.
  */
 ol.format.EsriJSON.readLineStringGeometry_ = function(object) {
-  goog.DEBUG && console.assert(Array.isArray(object.paths),
+  ol.DEBUG && console.assert(Array.isArray(object.paths),
       'object.paths should be an array');
-  goog.DEBUG && console.assert(object.paths.length === 1,
+  ol.DEBUG && console.assert(object.paths.length === 1,
       'object.paths array length should be 1');
   var layout = ol.format.EsriJSON.getGeometryLayout_(object);
   return new ol.geom.LineString(object.paths[0], layout);
@@ -184,9 +184,9 @@ ol.format.EsriJSON.readLineStringGeometry_ = function(object) {
  * @return {ol.geom.Geometry} MultiLineString.
  */
 ol.format.EsriJSON.readMultiLineStringGeometry_ = function(object) {
-  goog.DEBUG && console.assert(Array.isArray(object.paths),
+  ol.DEBUG && console.assert(Array.isArray(object.paths),
       'object.paths should be an array');
-  goog.DEBUG && console.assert(object.paths.length > 1,
+  ol.DEBUG && console.assert(object.paths.length > 1,
       'object.paths array length should be more than 1');
   var layout = ol.format.EsriJSON.getGeometryLayout_(object);
   return new ol.geom.MultiLineString(object.paths, layout);
@@ -228,7 +228,7 @@ ol.format.EsriJSON.readMultiPointGeometry_ = function(object) {
  * @return {ol.geom.Geometry} MultiPolygon.
  */
 ol.format.EsriJSON.readMultiPolygonGeometry_ = function(object) {
-  goog.DEBUG && console.assert(object.rings.length > 1,
+  ol.DEBUG && console.assert(object.rings.length > 1,
       'object.rings should have length larger than 1');
   var layout = ol.format.EsriJSON.getGeometryLayout_(object);
   return new ol.geom.MultiPolygon(
@@ -243,7 +243,7 @@ ol.format.EsriJSON.readMultiPolygonGeometry_ = function(object) {
  * @return {ol.geom.Geometry} Polygon.
  */
 ol.format.EsriJSON.readPolygonGeometry_ = function(object) {
-  goog.DEBUG && console.assert(object.rings);
+  ol.DEBUG && console.assert(object.rings);
   var layout = ol.format.EsriJSON.getGeometryLayout_(object);
   return new ol.geom.Polygon(object.rings, layout);
 };
@@ -469,7 +469,7 @@ ol.format.EsriJSON.prototype.readFeatures;
 ol.format.EsriJSON.prototype.readFeatureFromObject = function(
     object, opt_options) {
   var esriJSONFeature = /** @type {EsriJSONFeature} */ (object);
-  goog.DEBUG && console.assert(esriJSONFeature.geometry ||
+  ol.DEBUG && console.assert(esriJSONFeature.geometry ||
       esriJSONFeature.attributes,
       'geometry or attributes should be defined');
   var geometry = ol.format.EsriJSON.readGeometry_(esriJSONFeature.geometry,
@@ -481,7 +481,7 @@ ol.format.EsriJSON.prototype.readFeatureFromObject = function(
   feature.setGeometry(geometry);
   if (opt_options && opt_options.idField &&
       esriJSONFeature.attributes[opt_options.idField]) {
-    goog.DEBUG && console.assert(
+    ol.DEBUG && console.assert(
         typeof esriJSONFeature.attributes[opt_options.idField] === 'number',
         'objectIdFieldName value should be a number');
     feature.setId(/** @type {number} */(

--- a/src/ol/format/geojson.js
+++ b/src/ol/format/geojson.js
@@ -86,7 +86,7 @@ ol.format.GeoJSON.readGeometry_ = function(object, opt_options) {
  */
 ol.format.GeoJSON.readGeometryCollectionGeometry_ = function(
     object, opt_options) {
-  goog.DEBUG && console.assert(object.type == 'GeometryCollection',
+  ol.DEBUG && console.assert(object.type == 'GeometryCollection',
       'object.type should be GeometryCollection');
   var geometries = object.geometries.map(
       /**
@@ -106,7 +106,7 @@ ol.format.GeoJSON.readGeometryCollectionGeometry_ = function(
  * @return {ol.geom.Point} Point.
  */
 ol.format.GeoJSON.readPointGeometry_ = function(object) {
-  goog.DEBUG && console.assert(object.type == 'Point',
+  ol.DEBUG && console.assert(object.type == 'Point',
       'object.type should be Point');
   return new ol.geom.Point(object.coordinates);
 };
@@ -118,7 +118,7 @@ ol.format.GeoJSON.readPointGeometry_ = function(object) {
  * @return {ol.geom.LineString} LineString.
  */
 ol.format.GeoJSON.readLineStringGeometry_ = function(object) {
-  goog.DEBUG && console.assert(object.type == 'LineString',
+  ol.DEBUG && console.assert(object.type == 'LineString',
       'object.type should be LineString');
   return new ol.geom.LineString(object.coordinates);
 };
@@ -130,7 +130,7 @@ ol.format.GeoJSON.readLineStringGeometry_ = function(object) {
  * @return {ol.geom.MultiLineString} MultiLineString.
  */
 ol.format.GeoJSON.readMultiLineStringGeometry_ = function(object) {
-  goog.DEBUG && console.assert(object.type == 'MultiLineString',
+  ol.DEBUG && console.assert(object.type == 'MultiLineString',
       'object.type should be MultiLineString');
   return new ol.geom.MultiLineString(object.coordinates);
 };
@@ -142,7 +142,7 @@ ol.format.GeoJSON.readMultiLineStringGeometry_ = function(object) {
  * @return {ol.geom.MultiPoint} MultiPoint.
  */
 ol.format.GeoJSON.readMultiPointGeometry_ = function(object) {
-  goog.DEBUG && console.assert(object.type == 'MultiPoint',
+  ol.DEBUG && console.assert(object.type == 'MultiPoint',
       'object.type should be MultiPoint');
   return new ol.geom.MultiPoint(object.coordinates);
 };
@@ -154,7 +154,7 @@ ol.format.GeoJSON.readMultiPointGeometry_ = function(object) {
  * @return {ol.geom.MultiPolygon} MultiPolygon.
  */
 ol.format.GeoJSON.readMultiPolygonGeometry_ = function(object) {
-  goog.DEBUG && console.assert(object.type == 'MultiPolygon',
+  ol.DEBUG && console.assert(object.type == 'MultiPolygon',
       'object.type should be MultiPolygon');
   return new ol.geom.MultiPolygon(object.coordinates);
 };
@@ -166,7 +166,7 @@ ol.format.GeoJSON.readMultiPolygonGeometry_ = function(object) {
  * @return {ol.geom.Polygon} Polygon.
  */
 ol.format.GeoJSON.readPolygonGeometry_ = function(object) {
-  goog.DEBUG && console.assert(object.type == 'Polygon',
+  ol.DEBUG && console.assert(object.type == 'Polygon',
       'object.type should be Polygon');
   return new ol.geom.Polygon(object.coordinates);
 };
@@ -384,7 +384,7 @@ ol.format.GeoJSON.prototype.readFeatures;
 ol.format.GeoJSON.prototype.readFeatureFromObject = function(
     object, opt_options) {
   var geoJSONFeature = /** @type {GeoJSONFeature} */ (object);
-  goog.DEBUG && console.assert(geoJSONFeature.type == 'Feature',
+  ol.DEBUG && console.assert(geoJSONFeature.type == 'Feature',
       'geoJSONFeature.type should be Feature');
   var geometry = ol.format.GeoJSON.readGeometry_(geoJSONFeature.geometry,
       opt_options);

--- a/src/ol/format/gml2.js
+++ b/src/ol/format/gml2.js
@@ -100,9 +100,9 @@ ol.format.GML2.prototype.readFlatCoordinates_ = function(node, objectStack) {
  * @return {ol.Extent|undefined} Envelope.
  */
 ol.format.GML2.prototype.readBox_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Box', 'localName should be Box');
+  ol.DEBUG && console.assert(node.localName == 'Box', 'localName should be Box');
   /** @type {Array.<number>} */
   var flatCoordinates = ol.xml.pushParseAndPop([null],
       this.BOX_PARSERS_, node, objectStack, this);
@@ -118,9 +118,9 @@ ol.format.GML2.prototype.readBox_ = function(node, objectStack) {
  * @private
  */
 ol.format.GML2.prototype.innerBoundaryIsParser_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'innerBoundaryIs',
+  ol.DEBUG && console.assert(node.localName == 'innerBoundaryIs',
       'localName should be innerBoundaryIs');
   /** @type {Array.<number>|undefined} */
   var flatLinearRing = ol.xml.pushParseAndPop(undefined,
@@ -128,9 +128,9 @@ ol.format.GML2.prototype.innerBoundaryIsParser_ = function(node, objectStack) {
   if (flatLinearRing) {
     var flatLinearRings = /** @type {Array.<Array.<number>>} */
         (objectStack[objectStack.length - 1]);
-    goog.DEBUG && console.assert(Array.isArray(flatLinearRings),
+    ol.DEBUG && console.assert(Array.isArray(flatLinearRings),
         'flatLinearRings should be an array');
-    goog.DEBUG && console.assert(flatLinearRings.length > 0,
+    ol.DEBUG && console.assert(flatLinearRings.length > 0,
         'flatLinearRings should have an array length larger than 0');
     flatLinearRings.push(flatLinearRing);
   }
@@ -143,9 +143,9 @@ ol.format.GML2.prototype.innerBoundaryIsParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.GML2.prototype.outerBoundaryIsParser_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'outerBoundaryIs',
+  ol.DEBUG && console.assert(node.localName == 'outerBoundaryIs',
       'localName should be outerBoundaryIs');
   /** @type {Array.<number>|undefined} */
   var flatLinearRing = ol.xml.pushParseAndPop(undefined,
@@ -153,9 +153,9 @@ ol.format.GML2.prototype.outerBoundaryIsParser_ = function(node, objectStack) {
   if (flatLinearRing) {
     var flatLinearRings = /** @type {Array.<Array.<number>>} */
         (objectStack[objectStack.length - 1]);
-    goog.DEBUG && console.assert(Array.isArray(flatLinearRings),
+    ol.DEBUG && console.assert(Array.isArray(flatLinearRings),
         'flatLinearRings should be an array');
-    goog.DEBUG && console.assert(flatLinearRings.length > 0,
+    ol.DEBUG && console.assert(flatLinearRings.length > 0,
         'flatLinearRings should have an array length larger than 0');
     flatLinearRings[0] = flatLinearRing;
   }

--- a/src/ol/format/gml3.js
+++ b/src/ol/format/gml3.js
@@ -88,9 +88,9 @@ ol.format.GML3.schemaLocation_ = ol.format.GMLBase.GMLNS +
  * @return {ol.geom.MultiLineString|undefined} MultiLineString.
  */
 ol.format.GML3.prototype.readMultiCurve_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'MultiCurve',
+  ol.DEBUG && console.assert(node.localName == 'MultiCurve',
       'localName should be MultiCurve');
   /** @type {Array.<ol.geom.LineString>} */
   var lineStrings = ol.xml.pushParseAndPop([],
@@ -112,9 +112,9 @@ ol.format.GML3.prototype.readMultiCurve_ = function(node, objectStack) {
  * @return {ol.geom.MultiPolygon|undefined} MultiPolygon.
  */
 ol.format.GML3.prototype.readMultiSurface_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'MultiSurface',
+  ol.DEBUG && console.assert(node.localName == 'MultiSurface',
       'localName should be MultiSurface');
   /** @type {Array.<ol.geom.Polygon>} */
   var polygons = ol.xml.pushParseAndPop([],
@@ -135,9 +135,9 @@ ol.format.GML3.prototype.readMultiSurface_ = function(node, objectStack) {
  * @private
  */
 ol.format.GML3.prototype.curveMemberParser_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'curveMember' ||
+  ol.DEBUG && console.assert(node.localName == 'curveMember' ||
       node.localName == 'curveMembers',
       'localName should be curveMember or curveMembers');
   ol.xml.parseNode(this.CURVEMEMBER_PARSERS_, node, objectStack, this);
@@ -150,9 +150,9 @@ ol.format.GML3.prototype.curveMemberParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.GML3.prototype.surfaceMemberParser_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'surfaceMember' ||
+  ol.DEBUG && console.assert(node.localName == 'surfaceMember' ||
       node.localName == 'surfaceMembers',
       'localName should be surfaceMember or surfaceMembers');
   ol.xml.parseNode(this.SURFACEMEMBER_PARSERS_,
@@ -167,9 +167,9 @@ ol.format.GML3.prototype.surfaceMemberParser_ = function(node, objectStack) {
  * @return {Array.<(Array.<number>)>|undefined} flat coordinates.
  */
 ol.format.GML3.prototype.readPatch_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'patches',
+  ol.DEBUG && console.assert(node.localName == 'patches',
       'localName should be patches');
   return ol.xml.pushParseAndPop([null],
       this.PATCHES_PARSERS_, node, objectStack, this);
@@ -183,9 +183,9 @@ ol.format.GML3.prototype.readPatch_ = function(node, objectStack) {
  * @return {Array.<number>|undefined} flat coordinates.
  */
 ol.format.GML3.prototype.readSegment_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'segments',
+  ol.DEBUG && console.assert(node.localName == 'segments',
       'localName should be segments');
   return ol.xml.pushParseAndPop([null],
       this.SEGMENTS_PARSERS_, node, objectStack, this);
@@ -199,9 +199,9 @@ ol.format.GML3.prototype.readSegment_ = function(node, objectStack) {
  * @return {Array.<(Array.<number>)>|undefined} flat coordinates.
  */
 ol.format.GML3.prototype.readPolygonPatch_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'npde.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'PolygonPatch',
+  ol.DEBUG && console.assert(node.localName == 'PolygonPatch',
       'localName should be PolygonPatch');
   return ol.xml.pushParseAndPop([null],
       this.FLAT_LINEAR_RINGS_PARSERS_, node, objectStack, this);
@@ -215,9 +215,9 @@ ol.format.GML3.prototype.readPolygonPatch_ = function(node, objectStack) {
  * @return {Array.<number>|undefined} flat coordinates.
  */
 ol.format.GML3.prototype.readLineStringSegment_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'LineStringSegment',
+  ol.DEBUG && console.assert(node.localName == 'LineStringSegment',
       'localName should be LineStringSegment');
   return ol.xml.pushParseAndPop([null],
       this.GEOMETRY_FLAT_COORDINATES_PARSERS_,
@@ -231,9 +231,9 @@ ol.format.GML3.prototype.readLineStringSegment_ = function(node, objectStack) {
  * @private
  */
 ol.format.GML3.prototype.interiorParser_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'interior',
+  ol.DEBUG && console.assert(node.localName == 'interior',
       'localName should be interior');
   /** @type {Array.<number>|undefined} */
   var flatLinearRing = ol.xml.pushParseAndPop(undefined,
@@ -241,9 +241,9 @@ ol.format.GML3.prototype.interiorParser_ = function(node, objectStack) {
   if (flatLinearRing) {
     var flatLinearRings = /** @type {Array.<Array.<number>>} */
         (objectStack[objectStack.length - 1]);
-    goog.DEBUG && console.assert(Array.isArray(flatLinearRings),
+    ol.DEBUG && console.assert(Array.isArray(flatLinearRings),
         'flatLinearRings should be an array');
-    goog.DEBUG && console.assert(flatLinearRings.length > 0,
+    ol.DEBUG && console.assert(flatLinearRings.length > 0,
         'flatLinearRings should have an array length of 1 or more');
     flatLinearRings.push(flatLinearRing);
   }
@@ -256,9 +256,9 @@ ol.format.GML3.prototype.interiorParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.GML3.prototype.exteriorParser_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'exterior',
+  ol.DEBUG && console.assert(node.localName == 'exterior',
       'localName should be exterior');
    /** @type {Array.<number>|undefined} */
   var flatLinearRing = ol.xml.pushParseAndPop(undefined,
@@ -266,9 +266,9 @@ ol.format.GML3.prototype.exteriorParser_ = function(node, objectStack) {
   if (flatLinearRing) {
     var flatLinearRings = /** @type {Array.<Array.<number>>} */
         (objectStack[objectStack.length - 1]);
-    goog.DEBUG && console.assert(Array.isArray(flatLinearRings),
+    ol.DEBUG && console.assert(Array.isArray(flatLinearRings),
         'flatLinearRings should be an array');
-    goog.DEBUG && console.assert(flatLinearRings.length > 0,
+    ol.DEBUG && console.assert(flatLinearRings.length > 0,
         'flatLinearRings should have an array length of 1 or more');
     flatLinearRings[0] = flatLinearRing;
   }
@@ -282,9 +282,9 @@ ol.format.GML3.prototype.exteriorParser_ = function(node, objectStack) {
  * @return {ol.geom.Polygon|undefined} Polygon.
  */
 ol.format.GML3.prototype.readSurface_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Surface',
+  ol.DEBUG && console.assert(node.localName == 'Surface',
       'localName should be Surface');
   /** @type {Array.<Array.<number>>} */
   var flatLinearRings = ol.xml.pushParseAndPop([null],
@@ -314,9 +314,9 @@ ol.format.GML3.prototype.readSurface_ = function(node, objectStack) {
  * @return {ol.geom.LineString|undefined} LineString.
  */
 ol.format.GML3.prototype.readCurve_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Curve', 'localName should be Curve');
+  ol.DEBUG && console.assert(node.localName == 'Curve', 'localName should be Curve');
   /** @type {Array.<number>} */
   var flatCoordinates = ol.xml.pushParseAndPop([null],
       this.CURVE_PARSERS_, node, objectStack, this);
@@ -337,9 +337,9 @@ ol.format.GML3.prototype.readCurve_ = function(node, objectStack) {
  * @return {ol.Extent|undefined} Envelope.
  */
 ol.format.GML3.prototype.readEnvelope_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Envelope',
+  ol.DEBUG && console.assert(node.localName == 'Envelope',
       'localName should be Envelope');
   /** @type {Array.<number>} */
   var flatCoordinates = ol.xml.pushParseAndPop([null],
@@ -718,7 +718,7 @@ ol.format.GML3.ENVELOPE_SERIALIZERS_ = {
  * @param {Array.<*>} objectStack Node stack.
  */
 ol.format.GML3.prototype.writeEnvelope = function(node, extent, objectStack) {
-  goog.DEBUG && console.assert(extent.length == 4, 'extent should have 4 items');
+  ol.DEBUG && console.assert(extent.length == 4, 'extent should have 4 items');
   var context = objectStack[objectStack.length - 1];
   var srsName = context['srsName'];
   if (srsName) {
@@ -1179,7 +1179,7 @@ ol.format.GML3.MULTIGEOMETRY_TO_MEMBER_NODENAME_ = {
  */
 ol.format.GML3.prototype.MULTIGEOMETRY_MEMBER_NODE_FACTORY_ = function(value, objectStack, opt_nodeName) {
   var parentNode = objectStack[objectStack.length - 1].node;
-  goog.DEBUG && console.assert(ol.xml.isNode(parentNode),
+  ol.DEBUG && console.assert(ol.xml.isNode(parentNode),
       'parentNode should be a node');
   return ol.xml.createElementNS('http://www.opengis.net/gml',
       ol.format.GML3.MULTIGEOMETRY_TO_MEMBER_NODENAME_[parentNode.nodeName]);
@@ -1201,7 +1201,7 @@ ol.format.GML3.prototype.GEOMETRY_NODE_FACTORY_ = function(value, objectStack, o
   var curve = context['curve'];
   var multiCurve = context['multiCurve'];
   var parentNode = objectStack[objectStack.length - 1].node;
-  goog.DEBUG && console.assert(ol.xml.isNode(parentNode),
+  ol.DEBUG && console.assert(ol.xml.isNode(parentNode),
       'parentNode should be a node');
   var nodeName;
   if (!Array.isArray(value)) {

--- a/src/ol/format/gmlbase.js
+++ b/src/ol/format/gmlbase.js
@@ -107,7 +107,7 @@ ol.format.GMLBase.ONLY_WHITESPACE_RE_ = /^[\s\xa0]*$/;
  * @return {Array.<ol.Feature> | undefined} Features.
  */
 ol.format.GMLBase.prototype.readFeaturesInternal = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
   var localName = node.localName;
   var features = null;
@@ -259,14 +259,14 @@ ol.format.GMLBase.prototype.readFeatureElement = function(node, objectStack) {
  * @return {ol.geom.Point|undefined} Point.
  */
 ol.format.GMLBase.prototype.readPoint = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Point', 'localName should be Point');
+  ol.DEBUG && console.assert(node.localName == 'Point', 'localName should be Point');
   var flatCoordinates =
       this.readFlatCoordinatesFromNode_(node, objectStack);
   if (flatCoordinates) {
     var point = new ol.geom.Point(null);
-    goog.DEBUG && console.assert(flatCoordinates.length == 3,
+    ol.DEBUG && console.assert(flatCoordinates.length == 3,
         'flatCoordinates should have a length of 3');
     point.setFlatCoordinates(ol.geom.GeometryLayout.XYZ, flatCoordinates);
     return point;
@@ -280,9 +280,9 @@ ol.format.GMLBase.prototype.readPoint = function(node, objectStack) {
  * @return {ol.geom.MultiPoint|undefined} MultiPoint.
  */
 ol.format.GMLBase.prototype.readMultiPoint = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'MultiPoint',
+  ol.DEBUG && console.assert(node.localName == 'MultiPoint',
       'localName should be MultiPoint');
   /** @type {Array.<Array.<number>>} */
   var coordinates = ol.xml.pushParseAndPop([],
@@ -301,9 +301,9 @@ ol.format.GMLBase.prototype.readMultiPoint = function(node, objectStack) {
  * @return {ol.geom.MultiLineString|undefined} MultiLineString.
  */
 ol.format.GMLBase.prototype.readMultiLineString = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'MultiLineString',
+  ol.DEBUG && console.assert(node.localName == 'MultiLineString',
       'localName should be MultiLineString');
   /** @type {Array.<ol.geom.LineString>} */
   var lineStrings = ol.xml.pushParseAndPop([],
@@ -324,9 +324,9 @@ ol.format.GMLBase.prototype.readMultiLineString = function(node, objectStack) {
  * @return {ol.geom.MultiPolygon|undefined} MultiPolygon.
  */
 ol.format.GMLBase.prototype.readMultiPolygon = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'MultiPolygon',
+  ol.DEBUG && console.assert(node.localName == 'MultiPolygon',
       'localName should be MultiPolygon');
   /** @type {Array.<ol.geom.Polygon>} */
   var polygons = ol.xml.pushParseAndPop([],
@@ -347,9 +347,9 @@ ol.format.GMLBase.prototype.readMultiPolygon = function(node, objectStack) {
  * @private
  */
 ol.format.GMLBase.prototype.pointMemberParser_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'pointMember' ||
+  ol.DEBUG && console.assert(node.localName == 'pointMember' ||
       node.localName == 'pointMembers',
       'localName should be pointMember or pointMembers');
   ol.xml.parseNode(this.POINTMEMBER_PARSERS_,
@@ -363,9 +363,9 @@ ol.format.GMLBase.prototype.pointMemberParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.GMLBase.prototype.lineStringMemberParser_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'lineStringMember' ||
+  ol.DEBUG && console.assert(node.localName == 'lineStringMember' ||
       node.localName == 'lineStringMembers',
       'localName should be LineStringMember or LineStringMembers');
   ol.xml.parseNode(this.LINESTRINGMEMBER_PARSERS_,
@@ -379,9 +379,9 @@ ol.format.GMLBase.prototype.lineStringMemberParser_ = function(node, objectStack
  * @private
  */
 ol.format.GMLBase.prototype.polygonMemberParser_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'polygonMember' ||
+  ol.DEBUG && console.assert(node.localName == 'polygonMember' ||
       node.localName == 'polygonMembers',
       'localName should be polygonMember or polygonMembers');
   ol.xml.parseNode(this.POLYGONMEMBER_PARSERS_, node,
@@ -395,9 +395,9 @@ ol.format.GMLBase.prototype.polygonMemberParser_ = function(node, objectStack) {
  * @return {ol.geom.LineString|undefined} LineString.
  */
 ol.format.GMLBase.prototype.readLineString = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'LineString',
+  ol.DEBUG && console.assert(node.localName == 'LineString',
       'localName should be LineString');
   var flatCoordinates =
       this.readFlatCoordinatesFromNode_(node, objectStack);
@@ -418,9 +418,9 @@ ol.format.GMLBase.prototype.readLineString = function(node, objectStack) {
  * @return {Array.<number>|undefined} LinearRing flat coordinates.
  */
 ol.format.GMLBase.prototype.readFlatLinearRing_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'LinearRing',
+  ol.DEBUG && console.assert(node.localName == 'LinearRing',
       'localName should be LinearRing');
   var ring = ol.xml.pushParseAndPop(null,
       this.GEOMETRY_FLAT_COORDINATES_PARSERS_, node,
@@ -439,9 +439,9 @@ ol.format.GMLBase.prototype.readFlatLinearRing_ = function(node, objectStack) {
  * @return {ol.geom.LinearRing|undefined} LinearRing.
  */
 ol.format.GMLBase.prototype.readLinearRing = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'LinearRing',
+  ol.DEBUG && console.assert(node.localName == 'LinearRing',
       'localName should be LinearRing');
   var flatCoordinates =
       this.readFlatCoordinatesFromNode_(node, objectStack);
@@ -461,9 +461,9 @@ ol.format.GMLBase.prototype.readLinearRing = function(node, objectStack) {
  * @return {ol.geom.Polygon|undefined} Polygon.
  */
 ol.format.GMLBase.prototype.readPolygon = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Polygon',
+  ol.DEBUG && console.assert(node.localName == 'Polygon',
       'localName should be Polygon');
   /** @type {Array.<Array.<number>>} */
   var flatLinearRings = ol.xml.pushParseAndPop([null],
@@ -493,7 +493,7 @@ ol.format.GMLBase.prototype.readPolygon = function(node, objectStack) {
  * @return {Array.<number>} Flat coordinates.
  */
 ol.format.GMLBase.prototype.readFlatCoordinatesFromNode_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
   return ol.xml.pushParseAndPop(null,
       this.GEOMETRY_FLAT_COORDINATES_PARSERS_, node,

--- a/src/ol/format/gpx.js
+++ b/src/ol/format/gpx.js
@@ -72,7 +72,7 @@ ol.format.GPX.SCHEMA_LOCATION_ = 'http://www.topografix.com/GPX/1/1 ' +
  * @return {Array.<number>} Flat coordinates.
  */
 ol.format.GPX.appendCoordinate_ = function(flatCoordinates, node, values) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
   flatCoordinates.push(
       parseFloat(node.getAttribute('lon')),
@@ -99,9 +99,9 @@ ol.format.GPX.appendCoordinate_ = function(flatCoordinates, node, values) {
  * @private
  */
 ol.format.GPX.parseLink_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'link', 'localName should be link');
+  ol.DEBUG && console.assert(node.localName == 'link', 'localName should be link');
   var values = /** @type {Object} */ (objectStack[objectStack.length - 1]);
   var href = node.getAttribute('href');
   if (href !== null) {
@@ -117,9 +117,9 @@ ol.format.GPX.parseLink_ = function(node, objectStack) {
  * @private
  */
 ol.format.GPX.parseExtensions_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'extensions',
+  ol.DEBUG && console.assert(node.localName == 'extensions',
       'localName should be extensions');
   var values = /** @type {Object} */ (objectStack[objectStack.length - 1]);
   values['extensionsNode_'] = node;
@@ -132,9 +132,9 @@ ol.format.GPX.parseExtensions_ = function(node, objectStack) {
  * @private
  */
 ol.format.GPX.parseRtePt_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'rtept', 'localName should be rtept');
+  ol.DEBUG && console.assert(node.localName == 'rtept', 'localName should be rtept');
   var values = ol.xml.pushParseAndPop(
       {}, ol.format.GPX.RTEPT_PARSERS_, node, objectStack);
   if (values) {
@@ -152,9 +152,9 @@ ol.format.GPX.parseRtePt_ = function(node, objectStack) {
  * @private
  */
 ol.format.GPX.parseTrkPt_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'trkpt', 'localName should be trkpt');
+  ol.DEBUG && console.assert(node.localName == 'trkpt', 'localName should be trkpt');
   var values = ol.xml.pushParseAndPop(
       {}, ol.format.GPX.TRKPT_PARSERS_, node, objectStack);
   if (values) {
@@ -172,9 +172,9 @@ ol.format.GPX.parseTrkPt_ = function(node, objectStack) {
  * @private
  */
 ol.format.GPX.parseTrkSeg_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'trkseg',
+  ol.DEBUG && console.assert(node.localName == 'trkseg',
       'localName should be trkseg');
   var values = /** @type {Object} */ (objectStack[objectStack.length - 1]);
   ol.xml.parseNode(ol.format.GPX.TRKSEG_PARSERS_, node, objectStack);
@@ -192,9 +192,9 @@ ol.format.GPX.parseTrkSeg_ = function(node, objectStack) {
  * @return {ol.Feature|undefined} Track.
  */
 ol.format.GPX.readRte_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'rte', 'localName should be rte');
+  ol.DEBUG && console.assert(node.localName == 'rte', 'localName should be rte');
   var options = /** @type {olx.format.ReadOptions} */ (objectStack[0]);
   var values = ol.xml.pushParseAndPop({
     'flatCoordinates': []
@@ -221,9 +221,9 @@ ol.format.GPX.readRte_ = function(node, objectStack) {
  * @return {ol.Feature|undefined} Track.
  */
 ol.format.GPX.readTrk_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'trk', 'localName should be trk');
+  ol.DEBUG && console.assert(node.localName == 'trk', 'localName should be trk');
   var options = /** @type {olx.format.ReadOptions} */ (objectStack[0]);
   var values = ol.xml.pushParseAndPop({
     'flatCoordinates': [],
@@ -254,9 +254,9 @@ ol.format.GPX.readTrk_ = function(node, objectStack) {
  * @return {ol.Feature|undefined} Waypoint.
  */
 ol.format.GPX.readWpt_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'wpt', 'localName should be wpt');
+  ol.DEBUG && console.assert(node.localName == 'wpt', 'localName should be wpt');
   var options = /** @type {olx.format.ReadOptions} */ (objectStack[0]);
   var values = ol.xml.pushParseAndPop(
       {}, ol.format.GPX.WPT_PARSERS_, node, objectStack);
@@ -456,7 +456,7 @@ ol.format.GPX.prototype.readFeature;
  * @inheritDoc
  */
 ol.format.GPX.prototype.readFeatureFromNode = function(node, opt_options) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
   if (!ol.array.includes(ol.format.GPX.NAMESPACE_URIS_, node.namespaceURI)) {
     return null;
@@ -492,7 +492,7 @@ ol.format.GPX.prototype.readFeatures;
  * @inheritDoc
  */
 ol.format.GPX.prototype.readFeaturesFromNode = function(node, opt_options) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
   if (!ol.array.includes(ol.format.GPX.NAMESPACE_URIS_, node.namespaceURI)) {
     return [];
@@ -552,7 +552,7 @@ ol.format.GPX.writeLink_ = function(node, value, objectStack) {
 ol.format.GPX.writeWptType_ = function(node, coordinate, objectStack) {
   var context = objectStack[objectStack.length - 1];
   var parentNode = context.node;
-  goog.DEBUG && console.assert(ol.xml.isNode(parentNode),
+  ol.DEBUG && console.assert(ol.xml.isNode(parentNode),
       'parentNode should be an XML node');
   var namespaceURI = parentNode.namespaceURI;
   var properties = context['properties'];
@@ -859,7 +859,7 @@ ol.format.GPX.GPX_NODE_FACTORY_ = function(value, objectStack, opt_nodeName) {
     var nodeName = ol.format.GPX.GEOMETRY_TYPE_TO_NODENAME_[geometry.getType()];
     if (nodeName) {
       var parentNode = objectStack[objectStack.length - 1].node;
-      goog.DEBUG && console.assert(ol.xml.isNode(parentNode),
+      ol.DEBUG && console.assert(ol.xml.isNode(parentNode),
           'parentNode should be an XML node');
       return ol.xml.createElementNS(parentNode.namespaceURI, nodeName);
     }

--- a/src/ol/format/igc.js
+++ b/src/ol/format/igc.js
@@ -154,7 +154,7 @@ ol.format.IGC.prototype.readFeatureFromText = function(text, opt_options) {
           } else if (altitudeMode == ol.format.IGCZ.BAROMETRIC) {
             z = parseInt(m[12], 10);
           } else {
-            goog.DEBUG && console.assert(false, 'Unknown altitude mode.');
+            ol.DEBUG && console.assert(false, 'Unknown altitude mode.');
             z = 0;
           }
           flatCoordinates.push(z);

--- a/src/ol/format/kml.js
+++ b/src/ol/format/kml.js
@@ -559,9 +559,9 @@ ol.format.KML.readStyleMapValue_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.IconStyleParser_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be an ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'IconStyle',
+  ol.DEBUG && console.assert(node.localName == 'IconStyle',
       'localName should be IconStyle');
   // FIXME refreshMode
   // FIXME refreshInterval
@@ -670,9 +670,9 @@ ol.format.KML.IconStyleParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.LabelStyleParser_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'LabelStyle',
+  ol.DEBUG && console.assert(node.localName == 'LabelStyle',
       'localName should be LabelStyle');
   // FIXME colorMode
   var object = ol.xml.pushParseAndPop(
@@ -699,9 +699,9 @@ ol.format.KML.LabelStyleParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.LineStyleParser_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'LineStyle',
+  ol.DEBUG && console.assert(node.localName == 'LineStyle',
       'localName should be LineStyle');
   // FIXME colorMode
   // FIXME gx:outerColor
@@ -729,9 +729,9 @@ ol.format.KML.LineStyleParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.PolyStyleParser_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'PolyStyle',
+  ol.DEBUG && console.assert(node.localName == 'PolyStyle',
       'localName should be PolyStyle');
   // FIXME colorMode
   var object = ol.xml.pushParseAndPop(
@@ -764,9 +764,9 @@ ol.format.KML.PolyStyleParser_ = function(node, objectStack) {
  * @return {Array.<number>} LinearRing flat coordinates.
  */
 ol.format.KML.readFlatLinearRing_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'LinearRing',
+  ol.DEBUG && console.assert(node.localName == 'LinearRing',
       'localName should be LinearRing');
   return ol.xml.pushParseAndPop(null,
       ol.format.KML.FLAT_LINEAR_RING_PARSERS_, node, objectStack);
@@ -779,12 +779,12 @@ ol.format.KML.readFlatLinearRing_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.gxCoordParser_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(ol.array.includes(
+  ol.DEBUG && console.assert(ol.array.includes(
       ol.format.KML.GX_NAMESPACE_URIS_, node.namespaceURI),
       'namespaceURI of the node should be known to the KML parser');
-  goog.DEBUG && console.assert(node.localName == 'coord', 'localName should be coord');
+  ol.DEBUG && console.assert(node.localName == 'coord', 'localName should be coord');
   var gxTrackObject = /** @type {ol.KMLGxTrackObject_} */
       (objectStack[objectStack.length - 1]);
   var flatCoordinates = gxTrackObject.flatCoordinates;
@@ -810,12 +810,12 @@ ol.format.KML.gxCoordParser_ = function(node, objectStack) {
  * @return {ol.geom.MultiLineString|undefined} MultiLineString.
  */
 ol.format.KML.readGxMultiTrack_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(ol.array.includes(
+  ol.DEBUG && console.assert(ol.array.includes(
       ol.format.KML.GX_NAMESPACE_URIS_, node.namespaceURI),
       'namespaceURI of the node should be known to the KML parser');
-  goog.DEBUG && console.assert(node.localName == 'MultiTrack',
+  ol.DEBUG && console.assert(node.localName == 'MultiTrack',
       'localName should be MultiTrack');
   var lineStrings = ol.xml.pushParseAndPop([],
       ol.format.KML.GX_MULTITRACK_GEOMETRY_PARSERS_, node, objectStack);
@@ -835,12 +835,12 @@ ol.format.KML.readGxMultiTrack_ = function(node, objectStack) {
  * @return {ol.geom.LineString|undefined} LineString.
  */
 ol.format.KML.readGxTrack_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(ol.array.includes(
+  ol.DEBUG && console.assert(ol.array.includes(
       ol.format.KML.GX_NAMESPACE_URIS_, node.namespaceURI),
       'namespaceURI of the node should be known to the KML parser');
-  goog.DEBUG && console.assert(node.localName == 'Track', 'localName should be Track');
+  ol.DEBUG && console.assert(node.localName == 'Track', 'localName should be Track');
   var gxTrackObject = ol.xml.pushParseAndPop(
       /** @type {ol.KMLGxTrackObject_} */ ({
         flatCoordinates: [],
@@ -851,7 +851,7 @@ ol.format.KML.readGxTrack_ = function(node, objectStack) {
   }
   var flatCoordinates = gxTrackObject.flatCoordinates;
   var whens = gxTrackObject.whens;
-  goog.DEBUG && console.assert(flatCoordinates.length / 4 == whens.length,
+  ol.DEBUG && console.assert(flatCoordinates.length / 4 == whens.length,
       'the length of the flatCoordinates array divided by 4 should be the ' +
       'length of the whens array');
   var i, ii;
@@ -872,9 +872,9 @@ ol.format.KML.readGxTrack_ = function(node, objectStack) {
  * @return {Object} Icon object.
  */
 ol.format.KML.readIcon_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Icon', 'localName should be Icon');
+  ol.DEBUG && console.assert(node.localName == 'Icon', 'localName should be Icon');
   var iconObject = ol.xml.pushParseAndPop(
       {}, ol.format.KML.ICON_PARSERS_, node, objectStack);
   if (iconObject) {
@@ -892,7 +892,7 @@ ol.format.KML.readIcon_ = function(node, objectStack) {
  * @return {Array.<number>} Flat coordinates.
  */
 ol.format.KML.readFlatCoordinatesFromNode_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
   return ol.xml.pushParseAndPop(null,
       ol.format.KML.GEOMETRY_FLAT_COORDINATES_PARSERS_, node, objectStack);
@@ -906,9 +906,9 @@ ol.format.KML.readFlatCoordinatesFromNode_ = function(node, objectStack) {
  * @return {ol.geom.LineString|undefined} LineString.
  */
 ol.format.KML.readLineString_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'LineString',
+  ol.DEBUG && console.assert(node.localName == 'LineString',
       'localName should be LineString');
   var properties = ol.xml.pushParseAndPop({},
       ol.format.KML.EXTRUDE_AND_ALTITUDE_MODE_PARSERS_, node,
@@ -933,9 +933,9 @@ ol.format.KML.readLineString_ = function(node, objectStack) {
  * @return {ol.geom.Polygon|undefined} Polygon.
  */
 ol.format.KML.readLinearRing_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'LinearRing',
+  ol.DEBUG && console.assert(node.localName == 'LinearRing',
       'localName should be LinearRing');
   var properties = ol.xml.pushParseAndPop({},
       ol.format.KML.EXTRUDE_AND_ALTITUDE_MODE_PARSERS_, node,
@@ -961,9 +961,9 @@ ol.format.KML.readLinearRing_ = function(node, objectStack) {
  * @return {ol.geom.Geometry} Geometry.
  */
 ol.format.KML.readMultiGeometry_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'MultiGeometry',
+  ol.DEBUG && console.assert(node.localName == 'MultiGeometry',
       'localName should be MultiGeometry');
   var geometries = ol.xml.pushParseAndPop([],
       ol.format.KML.MULTI_GEOMETRY_PARSERS_, node, objectStack);
@@ -994,7 +994,7 @@ ol.format.KML.readMultiGeometry_ = function(node, objectStack) {
       flatCoordinates = point.getFlatCoordinates();
       for (i = 1, ii = geometries.length; i < ii; ++i) {
         geometry = geometries[i];
-        goog.DEBUG && console.assert(geometry.getLayout() == layout,
+        ol.DEBUG && console.assert(geometry.getLayout() == layout,
             'geometry layout should be consistent');
         ol.array.extend(flatCoordinates, geometry.getFlatCoordinates());
       }
@@ -1028,9 +1028,9 @@ ol.format.KML.readMultiGeometry_ = function(node, objectStack) {
  * @return {ol.geom.Point|undefined} Point.
  */
 ol.format.KML.readPoint_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Point', 'localName should be Point');
+  ol.DEBUG && console.assert(node.localName == 'Point', 'localName should be Point');
   var properties = ol.xml.pushParseAndPop({},
       ol.format.KML.EXTRUDE_AND_ALTITUDE_MODE_PARSERS_, node,
       objectStack);
@@ -1038,7 +1038,7 @@ ol.format.KML.readPoint_ = function(node, objectStack) {
       ol.format.KML.readFlatCoordinatesFromNode_(node, objectStack);
   if (flatCoordinates) {
     var point = new ol.geom.Point(null);
-    goog.DEBUG && console.assert(flatCoordinates.length == 3,
+    ol.DEBUG && console.assert(flatCoordinates.length == 3,
         'flatCoordinates should have a length of 3');
     point.setFlatCoordinates(ol.geom.GeometryLayout.XYZ, flatCoordinates);
     point.setProperties(properties);
@@ -1056,9 +1056,9 @@ ol.format.KML.readPoint_ = function(node, objectStack) {
  * @return {ol.geom.Polygon|undefined} Polygon.
  */
 ol.format.KML.readPolygon_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Polygon',
+  ol.DEBUG && console.assert(node.localName == 'Polygon',
       'localName should be Polygon');
   var properties = ol.xml.pushParseAndPop(/** @type {Object<string,*>} */ ({}),
       ol.format.KML.EXTRUDE_AND_ALTITUDE_MODE_PARSERS_, node,
@@ -1091,9 +1091,9 @@ ol.format.KML.readPolygon_ = function(node, objectStack) {
  * @return {Array.<ol.style.Style>} Style.
  */
 ol.format.KML.readStyle_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Style', 'localName should be Style');
+  ol.DEBUG && console.assert(node.localName == 'Style', 'localName should be Style');
   var styleObject = ol.xml.pushParseAndPop(
       {}, ol.format.KML.STYLE_PARSERS_, node, objectStack);
   if (!styleObject) {
@@ -1170,9 +1170,9 @@ ol.format.KML.setCommonGeometryProperties_ = function(multiGeometry,
  * @private
  */
 ol.format.KML.DataParser_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Data', 'localName should be Data');
+  ol.DEBUG && console.assert(node.localName == 'Data', 'localName should be Data');
   var name = node.getAttribute('name');
   if (name !== null) {
     var data = ol.xml.pushParseAndPop(
@@ -1192,9 +1192,9 @@ ol.format.KML.DataParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.ExtendedDataParser_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'ExtendedData',
+  ol.DEBUG && console.assert(node.localName == 'ExtendedData',
       'localName should be ExtendedData');
   ol.xml.parseNode(ol.format.KML.EXTENDED_DATA_PARSERS_, node, objectStack);
 };
@@ -1206,9 +1206,9 @@ ol.format.KML.ExtendedDataParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.PairDataParser_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Pair', 'localName should be Pair');
+  ol.DEBUG && console.assert(node.localName == 'Pair', 'localName should be Pair');
   var pairObject = ol.xml.pushParseAndPop(
       {}, ol.format.KML.PAIR_PARSERS_, node, objectStack);
   if (!pairObject) {
@@ -1237,9 +1237,9 @@ ol.format.KML.PairDataParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.PlacemarkStyleMapParser_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'StyleMap',
+  ol.DEBUG && console.assert(node.localName == 'StyleMap',
       'localName should be StyleMap');
   var styleMapValue = ol.format.KML.readStyleMapValue_(node, objectStack);
   if (!styleMapValue) {
@@ -1262,9 +1262,9 @@ ol.format.KML.PlacemarkStyleMapParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.SchemaDataParser_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'SchemaData',
+  ol.DEBUG && console.assert(node.localName == 'SchemaData',
       'localName should be SchemaData');
   ol.xml.parseNode(ol.format.KML.SCHEMA_DATA_PARSERS_, node, objectStack);
 };
@@ -1276,9 +1276,9 @@ ol.format.KML.SchemaDataParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.SimpleDataParser_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'SimpleData',
+  ol.DEBUG && console.assert(node.localName == 'SimpleData',
       'localName should be SimpleData');
   var name = node.getAttribute('name');
   if (name !== null) {
@@ -1296,9 +1296,9 @@ ol.format.KML.SimpleDataParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.innerBoundaryIsParser_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'innerBoundaryIs',
+  ol.DEBUG && console.assert(node.localName == 'innerBoundaryIs',
       'localName should be innerBoundaryIs');
   /** @type {Array.<number>|undefined} */
   var flatLinearRing = ol.xml.pushParseAndPop(undefined,
@@ -1306,9 +1306,9 @@ ol.format.KML.innerBoundaryIsParser_ = function(node, objectStack) {
   if (flatLinearRing) {
     var flatLinearRings = /** @type {Array.<Array.<number>>} */
         (objectStack[objectStack.length - 1]);
-    goog.DEBUG && console.assert(Array.isArray(flatLinearRings),
+    ol.DEBUG && console.assert(Array.isArray(flatLinearRings),
         'flatLinearRings should be an array');
-    goog.DEBUG && console.assert(flatLinearRings.length > 0,
+    ol.DEBUG && console.assert(flatLinearRings.length > 0,
         'flatLinearRings array should not be empty');
     flatLinearRings.push(flatLinearRing);
   }
@@ -1321,9 +1321,9 @@ ol.format.KML.innerBoundaryIsParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.outerBoundaryIsParser_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'outerBoundaryIs',
+  ol.DEBUG && console.assert(node.localName == 'outerBoundaryIs',
       'localName should be outerBoundaryIs');
   /** @type {Array.<number>|undefined} */
   var flatLinearRing = ol.xml.pushParseAndPop(undefined,
@@ -1331,9 +1331,9 @@ ol.format.KML.outerBoundaryIsParser_ = function(node, objectStack) {
   if (flatLinearRing) {
     var flatLinearRings = /** @type {Array.<Array.<number>>} */
         (objectStack[objectStack.length - 1]);
-    goog.DEBUG && console.assert(Array.isArray(flatLinearRings),
+    ol.DEBUG && console.assert(Array.isArray(flatLinearRings),
         'flatLinearRings should be an array');
-    goog.DEBUG && console.assert(flatLinearRings.length > 0,
+    ol.DEBUG && console.assert(flatLinearRings.length > 0,
         'flatLinearRings array should not be empty');
     flatLinearRings[0] = flatLinearRing;
   }
@@ -1346,9 +1346,9 @@ ol.format.KML.outerBoundaryIsParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.LinkParser_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Link', 'localName should be Link');
+  ol.DEBUG && console.assert(node.localName == 'Link', 'localName should be Link');
   ol.xml.parseNode(ol.format.KML.LINK_PARSERS_, node, objectStack);
 };
 
@@ -1359,9 +1359,9 @@ ol.format.KML.LinkParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.whenParser_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'when', 'localName should be when');
+  ol.DEBUG && console.assert(node.localName == 'when', 'localName should be when');
   var gxTrackObject = /** @type {ol.KMLGxTrackObject_} */
       (objectStack[objectStack.length - 1]);
   var whens = gxTrackObject.whens;
@@ -1700,10 +1700,10 @@ ol.format.KML.prototype.getExtensions = function() {
  * @return {Array.<ol.Feature>|undefined} Features.
  */
 ol.format.KML.prototype.readDocumentOrFolder_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
   var localName = node.localName;
-  goog.DEBUG && console.assert(localName == 'Document' || localName == 'Folder',
+  ol.DEBUG && console.assert(localName == 'Document' || localName == 'Folder',
       'localName should be Document or Folder');
   // FIXME use scope somehow
   var parsersNS = ol.xml.makeStructureNS(
@@ -1731,9 +1731,9 @@ ol.format.KML.prototype.readDocumentOrFolder_ = function(node, objectStack) {
  * @return {ol.Feature|undefined} Feature.
  */
 ol.format.KML.prototype.readPlacemark_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Placemark',
+  ol.DEBUG && console.assert(node.localName == 'Placemark',
       'localName should be Placemark');
   var object = ol.xml.pushParseAndPop({'geometry': null},
       ol.format.KML.PLACEMARK_PARSERS_, node, objectStack);
@@ -1778,9 +1778,9 @@ ol.format.KML.prototype.readPlacemark_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.prototype.readSharedStyle_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Style', 'localName should be Style');
+  ol.DEBUG && console.assert(node.localName == 'Style', 'localName should be Style');
   var id = node.getAttribute('id');
   if (id !== null) {
     var style = ol.format.KML.readStyle_(node, objectStack);
@@ -1804,9 +1804,9 @@ ol.format.KML.prototype.readSharedStyle_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.prototype.readSharedStyleMap_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'StyleMap',
+  ol.DEBUG && console.assert(node.localName == 'StyleMap',
       'localName should be StyleMap');
   var id = node.getAttribute('id');
   if (id === null) {
@@ -1845,12 +1845,12 @@ ol.format.KML.prototype.readFeature;
  * @inheritDoc
  */
 ol.format.KML.prototype.readFeatureFromNode = function(node, opt_options) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
   if (!ol.array.includes(ol.format.KML.NAMESPACE_URIS_, node.namespaceURI)) {
     return null;
   }
-  goog.DEBUG && console.assert(node.localName == 'Placemark',
+  ol.DEBUG && console.assert(node.localName == 'Placemark',
       'localName should be Placemark');
   var feature = this.readPlacemark_(
       node, [this.getReadOptions(node, opt_options)]);
@@ -1880,7 +1880,7 @@ ol.format.KML.prototype.readFeatures;
  * @inheritDoc
  */
 ol.format.KML.prototype.readFeaturesFromNode = function(node, opt_options) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
   if (!ol.array.includes(ol.format.KML.NAMESPACE_URIS_, node.namespaceURI)) {
     return [];
@@ -2376,7 +2376,7 @@ ol.format.KML.writePlacemark_ = function(node, feature, objectStack) {
  * @private
  */
 ol.format.KML.writePrimitiveGeometry_ = function(node, geometry, objectStack) {
-  goog.DEBUG && console.assert(
+  ol.DEBUG && console.assert(
       (geometry instanceof ol.geom.Point) ||
       (geometry instanceof ol.geom.LineString) ||
       (geometry instanceof ol.geom.LinearRing),
@@ -2401,7 +2401,7 @@ ol.format.KML.writePrimitiveGeometry_ = function(node, geometry, objectStack) {
  */
 ol.format.KML.writePolygon_ = function(node, polygon, objectStack) {
   var linearRings = polygon.getLinearRings();
-  goog.DEBUG && console.assert(linearRings.length > 0,
+  ol.DEBUG && console.assert(linearRings.length > 0,
       'linearRings should not be empty');
   var outerRing = linearRings.shift();
   var /** @type {ol.XmlNodeStackItem} */ context = {node: node};
@@ -2800,7 +2800,7 @@ ol.format.KML.GX_NODE_FACTORY_ = function(value, objectStack, opt_nodeName) {
 ol.format.KML.DOCUMENT_NODE_FACTORY_ = function(value, objectStack,
     opt_nodeName) {
   var parentNode = objectStack[objectStack.length - 1].node;
-  goog.DEBUG && console.assert(ol.xml.isNode(parentNode),
+  ol.DEBUG && console.assert(ol.xml.isNode(parentNode),
       'parentNode should be an XML node');
   return ol.xml.createElementNS(parentNode.namespaceURI, 'Placemark');
 };
@@ -2818,7 +2818,7 @@ ol.format.KML.GEOMETRY_NODE_FACTORY_ = function(value, objectStack,
     opt_nodeName) {
   if (value) {
     var parentNode = objectStack[objectStack.length - 1].node;
-    goog.DEBUG && console.assert(ol.xml.isNode(parentNode),
+    ol.DEBUG && console.assert(ol.xml.isNode(parentNode),
         'parentNode should be an XML node');
     return ol.xml.createElementNS(parentNode.namespaceURI,
         ol.format.KML.GEOMETRY_TYPE_TO_NODENAME_[/** @type {ol.geom.Geometry} */ (value).getType()]);

--- a/src/ol/format/osmxml.js
+++ b/src/ol/format/osmxml.js
@@ -57,9 +57,9 @@ ol.format.OSMXML.prototype.getExtensions = function() {
  * @private
  */
 ol.format.OSMXML.readNode_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'node', 'localName should be node');
+  ol.DEBUG && console.assert(node.localName == 'node', 'localName should be node');
   var options = /** @type {olx.format.ReadOptions} */ (objectStack[0]);
   var state = /** @type {Object} */ (objectStack[objectStack.length - 1]);
   var id = node.getAttribute('id');
@@ -90,9 +90,9 @@ ol.format.OSMXML.readNode_ = function(node, objectStack) {
  * @private
  */
 ol.format.OSMXML.readWay_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'way', 'localName should be way');
+  ol.DEBUG && console.assert(node.localName == 'way', 'localName should be way');
   var options = /** @type {olx.format.ReadOptions} */ (objectStack[0]);
   var id = node.getAttribute('id');
   var values = ol.xml.pushParseAndPop({
@@ -130,9 +130,9 @@ ol.format.OSMXML.readWay_ = function(node, objectStack) {
  * @private
  */
 ol.format.OSMXML.readNd_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'nd', 'localName should be nd');
+  ol.DEBUG && console.assert(node.localName == 'nd', 'localName should be nd');
   var values = /** @type {Object} */ (objectStack[objectStack.length - 1]);
   values.ndrefs.push(node.getAttribute('ref'));
 };
@@ -144,9 +144,9 @@ ol.format.OSMXML.readNd_ = function(node, objectStack) {
  * @private
  */
 ol.format.OSMXML.readTag_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'tag', 'localName should be tag');
+  ol.DEBUG && console.assert(node.localName == 'tag', 'localName should be tag');
   var values = /** @type {Object} */ (objectStack[objectStack.length - 1]);
   values.tags[node.getAttribute('k')] = node.getAttribute('v');
 };
@@ -213,7 +213,7 @@ ol.format.OSMXML.prototype.readFeatures;
  * @inheritDoc
  */
 ol.format.OSMXML.prototype.readFeaturesFromNode = function(node, opt_options) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
   var options = this.getReadOptions(node, opt_options);
   if (node.localName == 'osm') {

--- a/src/ol/format/ows.js
+++ b/src/ol/format/ows.js
@@ -22,7 +22,7 @@ ol.inherits(ol.format.OWS, ol.format.XML);
  * @return {Object} OWS object.
  */
 ol.format.OWS.prototype.readFromDocument = function(doc) {
-  goog.DEBUG && console.assert(doc.nodeType == Node.DOCUMENT_NODE,
+  ol.DEBUG && console.assert(doc.nodeType == Node.DOCUMENT_NODE,
       'doc.nodeType should be DOCUMENT');
   for (var n = doc.firstChild; n; n = n.nextSibling) {
     if (n.nodeType == Node.ELEMENT_NODE) {
@@ -38,7 +38,7 @@ ol.format.OWS.prototype.readFromDocument = function(doc) {
  * @return {Object} OWS object.
  */
 ol.format.OWS.prototype.readFromNode = function(node) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
   var owsObject = ol.xml.pushParseAndPop({},
       ol.format.OWS.PARSERS_, node, []);
@@ -53,9 +53,9 @@ ol.format.OWS.prototype.readFromNode = function(node) {
  * @return {Object|undefined} The address.
  */
 ol.format.OWS.readAddress_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Address',
+  ol.DEBUG && console.assert(node.localName == 'Address',
       'localName should be Address');
   return ol.xml.pushParseAndPop({},
       ol.format.OWS.ADDRESS_PARSERS_, node, objectStack);
@@ -69,9 +69,9 @@ ol.format.OWS.readAddress_ = function(node, objectStack) {
  * @return {Object|undefined} The values.
  */
 ol.format.OWS.readAllowedValues_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'AllowedValues',
+  ol.DEBUG && console.assert(node.localName == 'AllowedValues',
       'localName should be AllowedValues');
   return ol.xml.pushParseAndPop({},
       ol.format.OWS.ALLOWED_VALUES_PARSERS_, node, objectStack);
@@ -85,9 +85,9 @@ ol.format.OWS.readAllowedValues_ = function(node, objectStack) {
  * @return {Object|undefined} The constraint.
  */
 ol.format.OWS.readConstraint_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Constraint',
+  ol.DEBUG && console.assert(node.localName == 'Constraint',
       'localName should be Constraint');
   var name = node.getAttribute('name');
   if (!name) {
@@ -106,9 +106,9 @@ ol.format.OWS.readConstraint_ = function(node, objectStack) {
  * @return {Object|undefined} The contact info.
  */
 ol.format.OWS.readContactInfo_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'ContactInfo',
+  ol.DEBUG && console.assert(node.localName == 'ContactInfo',
       'localName should be ContactInfo');
   return ol.xml.pushParseAndPop({},
       ol.format.OWS.CONTACT_INFO_PARSERS_, node, objectStack);
@@ -122,9 +122,9 @@ ol.format.OWS.readContactInfo_ = function(node, objectStack) {
  * @return {Object|undefined} The DCP.
  */
 ol.format.OWS.readDcp_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'DCP', 'localName should be DCP');
+  ol.DEBUG && console.assert(node.localName == 'DCP', 'localName should be DCP');
   return ol.xml.pushParseAndPop({},
       ol.format.OWS.DCP_PARSERS_, node, objectStack);
 };
@@ -137,9 +137,9 @@ ol.format.OWS.readDcp_ = function(node, objectStack) {
  * @return {Object|undefined} The GET object.
  */
 ol.format.OWS.readGet_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Get', 'localName should be Get');
+  ol.DEBUG && console.assert(node.localName == 'Get', 'localName should be Get');
   var href = ol.format.XLink.readHref(node);
   if (!href) {
     return undefined;
@@ -156,9 +156,9 @@ ol.format.OWS.readGet_ = function(node, objectStack) {
  * @return {Object|undefined} The HTTP object.
  */
 ol.format.OWS.readHttp_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'HTTP', 'localName should be HTTP');
+  ol.DEBUG && console.assert(node.localName == 'HTTP', 'localName should be HTTP');
   return ol.xml.pushParseAndPop({}, ol.format.OWS.HTTP_PARSERS_,
       node, objectStack);
 };
@@ -171,9 +171,9 @@ ol.format.OWS.readHttp_ = function(node, objectStack) {
  * @return {Object|undefined} The operation.
  */
 ol.format.OWS.readOperation_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Operation',
+  ol.DEBUG && console.assert(node.localName == 'Operation',
       'localName should be Operation');
   var name = node.getAttribute('name');
   var value = ol.xml.pushParseAndPop({},
@@ -196,9 +196,9 @@ ol.format.OWS.readOperation_ = function(node, objectStack) {
  */
 ol.format.OWS.readOperationsMetadata_ = function(node,
     objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'OperationsMetadata',
+  ol.DEBUG && console.assert(node.localName == 'OperationsMetadata',
       'localName should be OperationsMetadata');
   return ol.xml.pushParseAndPop({},
       ol.format.OWS.OPERATIONS_METADATA_PARSERS_, node,
@@ -213,9 +213,9 @@ ol.format.OWS.readOperationsMetadata_ = function(node,
  * @return {Object|undefined} The phone.
  */
 ol.format.OWS.readPhone_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Phone', 'localName should be Phone');
+  ol.DEBUG && console.assert(node.localName == 'Phone', 'localName should be Phone');
   return ol.xml.pushParseAndPop({},
       ol.format.OWS.PHONE_PARSERS_, node, objectStack);
 };
@@ -229,9 +229,9 @@ ol.format.OWS.readPhone_ = function(node, objectStack) {
  */
 ol.format.OWS.readServiceIdentification_ = function(node,
     objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'ServiceIdentification',
+  ol.DEBUG && console.assert(node.localName == 'ServiceIdentification',
       'localName should be ServiceIdentification');
   return ol.xml.pushParseAndPop(
       {}, ol.format.OWS.SERVICE_IDENTIFICATION_PARSERS_, node,
@@ -246,9 +246,9 @@ ol.format.OWS.readServiceIdentification_ = function(node,
  * @return {Object|undefined} The service contact.
  */
 ol.format.OWS.readServiceContact_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'ServiceContact',
+  ol.DEBUG && console.assert(node.localName == 'ServiceContact',
       'localName should be ServiceContact');
   return ol.xml.pushParseAndPop(
       {}, ol.format.OWS.SERVICE_CONTACT_PARSERS_, node,
@@ -263,9 +263,9 @@ ol.format.OWS.readServiceContact_ = function(node, objectStack) {
  * @return {Object|undefined} The service provider.
  */
 ol.format.OWS.readServiceProvider_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'ServiceProvider',
+  ol.DEBUG && console.assert(node.localName == 'ServiceProvider',
       'localName should be ServiceProvider');
   return ol.xml.pushParseAndPop(
       {}, ol.format.OWS.SERVICE_PROVIDER_PARSERS_, node,
@@ -280,9 +280,9 @@ ol.format.OWS.readServiceProvider_ = function(node, objectStack) {
  * @return {string|undefined} The value.
  */
 ol.format.OWS.readValue_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Value', 'localName should be Value');
+  ol.DEBUG && console.assert(node.localName == 'Value', 'localName should be Value');
   return ol.format.XSD.readString(node);
 };
 

--- a/src/ol/format/polyline.js
+++ b/src/ol/format/polyline.js
@@ -367,7 +367,7 @@ ol.format.Polyline.prototype.writeFeatureText = function(feature, opt_options) {
  * @inheritDoc
  */
 ol.format.Polyline.prototype.writeFeaturesText = function(features, opt_options) {
-  goog.DEBUG && console.assert(features.length == 1,
+  ol.DEBUG && console.assert(features.length == 1,
       'features array should have 1 item');
   return this.writeFeatureText(features[0], opt_options);
 };

--- a/src/ol/format/wfs.js
+++ b/src/ol/format/wfs.js
@@ -184,7 +184,7 @@ ol.format.WFS.prototype.readFeatureCollectionMetadata = function(source) {
  *     FeatureCollection metadata.
  */
 ol.format.WFS.prototype.readFeatureCollectionMetadataFromDocument = function(doc) {
-  goog.DEBUG && console.assert(doc.nodeType == Node.DOCUMENT_NODE,
+  ol.DEBUG && console.assert(doc.nodeType == Node.DOCUMENT_NODE,
       'doc.nodeType should be DOCUMENT');
   for (var n = doc.firstChild; n; n = n.nextSibling) {
     if (n.nodeType == Node.ELEMENT_NODE) {
@@ -214,9 +214,9 @@ ol.format.WFS.FEATURE_COLLECTION_PARSERS_ = {
  *     FeatureCollection metadata.
  */
 ol.format.WFS.prototype.readFeatureCollectionMetadataFromNode = function(node) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'FeatureCollection',
+  ol.DEBUG && console.assert(node.localName == 'FeatureCollection',
       'localName should be FeatureCollection');
   var result = {};
   var value = ol.format.XSD.readNonNegativeIntegerString(
@@ -325,7 +325,7 @@ ol.format.WFS.TRANSACTION_RESPONSE_PARSERS_ = {
  * @return {ol.WFSTransactionResponse|undefined} Transaction response.
  */
 ol.format.WFS.prototype.readTransactionResponseFromDocument = function(doc) {
-  goog.DEBUG && console.assert(doc.nodeType == Node.DOCUMENT_NODE,
+  ol.DEBUG && console.assert(doc.nodeType == Node.DOCUMENT_NODE,
       'doc.nodeType should be DOCUMENT');
   for (var n = doc.firstChild; n; n = n.nextSibling) {
     if (n.nodeType == Node.ELEMENT_NODE) {
@@ -341,9 +341,9 @@ ol.format.WFS.prototype.readTransactionResponseFromDocument = function(doc) {
  * @return {ol.WFSTransactionResponse|undefined} Transaction response.
  */
 ol.format.WFS.prototype.readTransactionResponseFromNode = function(node) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should  be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'TransactionResponse',
+  ol.DEBUG && console.assert(node.localName == 'TransactionResponse',
       'localName should be TransactionResponse');
   return ol.xml.pushParseAndPop(
       /** @type {ol.WFSTransactionResponse} */({}),
@@ -935,7 +935,7 @@ ol.format.WFS.prototype.readProjection;
  * @inheritDoc
  */
 ol.format.WFS.prototype.readProjectionFromDocument = function(doc) {
-  goog.DEBUG && console.assert(doc.nodeType == Node.DOCUMENT_NODE,
+  ol.DEBUG && console.assert(doc.nodeType == Node.DOCUMENT_NODE,
       'doc.nodeType should be a DOCUMENT');
   for (var n = doc.firstChild; n; n = n.nextSibling) {
     if (n.nodeType == Node.ELEMENT_NODE) {
@@ -950,9 +950,9 @@ ol.format.WFS.prototype.readProjectionFromDocument = function(doc) {
  * @inheritDoc
  */
 ol.format.WFS.prototype.readProjectionFromNode = function(node) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'FeatureCollection',
+  ol.DEBUG && console.assert(node.localName == 'FeatureCollection',
       'localName should be FeatureCollection');
 
   if (node.firstElementChild &&

--- a/src/ol/format/wkt.js
+++ b/src/ol/format/wkt.js
@@ -165,7 +165,7 @@ ol.format.WKT.encodeMultiPolygonGeometry_ = function(geom) {
 ol.format.WKT.encode_ = function(geom) {
   var type = geom.getType();
   var geometryEncoder = ol.format.WKT.GeometryEncoder_[type];
-  goog.DEBUG && console.assert(geometryEncoder, 'geometryEncoder should be defined');
+  ol.DEBUG && console.assert(geometryEncoder, 'geometryEncoder should be defined');
   var enc = geometryEncoder(geom);
   type = type.toUpperCase();
   if (enc.length === 0) {
@@ -572,7 +572,7 @@ ol.format.WKT.Parser.prototype.match = function(type) {
 ol.format.WKT.Parser.prototype.parse = function() {
   this.consume_();
   var geometry = this.parseGeometry_();
-  goog.DEBUG && console.assert(this.token_.type == ol.format.WKT.TokenType.EOF,
+  ol.DEBUG && console.assert(this.token_.type == ol.format.WKT.TokenType.EOF,
       'token type should be end of file');
   return geometry;
 };

--- a/src/ol/format/wmscapabilities.js
+++ b/src/ol/format/wmscapabilities.js
@@ -43,7 +43,7 @@ ol.format.WMSCapabilities.prototype.read;
  * @return {Object} WMS Capability object.
  */
 ol.format.WMSCapabilities.prototype.readFromDocument = function(doc) {
-  goog.DEBUG && console.assert(doc.nodeType == Node.DOCUMENT_NODE,
+  ol.DEBUG && console.assert(doc.nodeType == Node.DOCUMENT_NODE,
       'doc.nodeType should be DOCUMENT');
   for (var n = doc.firstChild; n; n = n.nextSibling) {
     if (n.nodeType == Node.ELEMENT_NODE) {
@@ -59,9 +59,9 @@ ol.format.WMSCapabilities.prototype.readFromDocument = function(doc) {
  * @return {Object} WMS Capability object.
  */
 ol.format.WMSCapabilities.prototype.readFromNode = function(node) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'WMS_Capabilities' ||
+  ol.DEBUG && console.assert(node.localName == 'WMS_Capabilities' ||
       node.localName == 'WMT_MS_Capabilities',
       'localName should be WMS_Capabilities or WMT_MS_Capabilities');
   this.version = node.getAttribute('version').trim();
@@ -79,9 +79,9 @@ ol.format.WMSCapabilities.prototype.readFromNode = function(node) {
  * @return {Object|undefined} Attribution object.
  */
 ol.format.WMSCapabilities.readAttribution_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Attribution',
+  ol.DEBUG && console.assert(node.localName == 'Attribution',
       'localName should be Attribution');
   return ol.xml.pushParseAndPop(
       {}, ol.format.WMSCapabilities.ATTRIBUTION_PARSERS_, node, objectStack);
@@ -95,9 +95,9 @@ ol.format.WMSCapabilities.readAttribution_ = function(node, objectStack) {
  * @return {Object} Bounding box object.
  */
 ol.format.WMSCapabilities.readBoundingBox_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'BoundingBox',
+  ol.DEBUG && console.assert(node.localName == 'BoundingBox',
       'localName should be BoundingBox');
 
   var extent = [
@@ -127,9 +127,9 @@ ol.format.WMSCapabilities.readBoundingBox_ = function(node, objectStack) {
  * @return {ol.Extent|undefined} Bounding box object.
  */
 ol.format.WMSCapabilities.readEXGeographicBoundingBox_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'EX_GeographicBoundingBox',
+  ol.DEBUG && console.assert(node.localName == 'EX_GeographicBoundingBox',
       'localName should be EX_GeographicBoundingBox');
   var geographicBoundingBox = ol.xml.pushParseAndPop(
       {},
@@ -164,9 +164,9 @@ ol.format.WMSCapabilities.readEXGeographicBoundingBox_ = function(node, objectSt
  * @return {Object|undefined} Capability object.
  */
 ol.format.WMSCapabilities.readCapability_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Capability',
+  ol.DEBUG && console.assert(node.localName == 'Capability',
       'localName should be Capability');
   return ol.xml.pushParseAndPop(
       {}, ol.format.WMSCapabilities.CAPABILITY_PARSERS_, node, objectStack);
@@ -180,9 +180,9 @@ ol.format.WMSCapabilities.readCapability_ = function(node, objectStack) {
  * @return {Object|undefined} Service object.
  */
 ol.format.WMSCapabilities.readService_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Service',
+  ol.DEBUG && console.assert(node.localName == 'Service',
       'localName should be Service');
   return ol.xml.pushParseAndPop(
       {}, ol.format.WMSCapabilities.SERVICE_PARSERS_, node, objectStack);
@@ -196,9 +196,9 @@ ol.format.WMSCapabilities.readService_ = function(node, objectStack) {
  * @return {Object|undefined} Contact information object.
  */
 ol.format.WMSCapabilities.readContactInformation_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType shpuld be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'ContactInformation',
+  ol.DEBUG && console.assert(node.localName == 'ContactInformation',
       'localName should be ContactInformation');
   return ol.xml.pushParseAndPop(
       {}, ol.format.WMSCapabilities.CONTACT_INFORMATION_PARSERS_,
@@ -213,9 +213,9 @@ ol.format.WMSCapabilities.readContactInformation_ = function(node, objectStack) 
  * @return {Object|undefined} Contact person object.
  */
 ol.format.WMSCapabilities.readContactPersonPrimary_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'ContactPersonPrimary',
+  ol.DEBUG && console.assert(node.localName == 'ContactPersonPrimary',
       'localName should be ContactPersonPrimary');
   return ol.xml.pushParseAndPop(
       {}, ol.format.WMSCapabilities.CONTACT_PERSON_PARSERS_,
@@ -230,9 +230,9 @@ ol.format.WMSCapabilities.readContactPersonPrimary_ = function(node, objectStack
  * @return {Object|undefined} Contact address object.
  */
 ol.format.WMSCapabilities.readContactAddress_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'ContactAddress',
+  ol.DEBUG && console.assert(node.localName == 'ContactAddress',
       'localName should be ContactAddress');
   return ol.xml.pushParseAndPop(
       {}, ol.format.WMSCapabilities.CONTACT_ADDRESS_PARSERS_,
@@ -247,9 +247,9 @@ ol.format.WMSCapabilities.readContactAddress_ = function(node, objectStack) {
  * @return {Array.<string>|undefined} Format array.
  */
 ol.format.WMSCapabilities.readException_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Exception',
+  ol.DEBUG && console.assert(node.localName == 'Exception',
       'localName should be Exception');
   return ol.xml.pushParseAndPop(
       [], ol.format.WMSCapabilities.EXCEPTION_PARSERS_, node, objectStack);
@@ -263,9 +263,9 @@ ol.format.WMSCapabilities.readException_ = function(node, objectStack) {
  * @return {Object|undefined} Layer object.
  */
 ol.format.WMSCapabilities.readCapabilityLayer_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Layer', 'localName should be Layer');
+  ol.DEBUG && console.assert(node.localName == 'Layer', 'localName should be Layer');
   return ol.xml.pushParseAndPop(
       {}, ol.format.WMSCapabilities.LAYER_PARSERS_, node, objectStack);
 };
@@ -278,9 +278,9 @@ ol.format.WMSCapabilities.readCapabilityLayer_ = function(node, objectStack) {
  * @return {Object|undefined} Layer object.
  */
 ol.format.WMSCapabilities.readLayer_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Layer', 'localName should be Layer');
+  ol.DEBUG && console.assert(node.localName == 'Layer', 'localName should be Layer');
   var parentLayerObject = /**  @type {Object.<string,*>} */
       (objectStack[objectStack.length - 1]);
 
@@ -360,9 +360,9 @@ ol.format.WMSCapabilities.readLayer_ = function(node, objectStack) {
  * @return {Object} Dimension object.
  */
 ol.format.WMSCapabilities.readDimension_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Dimension',
+  ol.DEBUG && console.assert(node.localName == 'Dimension',
       'localName should be Dimension');
   var dimensionObject = {
     'name': node.getAttribute('name'),
@@ -387,7 +387,7 @@ ol.format.WMSCapabilities.readDimension_ = function(node, objectStack) {
  * @return {Object|undefined} Online resource object.
  */
 ol.format.WMSCapabilities.readFormatOnlineresource_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
   return ol.xml.pushParseAndPop(
       {}, ol.format.WMSCapabilities.FORMAT_ONLINERESOURCE_PARSERS_,
@@ -402,9 +402,9 @@ ol.format.WMSCapabilities.readFormatOnlineresource_ = function(node, objectStack
  * @return {Object|undefined} Request object.
  */
 ol.format.WMSCapabilities.readRequest_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Request',
+  ol.DEBUG && console.assert(node.localName == 'Request',
       'localName should be Request');
   return ol.xml.pushParseAndPop(
       {}, ol.format.WMSCapabilities.REQUEST_PARSERS_, node, objectStack);
@@ -418,9 +418,9 @@ ol.format.WMSCapabilities.readRequest_ = function(node, objectStack) {
  * @return {Object|undefined} DCP type object.
  */
 ol.format.WMSCapabilities.readDCPType_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'DCPType',
+  ol.DEBUG && console.assert(node.localName == 'DCPType',
       'localName should be DCPType');
   return ol.xml.pushParseAndPop(
       {}, ol.format.WMSCapabilities.DCPTYPE_PARSERS_, node, objectStack);
@@ -434,9 +434,9 @@ ol.format.WMSCapabilities.readDCPType_ = function(node, objectStack) {
  * @return {Object|undefined} HTTP object.
  */
 ol.format.WMSCapabilities.readHTTP_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'HTTP', 'localName should be HTTP');
+  ol.DEBUG && console.assert(node.localName == 'HTTP', 'localName should be HTTP');
   return ol.xml.pushParseAndPop(
       {}, ol.format.WMSCapabilities.HTTP_PARSERS_, node, objectStack);
 };
@@ -449,7 +449,7 @@ ol.format.WMSCapabilities.readHTTP_ = function(node, objectStack) {
  * @return {Object|undefined} Operation type object.
  */
 ol.format.WMSCapabilities.readOperationType_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
   return ol.xml.pushParseAndPop(
       {}, ol.format.WMSCapabilities.OPERATIONTYPE_PARSERS_, node, objectStack);
@@ -463,7 +463,7 @@ ol.format.WMSCapabilities.readOperationType_ = function(node, objectStack) {
  * @return {Object|undefined} Online resource object.
  */
 ol.format.WMSCapabilities.readSizedFormatOnlineresource_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
   var formatOnlineresource =
       ol.format.WMSCapabilities.readFormatOnlineresource_(node, objectStack);
@@ -486,9 +486,9 @@ ol.format.WMSCapabilities.readSizedFormatOnlineresource_ = function(node, object
  * @return {Object|undefined} Authority URL object.
  */
 ol.format.WMSCapabilities.readAuthorityURL_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'AuthorityURL',
+  ol.DEBUG && console.assert(node.localName == 'AuthorityURL',
       'localName should be AuthorityURL');
   var authorityObject =
       ol.format.WMSCapabilities.readFormatOnlineresource_(node, objectStack);
@@ -507,9 +507,9 @@ ol.format.WMSCapabilities.readAuthorityURL_ = function(node, objectStack) {
  * @return {Object|undefined} Metadata URL object.
  */
 ol.format.WMSCapabilities.readMetadataURL_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'MetadataURL',
+  ol.DEBUG && console.assert(node.localName == 'MetadataURL',
       'localName should be MetadataURL');
   var metadataObject =
       ol.format.WMSCapabilities.readFormatOnlineresource_(node, objectStack);
@@ -528,9 +528,9 @@ ol.format.WMSCapabilities.readMetadataURL_ = function(node, objectStack) {
  * @return {Object|undefined} Style object.
  */
 ol.format.WMSCapabilities.readStyle_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Style', 'localName should be Style');
+  ol.DEBUG && console.assert(node.localName == 'Style', 'localName should be Style');
   return ol.xml.pushParseAndPop(
       {}, ol.format.WMSCapabilities.STYLE_PARSERS_, node, objectStack);
 };
@@ -543,9 +543,9 @@ ol.format.WMSCapabilities.readStyle_ = function(node, objectStack) {
  * @return {Array.<string>|undefined} Keyword list.
  */
 ol.format.WMSCapabilities.readKeywordList_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'KeywordList',
+  ol.DEBUG && console.assert(node.localName == 'KeywordList',
       'localName should be KeywordList');
   return ol.xml.pushParseAndPop(
       [], ol.format.WMSCapabilities.KEYWORDLIST_PARSERS_, node, objectStack);

--- a/src/ol/format/wmsgetfeatureinfo.js
+++ b/src/ol/format/wmsgetfeatureinfo.js
@@ -72,7 +72,7 @@ ol.format.WMSGetFeatureInfo.layerIdentifier_ = '_layer';
 ol.format.WMSGetFeatureInfo.prototype.readFeatures_ = function(node, objectStack) {
 
   node.setAttribute('namespaceURI', this.featureNS_);
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
   var localName = node.localName;
   /** @type {Array.<ol.Feature>} */
@@ -88,7 +88,7 @@ ol.format.WMSGetFeatureInfo.prototype.readFeatures_ = function(node, objectStack
       }
       var context = objectStack[0];
 
-      goog.DEBUG && console.assert(layer.localName.indexOf(
+      ol.DEBUG && console.assert(layer.localName.indexOf(
           ol.format.WMSGetFeatureInfo.layerIdentifier_) >= 0,
           'localName of layer node should match layerIdentifier');
 

--- a/src/ol/format/wmtscapabilities.js
+++ b/src/ol/format/wmtscapabilities.js
@@ -45,7 +45,7 @@ ol.format.WMTSCapabilities.prototype.read;
  * @return {Object} WMTS Capability object.
  */
 ol.format.WMTSCapabilities.prototype.readFromDocument = function(doc) {
-  goog.DEBUG && console.assert(doc.nodeType == Node.DOCUMENT_NODE,
+  ol.DEBUG && console.assert(doc.nodeType == Node.DOCUMENT_NODE,
       'doc.nodeType should be DOCUMENT');
   for (var n = doc.firstChild; n; n = n.nextSibling) {
     if (n.nodeType == Node.ELEMENT_NODE) {
@@ -61,9 +61,9 @@ ol.format.WMTSCapabilities.prototype.readFromDocument = function(doc) {
  * @return {Object} WMTS Capability object.
  */
 ol.format.WMTSCapabilities.prototype.readFromNode = function(node) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Capabilities',
+  ol.DEBUG && console.assert(node.localName == 'Capabilities',
       'localName should be Capabilities');
   var version = node.getAttribute('version').trim();
   var WMTSCapabilityObject = this.owsParser_.readFromNode(node);
@@ -84,9 +84,9 @@ ol.format.WMTSCapabilities.prototype.readFromNode = function(node) {
  * @return {Object|undefined} Attribution object.
  */
 ol.format.WMTSCapabilities.readContents_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Contents',
+  ol.DEBUG && console.assert(node.localName == 'Contents',
       'localName should be Contents');
 
   return ol.xml.pushParseAndPop({},
@@ -101,9 +101,9 @@ ol.format.WMTSCapabilities.readContents_ = function(node, objectStack) {
  * @return {Object|undefined} Layers object.
  */
 ol.format.WMTSCapabilities.readLayer_ = function(node, objectStack) {
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
-  goog.DEBUG && console.assert(node.localName == 'Layer', 'localName should be Layer');
+  ol.DEBUG && console.assert(node.localName == 'Layer', 'localName should be Layer');
   return ol.xml.pushParseAndPop({},
       ol.format.WMTSCapabilities.LAYER_PARSERS_, node, objectStack);
 };

--- a/src/ol/format/xmlfeature.js
+++ b/src/ol/format/xmlfeature.js
@@ -208,7 +208,7 @@ ol.format.XMLFeature.prototype.readProjectionFromNode = function(node) {
  */
 ol.format.XMLFeature.prototype.writeFeature = function(feature, opt_options) {
   var node = this.writeFeatureNode(feature, opt_options);
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
   return this.xmlSerializer_.serializeToString(node);
 };
@@ -229,7 +229,7 @@ ol.format.XMLFeature.prototype.writeFeatureNode = function(feature, opt_options)
  */
 ol.format.XMLFeature.prototype.writeFeatures = function(features, opt_options) {
   var node = this.writeFeaturesNode(features, opt_options);
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
   return this.xmlSerializer_.serializeToString(node);
 };
@@ -249,7 +249,7 @@ ol.format.XMLFeature.prototype.writeFeaturesNode = function(features, opt_option
  */
 ol.format.XMLFeature.prototype.writeGeometry = function(geometry, opt_options) {
   var node = this.writeGeometryNode(geometry, opt_options);
-  goog.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
+  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
       'node.nodeType should be ELEMENT');
   return this.xmlSerializer_.serializeToString(node);
 };

--- a/src/ol/format/xsd.js
+++ b/src/ol/format/xsd.js
@@ -145,8 +145,8 @@ ol.format.XSD.writeDecimalTextNode = function(node, decimal) {
  * @param {number} nonNegativeInteger Non negative integer.
  */
 ol.format.XSD.writeNonNegativeIntegerTextNode = function(node, nonNegativeInteger) {
-  goog.DEBUG && console.assert(nonNegativeInteger >= 0, 'value should be more than 0');
-  goog.DEBUG && console.assert(nonNegativeInteger == (nonNegativeInteger | 0),
+  ol.DEBUG && console.assert(nonNegativeInteger >= 0, 'value should be more than 0');
+  ol.DEBUG && console.assert(nonNegativeInteger == (nonNegativeInteger | 0),
       'value should be an integer value');
   var string = nonNegativeInteger.toString();
   node.appendChild(ol.xml.DOCUMENT.createTextNode(string));

--- a/src/ol/geom/circle.js
+++ b/src/ol/geom/circle.js
@@ -163,7 +163,7 @@ ol.geom.Circle.prototype.intersectsExtent = function(extent) {
  */
 ol.geom.Circle.prototype.setCenter = function(center) {
   var stride = this.stride;
-  goog.DEBUG && console.assert(center.length == stride,
+  ol.DEBUG && console.assert(center.length == stride,
       'center array length should match stride');
   var radius = this.flatCoordinates[stride] - this.flatCoordinates[0];
   var flatCoordinates = center.slice();

--- a/src/ol/geom/flat/closest.js
+++ b/src/ol/geom/flat/closest.js
@@ -147,7 +147,7 @@ ol.geom.flat.closest.getClosestPoint = function(flatCoordinates, offset, end,
       return minSquaredDistance;
     }
   }
-  goog.DEBUG && console.assert(maxDelta > 0, 'maxDelta should be larger than 0');
+  ol.DEBUG && console.assert(maxDelta > 0, 'maxDelta should be larger than 0');
   var tmpPoint = opt_tmpPoint ? opt_tmpPoint : [NaN, NaN];
   var index = offset + stride;
   while (index < end) {

--- a/src/ol/geom/flat/contains.js
+++ b/src/ol/geom/flat/contains.js
@@ -64,7 +64,7 @@ ol.geom.flat.contains.linearRingContainsXY = function(flatCoordinates, offset, e
  * @return {boolean} Contains (x, y).
  */
 ol.geom.flat.contains.linearRingsContainsXY = function(flatCoordinates, offset, ends, stride, x, y) {
-  goog.DEBUG && console.assert(ends.length > 0, 'ends should not be an empty array');
+  ol.DEBUG && console.assert(ends.length > 0, 'ends should not be an empty array');
   if (ends.length === 0) {
     return false;
   }
@@ -93,7 +93,7 @@ ol.geom.flat.contains.linearRingsContainsXY = function(flatCoordinates, offset, 
  * @return {boolean} Contains (x, y).
  */
 ol.geom.flat.contains.linearRingssContainsXY = function(flatCoordinates, offset, endss, stride, x, y) {
-  goog.DEBUG && console.assert(endss.length > 0, 'endss should not be an empty array');
+  ol.DEBUG && console.assert(endss.length > 0, 'endss should not be an empty array');
   if (endss.length === 0) {
     return false;
   }

--- a/src/ol/geom/flat/deflate.js
+++ b/src/ol/geom/flat/deflate.js
@@ -9,7 +9,7 @@ goog.provide('ol.geom.flat.deflate');
  * @return {number} offset Offset.
  */
 ol.geom.flat.deflate.coordinate = function(flatCoordinates, offset, coordinate, stride) {
-  goog.DEBUG && console.assert(coordinate.length == stride,
+  ol.DEBUG && console.assert(coordinate.length == stride,
       'length of the coordinate array should match stride');
   var i, ii;
   for (i = 0, ii = coordinate.length; i < ii; ++i) {
@@ -30,7 +30,7 @@ ol.geom.flat.deflate.coordinates = function(flatCoordinates, offset, coordinates
   var i, ii;
   for (i = 0, ii = coordinates.length; i < ii; ++i) {
     var coordinate = coordinates[i];
-    goog.DEBUG && console.assert(coordinate.length == stride,
+    ol.DEBUG && console.assert(coordinate.length == stride,
         'length of coordinate array should match stride');
     var j;
     for (j = 0; j < stride; ++j) {

--- a/src/ol/geom/flat/geodesic.js
+++ b/src/ol/geom/flat/geodesic.js
@@ -64,7 +64,7 @@ ol.geom.flat.geodesic.line_ = function(interpolate, transform, squaredTolerance)
       // segment.
       flatCoordinates.push(b[0], b[1]);
       key = fracB.toString();
-      goog.DEBUG && console.assert(!(key in fractions),
+      ol.DEBUG && console.assert(!(key in fractions),
           'fractions object should contain key : ' + key);
       fractions[key] = true;
     } else {
@@ -75,7 +75,7 @@ ol.geom.flat.geodesic.line_ = function(interpolate, transform, squaredTolerance)
       geoStack.push(geoB, geoM, geoM, geoA);
     }
   }
-  goog.DEBUG && console.assert(maxIterations > 0,
+  ol.DEBUG && console.assert(maxIterations > 0,
       'maxIterations should be more than 0');
 
   return flatCoordinates;

--- a/src/ol/geom/flat/interiorpoint.js
+++ b/src/ol/geom/flat/interiorpoint.js
@@ -78,7 +78,7 @@ ol.geom.flat.interiorpoint.linearRings = function(flatCoordinates, offset,
  * @return {Array.<number>} Interior points.
  */
 ol.geom.flat.interiorpoint.linearRingss = function(flatCoordinates, offset, endss, stride, flatCenters) {
-  goog.DEBUG && console.assert(2 * endss.length == flatCenters.length,
+  ol.DEBUG && console.assert(2 * endss.length == flatCenters.length,
       'endss.length times 2 should be flatCenters.length');
   var interiorPoints = [];
   var i, ii;

--- a/src/ol/geom/flat/interpolate.js
+++ b/src/ol/geom/flat/interpolate.js
@@ -16,13 +16,13 @@ goog.require('ol.math');
 ol.geom.flat.interpolate.lineString = function(flatCoordinates, offset, end, stride, fraction, opt_dest) {
   // FIXME does not work when vertices are repeated
   // FIXME interpolate extra dimensions
-  goog.DEBUG && console.assert(0 <= fraction && fraction <= 1,
+  ol.DEBUG && console.assert(0 <= fraction && fraction <= 1,
       'fraction should be in between 0 and 1');
   var pointX = NaN;
   var pointY = NaN;
   var n = (end - offset) / stride;
   if (n === 0) {
-    goog.DEBUG && console.assert(false, 'n cannot be 0');
+    ol.DEBUG && console.assert(false, 'n cannot be 0');
   } else if (n == 1) {
     pointX = flatCoordinates[offset];
     pointY = flatCoordinates[offset + 1];
@@ -120,8 +120,8 @@ ol.geom.flat.lineStringCoordinateAtM = function(flatCoordinates, offset, end, st
     return flatCoordinates.slice((lo - 1) * stride, (lo - 1) * stride + stride);
   }
   var m1 = flatCoordinates[(lo + 1) * stride - 1];
-  goog.DEBUG && console.assert(m0 < m, 'm0 should be less than m');
-  goog.DEBUG && console.assert(m <= m1, 'm should be less than or equal to m1');
+  ol.DEBUG && console.assert(m0 < m, 'm0 should be less than m');
+  ol.DEBUG && console.assert(m <= m1, 'm should be less than or equal to m1');
   var t = (m - m0) / (m1 - m0);
   coordinate = [];
   var i;
@@ -130,7 +130,7 @@ ol.geom.flat.lineStringCoordinateAtM = function(flatCoordinates, offset, end, st
         flatCoordinates[lo * stride + i], t));
   }
   coordinate.push(m);
-  goog.DEBUG && console.assert(coordinate.length == stride,
+  ol.DEBUG && console.assert(coordinate.length == stride,
       'length of coordinate array should match stride');
   return coordinate;
 };
@@ -185,7 +185,7 @@ ol.geom.flat.lineStringsCoordinateAtM = function(
     }
     offset = end;
   }
-  goog.DEBUG && console.assert(false,
+  ol.DEBUG && console.assert(false,
       'ol.geom.flat.lineStringsCoordinateAtM should have returned');
   return null;
 };

--- a/src/ol/geom/flat/intersectsextent.js
+++ b/src/ol/geom/flat/intersectsextent.js
@@ -106,7 +106,7 @@ ol.geom.flat.intersectsextent.linearRing = function(flatCoordinates, offset, end
  * @return {boolean} True if the geometry and the extent intersect.
  */
 ol.geom.flat.intersectsextent.linearRings = function(flatCoordinates, offset, ends, stride, extent) {
-  goog.DEBUG && console.assert(ends.length > 0, 'ends should not be an empty array');
+  ol.DEBUG && console.assert(ends.length > 0, 'ends should not be an empty array');
   if (!ol.geom.flat.intersectsextent.linearRing(
       flatCoordinates, offset, ends[0], stride, extent)) {
     return false;
@@ -134,7 +134,7 @@ ol.geom.flat.intersectsextent.linearRings = function(flatCoordinates, offset, en
  * @return {boolean} True if the geometry and the extent intersect.
  */
 ol.geom.flat.intersectsextent.linearRingss = function(flatCoordinates, offset, endss, stride, extent) {
-  goog.DEBUG && console.assert(endss.length > 0, 'endss should not be an empty array');
+  ol.DEBUG && console.assert(endss.length > 0, 'endss should not be an empty array');
   var i, ii;
   for (i = 0, ii = endss.length; i < ii; ++i) {
     var ends = endss[i];

--- a/src/ol/geom/geometry.js
+++ b/src/ol/geom/geometry.js
@@ -279,7 +279,7 @@ ol.geom.Geometry.prototype.translate = function(deltaX, deltaY) {};
  * @api stable
  */
 ol.geom.Geometry.prototype.transform = function(source, destination) {
-  goog.DEBUG && console.assert(
+  ol.DEBUG && console.assert(
       ol.proj.get(source).getUnits() !== ol.proj.Units.TILE_PIXELS &&
       ol.proj.get(destination).getUnits() !== ol.proj.Units.TILE_PIXELS,
       'cannot transform geometries with TILE_PIXELS units');

--- a/src/ol/geom/linestring.js
+++ b/src/ol/geom/linestring.js
@@ -66,7 +66,7 @@ ol.inherits(ol.geom.LineString, ol.geom.SimpleGeometry);
  * @api stable
  */
 ol.geom.LineString.prototype.appendCoordinate = function(coordinate) {
-  goog.DEBUG && console.assert(coordinate.length == this.stride,
+  ol.DEBUG && console.assert(coordinate.length == this.stride,
       'length of coordinate array should match stride');
   if (!this.flatCoordinates) {
     this.flatCoordinates = coordinate.slice();

--- a/src/ol/geom/multilinestring.js
+++ b/src/ol/geom/multilinestring.js
@@ -59,7 +59,7 @@ ol.inherits(ol.geom.MultiLineString, ol.geom.SimpleGeometry);
  * @api stable
  */
 ol.geom.MultiLineString.prototype.appendLineString = function(lineString) {
-  goog.DEBUG && console.assert(lineString.getLayout() == this.layout,
+  ol.DEBUG && console.assert(lineString.getLayout() == this.layout,
       'layout of lineString should match the layout');
   if (!this.flatCoordinates) {
     this.flatCoordinates = lineString.getFlatCoordinates().slice();
@@ -165,7 +165,7 @@ ol.geom.MultiLineString.prototype.getEnds = function() {
  * @api stable
  */
 ol.geom.MultiLineString.prototype.getLineString = function(index) {
-  goog.DEBUG && console.assert(0 <= index && index < this.ends_.length,
+  ol.DEBUG && console.assert(0 <= index && index < this.ends_.length,
       'index should be in between 0 and length of the this.ends_ array');
   if (index < 0 || this.ends_.length <= index) {
     return null;
@@ -286,13 +286,13 @@ ol.geom.MultiLineString.prototype.setCoordinates = function(coordinates, opt_lay
  */
 ol.geom.MultiLineString.prototype.setFlatCoordinates = function(layout, flatCoordinates, ends) {
   if (!flatCoordinates) {
-    goog.DEBUG && console.assert(ends && ends.length === 0,
+    ol.DEBUG && console.assert(ends && ends.length === 0,
         'ends must be truthy and ends.length should be 0');
   } else if (ends.length === 0) {
-    goog.DEBUG && console.assert(flatCoordinates.length === 0,
+    ol.DEBUG && console.assert(flatCoordinates.length === 0,
         'flatCoordinates should be an empty array');
   } else {
-    goog.DEBUG && console.assert(flatCoordinates.length == ends[ends.length - 1],
+    ol.DEBUG && console.assert(flatCoordinates.length == ends[ends.length - 1],
         'length of flatCoordinates array should match the last value of ends');
   }
   this.setFlatCoordinatesInternal(layout, flatCoordinates);
@@ -315,7 +315,7 @@ ol.geom.MultiLineString.prototype.setLineStrings = function(lineStrings) {
       layout = lineString.getLayout();
     } else {
       // FIXME better handle the case of non-matching layouts
-      goog.DEBUG && console.assert(lineString.getLayout() == layout,
+      ol.DEBUG && console.assert(lineString.getLayout() == layout,
           'layout of lineString should match layout');
     }
     ol.array.extend(flatCoordinates, lineString.getFlatCoordinates());

--- a/src/ol/geom/multipoint.js
+++ b/src/ol/geom/multipoint.js
@@ -35,7 +35,7 @@ ol.inherits(ol.geom.MultiPoint, ol.geom.SimpleGeometry);
  * @api stable
  */
 ol.geom.MultiPoint.prototype.appendPoint = function(point) {
-  goog.DEBUG && console.assert(point.getLayout() == this.layout,
+  ol.DEBUG && console.assert(point.getLayout() == this.layout,
       'the layout of point should match layout');
   if (!this.flatCoordinates) {
     this.flatCoordinates = point.getFlatCoordinates().slice();
@@ -104,7 +104,7 @@ ol.geom.MultiPoint.prototype.getCoordinates = function() {
 ol.geom.MultiPoint.prototype.getPoint = function(index) {
   var n = !this.flatCoordinates ?
       0 : this.flatCoordinates.length / this.stride;
-  goog.DEBUG && console.assert(0 <= index && index < n,
+  ol.DEBUG && console.assert(0 <= index && index < n,
       'index should be in between 0 and n');
   if (index < 0 || n <= index) {
     return null;

--- a/src/ol/geom/multipolygon.js
+++ b/src/ol/geom/multipolygon.js
@@ -88,7 +88,7 @@ ol.inherits(ol.geom.MultiPolygon, ol.geom.SimpleGeometry);
  * @api stable
  */
 ol.geom.MultiPolygon.prototype.appendPolygon = function(polygon) {
-  goog.DEBUG && console.assert(polygon.getLayout() == this.layout,
+  ol.DEBUG && console.assert(polygon.getLayout() == this.layout,
       'layout of polygon should match layout');
   /** @type {Array.<number>} */
   var ends;
@@ -279,7 +279,7 @@ ol.geom.MultiPolygon.prototype.getSimplifiedGeometryInternal = function(squaredT
  * @api stable
  */
 ol.geom.MultiPolygon.prototype.getPolygon = function(index) {
-  goog.DEBUG && console.assert(0 <= index && index < this.endss_.length,
+  ol.DEBUG && console.assert(0 <= index && index < this.endss_.length,
       'index should be in between 0 and the length of this.endss_');
   if (index < 0 || this.endss_.length <= index) {
     return null;
@@ -389,13 +389,13 @@ ol.geom.MultiPolygon.prototype.setCoordinates = function(coordinates, opt_layout
  * @param {Array.<Array.<number>>} endss Endss.
  */
 ol.geom.MultiPolygon.prototype.setFlatCoordinates = function(layout, flatCoordinates, endss) {
-  goog.DEBUG && console.assert(endss, 'endss must be truthy');
+  ol.DEBUG && console.assert(endss, 'endss must be truthy');
   if (!flatCoordinates || flatCoordinates.length === 0) {
-    goog.DEBUG && console.assert(endss.length === 0, 'the length of endss should be 0');
+    ol.DEBUG && console.assert(endss.length === 0, 'the length of endss should be 0');
   } else {
-    goog.DEBUG && console.assert(endss.length > 0, 'endss cannot be an empty array');
+    ol.DEBUG && console.assert(endss.length > 0, 'endss cannot be an empty array');
     var ends = endss[endss.length - 1];
-    goog.DEBUG && console.assert(flatCoordinates.length == ends[ends.length - 1],
+    ol.DEBUG && console.assert(flatCoordinates.length == ends[ends.length - 1],
         'the length of flatCoordinates should be the last value of ends');
   }
   this.setFlatCoordinatesInternal(layout, flatCoordinates);
@@ -418,7 +418,7 @@ ol.geom.MultiPolygon.prototype.setPolygons = function(polygons) {
       layout = polygon.getLayout();
     } else {
       // FIXME better handle the case of non-matching layouts
-      goog.DEBUG && console.assert(polygon.getLayout() == layout,
+      ol.DEBUG && console.assert(polygon.getLayout() == layout,
           'layout of polygon should be layout');
     }
     var offset = flatCoordinates.length;

--- a/src/ol/geom/polygon.js
+++ b/src/ol/geom/polygon.js
@@ -88,7 +88,7 @@ ol.inherits(ol.geom.Polygon, ol.geom.SimpleGeometry);
  * @api stable
  */
 ol.geom.Polygon.prototype.appendLinearRing = function(linearRing) {
-  goog.DEBUG && console.assert(linearRing.getLayout() == this.layout,
+  ol.DEBUG && console.assert(linearRing.getLayout() == this.layout,
       'layout of linearRing should match layout');
   if (!this.flatCoordinates) {
     this.flatCoordinates = linearRing.getFlatCoordinates().slice();
@@ -236,7 +236,7 @@ ol.geom.Polygon.prototype.getLinearRingCount = function() {
  * @api stable
  */
 ol.geom.Polygon.prototype.getLinearRing = function(index) {
-  goog.DEBUG && console.assert(0 <= index && index < this.ends_.length,
+  ol.DEBUG && console.assert(0 <= index && index < this.ends_.length,
       'index should be in between 0 and and length of this.ends_');
   if (index < 0 || this.ends_.length <= index) {
     return null;
@@ -357,13 +357,13 @@ ol.geom.Polygon.prototype.setCoordinates = function(coordinates, opt_layout) {
  */
 ol.geom.Polygon.prototype.setFlatCoordinates = function(layout, flatCoordinates, ends) {
   if (!flatCoordinates) {
-    goog.DEBUG && console.assert(ends && ends.length === 0,
+    ol.DEBUG && console.assert(ends && ends.length === 0,
         'ends must be an empty array');
   } else if (ends.length === 0) {
-    goog.DEBUG && console.assert(flatCoordinates.length === 0,
+    ol.DEBUG && console.assert(flatCoordinates.length === 0,
         'flatCoordinates should be an empty array');
   } else {
-    goog.DEBUG && console.assert(flatCoordinates.length == ends[ends.length - 1],
+    ol.DEBUG && console.assert(flatCoordinates.length == ends[ends.length - 1],
         'the length of flatCoordinates should be the last entry of ends');
   }
   this.setFlatCoordinatesInternal(layout, flatCoordinates);
@@ -460,7 +460,7 @@ ol.geom.Polygon.makeRegular = function(polygon, center, radius, opt_angle) {
   var layout = polygon.getLayout();
   var stride = polygon.getStride();
   var ends = polygon.getEnds();
-  goog.DEBUG && console.assert(ends.length === 1, 'only 1 ring is supported');
+  ol.DEBUG && console.assert(ends.length === 1, 'only 1 ring is supported');
   var sides = flatCoordinates.length / stride - 1;
   var startAngle = opt_angle ? opt_angle : 0;
   var angle, offset;

--- a/src/ol/geom/simplegeometry.js
+++ b/src/ol/geom/simplegeometry.js
@@ -58,7 +58,7 @@ ol.geom.SimpleGeometry.getLayoutForStride_ = function(stride) {
   } else if (stride == 4) {
     layout = ol.geom.GeometryLayout.XYZM;
   }
-  goog.DEBUG && console.assert(layout, 'unsupported stride: ' + stride);
+  ol.DEBUG && console.assert(layout, 'unsupported stride: ' + stride);
   return /** @type {ol.geom.GeometryLayout} */ (layout);
 };
 
@@ -76,7 +76,7 @@ ol.geom.SimpleGeometry.getStrideForLayout = function(layout) {
   } else if (layout == ol.geom.GeometryLayout.XYZM) {
     stride = 4;
   }
-  goog.DEBUG && console.assert(stride, 'unsupported layout: ' + layout);
+  ol.DEBUG && console.assert(stride, 'unsupported layout: ' + layout);
   return /** @type {number} */ (stride);
 };
 

--- a/src/ol/graticule.js
+++ b/src/ol/graticule.js
@@ -92,7 +92,7 @@ ol.Graticule = function(opt_options) {
    * @private
    */
   this.maxLines_ = options.maxLines !== undefined ? options.maxLines : 100;
-  goog.DEBUG && console.assert(this.maxLines_ > 0,
+  ol.DEBUG && console.assert(this.maxLines_ > 0,
       'this.maxLines_ should be more than 0');
 
   /**
@@ -333,13 +333,13 @@ ol.Graticule.prototype.getMap = function() {
  */
 ol.Graticule.prototype.getMeridian_ = function(lon, minLat, maxLat,
                                                squaredTolerance, index) {
-  goog.DEBUG && console.assert(lon >= this.minLon_,
+  ol.DEBUG && console.assert(lon >= this.minLon_,
       'lon should be larger than or equal to this.minLon_');
-  goog.DEBUG && console.assert(lon <= this.maxLon_,
+  ol.DEBUG && console.assert(lon <= this.maxLon_,
       'lon should be smaller than or equal to this.maxLon_');
   var flatCoordinates = ol.geom.flat.geodesic.meridian(lon,
       minLat, maxLat, this.projection_, squaredTolerance);
-  goog.DEBUG && console.assert(flatCoordinates.length > 0,
+  ol.DEBUG && console.assert(flatCoordinates.length > 0,
       'flatCoordinates cannot be empty');
   var lineString = this.meridians_[index] !== undefined ?
       this.meridians_[index] : new ol.geom.LineString(null);
@@ -369,13 +369,13 @@ ol.Graticule.prototype.getMeridians = function() {
  */
 ol.Graticule.prototype.getParallel_ = function(lat, minLon, maxLon,
                                                squaredTolerance, index) {
-  goog.DEBUG && console.assert(lat >= this.minLat_,
+  ol.DEBUG && console.assert(lat >= this.minLat_,
       'lat should be larger than or equal to this.minLat_');
-  goog.DEBUG && console.assert(lat <= this.maxLat_,
+  ol.DEBUG && console.assert(lat <= this.maxLat_,
       'lat should be smaller than or equal to this.maxLat_');
   var flatCoordinates = ol.geom.flat.geodesic.parallel(lat,
       this.minLon_, this.maxLon_, this.projection_, squaredTolerance);
-  goog.DEBUG && console.assert(flatCoordinates.length > 0,
+  ol.DEBUG && console.assert(flatCoordinates.length > 0,
       'flatCoordinates cannot be empty');
   var lineString = this.parallels_[index] !== undefined ?
       this.parallels_[index] : new ol.geom.LineString(null);
@@ -472,18 +472,18 @@ ol.Graticule.prototype.updateProjectionInfo_ = function(projection) {
   var minLatP = worldExtentP[1];
   var minLonP = worldExtentP[0];
 
-  goog.DEBUG && console.assert(maxLat !== undefined, 'maxLat should be defined');
-  goog.DEBUG && console.assert(maxLon !== undefined, 'maxLon should be defined');
-  goog.DEBUG && console.assert(minLat !== undefined, 'minLat should be defined');
-  goog.DEBUG && console.assert(minLon !== undefined, 'minLon should be defined');
+  ol.DEBUG && console.assert(maxLat !== undefined, 'maxLat should be defined');
+  ol.DEBUG && console.assert(maxLon !== undefined, 'maxLon should be defined');
+  ol.DEBUG && console.assert(minLat !== undefined, 'minLat should be defined');
+  ol.DEBUG && console.assert(minLon !== undefined, 'minLon should be defined');
 
-  goog.DEBUG && console.assert(maxLatP !== undefined,
+  ol.DEBUG && console.assert(maxLatP !== undefined,
       'projected maxLat should be defined');
-  goog.DEBUG && console.assert(maxLonP !== undefined,
+  ol.DEBUG && console.assert(maxLonP !== undefined,
       'projected maxLon should be defined');
-  goog.DEBUG && console.assert(minLatP !== undefined,
+  ol.DEBUG && console.assert(minLatP !== undefined,
       'projected minLat should be defined');
-  goog.DEBUG && console.assert(minLonP !== undefined,
+  ol.DEBUG && console.assert(minLonP !== undefined,
       'projected minLon should be defined');
 
   this.maxLat_ = maxLat;

--- a/src/ol/has.js
+++ b/src/ol/has.js
@@ -1,12 +1,20 @@
 goog.provide('ol.has');
 
 goog.require('ol');
-goog.require('ol.dom');
 goog.require('ol.webgl');
 
 
 var ua = typeof navigator !== 'undefined' ?
     navigator.userAgent.toLowerCase() : '';
+
+var ie = ua.match(/msie ([0-9]{1,}[\.0-9]{0,})/);
+var trident = ua.match(/trident\/([0-9]{1,}[\.0-9]{0,})/);
+
+/**
+ * User agent string says we are dealing with IE >= 9 as browser.
+ * @type {boolean}
+ */
+ol.has.IE = !!(ie && parseFloat(ie[1]) >= 9 || trident && parseFloat(trident[1]) >= 6);
 
 /**
  * User agent string says we are dealing with Firefox as browser.
@@ -18,7 +26,13 @@ ol.has.FIREFOX = ua.indexOf('firefox') !== -1;
  * User agent string says we are dealing with Safari as browser.
  * @type {boolean}
  */
-ol.has.SAFARI = ua.indexOf('safari') !== -1 && ua.indexOf('chrom') === -1;
+ol.has.SAFARI = ua.indexOf('safari') !== -1 && ua.indexOf('chrom') == -1;
+
+/**
+ * User agent string says we are dealing with a WebKit engine.
+ * @type {boolean}
+ */
+ol.has.WEBKIT = ua.indexOf('webkit') !== -1 && ua.indexOf('edge') == -1;
 
 /**
  * User agent string says we are dealing with a Mac as platform.
@@ -60,7 +74,7 @@ ol.has.CANVAS = ol.ENABLE_CANVAS && (
         return false;
       }
       try {
-        var context = ol.dom.createCanvasContext2D();
+        var context = document.createElement('CANVAS').getContext('2d');
         if (!context) {
           return false;
         } else {

--- a/src/ol/image.js
+++ b/src/ol/image.js
@@ -131,7 +131,7 @@ ol.Image.prototype.load = function() {
   if (this.state == ol.Image.State.IDLE || this.state == ol.Image.State.ERROR) {
     this.state = ol.Image.State.LOADING;
     this.changed();
-    goog.DEBUG && console.assert(!this.imageListenerKeys_,
+    ol.DEBUG && console.assert(!this.imageListenerKeys_,
         'this.imageListenerKeys_ should be null');
     this.imageListenerKeys_ = [
       ol.events.listenOnce(this.image_, ol.events.EventType.ERROR,

--- a/src/ol/imagebase.js
+++ b/src/ol/imagebase.js
@@ -96,7 +96,7 @@ ol.ImageBase.prototype.getPixelRatio = function() {
  * @return {number} Resolution.
  */
 ol.ImageBase.prototype.getResolution = function() {
-  goog.DEBUG && console.assert(this.resolution !== undefined, 'resolution not yet set');
+  ol.DEBUG && console.assert(this.resolution !== undefined, 'resolution not yet set');
   return /** @type {number} */ (this.resolution);
 };
 

--- a/src/ol/imagecanvas.js
+++ b/src/ol/imagecanvas.js
@@ -77,7 +77,7 @@ ol.ImageCanvas.prototype.handleLoad_ = function(err) {
  */
 ol.ImageCanvas.prototype.load = function() {
   if (this.state == ol.Image.State.IDLE) {
-    goog.DEBUG && console.assert(this.loader_, 'this.loader_ must be set');
+    ol.DEBUG && console.assert(this.loader_, 'this.loader_ must be set');
     this.state = ol.Image.State.LOADING;
     this.changed();
     this.loader_(this.handleLoad_.bind(this));

--- a/src/ol/imagetile.js
+++ b/src/ol/imagetile.js
@@ -145,7 +145,7 @@ ol.ImageTile.prototype.load = function() {
   if (this.state == ol.Tile.State.IDLE || this.state == ol.Tile.State.ERROR) {
     this.state = ol.Tile.State.LOADING;
     this.changed();
-    goog.DEBUG && console.assert(!this.imageListenerKeys_,
+    ol.DEBUG && console.assert(!this.imageListenerKeys_,
         'this.imageListenerKeys_ should be null');
     this.imageListenerKeys_ = [
       ol.events.listenOnce(this.image_, ol.events.EventType.ERROR,

--- a/src/ol/index.js
+++ b/src/ol/index.js
@@ -8,6 +8,12 @@ goog.provide('ol');
  */
 
 
+ /**
+  * @define {boolean} Enable debug mode. Default is `true`.
+  */
+ol.DEBUG = true;
+
+
 /**
  * @define {boolean} Assume touch.  Default is `false`.
  */

--- a/src/ol/interaction/draganddrop.js
+++ b/src/ol/interaction/draganddrop.js
@@ -101,7 +101,7 @@ ol.interaction.DragAndDrop.prototype.handleResult_ = function(file, event) {
   if (!projection) {
     var view = map.getView();
     projection = view.getProjection();
-    goog.DEBUG && console.assert(projection !== undefined,
+    ol.DEBUG && console.assert(projection !== undefined,
         'projection should be defined');
   }
   var formatConstructors = this.formatConstructors_;

--- a/src/ol/interaction/dragpan.js
+++ b/src/ol/interaction/dragpan.js
@@ -67,7 +67,7 @@ ol.inherits(ol.interaction.DragPan, ol.interaction.Pointer);
  * @private
  */
 ol.interaction.DragPan.handleDragEvent_ = function(mapBrowserEvent) {
-  goog.DEBUG && console.assert(this.targetPointers.length >= 1,
+  ol.DEBUG && console.assert(this.targetPointers.length >= 1,
       'the length of this.targetPointers should be more than 1');
   var centroid =
       ol.interaction.Pointer.centroid(this.targetPointers);

--- a/src/ol/interaction/draw.js
+++ b/src/ol/interaction/draw.js
@@ -514,7 +514,7 @@ ol.interaction.Draw.prototype.startDrawing_ = function(event) {
         new ol.geom.LineString(this.sketchLineCoords_));
   }
   var geometry = this.geometryFunction_(this.sketchCoords_);
-  goog.DEBUG && console.assert(geometry !== undefined, 'geometry should be defined');
+  ol.DEBUG && console.assert(geometry !== undefined, 'geometry should be defined');
   this.sketchFeature_ = new ol.Feature();
   if (this.geometryName_) {
     this.sketchFeature_.setGeometryName(this.geometryName_);
@@ -550,7 +550,7 @@ ol.interaction.Draw.prototype.modifyDrawing_ = function(event) {
   }
   last[0] = coordinate[0];
   last[1] = coordinate[1];
-  goog.DEBUG && console.assert(this.sketchCoords_, 'sketchCoords_ expected');
+  ol.DEBUG && console.assert(this.sketchCoords_, 'sketchCoords_ expected');
   this.geometryFunction_(
       /** @type {!ol.Coordinate|!Array.<ol.Coordinate>|!Array.<Array.<ol.Coordinate>>} */ (this.sketchCoords_),
       geometry);
@@ -708,9 +708,9 @@ ol.interaction.Draw.prototype.abortDrawing_ = function() {
  */
 ol.interaction.Draw.prototype.extend = function(feature) {
   var geometry = feature.getGeometry();
-  goog.DEBUG && console.assert(this.mode_ == ol.interaction.DrawMode.LINE_STRING,
+  ol.DEBUG && console.assert(this.mode_ == ol.interaction.DrawMode.LINE_STRING,
       'interaction mode must be "line"');
-  goog.DEBUG && console.assert(geometry.getType() == ol.geom.GeometryType.LINE_STRING,
+  ol.DEBUG && console.assert(geometry.getType() == ol.geom.GeometryType.LINE_STRING,
       'feature geometry must be a line string');
   var lineString = /** @type {ol.geom.LineString} */ (geometry);
   this.sketchFeature_ = feature;

--- a/src/ol/interaction/modify.js
+++ b/src/ol/interaction/modify.js
@@ -975,7 +975,7 @@ ol.interaction.Modify.prototype.removeVertex_ = function() {
         segments.push(right.segment[1]);
       }
       if (left !== undefined && right !== undefined) {
-        goog.DEBUG && console.assert(newIndex >= 0, 'newIndex should be larger than 0');
+        ol.DEBUG && console.assert(newIndex >= 0, 'newIndex should be larger than 0');
 
         var newSegmentData = /** @type {ol.ModifySegmentDataType} */ ({
           depth: segmentData.depth,

--- a/src/ol/interaction/pinchrotate.js
+++ b/src/ol/interaction/pinchrotate.js
@@ -73,7 +73,7 @@ ol.inherits(ol.interaction.PinchRotate, ol.interaction.Pointer);
  * @private
  */
 ol.interaction.PinchRotate.handleDragEvent_ = function(mapBrowserEvent) {
-  goog.DEBUG && console.assert(this.targetPointers.length >= 2,
+  ol.DEBUG && console.assert(this.targetPointers.length >= 2,
       'length of this.targetPointers should be greater than or equal to 2');
   var rotationDelta = 0.0;
 

--- a/src/ol/interaction/pinchzoom.js
+++ b/src/ol/interaction/pinchzoom.js
@@ -61,7 +61,7 @@ ol.inherits(ol.interaction.PinchZoom, ol.interaction.Pointer);
  * @private
  */
 ol.interaction.PinchZoom.handleDragEvent_ = function(mapBrowserEvent) {
-  goog.DEBUG && console.assert(this.targetPointers.length >= 2,
+  ol.DEBUG && console.assert(this.targetPointers.length >= 2,
       'length of this.targetPointers should be 2 or more');
   var scaleDelta = 1.0;
 

--- a/src/ol/layer/group.js
+++ b/src/ol/layer/group.js
@@ -130,7 +130,7 @@ ol.layer.Group.prototype.handleLayersChanged_ = function(event) {
 ol.layer.Group.prototype.handleLayersAdd_ = function(collectionEvent) {
   var layer = /** @type {ol.layer.Base} */ (collectionEvent.element);
   var key = ol.getUid(layer).toString();
-  goog.DEBUG && console.assert(!(key in this.listenerKeys_),
+  ol.DEBUG && console.assert(!(key in this.listenerKeys_),
       'listeners already registered');
   this.listenerKeys_[key] = [
     ol.events.listen(layer, ol.ObjectEventType.PROPERTYCHANGE,
@@ -149,7 +149,7 @@ ol.layer.Group.prototype.handleLayersAdd_ = function(collectionEvent) {
 ol.layer.Group.prototype.handleLayersRemove_ = function(collectionEvent) {
   var layer = /** @type {ol.layer.Base} */ (collectionEvent.element);
   var key = ol.getUid(layer).toString();
-  goog.DEBUG && console.assert(key in this.listenerKeys_, 'no listeners to unregister');
+  ol.DEBUG && console.assert(key in this.listenerKeys_, 'no listeners to unregister');
   this.listenerKeys_[key].forEach(ol.events.unlistenByKey);
   delete this.listenerKeys_[key];
   this.changed();

--- a/src/ol/layer/heatmap.js
+++ b/src/ol/layer/heatmap.js
@@ -100,12 +100,12 @@ ol.layer.Heatmap = function(opt_options) {
   } else {
     weightFunction = weight;
   }
-  goog.DEBUG && console.assert(typeof weightFunction === 'function',
+  ol.DEBUG && console.assert(typeof weightFunction === 'function',
       'weightFunction should be a function');
 
   this.setStyle(function(feature, resolution) {
-    goog.DEBUG && console.assert(this.styleCache_, 'this.styleCache_ expected');
-    goog.DEBUG && console.assert(this.circleImage_ !== undefined,
+    ol.DEBUG && console.assert(this.styleCache_, 'this.styleCache_ expected');
+    ol.DEBUG && console.assert(this.circleImage_ !== undefined,
         'this.circleImage_ should be defined');
     var weight = weightFunction(feature);
     var opacity = weight !== undefined ? ol.math.clamp(weight, 0, 1) : 1;
@@ -173,7 +173,7 @@ ol.layer.Heatmap.createGradient_ = function(colors) {
 ol.layer.Heatmap.prototype.createCircle_ = function() {
   var radius = this.getRadius();
   var blur = this.getBlur();
-  goog.DEBUG && console.assert(radius !== undefined && blur !== undefined,
+  ol.DEBUG && console.assert(radius !== undefined && blur !== undefined,
       'radius and blur should be defined');
   var halfSize = radius + blur + 1;
   var size = 2 * halfSize;
@@ -246,9 +246,9 @@ ol.layer.Heatmap.prototype.handleStyleChanged_ = function() {
  * @private
  */
 ol.layer.Heatmap.prototype.handleRender_ = function(event) {
-  goog.DEBUG && console.assert(event.type == ol.render.EventType.RENDER,
+  ol.DEBUG && console.assert(event.type == ol.render.EventType.RENDER,
       'event.type should be RENDER');
-  goog.DEBUG && console.assert(this.gradient_, 'this.gradient_ expected');
+  ol.DEBUG && console.assert(this.gradient_, 'this.gradient_ expected');
   var context = event.context;
   var canvas = context.canvas;
   var image = context.getImageData(0, 0, canvas.width, canvas.height);

--- a/src/ol/layer/vector.js
+++ b/src/ol/layer/vector.js
@@ -32,7 +32,7 @@ ol.layer.Vector = function(opt_options) {
   var options = opt_options ?
       opt_options : /** @type {olx.layer.VectorOptions} */ ({});
 
-  goog.DEBUG && console.assert(
+  ol.DEBUG && console.assert(
       options.renderOrder === undefined || !options.renderOrder ||
       typeof options.renderOrder === 'function',
       'renderOrder must be a comparator function');
@@ -158,7 +158,7 @@ ol.layer.Vector.prototype.getUpdateWhileInteracting = function() {
  *     Render order.
  */
 ol.layer.Vector.prototype.setRenderOrder = function(renderOrder) {
-  goog.DEBUG && console.assert(
+  ol.DEBUG && console.assert(
       renderOrder === undefined || !renderOrder ||
       typeof renderOrder === 'function',
       'renderOrder must be a comparator function');

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -1047,7 +1047,7 @@ ol.Map.prototype.handleTargetChanged_ = function() {
   var targetElement;
   if (this.getTarget()) {
     targetElement = this.getTargetElement();
-    goog.DEBUG && console.assert(targetElement !== null,
+    ol.DEBUG && console.assert(targetElement !== null,
         'expects a non-null value for targetElement');
   }
 

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -5,7 +5,6 @@
 goog.provide('ol.Map');
 goog.provide('ol.MapProperty');
 
-goog.require('goog.async.nextTick');
 goog.require('ol');
 goog.require('ol.Collection');
 goog.require('ol.MapBrowserEvent');
@@ -1314,7 +1313,7 @@ ol.Map.prototype.renderFrame_ = function(time) {
   this.dispatchEvent(
       new ol.MapEvent(ol.MapEventType.POSTRENDER, this, frameState));
 
-  goog.async.nextTick(this.handlePostRender, this);
+  ol.global.setTimeout(this.handlePostRender.bind(this), 0);
 
 };
 

--- a/src/ol/mapbrowserevent.js
+++ b/src/ol/mapbrowserevent.js
@@ -270,11 +270,11 @@ ol.MapBrowserEventHandler.prototype.handlePointerUp_ = function(pointerEvent) {
   // to 0).
   // See http://www.w3.org/TR/pointerevents/#button-states
   if (!this.dragging_ && this.isMouseActionButton_(pointerEvent)) {
-    goog.DEBUG && console.assert(this.down_, 'this.down_ must be truthy');
+    ol.DEBUG && console.assert(this.down_, 'this.down_ must be truthy');
     this.emulateClick_(this.down_);
   }
 
-  goog.DEBUG && console.assert(this.activePointers_ >= 0,
+  ol.DEBUG && console.assert(this.activePointers_ >= 0,
       'this.activePointers_ should be equal to or larger than 0');
   if (this.activePointers_ === 0) {
     this.dragListenerKeys_.forEach(ol.events.unlistenByKey);

--- a/src/ol/math.js
+++ b/src/ol/math.js
@@ -106,7 +106,7 @@ ol.math.squaredDistance = function(x1, y1, x2, y2) {
 ol.math.solveLinearSystem = function(mat) {
   var n = mat.length;
 
-  if (goog.DEBUG) {
+  if (ol.DEBUG) {
     for (var row = 0; row < n; row++) {
       console.assert(mat[row].length == n + 1,
                           'every row should have correct number of columns');

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -495,7 +495,7 @@ ol.Overlay.prototype.updateRenderedPosition = function(pixel, mapSize) {
   var offset = this.getOffset();
 
   var positioning = this.getPositioning();
-  goog.DEBUG && console.assert(positioning !== undefined,
+  ol.DEBUG && console.assert(positioning !== undefined,
       'positioning should be defined');
 
   var offsetX = offset[0];

--- a/src/ol/proj/epsg3857.js
+++ b/src/ol/proj/epsg3857.js
@@ -114,7 +114,7 @@ ol.proj.EPSG3857.fromEPSG4326 = function(input, opt_output, opt_dimension) {
       output = new Array(length);
     }
   }
-  goog.DEBUG && console.assert(output.length % dimension === 0,
+  ol.DEBUG && console.assert(output.length % dimension === 0,
       'modulus of output.length with dimension should be 0');
   for (var i = 0; i < length; i += dimension) {
     output[i] = ol.proj.EPSG3857.RADIUS * Math.PI * input[i] / 180;
@@ -145,7 +145,7 @@ ol.proj.EPSG3857.toEPSG4326 = function(input, opt_output, opt_dimension) {
       output = new Array(length);
     }
   }
-  goog.DEBUG && console.assert(output.length % dimension === 0,
+  ol.DEBUG && console.assert(output.length % dimension === 0,
       'modulus of output.length with dimension should be 0');
   for (var i = 0; i < length; i += dimension) {
     output[i] = 180 * input[i] / (ol.proj.EPSG3857.RADIUS * Math.PI);

--- a/src/ol/proj/index.js
+++ b/src/ol/proj/index.js
@@ -136,7 +136,7 @@ ol.proj.Projection = function(options) {
 
   var projections = ol.proj.projections_;
   var code = options.code;
-  goog.DEBUG && console.assert(code !== undefined,
+  ol.DEBUG && console.assert(code !== undefined,
       'Option "code" is required for constructing instance');
   if (ol.ENABLE_PROJ4JS) {
     var proj4js = ol.proj.proj4_ || ol.global['proj4'];
@@ -416,7 +416,7 @@ if (ol.ENABLE_PROJ4JS) {
    * @api
    */
   ol.proj.setProj4 = function(proj4) {
-    goog.DEBUG && console.assert(typeof proj4 == 'function',
+    ol.DEBUG && console.assert(typeof proj4 == 'function',
         'proj4 argument should be a function');
     ol.proj.proj4_ = proj4;
   };
@@ -608,9 +608,9 @@ ol.proj.removeTransform = function(source, destination) {
   var sourceCode = source.getCode();
   var destinationCode = destination.getCode();
   var transforms = ol.proj.transforms_;
-  goog.DEBUG && console.assert(sourceCode in transforms,
+  ol.DEBUG && console.assert(sourceCode in transforms,
       'sourceCode should be in transforms');
-  goog.DEBUG && console.assert(destinationCode in transforms[sourceCode],
+  ol.DEBUG && console.assert(destinationCode in transforms[sourceCode],
       'destinationCode should be in transforms of sourceCode');
   var transform = transforms[sourceCode][destinationCode];
   delete transforms[sourceCode][destinationCode];
@@ -741,7 +741,7 @@ ol.proj.getTransformFromProjections = function(sourceProjection, destinationProj
     transform = transforms[sourceCode][destinationCode];
   }
   if (transform === undefined) {
-    goog.DEBUG && console.assert(transform !== undefined, 'transform should be defined');
+    ol.DEBUG && console.assert(transform !== undefined, 'transform should be defined');
     transform = ol.proj.identityTransform;
   }
   return transform;
@@ -757,7 +757,7 @@ ol.proj.getTransformFromProjections = function(sourceProjection, destinationProj
 ol.proj.identityTransform = function(input, opt_output, opt_dimension) {
   if (opt_output !== undefined && input !== opt_output) {
     // TODO: consider making this a warning instead
-    goog.DEBUG && console.assert(false, 'This should not be used internally.');
+    ol.DEBUG && console.assert(false, 'This should not be used internally.');
     for (var i = 0, ii = input.length; i < ii; ++i) {
       opt_output[i] = input[i];
     }

--- a/src/ol/render/canvas/immediate.js
+++ b/src/ol/render/canvas/immediate.js
@@ -252,8 +252,8 @@ ol.render.canvas.Immediate.prototype.drawImages_ = function(flatCoordinates, off
   if (!this.image_) {
     return;
   }
-  goog.DEBUG && console.assert(offset === 0, 'offset should be 0');
-  goog.DEBUG && console.assert(end == flatCoordinates.length,
+  ol.DEBUG && console.assert(offset === 0, 'offset should be 0');
+  ol.DEBUG && console.assert(end == flatCoordinates.length,
       'end should be equal to the length of flatCoordinates');
   var pixelCoordinates = ol.geom.flat.transform.transform2D(
       flatCoordinates, offset, end, 2, this.transform_,
@@ -317,8 +317,8 @@ ol.render.canvas.Immediate.prototype.drawText_ = function(flatCoordinates, offse
     this.setContextStrokeState_(this.textStrokeState_);
   }
   this.setContextTextState_(this.textState_);
-  goog.DEBUG && console.assert(offset === 0, 'offset should be 0');
-  goog.DEBUG && console.assert(end == flatCoordinates.length,
+  ol.DEBUG && console.assert(offset === 0, 'offset should be 0');
+  ol.DEBUG && console.assert(end == flatCoordinates.length,
       'end should be equal to the length of flatCoordinates');
   var pixelCoordinates = ol.geom.flat.transform.transform2D(
       flatCoordinates, offset, end, stride, this.transform_,
@@ -488,7 +488,7 @@ ol.render.canvas.Immediate.prototype.drawGeometry = function(geometry) {
       this.drawCircle(/** @type {ol.geom.Circle} */ (geometry));
       break;
     default:
-      goog.DEBUG && console.assert(false, 'Unsupported geometry type: ' + type);
+      ol.DEBUG && console.assert(false, 'Unsupported geometry type: ' + type);
   }
 };
 
@@ -863,7 +863,7 @@ ol.render.canvas.Immediate.prototype.setImageStyle = function(imageStyle) {
     var imageImage = imageStyle.getImage(1);
     var imageOrigin = imageStyle.getOrigin();
     var imageSize = imageStyle.getSize();
-    goog.DEBUG && console.assert(imageImage, 'imageImage must be truthy');
+    ol.DEBUG && console.assert(imageImage, 'imageImage must be truthy');
     this.imageAnchorX_ = imageAnchor[0];
     this.imageAnchorY_ = imageAnchor[1];
     this.imageHeight_ = imageSize[1];

--- a/src/ol/render/canvas/replay.js
+++ b/src/ol/render/canvas/replay.js
@@ -253,7 +253,7 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         this.coordinates, 0, this.coordinates.length, 2,
         transform, this.pixelCoordinates_);
     ol.transform.setFromArray(this.renderedTransform_, transform);
-    goog.DEBUG && console.assert(pixelCoordinates === this.pixelCoordinates_,
+    ol.DEBUG && console.assert(pixelCoordinates === this.pixelCoordinates_,
         'pixelCoordinates should be the same as this.pixelCoordinates_');
   }
   var skipFeatures = !ol.obj.isEmpty(skippedFeaturesHash);
@@ -303,7 +303,7 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         ++i;
         break;
       case ol.render.canvas.Instruction.CIRCLE:
-        goog.DEBUG && console.assert(typeof instruction[1] === 'number',
+        ol.DEBUG && console.assert(typeof instruction[1] === 'number',
             'second instruction should be a number');
         d = /** @type {number} */ (instruction[1]);
         var x1 = pixelCoordinates[d];
@@ -322,10 +322,10 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         ++i;
         break;
       case ol.render.canvas.Instruction.DRAW_IMAGE:
-        goog.DEBUG && console.assert(typeof instruction[1] === 'number',
+        ol.DEBUG && console.assert(typeof instruction[1] === 'number',
             'second instruction should be a number');
         d = /** @type {number} */ (instruction[1]);
-        goog.DEBUG && console.assert(typeof instruction[2] === 'number',
+        ol.DEBUG && console.assert(typeof instruction[2] === 'number',
             'third instruction should be a number');
         dd = /** @type {number} */ (instruction[2]);
         var image =  /** @type {HTMLCanvasElement|HTMLVideoElement|Image} */
@@ -381,31 +381,31 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         ++i;
         break;
       case ol.render.canvas.Instruction.DRAW_TEXT:
-        goog.DEBUG && console.assert(typeof instruction[1] === 'number',
+        ol.DEBUG && console.assert(typeof instruction[1] === 'number',
             '2nd instruction should be a number');
         d = /** @type {number} */ (instruction[1]);
-        goog.DEBUG && console.assert(typeof instruction[2] === 'number',
+        ol.DEBUG && console.assert(typeof instruction[2] === 'number',
             '3rd instruction should be a number');
         dd = /** @type {number} */ (instruction[2]);
-        goog.DEBUG && console.assert(typeof instruction[3] === 'string',
+        ol.DEBUG && console.assert(typeof instruction[3] === 'string',
             '4th instruction should be a string');
         text = /** @type {string} */ (instruction[3]);
-        goog.DEBUG && console.assert(typeof instruction[4] === 'number',
+        ol.DEBUG && console.assert(typeof instruction[4] === 'number',
             '5th instruction should be a number');
         var offsetX = /** @type {number} */ (instruction[4]) * pixelRatio;
-        goog.DEBUG && console.assert(typeof instruction[5] === 'number',
+        ol.DEBUG && console.assert(typeof instruction[5] === 'number',
             '6th instruction should be a number');
         var offsetY = /** @type {number} */ (instruction[5]) * pixelRatio;
-        goog.DEBUG && console.assert(typeof instruction[6] === 'number',
+        ol.DEBUG && console.assert(typeof instruction[6] === 'number',
             '7th instruction should be a number');
         rotation = /** @type {number} */ (instruction[6]);
-        goog.DEBUG && console.assert(typeof instruction[7] === 'number',
+        ol.DEBUG && console.assert(typeof instruction[7] === 'number',
             '8th instruction should be a number');
         scale = /** @type {number} */ (instruction[7]) * pixelRatio;
-        goog.DEBUG && console.assert(typeof instruction[8] === 'boolean',
+        ol.DEBUG && console.assert(typeof instruction[8] === 'boolean',
             '9th instruction should be a boolean');
         fill = /** @type {boolean} */ (instruction[8]);
-        goog.DEBUG && console.assert(typeof instruction[9] === 'boolean',
+        ol.DEBUG && console.assert(typeof instruction[9] === 'boolean',
             '10th instruction should be a boolean');
         stroke = /** @type {boolean} */ (instruction[9]);
         rotateWithView = /** @type {boolean} */ (instruction[10]);
@@ -474,10 +474,10 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         ++i;
         break;
       case ol.render.canvas.Instruction.MOVE_TO_LINE_TO:
-        goog.DEBUG && console.assert(typeof instruction[1] === 'number',
+        ol.DEBUG && console.assert(typeof instruction[1] === 'number',
             '2nd instruction should be a number');
         d = /** @type {number} */ (instruction[1]);
-        goog.DEBUG && console.assert(typeof instruction[2] === 'number',
+        ol.DEBUG && console.assert(typeof instruction[2] === 'number',
             '3rd instruction should be a number');
         dd = /** @type {number} */ (instruction[2]);
         x = pixelCoordinates[d];
@@ -503,7 +503,7 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         ++i;
         break;
       case ol.render.canvas.Instruction.SET_FILL_STYLE:
-        goog.DEBUG && console.assert(
+        ol.DEBUG && console.assert(
             ol.colorlike.isColorLike(instruction[1]),
             '2nd instruction should be a string, ' +
             'CanvasPattern, or CanvasGradient');
@@ -516,17 +516,17 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         ++i;
         break;
       case ol.render.canvas.Instruction.SET_STROKE_STYLE:
-        goog.DEBUG && console.assert(typeof instruction[1] === 'string',
+        ol.DEBUG && console.assert(typeof instruction[1] === 'string',
             '2nd instruction should be a string');
-        goog.DEBUG && console.assert(typeof instruction[2] === 'number',
+        ol.DEBUG && console.assert(typeof instruction[2] === 'number',
             '3rd instruction should be a number');
-        goog.DEBUG && console.assert(typeof instruction[3] === 'string',
+        ol.DEBUG && console.assert(typeof instruction[3] === 'string',
             '4rd instruction should be a string');
-        goog.DEBUG && console.assert(typeof instruction[4] === 'string',
+        ol.DEBUG && console.assert(typeof instruction[4] === 'string',
             '5th instruction should be a string');
-        goog.DEBUG && console.assert(typeof instruction[5] === 'number',
+        ol.DEBUG && console.assert(typeof instruction[5] === 'number',
             '6th instruction should be a number');
-        goog.DEBUG && console.assert(instruction[6],
+        ol.DEBUG && console.assert(instruction[6],
             '7th instruction should not be null');
         var usePixelRatio = instruction[7] !== undefined ?
             instruction[7] : true;
@@ -548,11 +548,11 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         ++i;
         break;
       case ol.render.canvas.Instruction.SET_TEXT_STYLE:
-        goog.DEBUG && console.assert(typeof instruction[1] === 'string',
+        ol.DEBUG && console.assert(typeof instruction[1] === 'string',
             '2nd instruction should be a string');
-        goog.DEBUG && console.assert(typeof instruction[2] === 'string',
+        ol.DEBUG && console.assert(typeof instruction[2] === 'string',
             '3rd instruction should be a string');
-        goog.DEBUG && console.assert(typeof instruction[3] === 'string',
+        ol.DEBUG && console.assert(typeof instruction[3] === 'string',
             '4th instruction should be a string');
         context.font = /** @type {string} */ (instruction[1]);
         context.textAlign = /** @type {string} */ (instruction[2]);
@@ -568,7 +568,7 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         ++i;
         break;
       default:
-        goog.DEBUG && console.assert(false, 'Unknown canvas render instruction');
+        ol.DEBUG && console.assert(false, 'Unknown canvas render instruction');
         ++i; // consume the instruction anyway, to avoid an infinite loop
         break;
     }
@@ -580,7 +580,7 @@ ol.render.canvas.Replay.prototype.replay_ = function(
     context.stroke();
   }
   // assert that all instructions were consumed
-  goog.DEBUG && console.assert(i == instructions.length,
+  ol.DEBUG && console.assert(i == instructions.length,
       'all instructions should be consumed');
   return undefined;
 };
@@ -641,11 +641,11 @@ ol.render.canvas.Replay.prototype.reverseHitDetectionInstructions_ = function() 
     instruction = hitDetectionInstructions[i];
     type = /** @type {ol.render.canvas.Instruction} */ (instruction[0]);
     if (type == ol.render.canvas.Instruction.END_GEOMETRY) {
-      goog.DEBUG && console.assert(begin == -1, 'begin should be -1');
+      ol.DEBUG && console.assert(begin == -1, 'begin should be -1');
       begin = i;
     } else if (type == ol.render.canvas.Instruction.BEGIN_GEOMETRY) {
       instruction[2] = i;
-      goog.DEBUG && console.assert(begin >= 0,
+      ol.DEBUG && console.assert(begin >= 0,
           'begin should be larger than or equal to 0');
       ol.array.reverseSubArray(this.hitDetectionInstructions, begin, i);
       begin = -1;
@@ -659,11 +659,11 @@ ol.render.canvas.Replay.prototype.reverseHitDetectionInstructions_ = function() 
  * @param {ol.Feature|ol.render.Feature} feature Feature.
  */
 ol.render.canvas.Replay.prototype.endGeometry = function(geometry, feature) {
-  goog.DEBUG && console.assert(this.beginGeometryInstruction1_,
+  ol.DEBUG && console.assert(this.beginGeometryInstruction1_,
       'this.beginGeometryInstruction1_ should not be null');
   this.beginGeometryInstruction1_[2] = this.instructions.length;
   this.beginGeometryInstruction1_ = null;
-  goog.DEBUG && console.assert(this.beginGeometryInstruction2_,
+  ol.DEBUG && console.assert(this.beginGeometryInstruction2_,
       'this.beginGeometryInstruction2_ should not be null');
   this.beginGeometryInstruction2_[2] = this.hitDetectionInstructions.length;
   this.beginGeometryInstruction2_ = null;
@@ -808,25 +808,25 @@ ol.render.canvas.ImageReplay.prototype.drawPoint = function(pointGeometry, featu
   if (!this.image_) {
     return;
   }
-  goog.DEBUG && console.assert(this.anchorX_ !== undefined,
+  ol.DEBUG && console.assert(this.anchorX_ !== undefined,
       'this.anchorX_ should be defined');
-  goog.DEBUG && console.assert(this.anchorY_ !== undefined,
+  ol.DEBUG && console.assert(this.anchorY_ !== undefined,
       'this.anchorY_ should be defined');
-  goog.DEBUG && console.assert(this.height_ !== undefined,
+  ol.DEBUG && console.assert(this.height_ !== undefined,
       'this.height_ should be defined');
-  goog.DEBUG && console.assert(this.opacity_ !== undefined,
+  ol.DEBUG && console.assert(this.opacity_ !== undefined,
       'this.opacity_ should be defined');
-  goog.DEBUG && console.assert(this.originX_ !== undefined,
+  ol.DEBUG && console.assert(this.originX_ !== undefined,
       'this.originX_ should be defined');
-  goog.DEBUG && console.assert(this.originY_ !== undefined,
+  ol.DEBUG && console.assert(this.originY_ !== undefined,
       'this.originY_ should be defined');
-  goog.DEBUG && console.assert(this.rotateWithView_ !== undefined,
+  ol.DEBUG && console.assert(this.rotateWithView_ !== undefined,
       'this.rotateWithView_ should be defined');
-  goog.DEBUG && console.assert(this.rotation_ !== undefined,
+  ol.DEBUG && console.assert(this.rotation_ !== undefined,
       'this.rotation_ should be defined');
-  goog.DEBUG && console.assert(this.scale_ !== undefined,
+  ol.DEBUG && console.assert(this.scale_ !== undefined,
       'this.scale_ should be defined');
-  goog.DEBUG && console.assert(this.width_ !== undefined,
+  ol.DEBUG && console.assert(this.width_ !== undefined,
       'this.width_ should be defined');
   this.beginGeometry(pointGeometry, feature);
   var flatCoordinates = pointGeometry.getFlatCoordinates();
@@ -860,25 +860,25 @@ ol.render.canvas.ImageReplay.prototype.drawMultiPoint = function(multiPointGeome
   if (!this.image_) {
     return;
   }
-  goog.DEBUG && console.assert(this.anchorX_ !== undefined,
+  ol.DEBUG && console.assert(this.anchorX_ !== undefined,
       'this.anchorX_ should be defined');
-  goog.DEBUG && console.assert(this.anchorY_ !== undefined,
+  ol.DEBUG && console.assert(this.anchorY_ !== undefined,
       'this.anchorY_ should be defined');
-  goog.DEBUG && console.assert(this.height_ !== undefined,
+  ol.DEBUG && console.assert(this.height_ !== undefined,
       'this.height_ should be defined');
-  goog.DEBUG && console.assert(this.opacity_ !== undefined,
+  ol.DEBUG && console.assert(this.opacity_ !== undefined,
       'this.opacity_ should be defined');
-  goog.DEBUG && console.assert(this.originX_ !== undefined,
+  ol.DEBUG && console.assert(this.originX_ !== undefined,
       'this.originX_ should be defined');
-  goog.DEBUG && console.assert(this.originY_ !== undefined,
+  ol.DEBUG && console.assert(this.originY_ !== undefined,
       'this.originY_ should be defined');
-  goog.DEBUG && console.assert(this.rotateWithView_ !== undefined,
+  ol.DEBUG && console.assert(this.rotateWithView_ !== undefined,
       'this.rotateWithView_ should be defined');
-  goog.DEBUG && console.assert(this.rotation_ !== undefined,
+  ol.DEBUG && console.assert(this.rotation_ !== undefined,
       'this.rotation_ should be defined');
-  goog.DEBUG && console.assert(this.scale_ !== undefined,
+  ol.DEBUG && console.assert(this.scale_ !== undefined,
       'this.scale_ should be defined');
-  goog.DEBUG && console.assert(this.width_ !== undefined,
+  ol.DEBUG && console.assert(this.width_ !== undefined,
       'this.width_ should be defined');
   this.beginGeometry(multiPointGeometry, feature);
   var flatCoordinates = multiPointGeometry.getFlatCoordinates();
@@ -931,18 +931,18 @@ ol.render.canvas.ImageReplay.prototype.finish = function() {
  * @inheritDoc
  */
 ol.render.canvas.ImageReplay.prototype.setImageStyle = function(imageStyle) {
-  goog.DEBUG && console.assert(imageStyle, 'imageStyle should not be null');
+  ol.DEBUG && console.assert(imageStyle, 'imageStyle should not be null');
   var anchor = imageStyle.getAnchor();
-  goog.DEBUG && console.assert(anchor, 'anchor should not be null');
+  ol.DEBUG && console.assert(anchor, 'anchor should not be null');
   var size = imageStyle.getSize();
-  goog.DEBUG && console.assert(size, 'size should not be null');
+  ol.DEBUG && console.assert(size, 'size should not be null');
   var hitDetectionImage = imageStyle.getHitDetectionImage(1);
-  goog.DEBUG && console.assert(hitDetectionImage,
+  ol.DEBUG && console.assert(hitDetectionImage,
       'hitDetectionImage should not be null');
   var image = imageStyle.getImage(1);
-  goog.DEBUG && console.assert(image, 'image should not be null');
+  ol.DEBUG && console.assert(image, 'image should not be null');
   var origin = imageStyle.getOrigin();
-  goog.DEBUG && console.assert(origin, 'origin should not be null');
+  ol.DEBUG && console.assert(origin, 'origin should not be null');
   this.anchorX_ = anchor[0];
   this.anchorY_ = anchor[1];
   this.hitDetectionImage_ = hitDetectionImage;
@@ -1055,13 +1055,13 @@ ol.render.canvas.LineStringReplay.prototype.setStrokeStyle_ = function() {
   var lineJoin = state.lineJoin;
   var lineWidth = state.lineWidth;
   var miterLimit = state.miterLimit;
-  goog.DEBUG && console.assert(strokeStyle !== undefined,
+  ol.DEBUG && console.assert(strokeStyle !== undefined,
       'strokeStyle should be defined');
-  goog.DEBUG && console.assert(lineCap !== undefined, 'lineCap should be defined');
-  goog.DEBUG && console.assert(lineDash, 'lineDash should not be null');
-  goog.DEBUG && console.assert(lineJoin !== undefined, 'lineJoin should be defined');
-  goog.DEBUG && console.assert(lineWidth !== undefined, 'lineWidth should be defined');
-  goog.DEBUG && console.assert(miterLimit !== undefined, 'miterLimit should be defined');
+  ol.DEBUG && console.assert(lineCap !== undefined, 'lineCap should be defined');
+  ol.DEBUG && console.assert(lineDash, 'lineDash should not be null');
+  ol.DEBUG && console.assert(lineJoin !== undefined, 'lineJoin should be defined');
+  ol.DEBUG && console.assert(lineWidth !== undefined, 'lineWidth should be defined');
+  ol.DEBUG && console.assert(miterLimit !== undefined, 'miterLimit should be defined');
   if (state.currentStrokeStyle != strokeStyle ||
       state.currentLineCap != lineCap ||
       !ol.array.equals(state.currentLineDash, lineDash) ||
@@ -1092,7 +1092,7 @@ ol.render.canvas.LineStringReplay.prototype.setStrokeStyle_ = function() {
  */
 ol.render.canvas.LineStringReplay.prototype.drawLineString = function(lineStringGeometry, feature) {
   var state = this.state_;
-  goog.DEBUG && console.assert(state, 'state should not be null');
+  ol.DEBUG && console.assert(state, 'state should not be null');
   var strokeStyle = state.strokeStyle;
   var lineWidth = state.lineWidth;
   if (strokeStyle === undefined || lineWidth === undefined) {
@@ -1119,7 +1119,7 @@ ol.render.canvas.LineStringReplay.prototype.drawLineString = function(lineString
  */
 ol.render.canvas.LineStringReplay.prototype.drawMultiLineString = function(multiLineStringGeometry, feature) {
   var state = this.state_;
-  goog.DEBUG && console.assert(state, 'state should not be null');
+  ol.DEBUG && console.assert(state, 'state should not be null');
   var strokeStyle = state.strokeStyle;
   var lineWidth = state.lineWidth;
   if (strokeStyle === undefined || lineWidth === undefined) {
@@ -1151,7 +1151,7 @@ ol.render.canvas.LineStringReplay.prototype.drawMultiLineString = function(multi
  */
 ol.render.canvas.LineStringReplay.prototype.finish = function() {
   var state = this.state_;
-  goog.DEBUG && console.assert(state, 'state should not be null');
+  ol.DEBUG && console.assert(state, 'state should not be null');
   if (state.lastStroke != this.coordinates.length) {
     this.instructions.push([ol.render.canvas.Instruction.STROKE]);
   }
@@ -1164,9 +1164,9 @@ ol.render.canvas.LineStringReplay.prototype.finish = function() {
  * @inheritDoc
  */
 ol.render.canvas.LineStringReplay.prototype.setFillStrokeStyle = function(fillStyle, strokeStyle) {
-  goog.DEBUG && console.assert(this.state_, 'this.state_ should not be null');
-  goog.DEBUG && console.assert(!fillStyle, 'fillStyle should be null');
-  goog.DEBUG && console.assert(strokeStyle, 'strokeStyle should not be null');
+  ol.DEBUG && console.assert(this.state_, 'this.state_ should not be null');
+  ol.DEBUG && console.assert(!fillStyle, 'fillStyle should be null');
+  ol.DEBUG && console.assert(strokeStyle, 'strokeStyle should not be null');
   var strokeStyleColor = strokeStyle.getColor();
   this.state_.strokeStyle = ol.color.asString(strokeStyleColor ?
       strokeStyleColor : ol.render.canvas.defaultStrokeStyle);
@@ -1291,7 +1291,7 @@ ol.render.canvas.PolygonReplay.prototype.drawFlatCoordinatess_ = function(flatCo
     this.instructions.push(fillInstruction);
   }
   if (stroke) {
-    goog.DEBUG && console.assert(state.lineWidth !== undefined,
+    ol.DEBUG && console.assert(state.lineWidth !== undefined,
         'state.lineWidth should be defined');
     var strokeInstruction = [ol.render.canvas.Instruction.STROKE];
     this.instructions.push(strokeInstruction);
@@ -1306,14 +1306,14 @@ ol.render.canvas.PolygonReplay.prototype.drawFlatCoordinatess_ = function(flatCo
  */
 ol.render.canvas.PolygonReplay.prototype.drawCircle = function(circleGeometry, feature) {
   var state = this.state_;
-  goog.DEBUG && console.assert(state, 'state should not be null');
+  ol.DEBUG && console.assert(state, 'state should not be null');
   var fillStyle = state.fillStyle;
   var strokeStyle = state.strokeStyle;
   if (fillStyle === undefined && strokeStyle === undefined) {
     return;
   }
   if (strokeStyle !== undefined) {
-    goog.DEBUG && console.assert(state.lineWidth !== undefined,
+    ol.DEBUG && console.assert(state.lineWidth !== undefined,
         'state.lineWidth should be defined');
   }
   this.setFillStrokeStyles_();
@@ -1343,7 +1343,7 @@ ol.render.canvas.PolygonReplay.prototype.drawCircle = function(circleGeometry, f
     this.instructions.push(fillInstruction);
   }
   if (state.strokeStyle !== undefined) {
-    goog.DEBUG && console.assert(state.lineWidth !== undefined,
+    ol.DEBUG && console.assert(state.lineWidth !== undefined,
         'state.lineWidth should be defined');
     var strokeInstruction = [ol.render.canvas.Instruction.STROKE];
     this.instructions.push(strokeInstruction);
@@ -1358,14 +1358,14 @@ ol.render.canvas.PolygonReplay.prototype.drawCircle = function(circleGeometry, f
  */
 ol.render.canvas.PolygonReplay.prototype.drawPolygon = function(polygonGeometry, feature) {
   var state = this.state_;
-  goog.DEBUG && console.assert(state, 'state should not be null');
+  ol.DEBUG && console.assert(state, 'state should not be null');
   var fillStyle = state.fillStyle;
   var strokeStyle = state.strokeStyle;
   if (fillStyle === undefined && strokeStyle === undefined) {
     return;
   }
   if (strokeStyle !== undefined) {
-    goog.DEBUG && console.assert(state.lineWidth !== undefined,
+    ol.DEBUG && console.assert(state.lineWidth !== undefined,
         'state.lineWidth should be defined');
   }
   this.setFillStrokeStyles_();
@@ -1393,14 +1393,14 @@ ol.render.canvas.PolygonReplay.prototype.drawPolygon = function(polygonGeometry,
  */
 ol.render.canvas.PolygonReplay.prototype.drawMultiPolygon = function(multiPolygonGeometry, feature) {
   var state = this.state_;
-  goog.DEBUG && console.assert(state, 'state should not be null');
+  ol.DEBUG && console.assert(state, 'state should not be null');
   var fillStyle = state.fillStyle;
   var strokeStyle = state.strokeStyle;
   if (fillStyle === undefined && strokeStyle === undefined) {
     return;
   }
   if (strokeStyle !== undefined) {
-    goog.DEBUG && console.assert(state.lineWidth !== undefined,
+    ol.DEBUG && console.assert(state.lineWidth !== undefined,
         'state.lineWidth should be defined');
   }
   this.setFillStrokeStyles_();
@@ -1432,7 +1432,7 @@ ol.render.canvas.PolygonReplay.prototype.drawMultiPolygon = function(multiPolygo
  * @inheritDoc
  */
 ol.render.canvas.PolygonReplay.prototype.finish = function() {
-  goog.DEBUG && console.assert(this.state_, 'this.state_ should not be null');
+  ol.DEBUG && console.assert(this.state_, 'this.state_ should not be null');
   this.reverseHitDetectionInstructions_();
   this.state_ = null;
   // We want to preserve topology when drawing polygons.  Polygons are
@@ -1469,8 +1469,8 @@ ol.render.canvas.PolygonReplay.prototype.getBufferedMaxExtent = function() {
  * @inheritDoc
  */
 ol.render.canvas.PolygonReplay.prototype.setFillStrokeStyle = function(fillStyle, strokeStyle) {
-  goog.DEBUG && console.assert(this.state_, 'this.state_ should not be null');
-  goog.DEBUG && console.assert(fillStyle || strokeStyle,
+  ol.DEBUG && console.assert(this.state_, 'this.state_ should not be null');
+  ol.DEBUG && console.assert(fillStyle || strokeStyle,
       'fillStyle or strokeStyle should not be null');
   var state = this.state_;
   if (fillStyle) {
@@ -1534,11 +1534,11 @@ ol.render.canvas.PolygonReplay.prototype.setFillStrokeStyles_ = function() {
     state.currentFillStyle = state.fillStyle;
   }
   if (strokeStyle !== undefined) {
-    goog.DEBUG && console.assert(lineCap !== undefined, 'lineCap should be defined');
-    goog.DEBUG && console.assert(lineDash, 'lineDash should not be null');
-    goog.DEBUG && console.assert(lineJoin !== undefined, 'lineJoin should be defined');
-    goog.DEBUG && console.assert(lineWidth !== undefined, 'lineWidth should be defined');
-    goog.DEBUG && console.assert(miterLimit !== undefined,
+    ol.DEBUG && console.assert(lineCap !== undefined, 'lineCap should be defined');
+    ol.DEBUG && console.assert(lineDash, 'lineDash should not be null');
+    ol.DEBUG && console.assert(lineJoin !== undefined, 'lineJoin should be defined');
+    ol.DEBUG && console.assert(lineWidth !== undefined, 'lineWidth should be defined');
+    ol.DEBUG && console.assert(miterLimit !== undefined,
         'miterLimit should be defined');
     if (state.currentStrokeStyle != strokeStyle ||
         state.currentLineCap != lineCap ||
@@ -2025,7 +2025,7 @@ ol.render.canvas.ReplayGroup.prototype.getReplay = function(zIndex, replayType) 
   var replay = replays[replayType];
   if (replay === undefined) {
     var Constructor = ol.render.canvas.BATCH_CONSTRUCTORS_[replayType];
-    goog.DEBUG && console.assert(Constructor !== undefined,
+    ol.DEBUG && console.assert(Constructor !== undefined,
         replayType +
         ' constructor missing from ol.render.canvas.BATCH_CONSTRUCTORS_');
     replay = new Constructor(this.tolerance_, this.maxExtent_,

--- a/src/ol/render/feature.js
+++ b/src/ol/render/feature.js
@@ -25,7 +25,7 @@ ol.render.Feature = function(type, flatCoordinates, ends, properties) {
    */
   this.extent_;
 
-  goog.DEBUG && console.assert(type === ol.geom.GeometryType.POINT ||
+  ol.DEBUG && console.assert(type === ol.geom.GeometryType.POINT ||
       type === ol.geom.GeometryType.MULTI_POINT ||
       type === ol.geom.GeometryType.LINE_STRING ||
       type === ol.geom.GeometryType.MULTI_LINE_STRING ||

--- a/src/ol/render/webgl/imagereplay/defaultshader.js
+++ b/src/ol/render/webgl/imagereplay/defaultshader.js
@@ -35,7 +35,7 @@ ol.render.webgl.imagereplay.defaultshader.Fragment.OPTIMIZED_SOURCE = 'precision
  * @const
  * @type {string}
  */
-ol.render.webgl.imagereplay.defaultshader.Fragment.SOURCE = goog.DEBUG ?
+ol.render.webgl.imagereplay.defaultshader.Fragment.SOURCE = ol.DEBUG ?
     ol.render.webgl.imagereplay.defaultshader.Fragment.DEBUG_SOURCE :
     ol.render.webgl.imagereplay.defaultshader.Fragment.OPTIMIZED_SOURCE;
 
@@ -72,7 +72,7 @@ ol.render.webgl.imagereplay.defaultshader.Vertex.OPTIMIZED_SOURCE = 'varying vec
  * @const
  * @type {string}
  */
-ol.render.webgl.imagereplay.defaultshader.Vertex.SOURCE = goog.DEBUG ?
+ol.render.webgl.imagereplay.defaultshader.Vertex.SOURCE = ol.DEBUG ?
     ol.render.webgl.imagereplay.defaultshader.Vertex.DEBUG_SOURCE :
     ol.render.webgl.imagereplay.defaultshader.Vertex.OPTIMIZED_SOURCE;
 
@@ -92,59 +92,59 @@ ol.render.webgl.imagereplay.defaultshader.Locations = function(gl, program) {
    * @type {WebGLUniformLocation}
    */
   this.u_image = gl.getUniformLocation(
-      program, goog.DEBUG ? 'u_image' : 'l');
+      program, ol.DEBUG ? 'u_image' : 'l');
 
   /**
    * @type {WebGLUniformLocation}
    */
   this.u_offsetRotateMatrix = gl.getUniformLocation(
-      program, goog.DEBUG ? 'u_offsetRotateMatrix' : 'j');
+      program, ol.DEBUG ? 'u_offsetRotateMatrix' : 'j');
 
   /**
    * @type {WebGLUniformLocation}
    */
   this.u_offsetScaleMatrix = gl.getUniformLocation(
-      program, goog.DEBUG ? 'u_offsetScaleMatrix' : 'i');
+      program, ol.DEBUG ? 'u_offsetScaleMatrix' : 'i');
 
   /**
    * @type {WebGLUniformLocation}
    */
   this.u_opacity = gl.getUniformLocation(
-      program, goog.DEBUG ? 'u_opacity' : 'k');
+      program, ol.DEBUG ? 'u_opacity' : 'k');
 
   /**
    * @type {WebGLUniformLocation}
    */
   this.u_projectionMatrix = gl.getUniformLocation(
-      program, goog.DEBUG ? 'u_projectionMatrix' : 'h');
+      program, ol.DEBUG ? 'u_projectionMatrix' : 'h');
 
   /**
    * @type {number}
    */
   this.a_offsets = gl.getAttribLocation(
-      program, goog.DEBUG ? 'a_offsets' : 'e');
+      program, ol.DEBUG ? 'a_offsets' : 'e');
 
   /**
    * @type {number}
    */
   this.a_opacity = gl.getAttribLocation(
-      program, goog.DEBUG ? 'a_opacity' : 'f');
+      program, ol.DEBUG ? 'a_opacity' : 'f');
 
   /**
    * @type {number}
    */
   this.a_position = gl.getAttribLocation(
-      program, goog.DEBUG ? 'a_position' : 'c');
+      program, ol.DEBUG ? 'a_position' : 'c');
 
   /**
    * @type {number}
    */
   this.a_rotateWithView = gl.getAttribLocation(
-      program, goog.DEBUG ? 'a_rotateWithView' : 'g');
+      program, ol.DEBUG ? 'a_rotateWithView' : 'g');
 
   /**
    * @type {number}
    */
   this.a_texCoord = gl.getAttribLocation(
-      program, goog.DEBUG ? 'a_texCoord' : 'd');
+      program, ol.DEBUG ? 'a_texCoord' : 'd');
 };

--- a/src/ol/render/webgl/imagereplay/index.js
+++ b/src/ol/render/webgl/imagereplay/index.js
@@ -224,9 +224,9 @@ ol.render.webgl.ImageReplay.prototype.getDeleteResourcesFunction = function(cont
   // be used by other ImageReplay instances (for other layers). And
   // they will be deleted when disposing of the ol.webgl.Context
   // object.
-  goog.DEBUG && console.assert(this.verticesBuffer_,
+  ol.DEBUG && console.assert(this.verticesBuffer_,
       'verticesBuffer must not be null');
-  goog.DEBUG && console.assert(this.indicesBuffer_,
+  ol.DEBUG && console.assert(this.indicesBuffer_,
       'indicesBuffer must not be null');
   var verticesBuffer = this.verticesBuffer_;
   var indicesBuffer = this.indicesBuffer_;
@@ -258,20 +258,20 @@ ol.render.webgl.ImageReplay.prototype.getDeleteResourcesFunction = function(cont
  * @private
  */
 ol.render.webgl.ImageReplay.prototype.drawCoordinates_ = function(flatCoordinates, offset, end, stride) {
-  goog.DEBUG && console.assert(this.anchorX_ !== undefined, 'anchorX is defined');
-  goog.DEBUG && console.assert(this.anchorY_ !== undefined, 'anchorY is defined');
-  goog.DEBUG && console.assert(this.height_ !== undefined, 'height is defined');
-  goog.DEBUG && console.assert(this.imageHeight_ !== undefined,
+  ol.DEBUG && console.assert(this.anchorX_ !== undefined, 'anchorX is defined');
+  ol.DEBUG && console.assert(this.anchorY_ !== undefined, 'anchorY is defined');
+  ol.DEBUG && console.assert(this.height_ !== undefined, 'height is defined');
+  ol.DEBUG && console.assert(this.imageHeight_ !== undefined,
       'imageHeight is defined');
-  goog.DEBUG && console.assert(this.imageWidth_ !== undefined, 'imageWidth is defined');
-  goog.DEBUG && console.assert(this.opacity_ !== undefined, 'opacity is defined');
-  goog.DEBUG && console.assert(this.originX_ !== undefined, 'originX is defined');
-  goog.DEBUG && console.assert(this.originY_ !== undefined, 'originY is defined');
-  goog.DEBUG && console.assert(this.rotateWithView_ !== undefined,
+  ol.DEBUG && console.assert(this.imageWidth_ !== undefined, 'imageWidth is defined');
+  ol.DEBUG && console.assert(this.opacity_ !== undefined, 'opacity is defined');
+  ol.DEBUG && console.assert(this.originX_ !== undefined, 'originX is defined');
+  ol.DEBUG && console.assert(this.originY_ !== undefined, 'originY is defined');
+  ol.DEBUG && console.assert(this.rotateWithView_ !== undefined,
       'rotateWithView is defined');
-  goog.DEBUG && console.assert(this.rotation_ !== undefined, 'rotation is defined');
-  goog.DEBUG && console.assert(this.scale_ !== undefined, 'scale is defined');
-  goog.DEBUG && console.assert(this.width_ !== undefined, 'width is defined');
+  ol.DEBUG && console.assert(this.rotation_ !== undefined, 'rotation is defined');
+  ol.DEBUG && console.assert(this.scale_ !== undefined, 'scale is defined');
+  ol.DEBUG && console.assert(this.width_ !== undefined, 'width is defined');
   var anchorX = /** @type {number} */ (this.anchorX_);
   var anchorY = /** @type {number} */ (this.anchorY_);
   var height = /** @type {number} */ (this.height_);
@@ -398,10 +398,10 @@ ol.render.webgl.ImageReplay.prototype.finish = function(context) {
   var gl = context.getGL();
 
   this.groupIndices_.push(this.indices_.length);
-  goog.DEBUG && console.assert(this.images_.length === this.groupIndices_.length,
+  ol.DEBUG && console.assert(this.images_.length === this.groupIndices_.length,
       'number of images and groupIndices match');
   this.hitDetectionGroupIndices_.push(this.indices_.length);
-  goog.DEBUG && console.assert(this.hitDetectionImages_.length ===
+  ol.DEBUG && console.assert(this.hitDetectionImages_.length ===
       this.hitDetectionGroupIndices_.length,
       'number of hitDetectionImages and hitDetectionGroupIndices match');
 
@@ -411,7 +411,7 @@ ol.render.webgl.ImageReplay.prototype.finish = function(context) {
 
   var indices = this.indices_;
   var bits = context.hasOESElementIndexUint ? 32 : 16;
-  goog.DEBUG && console.assert(indices[indices.length - 1] < Math.pow(2, bits),
+  ol.DEBUG && console.assert(indices[indices.length - 1] < Math.pow(2, bits),
       'Too large element index detected [%s] (OES_element_index_uint "%s")',
       indices[indices.length - 1], context.hasOESElementIndexUint);
 
@@ -424,12 +424,12 @@ ol.render.webgl.ImageReplay.prototype.finish = function(context) {
   var texturePerImage = {};
 
   this.createTextures_(this.textures_, this.images_, texturePerImage, gl);
-  goog.DEBUG && console.assert(this.textures_.length === this.groupIndices_.length,
+  ol.DEBUG && console.assert(this.textures_.length === this.groupIndices_.length,
       'number of textures and groupIndices match');
 
   this.createTextures_(this.hitDetectionTextures_, this.hitDetectionImages_,
       texturePerImage, gl);
-  goog.DEBUG && console.assert(this.hitDetectionTextures_.length ===
+  ol.DEBUG && console.assert(this.hitDetectionTextures_.length ===
       this.hitDetectionGroupIndices_.length,
       'number of hitDetectionTextures and hitDetectionGroupIndices match');
 
@@ -461,7 +461,7 @@ ol.render.webgl.ImageReplay.prototype.finish = function(context) {
  * @param {WebGLRenderingContext} gl Gl.
  */
 ol.render.webgl.ImageReplay.prototype.createTextures_ = function(textures, images, texturePerImage, gl) {
-  goog.DEBUG && console.assert(textures.length === 0,
+  ol.DEBUG && console.assert(textures.length === 0,
       'upon creation, textures is empty');
 
   var texture, image, uid, i;
@@ -506,12 +506,12 @@ ol.render.webgl.ImageReplay.prototype.replay = function(context,
   var gl = context.getGL();
 
   // bind the vertices buffer
-  goog.DEBUG && console.assert(this.verticesBuffer_,
+  ol.DEBUG && console.assert(this.verticesBuffer_,
       'verticesBuffer must not be null');
   context.bindBuffer(ol.webgl.ARRAY_BUFFER, this.verticesBuffer_);
 
   // bind the indices buffer
-  goog.DEBUG && console.assert(this.indicesBuffer_,
+  ol.DEBUG && console.assert(this.indicesBuffer_,
       'indecesBuffer must not be null');
   context.bindBuffer(ol.webgl.ELEMENT_ARRAY_BUFFER, this.indicesBuffer_);
 
@@ -608,7 +608,7 @@ ol.render.webgl.ImageReplay.prototype.replay = function(context,
  * @param {Array.<number>} groupIndices Texture group indices.
  */
 ol.render.webgl.ImageReplay.prototype.drawReplay_ = function(gl, context, skippedFeaturesHash, textures, groupIndices) {
-  goog.DEBUG && console.assert(textures.length === groupIndices.length,
+  ol.DEBUG && console.assert(textures.length === groupIndices.length,
       'number of textures and groupIndeces match');
   var elementType = context.hasOESElementIndexUint ?
       ol.webgl.UNSIGNED_INT : ol.webgl.UNSIGNED_SHORT;
@@ -782,7 +782,7 @@ ol.render.webgl.ImageReplay.prototype.drawHitDetectionReplayAll_ = function(gl, 
  */
 ol.render.webgl.ImageReplay.prototype.drawHitDetectionReplayOneByOne_ = function(gl, context, skippedFeaturesHash, featureCallback,
     opt_hitExtent) {
-  goog.DEBUG && console.assert(this.hitDetectionTextures_.length ===
+  ol.DEBUG && console.assert(this.hitDetectionTextures_.length ===
       this.hitDetectionGroupIndices_.length,
       'number of hitDetectionTextures and hitDetectionGroupIndices match');
   var elementType = context.hasOESElementIndexUint ?
@@ -847,21 +847,21 @@ ol.render.webgl.ImageReplay.prototype.setImageStyle = function(imageStyle) {
   var rotation = imageStyle.getRotation();
   var size = imageStyle.getSize();
   var scale = imageStyle.getScale();
-  goog.DEBUG && console.assert(anchor, 'imageStyle anchor is not null');
-  goog.DEBUG && console.assert(image, 'imageStyle image is not null');
-  goog.DEBUG && console.assert(imageSize,
+  ol.DEBUG && console.assert(anchor, 'imageStyle anchor is not null');
+  ol.DEBUG && console.assert(image, 'imageStyle image is not null');
+  ol.DEBUG && console.assert(imageSize,
       'imageStyle imageSize is not null');
-  goog.DEBUG && console.assert(hitDetectionImage,
+  ol.DEBUG && console.assert(hitDetectionImage,
       'imageStyle hitDetectionImage is not null');
-  goog.DEBUG && console.assert(hitDetectionImageSize,
+  ol.DEBUG && console.assert(hitDetectionImageSize,
       'imageStyle hitDetectionImageSize is not null');
-  goog.DEBUG && console.assert(opacity !== undefined, 'imageStyle opacity is defined');
-  goog.DEBUG && console.assert(origin, 'imageStyle origin is not null');
-  goog.DEBUG && console.assert(rotateWithView !== undefined,
+  ol.DEBUG && console.assert(opacity !== undefined, 'imageStyle opacity is defined');
+  ol.DEBUG && console.assert(origin, 'imageStyle origin is not null');
+  ol.DEBUG && console.assert(rotateWithView !== undefined,
       'imageStyle rotateWithView is defined');
-  goog.DEBUG && console.assert(rotation !== undefined, 'imageStyle rotation is defined');
-  goog.DEBUG && console.assert(size, 'imageStyle size is not null');
-  goog.DEBUG && console.assert(scale !== undefined, 'imageStyle scale is defined');
+  ol.DEBUG && console.assert(rotation !== undefined, 'imageStyle rotation is defined');
+  ol.DEBUG && console.assert(size, 'imageStyle size is not null');
+  ol.DEBUG && console.assert(scale !== undefined, 'imageStyle scale is defined');
 
   var currentImage;
   if (this.images_.length === 0) {
@@ -870,7 +870,7 @@ ol.render.webgl.ImageReplay.prototype.setImageStyle = function(imageStyle) {
     currentImage = this.images_[this.images_.length - 1];
     if (ol.getUid(currentImage) != ol.getUid(image)) {
       this.groupIndices_.push(this.indices_.length);
-      goog.DEBUG && console.assert(this.groupIndices_.length === this.images_.length,
+      ol.DEBUG && console.assert(this.groupIndices_.length === this.images_.length,
           'number of groupIndices and images match');
       this.images_.push(image);
     }
@@ -883,7 +883,7 @@ ol.render.webgl.ImageReplay.prototype.setImageStyle = function(imageStyle) {
         this.hitDetectionImages_[this.hitDetectionImages_.length - 1];
     if (ol.getUid(currentImage) != ol.getUid(hitDetectionImage)) {
       this.hitDetectionGroupIndices_.push(this.indices_.length);
-      goog.DEBUG && console.assert(this.hitDetectionGroupIndices_.length ===
+      ol.DEBUG && console.assert(this.hitDetectionGroupIndices_.length ===
           this.hitDetectionImages_.length,
           'number of hitDetectionGroupIndices and hitDetectionImages match');
       this.hitDetectionImages_.push(hitDetectionImage);

--- a/src/ol/render/webgl/immediate.js
+++ b/src/ol/render/webgl/immediate.js
@@ -100,7 +100,7 @@ ol.render.webgl.Immediate.prototype.drawGeometry = function(geometry) {
       this.drawGeometryCollection(/** @type {ol.geom.GeometryCollection} */ (geometry), null);
       break;
     default:
-      goog.DEBUG && console.assert(false, 'Unsupported geometry type: ' + type);
+      ol.DEBUG && console.assert(false, 'Unsupported geometry type: ' + type);
   }
 };
 
@@ -116,7 +116,7 @@ ol.render.webgl.Immediate.prototype.drawFeature = function(feature, style) {
     return;
   }
   this.setStyle(style);
-  goog.DEBUG && console.assert(geometry, 'geometry must be truthy');
+  ol.DEBUG && console.assert(geometry, 'geometry must be truthy');
   this.drawGeometry(geometry);
 };
 

--- a/src/ol/renderer/canvas/imagelayer.js
+++ b/src/ol/renderer/canvas/imagelayer.js
@@ -167,7 +167,7 @@ ol.renderer.canvas.ImageLayer.prototype.prepareFrame = function(frameState, laye
     if (!ol.ENABLE_RASTER_REPROJECTION) {
       var sourceProjection = imageSource.getProjection();
       if (sourceProjection) {
-        goog.DEBUG && console.assert(ol.proj.equivalent(projection, sourceProjection),
+        ol.DEBUG && console.assert(ol.proj.equivalent(projection, sourceProjection),
             'projection and sourceProjection are equivalent');
         projection = sourceProjection;
       }

--- a/src/ol/renderer/canvas/map.js
+++ b/src/ol/renderer/canvas/map.js
@@ -81,7 +81,7 @@ ol.renderer.canvas.Map.prototype.createLayerRenderer = function(layer) {
   } else if (ol.ENABLE_VECTOR && layer instanceof ol.layer.Vector) {
     return new ol.renderer.canvas.VectorLayer(layer);
   } else {
-    goog.DEBUG && console.assert(false, 'unexpected layer configuration');
+    ol.DEBUG && console.assert(false, 'unexpected layer configuration');
     return null;
   }
 };

--- a/src/ol/renderer/dom/imagelayer.js
+++ b/src/ol/renderer/dom/imagelayer.js
@@ -96,7 +96,7 @@ ol.renderer.dom.ImageLayer.prototype.prepareFrame = function(frameState, layerSt
     if (!ol.ENABLE_RASTER_REPROJECTION) {
       var sourceProjection = imageSource.getProjection();
       if (sourceProjection) {
-        goog.DEBUG && console.assert(ol.proj.equivalent(projection, sourceProjection),
+        ol.DEBUG && console.assert(ol.proj.equivalent(projection, sourceProjection),
             'projection and sourceProjection are equivalent');
         projection = sourceProjection;
       }

--- a/src/ol/renderer/dom/map.js
+++ b/src/ol/renderer/dom/map.js
@@ -99,7 +99,7 @@ ol.renderer.dom.Map.prototype.createLayerRenderer = function(layer) {
   } else if (ol.ENABLE_VECTOR && layer instanceof ol.layer.Vector) {
     layerRenderer = new ol.renderer.dom.VectorLayer(layer);
   } else {
-    goog.DEBUG && console.assert(false, 'unexpected layer configuration');
+    ol.DEBUG && console.assert(false, 'unexpected layer configuration');
     return null;
   }
   return layerRenderer;

--- a/src/ol/renderer/dom/tilelayer.js
+++ b/src/ol/renderer/dom/tilelayer.js
@@ -329,7 +329,7 @@ ol.renderer.dom.TileLayerZ_.prototype.addTile = function(tile, tileGutter) {
   var tileCoordZ = tileCoord[0];
   var tileCoordX = tileCoord[1];
   var tileCoordY = tileCoord[2];
-  goog.DEBUG && console.assert(tileCoordZ == this.tileCoordOrigin_[0],
+  ol.DEBUG && console.assert(tileCoordZ == this.tileCoordOrigin_[0],
       'tileCoordZ matches z of tileCoordOrigin');
   var tileCoordKey = tileCoord.toString();
   if (tileCoordKey in this.tiles_) {

--- a/src/ol/renderer/layer.js
+++ b/src/ol/renderer/layer.js
@@ -141,7 +141,7 @@ ol.renderer.Layer.prototype.loadImage = function(image) {
       imageState != ol.Image.State.ERROR) {
     // the image is either "idle" or "loading", register the change
     // listener (a noop if the listener was already registered)
-    goog.DEBUG && console.assert(imageState == ol.Image.State.IDLE ||
+    ol.DEBUG && console.assert(imageState == ol.Image.State.IDLE ||
         imageState == ol.Image.State.LOADING,
         'imageState is "idle" or "loading"');
     ol.events.listen(image, ol.events.EventType.CHANGE,
@@ -150,7 +150,7 @@ ol.renderer.Layer.prototype.loadImage = function(image) {
   if (imageState == ol.Image.State.IDLE) {
     image.load();
     imageState = image.getState();
-    goog.DEBUG && console.assert(imageState == ol.Image.State.LOADING ||
+    ol.DEBUG && console.assert(imageState == ol.Image.State.LOADING ||
         imageState == ol.Image.State.LOADED,
         'imageState is "loading" or "loaded"');
   }

--- a/src/ol/renderer/map.js
+++ b/src/ol/renderer/map.js
@@ -65,7 +65,7 @@ ol.renderer.Map.prototype.calculateMatrices2D = function(frameState) {
   var viewState = frameState.viewState;
   var coordinateToPixelTransform = frameState.coordinateToPixelTransform;
   var pixelToCoordinateTransform = frameState.pixelToCoordinateTransform;
-  goog.DEBUG && console.assert(coordinateToPixelTransform,
+  ol.DEBUG && console.assert(coordinateToPixelTransform,
       'frameState has a coordinateToPixelTransform');
 
   ol.transform.compose(coordinateToPixelTransform,
@@ -263,7 +263,7 @@ ol.renderer.Map.prototype.getLayerRenderer = function(layer) {
  * @return {ol.renderer.Layer} Layer renderer.
  */
 ol.renderer.Map.prototype.getLayerRendererByKey = function(layerKey) {
-  goog.DEBUG && console.assert(layerKey in this.layerRenderers_,
+  ol.DEBUG && console.assert(layerKey in this.layerRenderers_,
       'given layerKey (%s) exists in layerRenderers', layerKey);
   return this.layerRenderers_[layerKey];
 };
@@ -308,12 +308,12 @@ ol.renderer.Map.prototype.handleLayerRendererChange_ = function() {
  * @private
  */
 ol.renderer.Map.prototype.removeLayerRendererByKey_ = function(layerKey) {
-  goog.DEBUG && console.assert(layerKey in this.layerRenderers_,
+  ol.DEBUG && console.assert(layerKey in this.layerRenderers_,
       'given layerKey (%s) exists in layerRenderers', layerKey);
   var layerRenderer = this.layerRenderers_[layerKey];
   delete this.layerRenderers_[layerKey];
 
-  goog.DEBUG && console.assert(layerKey in this.layerRendererListeners_,
+  ol.DEBUG && console.assert(layerKey in this.layerRendererListeners_,
       'given layerKey (%s) exists in layerRendererListeners', layerKey);
   ol.events.unlistenByKey(this.layerRendererListeners_[layerKey]);
   delete this.layerRendererListeners_[layerKey];

--- a/src/ol/renderer/vector.js
+++ b/src/ol/renderer/vector.js
@@ -87,7 +87,7 @@ ol.renderer.vector.renderFeature = function(
         imageStyle.load();
       }
       imageState = imageStyle.getImageState();
-      goog.DEBUG && console.assert(imageState == ol.Image.State.LOADING,
+      ol.DEBUG && console.assert(imageState == ol.Image.State.LOADING,
           'imageState should be LOADING');
       imageStyle.listenImageChange(listener, thisArg);
       loading = true;

--- a/src/ol/renderer/webgl/defaultmapshader.js
+++ b/src/ol/renderer/webgl/defaultmapshader.js
@@ -35,7 +35,7 @@ ol.renderer.webgl.defaultmapshader.Fragment.OPTIMIZED_SOURCE = 'precision medium
  * @const
  * @type {string}
  */
-ol.renderer.webgl.defaultmapshader.Fragment.SOURCE = goog.DEBUG ?
+ol.renderer.webgl.defaultmapshader.Fragment.SOURCE = ol.DEBUG ?
     ol.renderer.webgl.defaultmapshader.Fragment.DEBUG_SOURCE :
     ol.renderer.webgl.defaultmapshader.Fragment.OPTIMIZED_SOURCE;
 
@@ -72,7 +72,7 @@ ol.renderer.webgl.defaultmapshader.Vertex.OPTIMIZED_SOURCE = 'varying vec2 a;att
  * @const
  * @type {string}
  */
-ol.renderer.webgl.defaultmapshader.Vertex.SOURCE = goog.DEBUG ?
+ol.renderer.webgl.defaultmapshader.Vertex.SOURCE = ol.DEBUG ?
     ol.renderer.webgl.defaultmapshader.Vertex.DEBUG_SOURCE :
     ol.renderer.webgl.defaultmapshader.Vertex.OPTIMIZED_SOURCE;
 
@@ -92,35 +92,35 @@ ol.renderer.webgl.defaultmapshader.Locations = function(gl, program) {
    * @type {WebGLUniformLocation}
    */
   this.u_opacity = gl.getUniformLocation(
-      program, goog.DEBUG ? 'u_opacity' : 'f');
+      program, ol.DEBUG ? 'u_opacity' : 'f');
 
   /**
    * @type {WebGLUniformLocation}
    */
   this.u_projectionMatrix = gl.getUniformLocation(
-      program, goog.DEBUG ? 'u_projectionMatrix' : 'e');
+      program, ol.DEBUG ? 'u_projectionMatrix' : 'e');
 
   /**
    * @type {WebGLUniformLocation}
    */
   this.u_texCoordMatrix = gl.getUniformLocation(
-      program, goog.DEBUG ? 'u_texCoordMatrix' : 'd');
+      program, ol.DEBUG ? 'u_texCoordMatrix' : 'd');
 
   /**
    * @type {WebGLUniformLocation}
    */
   this.u_texture = gl.getUniformLocation(
-      program, goog.DEBUG ? 'u_texture' : 'g');
+      program, ol.DEBUG ? 'u_texture' : 'g');
 
   /**
    * @type {number}
    */
   this.a_position = gl.getAttribLocation(
-      program, goog.DEBUG ? 'a_position' : 'b');
+      program, ol.DEBUG ? 'a_position' : 'b');
 
   /**
    * @type {number}
    */
   this.a_texCoord = gl.getAttribLocation(
-      program, goog.DEBUG ? 'a_texCoord' : 'c');
+      program, ol.DEBUG ? 'a_texCoord' : 'c');
 };

--- a/src/ol/renderer/webgl/imagelayer.js
+++ b/src/ol/renderer/webgl/imagelayer.js
@@ -118,7 +118,7 @@ ol.renderer.webgl.ImageLayer.prototype.prepareFrame = function(frameState, layer
     if (!ol.ENABLE_RASTER_REPROJECTION) {
       var sourceProjection = imageSource.getProjection();
       if (sourceProjection) {
-        goog.DEBUG && console.assert(ol.proj.equivalent(projection, sourceProjection),
+        ol.DEBUG && console.assert(ol.proj.equivalent(projection, sourceProjection),
             'projection and sourceProjection are equivalent');
         projection = sourceProjection;
       }
@@ -149,7 +149,7 @@ ol.renderer.webgl.ImageLayer.prototype.prepareFrame = function(frameState, layer
   }
 
   if (image) {
-    goog.DEBUG && console.assert(texture, 'texture is truthy');
+    ol.DEBUG && console.assert(texture, 'texture is truthy');
 
     var canvas = this.mapRenderer.getContext().getCanvas();
 

--- a/src/ol/renderer/webgl/map.js
+++ b/src/ol/renderer/webgl/map.js
@@ -83,7 +83,7 @@ ol.renderer.webgl.Map = function(container, map) {
     preserveDrawingBuffer: false,
     stencil: true
   });
-  goog.DEBUG && console.assert(this.gl_, 'got a WebGLRenderingContext');
+  ol.DEBUG && console.assert(this.gl_, 'got a WebGLRenderingContext');
 
   /**
    * @private
@@ -244,7 +244,7 @@ ol.renderer.webgl.Map.prototype.createLayerRenderer = function(layer) {
   } else if (ol.ENABLE_VECTOR && layer instanceof ol.layer.Vector) {
     return new ol.renderer.webgl.VectorLayer(this, layer);
   } else {
-    goog.DEBUG && console.assert(false, 'unexpected layer configuration');
+    ol.DEBUG && console.assert(false, 'unexpected layer configuration');
     return null;
   }
 };

--- a/src/ol/renderer/webgl/tilelayershader.js
+++ b/src/ol/renderer/webgl/tilelayershader.js
@@ -35,7 +35,7 @@ ol.renderer.webgl.tilelayershader.Fragment.OPTIMIZED_SOURCE = 'precision mediump
  * @const
  * @type {string}
  */
-ol.renderer.webgl.tilelayershader.Fragment.SOURCE = goog.DEBUG ?
+ol.renderer.webgl.tilelayershader.Fragment.SOURCE = ol.DEBUG ?
     ol.renderer.webgl.tilelayershader.Fragment.DEBUG_SOURCE :
     ol.renderer.webgl.tilelayershader.Fragment.OPTIMIZED_SOURCE;
 
@@ -72,7 +72,7 @@ ol.renderer.webgl.tilelayershader.Vertex.OPTIMIZED_SOURCE = 'varying vec2 a;attr
  * @const
  * @type {string}
  */
-ol.renderer.webgl.tilelayershader.Vertex.SOURCE = goog.DEBUG ?
+ol.renderer.webgl.tilelayershader.Vertex.SOURCE = ol.DEBUG ?
     ol.renderer.webgl.tilelayershader.Vertex.DEBUG_SOURCE :
     ol.renderer.webgl.tilelayershader.Vertex.OPTIMIZED_SOURCE;
 
@@ -92,23 +92,23 @@ ol.renderer.webgl.tilelayershader.Locations = function(gl, program) {
    * @type {WebGLUniformLocation}
    */
   this.u_texture = gl.getUniformLocation(
-      program, goog.DEBUG ? 'u_texture' : 'e');
+      program, ol.DEBUG ? 'u_texture' : 'e');
 
   /**
    * @type {WebGLUniformLocation}
    */
   this.u_tileOffset = gl.getUniformLocation(
-      program, goog.DEBUG ? 'u_tileOffset' : 'd');
+      program, ol.DEBUG ? 'u_tileOffset' : 'd');
 
   /**
    * @type {number}
    */
   this.a_position = gl.getAttribLocation(
-      program, goog.DEBUG ? 'a_position' : 'b');
+      program, ol.DEBUG ? 'a_position' : 'b');
 
   /**
    * @type {number}
    */
   this.a_texCoord = gl.getAttribLocation(
-      program, goog.DEBUG ? 'a_texCoord' : 'c');
+      program, ol.DEBUG ? 'a_texCoord' : 'c');
 };

--- a/src/ol/reproj/image.js
+++ b/src/ol/reproj/image.js
@@ -194,7 +194,7 @@ ol.reproj.Image.prototype.load = function() {
  * @private
  */
 ol.reproj.Image.prototype.unlistenSource_ = function() {
-  goog.DEBUG && console.assert(this.sourceListenerKey_,
+  ol.DEBUG && console.assert(this.sourceListenerKey_,
       'this.sourceListenerKey_ should not be null');
   ol.events.unlistenByKey(/** @type {!ol.EventsKey} */ (this.sourceListenerKey_));
   this.sourceListenerKey_ = null;

--- a/src/ol/reproj/tile.js
+++ b/src/ol/reproj/tile.js
@@ -180,7 +180,7 @@ ol.reproj.Tile = function(sourceProj, sourceTileGrid,
         sourceExtent, this.sourceZ_);
 
     var tilesRequired = sourceRange.getWidth() * sourceRange.getHeight();
-    if (goog.DEBUG && !(tilesRequired < ol.RASTER_REPROJECTION_MAX_SOURCE_TILES)) {
+    if (ol.DEBUG && !(tilesRequired < ol.RASTER_REPROJECTION_MAX_SOURCE_TILES)) {
       console.assert(false, 'reasonable number of tiles is required');
       this.state = ol.Tile.State.ERROR;
       return;
@@ -283,7 +283,7 @@ ol.reproj.Tile.prototype.load = function() {
 
     var leftToLoad = 0;
 
-    goog.DEBUG && console.assert(!this.sourcesListenerKeys_,
+    ol.DEBUG && console.assert(!this.sourcesListenerKeys_,
         'this.sourcesListenerKeys_ should be null');
 
     this.sourcesListenerKeys_ = [];
@@ -301,7 +301,7 @@ ol.reproj.Tile.prototype.load = function() {
                   state == ol.Tile.State.EMPTY) {
                 ol.events.unlistenByKey(sourceListenKey);
                 leftToLoad--;
-                goog.DEBUG && console.assert(leftToLoad >= 0,
+                ol.DEBUG && console.assert(leftToLoad >= 0,
                     'leftToLoad should not be negative');
                 if (leftToLoad === 0) {
                   this.unlistenSources_();

--- a/src/ol/reproj/triangulation.js
+++ b/src/ol/reproj/triangulation.js
@@ -118,7 +118,7 @@ ol.reproj.Triangulation = function(sourceProj, targetProj, targetExtent,
     // Fix coordinates (ol.proj returns wrapped coordinates, "unwrap" here).
     // This significantly simplifies the rest of the reprojection process.
 
-    goog.DEBUG && console.assert(this.sourceWorldWidth_ !== null);
+    ol.DEBUG && console.assert(this.sourceWorldWidth_ !== null);
     var leftBound = Infinity;
     this.triangles_.forEach(function(triangle, i, arr) {
       leftBound = Math.min(leftBound,

--- a/src/ol/source/bingmaps.js
+++ b/src/ol/source/bingmaps.js
@@ -91,7 +91,7 @@ ol.source.BingMaps.prototype.handleImageryMetadataResponse = function(response) 
   }
   //var copyright = response.copyright;  // FIXME do we need to display this?
   var resource = response.resourceSets[0].resources[0];
-  goog.DEBUG && console.assert(resource.imageWidth == resource.imageHeight,
+  ol.DEBUG && console.assert(resource.imageWidth == resource.imageHeight,
       'resource has imageWidth equal to imageHeight, i.e. is square');
   var maxZoom = this.maxZoom_ == -1 ? resource.zoomMax : this.maxZoom_;
 
@@ -122,7 +122,7 @@ ol.source.BingMaps.prototype.handleImageryMetadataResponse = function(response) 
              * @return {string|undefined} Tile URL.
              */
             function(tileCoord, pixelRatio, projection) {
-              goog.DEBUG && console.assert(ol.proj.equivalent(
+              ol.DEBUG && console.assert(ol.proj.equivalent(
                   projection, sourceProjection),
                   'projections are equivalent');
               if (!tileCoord) {

--- a/src/ol/source/cluster.js
+++ b/src/ol/source/cluster.js
@@ -149,7 +149,7 @@ ol.source.Cluster.prototype.cluster_ = function() {
         ol.extent.buffer(extent, mapDistance, extent);
 
         var neighbors = this.source_.getFeaturesInExtent(extent);
-        goog.DEBUG && console.assert(neighbors.length >= 1, 'at least one neighbor found');
+        ol.DEBUG && console.assert(neighbors.length >= 1, 'at least one neighbor found');
         neighbors = neighbors.filter(function(neighbor) {
           var uid = ol.getUid(neighbor).toString();
           if (!(uid in clustered)) {
@@ -163,7 +163,7 @@ ol.source.Cluster.prototype.cluster_ = function() {
       }
     }
   }
-  goog.DEBUG && console.assert(
+  ol.DEBUG && console.assert(
       Object.keys(clustered).length == this.source_.getFeatures().length,
       'number of clustered equals number of features in the source');
 };

--- a/src/ol/source/image.js
+++ b/src/ol/source/image.js
@@ -38,7 +38,7 @@ ol.source.Image = function(options) {
    */
   this.resolutions_ = options.resolutions !== undefined ?
       options.resolutions : null;
-  goog.DEBUG && console.assert(!this.resolutions_ ||
+  ol.DEBUG && console.assert(!this.resolutions_ ||
       ol.array.isSorted(this.resolutions_,
           function(a, b) {
             return b - a;

--- a/src/ol/source/imagearcgisrest.js
+++ b/src/ol/source/imagearcgisrest.js
@@ -195,7 +195,7 @@ ol.source.ImageArcGISRest.prototype.getImageLoadFunction = function() {
  */
 ol.source.ImageArcGISRest.prototype.getRequestUrl_ = function(extent, size, pixelRatio, projection, params) {
 
-  goog.DEBUG && console.assert(this.url_ !== undefined, 'url is defined');
+  ol.DEBUG && console.assert(this.url_ !== undefined, 'url is defined');
 
   // ArcGIS Server only wants the numeric portion of the projection ID.
   var srid = projection.getCode().split(':').pop();

--- a/src/ol/source/imagewms.js
+++ b/src/ol/source/imagewms.js
@@ -135,7 +135,7 @@ ol.source.ImageWMS.GETFEATUREINFO_IMAGE_SIZE_ = [101, 101];
  */
 ol.source.ImageWMS.prototype.getGetFeatureInfoUrl = function(coordinate, resolution, projection, params) {
 
-  goog.DEBUG && console.assert(!('VERSION' in params),
+  ol.DEBUG && console.assert(!('VERSION' in params),
       'key VERSION is not allowed in params');
 
   if (this.url_ === undefined) {

--- a/src/ol/source/raster.js
+++ b/src/ol/source/raster.js
@@ -425,7 +425,7 @@ ol.source.Raster.createRenderer_ = function(source) {
   } else if (source instanceof ol.source.Image) {
     renderer = ol.source.Raster.createImageRenderer_(source);
   } else {
-    goog.DEBUG && console.assert(false, 'Unsupported source type: ' + source);
+    ol.DEBUG && console.assert(false, 'Unsupported source type: ' + source);
   }
   return renderer;
 };

--- a/src/ol/source/stamen.js
+++ b/src/ol/source/stamen.js
@@ -89,11 +89,11 @@ ol.source.Stamen = function(options) {
 
   var i = options.layer.indexOf('-');
   var provider = i == -1 ? options.layer : options.layer.slice(0, i);
-  goog.DEBUG && console.assert(provider in ol.source.StamenProviderConfig,
+  ol.DEBUG && console.assert(provider in ol.source.StamenProviderConfig,
       'known provider configured');
   var providerConfig = ol.source.StamenProviderConfig[provider];
 
-  goog.DEBUG && console.assert(options.layer in ol.source.StamenLayerConfig,
+  ol.DEBUG && console.assert(options.layer in ol.source.StamenLayerConfig,
       'known layer configured');
   var layerConfig = ol.source.StamenLayerConfig[options.layer];
 

--- a/src/ol/source/tileimage.js
+++ b/src/ol/source/tileimage.js
@@ -303,8 +303,8 @@ ol.source.TileImage.prototype.getTileInternal = function(z, x, y, pixelRatio, pr
       // cases we attempt to assign an interim tile to the new tile.
       var /** @type {ol.Tile} */ interimTile = tile;
       if (tile.interimTile && tile.interimTile.key == key) {
-        goog.DEBUG && console.assert(tile.interimTile.getState() == ol.Tile.State.LOADED);
-        goog.DEBUG && console.assert(tile.interimTile.interimTile === null);
+        ol.DEBUG && console.assert(tile.interimTile.getState() == ol.Tile.State.LOADED);
+        ol.DEBUG && console.assert(tile.interimTile.interimTile === null);
         tile = tile.interimTile;
         if (interimTile.getState() == ol.Tile.State.LOADED) {
           tile.interimTile = interimTile;

--- a/src/ol/source/tilejson.js
+++ b/src/ol/source/tilejson.js
@@ -118,7 +118,7 @@ ol.source.TileJSON.prototype.handleTileJSONResponse = function(tileJSON) {
   }
 
   if (tileJSON.scheme !== undefined) {
-    goog.DEBUG && console.assert(tileJSON.scheme == 'xyz', 'tileJSON-scheme is "xyz"');
+    ol.DEBUG && console.assert(tileJSON.scheme == 'xyz', 'tileJSON-scheme is "xyz"');
   }
   var minZoom = tileJSON.minzoom || 0;
   var maxZoom = tileJSON.maxzoom || 22;

--- a/src/ol/source/tileutfgrid.js
+++ b/src/ol/source/tileutfgrid.js
@@ -175,7 +175,7 @@ ol.source.TileUTFGrid.prototype.handleTileJSONResponse = function(tileJSON) {
   }
 
   if (tileJSON.scheme !== undefined) {
-    goog.DEBUG && console.assert(tileJSON.scheme == 'xyz', 'tileJSON-scheme is "xyz"');
+    ol.DEBUG && console.assert(tileJSON.scheme == 'xyz', 'tileJSON-scheme is "xyz"');
   }
   var minZoom = tileJSON.minzoom || 0;
   var maxZoom = tileJSON.maxzoom || 22;
@@ -229,7 +229,7 @@ ol.source.TileUTFGrid.prototype.getTile = function(z, x, y, pixelRatio, projecti
   if (this.tileCache.containsKey(tileCoordKey)) {
     return /** @type {!ol.Tile} */ (this.tileCache.get(tileCoordKey));
   } else {
-    goog.DEBUG && console.assert(projection, 'argument projection is truthy');
+    ol.DEBUG && console.assert(projection, 'argument projection is truthy');
     var tileCoord = [z, x, y];
     var urlTileCoord =
         this.getTileCoordForTileUrlFunction(tileCoord, projection);

--- a/src/ol/source/tileutfgrid.js
+++ b/src/ol/source/tileutfgrid.js
@@ -1,6 +1,5 @@
 goog.provide('ol.source.TileUTFGrid');
 
-goog.require('goog.async.nextTick');
 goog.require('ol');
 goog.require('ol.Attribution');
 goog.require('ol.Tile');
@@ -140,9 +139,9 @@ ol.source.TileUTFGrid.prototype.forDataAtCoordinateAndResolution = function(
     tile.forDataAtCoordinate(coordinate, callback, opt_this, opt_request);
   } else {
     if (opt_request === true) {
-      goog.async.nextTick(function() {
+      ol.global.setTimeout(function() {
         callback.call(opt_this, null);
-      });
+      }, 0);
     } else {
       callback.call(opt_this, null);
     }
@@ -392,9 +391,9 @@ ol.source.TileUTFGridTile_.prototype.forDataAtCoordinate = function(coordinate, 
     this.loadInternal_();
   } else {
     if (opt_request === true) {
-      goog.async.nextTick(function() {
+      ol.global.setTimeout(function() {
         callback.call(opt_this, this.getData(coordinate));
-      }, this);
+      }.bind(this), 0);
     } else {
       callback.call(opt_this, this.getData(coordinate));
     }

--- a/src/ol/source/tilewms.js
+++ b/src/ol/source/tilewms.js
@@ -116,7 +116,7 @@ ol.inherits(ol.source.TileWMS, ol.source.TileImage);
  */
 ol.source.TileWMS.prototype.getGetFeatureInfoUrl = function(coordinate, resolution, projection, params) {
 
-  goog.DEBUG && console.assert(!('VERSION' in params),
+  ol.DEBUG && console.assert(!('VERSION' in params),
       'key VERSION is not allowed in params');
 
   var projectionObj = ol.proj.get(projection);

--- a/src/ol/source/vector.js
+++ b/src/ol/source/vector.js
@@ -237,7 +237,7 @@ ol.source.Vector.prototype.addFeatureInternal = function(feature) {
  * @private
  */
 ol.source.Vector.prototype.setupChangeEvents_ = function(featureKey, feature) {
-  goog.DEBUG && console.assert(!(featureKey in this.featureChangeKeys_),
+  ol.DEBUG && console.assert(!(featureKey in this.featureChangeKeys_),
       'key (%s) not yet registered in featureChangeKey', featureKey);
   this.featureChangeKeys_[featureKey] = [
     ol.events.listen(feature, ol.events.EventType.CHANGE,
@@ -334,7 +334,7 @@ ol.source.Vector.prototype.addFeaturesInternal = function(features) {
  * @private
  */
 ol.source.Vector.prototype.bindFeaturesCollection_ = function(collection) {
-  goog.DEBUG && console.assert(!this.featuresCollection_,
+  ol.DEBUG && console.assert(!this.featuresCollection_,
       'bindFeaturesCollection can only be called once');
   var modifyingCollection = false;
   ol.events.listen(this, ol.source.VectorEventType.ADDFEATURE,
@@ -400,11 +400,11 @@ ol.source.Vector.prototype.clear = function(opt_fast) {
   if (this.featuresCollection_) {
     this.featuresCollection_.clear();
   }
-  goog.DEBUG && console.assert(ol.obj.isEmpty(this.featureChangeKeys_),
+  ol.DEBUG && console.assert(ol.obj.isEmpty(this.featureChangeKeys_),
       'featureChangeKeys is an empty object now');
-  goog.DEBUG && console.assert(ol.obj.isEmpty(this.idIndex_),
+  ol.DEBUG && console.assert(ol.obj.isEmpty(this.idIndex_),
       'idIndex is an empty object now');
-  goog.DEBUG && console.assert(ol.obj.isEmpty(this.undefIdIndex_),
+  ol.DEBUG && console.assert(ol.obj.isEmpty(this.undefIdIndex_),
       'undefIdIndex is an empty object now');
 
   if (this.featuresRtree_) {
@@ -457,7 +457,7 @@ ol.source.Vector.prototype.forEachFeatureAtCoordinateDirect = function(coordinat
   var extent = [coordinate[0], coordinate[1], coordinate[0], coordinate[1]];
   return this.forEachFeatureInExtent(extent, function(feature) {
     var geometry = feature.getGeometry();
-    goog.DEBUG && console.assert(geometry, 'feature geometry is defined and not null');
+    ol.DEBUG && console.assert(geometry, 'feature geometry is defined and not null');
     if (geometry.intersectsCoordinate(coordinate)) {
       return callback.call(opt_this, feature);
     } else {
@@ -523,7 +523,7 @@ ol.source.Vector.prototype.forEachFeatureIntersectingExtent = function(extent, c
        */
       function(feature) {
         var geometry = feature.getGeometry();
-        goog.DEBUG && console.assert(geometry,
+        ol.DEBUG && console.assert(geometry,
             'feature geometry is defined and not null');
         if (geometry.intersectsExtent(extent)) {
           var result = callback.call(opt_this, feature);
@@ -594,7 +594,7 @@ ol.source.Vector.prototype.getFeaturesAtCoordinate = function(coordinate) {
  * @api
  */
 ol.source.Vector.prototype.getFeaturesInExtent = function(extent) {
-  goog.DEBUG && console.assert(this.featuresRtree_,
+  ol.DEBUG && console.assert(this.featuresRtree_,
       'getFeaturesInExtent does not work when useSpatialIndex is set to false');
   return this.featuresRtree_.getInExtent(extent);
 };
@@ -626,7 +626,7 @@ ol.source.Vector.prototype.getClosestFeatureToCoordinate = function(coordinate, 
   var closestPoint = [NaN, NaN];
   var minSquaredDistance = Infinity;
   var extent = [-Infinity, -Infinity, Infinity, Infinity];
-  goog.DEBUG && console.assert(this.featuresRtree_,
+  ol.DEBUG && console.assert(this.featuresRtree_,
       'getClosestFeatureToCoordinate does not work with useSpatialIndex set ' +
       'to false');
   var filter = opt_filter ? opt_filter : ol.functions.TRUE;
@@ -637,7 +637,7 @@ ol.source.Vector.prototype.getClosestFeatureToCoordinate = function(coordinate, 
       function(feature) {
         if (filter(feature)) {
           var geometry = feature.getGeometry();
-          goog.DEBUG && console.assert(geometry,
+          ol.DEBUG && console.assert(geometry,
               'feature geometry is defined and not null');
           var previousMinSquaredDistance = minSquaredDistance;
           minSquaredDistance = geometry.closestPointXY(
@@ -669,7 +669,7 @@ ol.source.Vector.prototype.getClosestFeatureToCoordinate = function(coordinate, 
  * @api stable
  */
 ol.source.Vector.prototype.getExtent = function() {
-  goog.DEBUG && console.assert(this.featuresRtree_,
+  ol.DEBUG && console.assert(this.featuresRtree_,
       'getExtent does not work when useSpatialIndex is set to false');
   return this.featuresRtree_.getExtent();
 };
@@ -758,7 +758,7 @@ ol.source.Vector.prototype.handleFeatureChange_ = function(event) {
     } else {
       if (this.idIndex_[sid] !== feature) {
         removed = this.removeFromIdIndex_(feature);
-        goog.DEBUG && console.assert(removed,
+        ol.DEBUG && console.assert(removed,
             'Expected feature to be removed from index');
         this.idIndex_[sid] = feature;
       }
@@ -766,11 +766,11 @@ ol.source.Vector.prototype.handleFeatureChange_ = function(event) {
   } else {
     if (!(featureKey in this.undefIdIndex_)) {
       removed = this.removeFromIdIndex_(feature);
-      goog.DEBUG && console.assert(removed,
+      ol.DEBUG && console.assert(removed,
           'Expected feature to be removed from index');
       this.undefIdIndex_[featureKey] = feature;
     } else {
-      goog.DEBUG && console.assert(this.undefIdIndex_[featureKey] === feature,
+      ol.DEBUG && console.assert(this.undefIdIndex_[featureKey] === feature,
           'feature keyed under %s in undefIdKeys', featureKey);
     }
   }
@@ -845,7 +845,7 @@ ol.source.Vector.prototype.removeFeature = function(feature) {
  */
 ol.source.Vector.prototype.removeFeatureInternal = function(feature) {
   var featureKey = ol.getUid(feature).toString();
-  goog.DEBUG && console.assert(featureKey in this.featureChangeKeys_,
+  ol.DEBUG && console.assert(featureKey in this.featureChangeKeys_,
       'featureKey exists in featureChangeKeys');
   this.featureChangeKeys_[featureKey].forEach(ol.events.unlistenByKey);
   delete this.featureChangeKeys_[featureKey];

--- a/src/ol/source/wmts.js
+++ b/src/ol/source/wmts.js
@@ -308,16 +308,16 @@ ol.source.WMTS.prototype.updateDimensions = function(dimensions) {
 ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
 
   // TODO: add support for TileMatrixLimits
-  goog.DEBUG && console.assert(config['layer'],
+  ol.DEBUG && console.assert(config['layer'],
       'config "layer" must not be null');
 
   var layers = wmtsCap['Contents']['Layer'];
   var l = ol.array.find(layers, function(elt, index, array) {
     return elt['Identifier'] == config['layer'];
   });
-  goog.DEBUG && console.assert(l, 'found a matching layer in Contents/Layer');
+  ol.DEBUG && console.assert(l, 'found a matching layer in Contents/Layer');
 
-  goog.DEBUG && console.assert(l['TileMatrixSetLink'].length > 0,
+  ol.DEBUG && console.assert(l['TileMatrixSetLink'].length > 0,
       'layer has TileMatrixSetLink');
   var tileMatrixSets = wmtsCap['Contents']['TileMatrixSet'];
   var idx, matrixSet;
@@ -347,7 +347,7 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
   matrixSet = /** @type {string} */
       (l['TileMatrixSetLink'][idx]['TileMatrixSet']);
 
-  goog.DEBUG && console.assert(matrixSet, 'TileMatrixSet must not be null');
+  ol.DEBUG && console.assert(matrixSet, 'TileMatrixSet must not be null');
 
   var format = /** @type {string} */ (l['Format'][0]);
   if ('format' in config) {
@@ -371,12 +371,12 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
       var key = elt['Identifier'];
       var value = elt['Default'];
       if (value !== undefined) {
-        goog.DEBUG && console.assert(ol.array.includes(elt['Value'], value),
+        ol.DEBUG && console.assert(ol.array.includes(elt['Value'], value),
             'default value contained in values');
       } else {
         value = elt['Value'][0];
       }
-      goog.DEBUG && console.assert(value !== undefined, 'value could be found');
+      ol.DEBUG && console.assert(value !== undefined, 'value could be found');
       dimensions[key] = value;
     });
   }
@@ -385,7 +385,7 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
   var matrixSetObj = ol.array.find(matrixSets, function(elt, index, array) {
     return elt['Identifier'] == matrixSet;
   });
-  goog.DEBUG && console.assert(matrixSetObj,
+  ol.DEBUG && console.assert(matrixSetObj,
       'found matrixSet in Contents/TileMatrixSet');
 
   var projection;
@@ -422,21 +422,21 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
   var requestEncoding = config['requestEncoding'];
   requestEncoding = requestEncoding !== undefined ? requestEncoding : '';
 
-  goog.DEBUG && console.assert(
+  ol.DEBUG && console.assert(
       ol.array.includes(['REST', 'RESTful', 'KVP', ''], requestEncoding),
       'requestEncoding (%s) is one of "REST", "RESTful", "KVP" or ""',
       requestEncoding);
 
   if ('OperationsMetadata' in wmtsCap && 'GetTile' in wmtsCap['OperationsMetadata']) {
     var gets = wmtsCap['OperationsMetadata']['GetTile']['DCP']['HTTP']['Get'];
-    goog.DEBUG && console.assert(gets.length >= 1);
+    ol.DEBUG && console.assert(gets.length >= 1);
 
     for (var i = 0, ii = gets.length; i < ii; ++i) {
       var constraint = ol.array.find(gets[i]['Constraint'], function(element) {
         return element['name'] == 'GetEncoding';
       });
       var encodings = constraint['AllowedValues']['Value'];
-      goog.DEBUG && console.assert(encodings.length >= 1);
+      ol.DEBUG && console.assert(encodings.length >= 1);
 
       if (requestEncoding === '') {
         // requestEncoding not provided, use the first encoding from the list
@@ -460,7 +460,7 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
       }
     });
   }
-  goog.DEBUG && console.assert(urls.length > 0, 'At least one URL found');
+  ol.DEBUG && console.assert(urls.length > 0, 'At least one URL found');
 
   return {
     urls: urls,

--- a/src/ol/structs/lrucache.js
+++ b/src/ol/structs/lrucache.js
@@ -41,7 +41,7 @@ ol.structs.LRUCache = function() {
 };
 
 
-if (goog.DEBUG) {
+if (ol.DEBUG) {
   /**
    * FIXME empty description for jsdoc
    */
@@ -168,7 +168,7 @@ ol.structs.LRUCache.prototype.getKeys = function() {
   for (entry = this.newest_; entry; entry = entry.older) {
     keys[i++] = entry.key_;
   }
-  goog.DEBUG && console.assert(i == this.count_, 'iterated correct number of times');
+  ol.DEBUG && console.assert(i == this.count_, 'iterated correct number of times');
   return keys;
 };
 
@@ -183,7 +183,7 @@ ol.structs.LRUCache.prototype.getValues = function() {
   for (entry = this.newest_; entry; entry = entry.older) {
     values[i++] = entry.value_;
   }
-  goog.DEBUG && console.assert(i == this.count_, 'iterated correct number of times');
+  ol.DEBUG && console.assert(i == this.count_, 'iterated correct number of times');
   return values;
 };
 
@@ -192,7 +192,7 @@ ol.structs.LRUCache.prototype.getValues = function() {
  * @return {T} Last value.
  */
 ol.structs.LRUCache.prototype.peekLast = function() {
-  goog.DEBUG && console.assert(this.oldest_, 'oldest must not be null');
+  ol.DEBUG && console.assert(this.oldest_, 'oldest must not be null');
   return this.oldest_.value_;
 };
 
@@ -201,7 +201,7 @@ ol.structs.LRUCache.prototype.peekLast = function() {
  * @return {string} Last key.
  */
 ol.structs.LRUCache.prototype.peekLastKey = function() {
-  goog.DEBUG && console.assert(this.oldest_, 'oldest must not be null');
+  ol.DEBUG && console.assert(this.oldest_, 'oldest must not be null');
   return this.oldest_.key_;
 };
 
@@ -210,10 +210,10 @@ ol.structs.LRUCache.prototype.peekLastKey = function() {
  * @return {T} value Value.
  */
 ol.structs.LRUCache.prototype.pop = function() {
-  goog.DEBUG && console.assert(this.oldest_, 'oldest must not be null');
-  goog.DEBUG && console.assert(this.newest_, 'newest must not be null');
+  ol.DEBUG && console.assert(this.oldest_, 'oldest must not be null');
+  ol.DEBUG && console.assert(this.newest_, 'newest must not be null');
   var entry = this.oldest_;
-  goog.DEBUG && console.assert(entry.key_ in this.entries_,
+  ol.DEBUG && console.assert(entry.key_ in this.entries_,
       'oldest is indexed in entries');
   delete this.entries_[entry.key_];
   if (entry.newer) {
@@ -243,7 +243,7 @@ ol.structs.LRUCache.prototype.replace = function(key, value) {
  * @param {T} value Value.
  */
 ol.structs.LRUCache.prototype.set = function(key, value) {
-  goog.DEBUG && console.assert(!(key in {}),
+  ol.DEBUG && console.assert(!(key in {}),
       'key is not a standard property of objects (e.g. "__proto__")');
   ol.asserts.assert(!(key in this.entries_),
       16); // Tried to set a value for a key that is used already

--- a/src/ol/structs/priorityqueue.js
+++ b/src/ol/structs/priorityqueue.js
@@ -61,7 +61,7 @@ ol.structs.PriorityQueue = function(priorityFunction, keyFunction) {
 ol.structs.PriorityQueue.DROP = Infinity;
 
 
-if (goog.DEBUG) {
+if (ol.DEBUG) {
   /**
    * FIXME empty description for jsdoc
    */
@@ -100,7 +100,7 @@ ol.structs.PriorityQueue.prototype.clear = function() {
  */
 ol.structs.PriorityQueue.prototype.dequeue = function() {
   var elements = this.elements_;
-  goog.DEBUG && console.assert(elements.length > 0,
+  ol.DEBUG && console.assert(elements.length > 0,
       'must have elements in order to be able to dequeue');
   var priorities = this.priorities_;
   var element = elements[0];
@@ -113,7 +113,7 @@ ol.structs.PriorityQueue.prototype.dequeue = function() {
     this.siftUp_(0);
   }
   var elementKey = this.keyFunction_(element);
-  goog.DEBUG && console.assert(elementKey in this.queuedElements_,
+  ol.DEBUG && console.assert(elementKey in this.queuedElements_,
       'key %s is not listed as queued', elementKey);
   delete this.queuedElements_[elementKey];
   return element;

--- a/src/ol/structs/rbush.js
+++ b/src/ol/structs/rbush.js
@@ -30,7 +30,7 @@ ol.structs.RBush = function(opt_maxEntries) {
    */
   this.items_ = {};
 
-  if (goog.DEBUG) {
+  if (ol.DEBUG) {
     /**
      * @private
      * @type {number}
@@ -46,7 +46,7 @@ ol.structs.RBush = function(opt_maxEntries) {
  * @param {T} value Value.
  */
 ol.structs.RBush.prototype.insert = function(extent, value) {
-  if (goog.DEBUG && this.readers_) {
+  if (ol.DEBUG && this.readers_) {
     throw new Error('Can not insert value while reading');
   }
   /** @type {ol.RBushEntry} */
@@ -60,7 +60,7 @@ ol.structs.RBush.prototype.insert = function(extent, value) {
 
   this.rbush_.insert(item);
   // remember the object that was added to the internal rbush
-  goog.DEBUG && console.assert(!(ol.getUid(value) in this.items_),
+  ol.DEBUG && console.assert(!(ol.getUid(value) in this.items_),
       'uid (%s) of value (%s) already exists', ol.getUid(value), value);
   this.items_[ol.getUid(value)] = item;
 };
@@ -72,10 +72,10 @@ ol.structs.RBush.prototype.insert = function(extent, value) {
  * @param {Array.<T>} values Values.
  */
 ol.structs.RBush.prototype.load = function(extents, values) {
-  if (goog.DEBUG && this.readers_) {
+  if (ol.DEBUG && this.readers_) {
     throw new Error('Can not insert values while reading');
   }
-  goog.DEBUG && console.assert(extents.length === values.length,
+  ol.DEBUG && console.assert(extents.length === values.length,
       'extens and values must have same length (%s === %s)',
       extents.length, values.length);
 
@@ -93,7 +93,7 @@ ol.structs.RBush.prototype.load = function(extents, values) {
       value: value
     };
     items[i] = item;
-    goog.DEBUG && console.assert(!(ol.getUid(value) in this.items_),
+    ol.DEBUG && console.assert(!(ol.getUid(value) in this.items_),
         'uid (%s) of value (%s) already exists', ol.getUid(value), value);
     this.items_[ol.getUid(value)] = item;
   }
@@ -107,11 +107,11 @@ ol.structs.RBush.prototype.load = function(extents, values) {
  * @return {boolean} Removed.
  */
 ol.structs.RBush.prototype.remove = function(value) {
-  if (goog.DEBUG && this.readers_) {
+  if (ol.DEBUG && this.readers_) {
     throw new Error('Can not remove value while reading');
   }
   var uid = ol.getUid(value);
-  goog.DEBUG && console.assert(uid in this.items_,
+  ol.DEBUG && console.assert(uid in this.items_,
       'uid (%s) of value (%s) does not exist', uid, value);
 
   // get the object in which the value was wrapped when adding to the
@@ -128,13 +128,13 @@ ol.structs.RBush.prototype.remove = function(value) {
  * @param {T} value Value.
  */
 ol.structs.RBush.prototype.update = function(extent, value) {
-  goog.DEBUG && console.assert(ol.getUid(value) in this.items_,
+  ol.DEBUG && console.assert(ol.getUid(value) in this.items_,
       'uid (%s) of value (%s) does not exist', ol.getUid(value), value);
 
   var item = this.items_[ol.getUid(value)];
   var bbox = [item.minX, item.minY, item.maxX, item.maxY];
   if (!ol.extent.equals(bbox, extent)) {
-    if (goog.DEBUG && this.readers_) {
+    if (ol.DEBUG && this.readers_) {
       throw new Error('Can not update extent while reading');
     }
     this.remove(value);
@@ -185,7 +185,7 @@ ol.structs.RBush.prototype.getInExtent = function(extent) {
  * @template S
  */
 ol.structs.RBush.prototype.forEach = function(callback, opt_this) {
-  if (goog.DEBUG) {
+  if (ol.DEBUG) {
     ++this.readers_;
     try {
       return this.forEach_(this.getAll(), callback, opt_this);
@@ -207,7 +207,7 @@ ol.structs.RBush.prototype.forEach = function(callback, opt_this) {
  * @template S
  */
 ol.structs.RBush.prototype.forEachInExtent = function(extent, callback, opt_this) {
-  if (goog.DEBUG) {
+  if (ol.DEBUG) {
     ++this.readers_;
     try {
       return this.forEach_(this.getInExtent(extent), callback, opt_this);

--- a/src/ol/style/atlasmanager.js
+++ b/src/ol/style/atlasmanager.js
@@ -119,9 +119,9 @@ ol.style.AtlasManager.prototype.getInfo_ = function(atlases, id) {
  *    entry, or `null` if the entry is not part of the atlases.
  */
 ol.style.AtlasManager.prototype.mergeInfos_ = function(info, hitInfo) {
-  goog.DEBUG && console.assert(info.offsetX === hitInfo.offsetX,
+  ol.DEBUG && console.assert(info.offsetX === hitInfo.offsetX,
       'in order to merge, offsetX of info and hitInfo must be equal');
-  goog.DEBUG && console.assert(info.offsetY === hitInfo.offsetY,
+  ol.DEBUG && console.assert(info.offsetY === hitInfo.offsetY,
       'in order to merge, offsetY of info and hitInfo must be equal');
   return /** @type {ol.AtlasManagerInfo} */ ({
     offsetX: info.offsetX,
@@ -220,7 +220,7 @@ ol.style.AtlasManager.prototype.add_ = function(isHitAtlas, id, width, height,
       ++ii;
     }
   }
-  goog.DEBUG && console.assert(false, 'Failed to add to atlasmanager');
+  ol.DEBUG && console.assert(false, 'Failed to add to atlasmanager');
   return null;
 };
 

--- a/src/ol/style/circle.js
+++ b/src/ol/style/circle.js
@@ -286,7 +286,7 @@ ol.style.Circle.prototype.render_ = function(atlasManager) {
     var info = atlasManager.add(
         id, size, size, this.draw_.bind(this, renderOptions),
         renderHitDetectionCallback);
-    goog.DEBUG && console.assert(info, 'circle radius is too large');
+    ol.DEBUG && console.assert(info, 'circle radius is too large');
 
     this.canvas_ = info.image;
     this.origin_ = [info.offsetX, info.offsetY];

--- a/src/ol/style/iconimage.js
+++ b/src/ol/style/iconimage.js
@@ -220,9 +220,9 @@ ol.style.IconImage.prototype.getSrc = function() {
  */
 ol.style.IconImage.prototype.load = function() {
   if (this.imageState_ == ol.Image.State.IDLE) {
-    goog.DEBUG && console.assert(this.src_ !== undefined,
+    ol.DEBUG && console.assert(this.src_ !== undefined,
         'this.src_ must not be undefined');
-    goog.DEBUG && console.assert(!this.imageListenerKeys_,
+    ol.DEBUG && console.assert(!this.imageListenerKeys_,
         'no listener keys existing');
     this.imageState_ = ol.Image.State.LOADING;
     this.imageListenerKeys_ = [

--- a/src/ol/style/iconimagecache.js
+++ b/src/ol/style/iconimagecache.js
@@ -36,7 +36,7 @@ ol.style.IconImageCache = function() {
  * @return {string} Cache key.
  */
 ol.style.IconImageCache.getKey = function(src, crossOrigin, color) {
-  goog.DEBUG && console.assert(crossOrigin !== undefined,
+  ol.DEBUG && console.assert(crossOrigin !== undefined,
       'argument crossOrigin must be defined');
   var colorString = color ? ol.color.asString(color) : 'null';
   return crossOrigin + ':' + src + ':' + colorString;

--- a/src/ol/style/regularshape.js
+++ b/src/ol/style/regularshape.js
@@ -23,7 +23,7 @@ goog.require('ol.style.Image');
  */
 ol.style.RegularShape = function(options) {
 
-  goog.DEBUG && console.assert(
+  ol.DEBUG && console.assert(
       options.radius !== undefined || options.radius1 !== undefined,
       'must provide either "radius" or "radius1"');
 
@@ -363,7 +363,7 @@ ol.style.RegularShape.prototype.render_ = function(atlasManager) {
     var info = atlasManager.add(
         id, size, size, this.draw_.bind(this, renderOptions),
         renderHitDetectionCallback);
-    goog.DEBUG && console.assert(info, 'shape size is too large');
+    ol.DEBUG && console.assert(info, 'shape size is too large');
 
     this.canvas_ = info.image;
     this.origin_ = [info.offsetX, info.offsetY];

--- a/src/ol/style/stroke.js
+++ b/src/ol/style/stroke.js
@@ -1,7 +1,5 @@
 goog.provide('ol.style.Stroke');
 
-goog.require('goog.crypt');
-goog.require('goog.crypt.Md5');
 goog.require('ol.color');
 
 
@@ -207,7 +205,7 @@ ol.style.Stroke.prototype.setWidth = function(width) {
  */
 ol.style.Stroke.prototype.getChecksum = function() {
   if (this.checksum_ === undefined) {
-    var raw = 's' +
+    this.checksum_ = 's' +
         (this.color_ ?
             ol.color.asString(this.color_) : '-') + ',' +
         (this.lineCap_ !== undefined ?
@@ -220,10 +218,6 @@ ol.style.Stroke.prototype.getChecksum = function() {
             this.miterLimit_.toString() : '-') + ',' +
         (this.width_ !== undefined ?
             this.width_.toString() : '-');
-
-    var md5 = new goog.crypt.Md5();
-    md5.update(raw);
-    this.checksum_ = goog.crypt.byteArrayToString(md5.digest());
   }
 
   return this.checksum_;

--- a/src/ol/tilecoord.js
+++ b/src/ol/tilecoord.js
@@ -19,7 +19,7 @@ ol.QuadKeyCharCode = {
  */
 ol.tilecoord.createFromString = function(str) {
   var v = str.split('/');
-  goog.DEBUG && console.assert(v.length === 3,
+  ol.DEBUG && console.assert(v.length === 3,
       'must provide a string in "z/x/y" format, got "%s"', str);
   return v.map(function(e) {
     return parseInt(e, 10);

--- a/src/ol/tilegrid/tilegrid.js
+++ b/src/ol/tilegrid/tilegrid.js
@@ -114,11 +114,11 @@ ol.tilegrid.TileGrid = function(options) {
   this.tmpSize_ = [0, 0];
 
   if (options.sizes !== undefined) {
-    goog.DEBUG && console.assert(options.sizes.length == this.resolutions_.length,
+    ol.DEBUG && console.assert(options.sizes.length == this.resolutions_.length,
         'number of sizes and resolutions must be equal');
     this.fullTileRanges_ = options.sizes.map(function(size, z) {
-      goog.DEBUG && console.assert(size[0] !== 0, 'width must not be 0');
-      goog.DEBUG && console.assert(size[1] !== 0, 'height must not be 0');
+      ol.DEBUG && console.assert(size[0] !== 0, 'width must not be 0');
+      ol.DEBUG && console.assert(size[1] !== 0, 'height must not be 0');
       var tileRange = new ol.TileRange(
           Math.min(0, size[0]), Math.max(size[0] - 1, -1),
           Math.min(0, size[1]), Math.max(size[1] - 1, -1));
@@ -218,7 +218,7 @@ ol.tilegrid.TileGrid.prototype.getOrigin = function(z) {
   if (this.origin_) {
     return this.origin_;
   } else {
-    goog.DEBUG && console.assert(this.minZoom <= z && z <= this.maxZoom,
+    ol.DEBUG && console.assert(this.minZoom <= z && z <= this.maxZoom,
         'given z is not in allowed range (%s <= %s <= %s)',
         this.minZoom, z, this.maxZoom);
     return this.origins_[z];
@@ -233,7 +233,7 @@ ol.tilegrid.TileGrid.prototype.getOrigin = function(z) {
  * @api stable
  */
 ol.tilegrid.TileGrid.prototype.getResolution = function(z) {
-  goog.DEBUG && console.assert(this.minZoom <= z && z <= this.maxZoom,
+  ol.DEBUG && console.assert(this.minZoom <= z && z <= this.maxZoom,
       'given z is not in allowed range (%s <= %s <= %s)',
       this.minZoom, z, this.maxZoom);
   return this.resolutions_[z];
@@ -426,7 +426,7 @@ ol.tilegrid.TileGrid.prototype.getTileCoordForCoordAndZ = function(coordinate, z
  * @return {number} Tile resolution.
  */
 ol.tilegrid.TileGrid.prototype.getTileCoordResolution = function(tileCoord) {
-  goog.DEBUG && console.assert(
+  ol.DEBUG && console.assert(
       this.minZoom <= tileCoord[0] && tileCoord[0] <= this.maxZoom,
       'z of given tilecoord is not in allowed range (%s <= %s <= %s',
       this.minZoom, tileCoord[0], this.maxZoom);
@@ -446,7 +446,7 @@ ol.tilegrid.TileGrid.prototype.getTileSize = function(z) {
   if (this.tileSize_) {
     return this.tileSize_;
   } else {
-    goog.DEBUG && console.assert(this.minZoom <= z && z <= this.maxZoom,
+    ol.DEBUG && console.assert(this.minZoom <= z && z <= this.maxZoom,
         'z is not in allowed range (%s <= %s <= %s',
         this.minZoom, z, this.maxZoom);
     return this.tileSizes_[z];
@@ -462,7 +462,7 @@ ol.tilegrid.TileGrid.prototype.getFullTileRange = function(z) {
   if (!this.fullTileRanges_) {
     return null;
   } else {
-    goog.DEBUG && console.assert(this.minZoom <= z && z <= this.maxZoom,
+    ol.DEBUG && console.assert(this.minZoom <= z && z <= this.maxZoom,
         'z is not in allowed range (%s <= %s <= %s',
         this.minZoom, z, this.maxZoom);
     return this.fullTileRanges_[z];

--- a/src/ol/tilegrid/wmts.js
+++ b/src/ol/tilegrid/wmts.js
@@ -17,7 +17,7 @@ goog.require('ol.tilegrid.TileGrid');
  */
 ol.tilegrid.WMTS = function(options) {
 
-  goog.DEBUG && console.assert(
+  ol.DEBUG && console.assert(
       options.resolutions.length == options.matrixIds.length,
       'options resolutions and matrixIds must have equal length (%s == %s)',
       options.resolutions.length, options.matrixIds.length);
@@ -48,7 +48,7 @@ ol.inherits(ol.tilegrid.WMTS, ol.tilegrid.TileGrid);
  * @return {string} MatrixId..
  */
 ol.tilegrid.WMTS.prototype.getMatrixId = function(z) {
-  goog.DEBUG && console.assert(0 <= z && z < this.matrixIds_.length,
+  ol.DEBUG && console.assert(0 <= z && z < this.matrixIds_.length,
       'attempted to retrieve matrixId for illegal z (%s)', z);
   return this.matrixIds_[z];
 };

--- a/src/ol/tilequeue.js
+++ b/src/ol/tilequeue.js
@@ -97,7 +97,7 @@ ol.TileQueue.prototype.handleTileChange = function(event) {
     }
     this.tileChangeCallback_();
   }
-  goog.DEBUG && console.assert(Object.keys(this.tilesLoadingKeys_).length === this.tilesLoading_);
+  ol.DEBUG && console.assert(Object.keys(this.tilesLoadingKeys_).length === this.tilesLoading_);
 };
 
 
@@ -118,6 +118,6 @@ ol.TileQueue.prototype.loadMoreTiles = function(maxTotalLoading, maxNewLoads) {
       ++newLoads;
       tile.load();
     }
-    goog.DEBUG && console.assert(Object.keys(this.tilesLoadingKeys_).length === this.tilesLoading_);
+    ol.DEBUG && console.assert(Object.keys(this.tilesLoadingKeys_).length === this.tilesLoading_);
   }
 };

--- a/src/ol/tileurlfunction.js
+++ b/src/ol/tileurlfunction.js
@@ -65,7 +65,7 @@ ol.TileUrlFunction.createFromTemplates = function(templates, tileGrid) {
  * @return {ol.TileUrlFunctionType} Tile URL function.
  */
 ol.TileUrlFunction.createFromTileUrlFunctions = function(tileUrlFunctions) {
-  goog.DEBUG && console.assert(tileUrlFunctions.length > 0,
+  ol.DEBUG && console.assert(tileUrlFunctions.length > 0,
       'Length of tile url functions should be greater than 0');
   if (tileUrlFunctions.length === 1) {
     return tileUrlFunctions[0];

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -365,7 +365,7 @@ ol.View.prototype.getResolutionForValueFunction = function(opt_power) {
        */
       function(value) {
         var resolution = maxResolution / Math.pow(power, value * max);
-        goog.DEBUG && console.assert(resolution >= minResolution &&
+        ol.DEBUG && console.assert(resolution >= minResolution &&
             resolution <= maxResolution,
             'calculated resolution outside allowed bounds (%s <= %s <= %s)',
             minResolution, resolution, maxResolution);
@@ -404,7 +404,7 @@ ol.View.prototype.getValueForResolutionFunction = function(opt_power) {
       function(resolution) {
         var value =
             (Math.log(maxResolution / resolution) / Math.log(power)) / max;
-        goog.DEBUG && console.assert(value >= 0 && value <= 1,
+        ol.DEBUG && console.assert(value >= 0 && value <= 1,
             'calculated value (%s) ouside allowed range (0-1)', value);
         return value;
       });
@@ -415,7 +415,7 @@ ol.View.prototype.getValueForResolutionFunction = function(opt_power) {
  * @return {olx.ViewState} View state.
  */
 ol.View.prototype.getState = function() {
-  goog.DEBUG && console.assert(this.isDef(),
+  ol.DEBUG && console.assert(this.isDef(),
       'the view was not defined (had no center and/or resolution)');
   var center = /** @type {ol.Coordinate} */ (this.getCenter());
   var projection = this.getProjection();
@@ -499,7 +499,7 @@ ol.View.prototype.fit = function(geometry, size, opt_options) {
 
   // calculate rotated extent
   var rotation = this.getRotation();
-  goog.DEBUG && console.assert(rotation !== undefined, 'rotation was not defined');
+  ol.DEBUG && console.assert(rotation !== undefined, 'rotation was not defined');
   var cosAngle = Math.cos(-rotation);
   var sinAngle = Math.sin(-rotation);
   var minRotX = +Infinity;
@@ -612,10 +612,10 @@ ol.View.prototype.setCenter = function(center) {
  * @return {number} New value.
  */
 ol.View.prototype.setHint = function(hint, delta) {
-  goog.DEBUG && console.assert(0 <= hint && hint < this.hints_.length,
+  ol.DEBUG && console.assert(0 <= hint && hint < this.hints_.length,
       'illegal hint (%s), must be between 0 and %s', hint, this.hints_.length);
   this.hints_[hint] += delta;
-  goog.DEBUG && console.assert(this.hints_[hint] >= 0,
+  ol.DEBUG && console.assert(this.hints_[hint] >= 0,
       'Hint at %s must be positive, was %s', hint, this.hints_[hint]);
   return this.hints_[hint];
 };
@@ -768,7 +768,7 @@ ol.View.createRotationConstraint_ = function(options) {
     } else if (typeof constrainRotation === 'number') {
       return ol.RotationConstraint.createSnapToN(constrainRotation);
     } else {
-      goog.DEBUG && console.assert(false,
+      ol.DEBUG && console.assert(false,
           'illegal option for constrainRotation (%s)', constrainRotation);
       return ol.RotationConstraint.none;
     }

--- a/src/ol/webgl/context.js
+++ b/src/ol/webgl/context.js
@@ -83,7 +83,7 @@ ol.webgl.Context = function(canvas, gl) {
   // use the OES_element_index_uint extension if available
   if (this.hasOESElementIndexUint) {
     var ext = gl.getExtension('OES_element_index_uint');
-    goog.DEBUG && console.assert(ext,
+    ol.DEBUG && console.assert(ext,
         'Failed to get extension "OES_element_index_uint"');
   }
 
@@ -113,7 +113,7 @@ ol.webgl.Context.prototype.bindBuffer = function(target, buf) {
   } else {
     var buffer = gl.createBuffer();
     gl.bindBuffer(target, buffer);
-    goog.DEBUG && console.assert(target == ol.webgl.ARRAY_BUFFER ||
+    ol.DEBUG && console.assert(target == ol.webgl.ARRAY_BUFFER ||
         target == ol.webgl.ELEMENT_ARRAY_BUFFER,
         'target is supposed to be an ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER');
     var /** @type {ArrayBufferView} */ arrayBuffer;
@@ -138,7 +138,7 @@ ol.webgl.Context.prototype.bindBuffer = function(target, buf) {
 ol.webgl.Context.prototype.deleteBuffer = function(buf) {
   var gl = this.getGL();
   var bufferKey = String(ol.getUid(buf));
-  goog.DEBUG && console.assert(bufferKey in this.bufferCache_,
+  ol.DEBUG && console.assert(bufferKey in this.bufferCache_,
       'attempted to delete uncached buffer');
   var bufferCacheEntry = this.bufferCache_[bufferKey];
   if (!gl.isContextLost()) {
@@ -218,7 +218,7 @@ ol.webgl.Context.prototype.getShader = function(shaderObject) {
     var shader = gl.createShader(shaderObject.getType());
     gl.shaderSource(shader, shaderObject.getSource());
     gl.compileShader(shader);
-    goog.DEBUG && console.assert(
+    ol.DEBUG && console.assert(
         gl.getShaderParameter(shader, ol.webgl.COMPILE_STATUS) ||
         gl.isContextLost(),
         gl.getShaderInfoLog(shader) || 'illegal state, shader not compiled or context lost');
@@ -248,7 +248,7 @@ ol.webgl.Context.prototype.getProgram = function(
     gl.attachShader(program, this.getShader(fragmentShaderObject));
     gl.attachShader(program, this.getShader(vertexShaderObject));
     gl.linkProgram(program);
-    goog.DEBUG && console.assert(
+    ol.DEBUG && console.assert(
         gl.getProgramParameter(program, ol.webgl.LINK_STATUS) ||
         gl.isContextLost(),
         gl.getProgramInfoLog(program) || 'illegal state, shader not linked or context lost');

--- a/src/ol/webgl/shader.mustache
+++ b/src/ol/webgl/shader.mustache
@@ -35,7 +35,7 @@ ol.inherits({{className}}.Fragment, ol.webgl.Fragment);
  * @const
  * @type {string}
  */
-{{className}}.Fragment.SOURCE = goog.DEBUG ?
+{{className}}.Fragment.SOURCE = ol.DEBUG ?
     {{className}}.Fragment.DEBUG_SOURCE :
     {{className}}.Fragment.OPTIMIZED_SOURCE;
 
@@ -72,7 +72,7 @@ ol.inherits({{className}}.Vertex, ol.webgl.Vertex);
  * @const
  * @type {string}
  */
-{{className}}.Vertex.SOURCE = goog.DEBUG ?
+{{className}}.Vertex.SOURCE = ol.DEBUG ?
     {{className}}.Vertex.DEBUG_SOURCE :
     {{className}}.Vertex.OPTIMIZED_SOURCE;
 
@@ -93,7 +93,7 @@ ol.inherits({{className}}.Vertex, ol.webgl.Vertex);
    * @type {WebGLUniformLocation}
    */
   this.{{originalName}} = gl.getUniformLocation(
-      program, goog.DEBUG ? '{{originalName}}' : '{{shortName}}');
+      program, ol.DEBUG ? '{{originalName}}' : '{{shortName}}');
 {{/getUniforms}}
 {{#getAttributes}}
 
@@ -101,6 +101,6 @@ ol.inherits({{className}}.Vertex, ol.webgl.Vertex);
    * @type {number}
    */
   this.{{originalName}} = gl.getAttribLocation(
-      program, goog.DEBUG ? '{{originalName}}' : '{{shortName}}');
+      program, ol.DEBUG ? '{{originalName}}' : '{{shortName}}');
 {{/getAttributes}}
 };

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -133,11 +133,11 @@ ol.xml.makeArrayExtender = function(valueReader, opt_this) {
       function(node, objectStack) {
         var value = valueReader.call(opt_this, node, objectStack);
         if (value !== undefined) {
-          goog.DEBUG && console.assert(Array.isArray(value),
+          ol.DEBUG && console.assert(Array.isArray(value),
               'valueReader function is expected to return an array of values');
           var array = /** @type {Array.<*>} */
               (objectStack[objectStack.length - 1]);
-          goog.DEBUG && console.assert(Array.isArray(array),
+          ol.DEBUG && console.assert(Array.isArray(array),
               'objectStack is supposed to be an array of arrays');
           ol.array.extend(array, value);
         }
@@ -164,7 +164,7 @@ ol.xml.makeArrayPusher = function(valueReader, opt_this) {
             node, objectStack);
         if (value !== undefined) {
           var array = objectStack[objectStack.length - 1];
-          goog.DEBUG && console.assert(Array.isArray(array),
+          ol.DEBUG && console.assert(Array.isArray(array),
               'objectStack is supposed to be an array of arrays');
           array.push(value);
         }
@@ -206,7 +206,7 @@ ol.xml.makeReplacer = function(valueReader, opt_this) {
  * @template T
  */
 ol.xml.makeObjectPropertyPusher = function(valueReader, opt_property, opt_this) {
-  goog.DEBUG && console.assert(valueReader !== undefined,
+  ol.DEBUG && console.assert(valueReader !== undefined,
       'undefined valueReader, expected function(this: T, Node, Array.<*>)');
   return (
       /**
@@ -242,7 +242,7 @@ ol.xml.makeObjectPropertyPusher = function(valueReader, opt_property, opt_this) 
  * @template T
  */
 ol.xml.makeObjectPropertySetter = function(valueReader, opt_property, opt_this) {
-  goog.DEBUG && console.assert(valueReader !== undefined,
+  ol.DEBUG && console.assert(valueReader !== undefined,
       'undefined valueReader, expected function(this: T, Node, Array.<*>)');
   return (
       /**
@@ -279,7 +279,7 @@ ol.xml.makeChildAppender = function(nodeWriter, opt_this) {
         node, value, objectStack);
     var parent = objectStack[objectStack.length - 1];
     var parentNode = parent.node;
-    goog.DEBUG && console.assert(ol.xml.isNode(parentNode) ||
+    ol.DEBUG && console.assert(ol.xml.isNode(parentNode) ||
         ol.xml.isDocument(parentNode),
         'expected parentNode %s to be a Node or a Document', parentNode);
     parentNode.appendChild(node);
@@ -340,7 +340,7 @@ ol.xml.makeSimpleNodeFactory = function(opt_nodeName, opt_namespaceURI) {
       function(value, objectStack, opt_nodeName) {
         var context = objectStack[objectStack.length - 1];
         var node = context.node;
-        goog.DEBUG && console.assert(ol.xml.isNode(node) || ol.xml.isDocument(node),
+        ol.DEBUG && console.assert(ol.xml.isNode(node) || ol.xml.isDocument(node),
             'expected node %s to be a Node or a Document', node);
         var nodeName = fixedNodeName;
         if (nodeName === undefined) {
@@ -350,7 +350,7 @@ ol.xml.makeSimpleNodeFactory = function(opt_nodeName, opt_namespaceURI) {
         if (opt_namespaceURI === undefined) {
           namespaceURI = node.namespaceURI;
         }
-        goog.DEBUG && console.assert(nodeName !== undefined, 'nodeName was undefined');
+        ol.DEBUG && console.assert(nodeName !== undefined, 'nodeName was undefined');
         return ol.xml.createElementNS(namespaceURI, /** @type {string} */ (nodeName));
       }
   );

--- a/tasks/readme.md
+++ b/tasks/readme.md
@@ -56,7 +56,7 @@ Below is a complete `build.json` configuration file that would generate a 'full'
       "externs/topojson.js"
     ],
     "define": [
-      "goog.DEBUG=false"
+      "ol.DEBUG=false"
     ],
     "compilation_level": "ADVANCED",
     "output_wrapper": "(function(){%output%})();",

--- a/test/spec/ol/dom/dom.test.js
+++ b/test/spec/ol/dom/dom.test.js
@@ -1,7 +1,6 @@
 /*global Modernizr*/
 goog.provide('ol.test.dom');
 
-goog.require('goog.userAgent');
 goog.require('ol.transform');
 goog.require('ol.dom');
 
@@ -92,10 +91,13 @@ describe('ol.dom', function() {
 
   describe('ol.dom.setTransform', function() {
     var element = null;
+    var originalIsIE;
     beforeEach(function() {
       element = document.createElement('div');
+      originalIsIE = ol.has.IE;
     });
     afterEach(function() {
+      ol.has.IE = originalIsIE;
       element = null;
     });
 
@@ -115,35 +117,24 @@ describe('ol.dom', function() {
     });
 
     it('sets transform origin for IE 9', function() {
-      // save old user agent information
-      var originalIsIE = goog.userAgent.IE;
-      var originalIsVersionOrHigher = goog.userAgent.isVersionOrHigher;
-
       // Mock up IE 9
-      goog.userAgent.IE = true;
-      goog.userAgent.isVersionOrHigher = function() {
-        return true;
-      };
+      ol.has.IE = true;
 
       ol.dom.setTransform(element, 'rotate(48deg)');
       expect(element.style.transformOrigin).to.not.be('');
-
-      // revert mock-ups
-      goog.userAgent.IE = originalIsIE;
-      goog.userAgent.isVersionOrHigher = originalIsVersionOrHigher;
     });
 
     it('sets transform origin *only* for IE 9', function() {
       // save old user agent information
-      var originalIsIE = goog.userAgent.IE;
+      var originalIsIE = ol.has.IE;
       // Mock up some non-IE browser
-      goog.userAgent.IE = false;
+      ol.has.IE = false;
 
       ol.dom.setTransform(element, 'rotate(48deg)');
       expect(!element.style.transformOrigin).to.be(true);
 
       // revert mock-ups
-      goog.userAgent.IE = originalIsIE;
+      ol.has.IE = originalIsIE;
     });
 
   });


### PR DESCRIPTION
This pull request removes the remaining bits of Closure Library, and renames `goog.DEBUG` to `ol.DEBUG`.

Fixes #4128.