### PR TITLE
Always close polygon rings

### DIFF
--- a/src/ol/render/canvas/polygonreplay.js
+++ b/src/ol/render/canvas/polygonreplay.js
@@ -89,10 +89,8 @@ ol.render.canvas.PolygonReplay.prototype.drawFlatCoordinatess_ = function(flatCo
   for (var i = 0; i < numEnds; ++i) {
     var end = ends[i];
     var myBegin = this.coordinates.length;
-    var myEnd = this.appendFlatCoordinates(flatCoordinates, offset, end, stride,
-        // Performance optimization: only close the ring when we do not have a
-        // stroke. Otherwise closePath() will take care of that.
-        !stroke);
+    var myEnd = this.appendFlatCoordinates(
+        flatCoordinates, offset, end, stride, true);
     var moveToLineToInstruction =
         [ol.render.canvas.Instruction.MOVE_TO_LINE_TO, myBegin, myEnd];
     this.instructions.push(moveToLineToInstruction);


### PR DESCRIPTION
This ensures that we do not optimize away the last vertex of a polygon.

Replaces #5826.

Fixes #5822.