### PR TITLE
Revert "Do not close the ring when we use closePath()"

### DIFF
--- a/src/ol/render/canvas/replay.js
+++ b/src/ol/render/canvas/replay.js
@@ -1268,10 +1268,8 @@ ol.render.canvas.PolygonReplay.prototype.drawFlatCoordinatess_ = function(flatCo
   for (var i = 0; i < numEnds; ++i) {
     var end = ends[i];
     var myBegin = this.coordinates.length;
-    var myEnd = this.appendFlatCoordinates(flatCoordinates, offset, end, stride,
-        // Performance optimization: only close the ring when we do not have a
-        // stroke. Otherwise closePath() will take care of that.
-        !stroke);
+    var myEnd = this.appendFlatCoordinates(
+        flatCoordinates, offset, end, stride, true);
     var moveToLineToInstruction =
         [ol.render.canvas.Instruction.MOVE_TO_LINE_TO, myBegin, myEnd];
     this.instructions.push(moveToLineToInstruction);


### PR DESCRIPTION
This reverts commit 370c0c084673259d1c90c211b34217be0a2a0ba1. That optimisation left us with a missing end point when the last vertex of a polygon was skipped.

Fixes #5822.