### PR TITLE
Add ArrayBuffer.isView method in externs/closure-compiler.js

### DIFF
--- a/externs/closure-compiler.js
+++ b/externs/closure-compiler.js
@@ -8,6 +8,18 @@
  * @externs
  */
 
+
+// see https://github.com/google/closure-compiler/pull/1991
+
+/**
+ * @param {*} arg
+ * @return {boolean}
+ * @nosideeffects
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/isView
+ */
+ArrayBuffer.isView = function(arg) {};
+
+
 // see https://github.com/google/closure-compiler/pull/1206
 
 /**


### PR DESCRIPTION
fixes #5818 
