### PR TITLE
document and test ol.getUid sequence behavior

### DIFF
--- a/src/ol/index.js
+++ b/src/ol/index.js
@@ -270,8 +270,8 @@ ol.nullFunction = function() {};
 
 /**
  * Gets a unique ID for an object. This mutates the object so that further calls
- * with the same object as a parameter returns the same value. Adapted from
- * goog.getUid.
+ * with the same object as a parameter returns the same value. Unique IDs are generated
+ * as a strictly increasing sequence. Adapted from goog.getUid.
  *
  * @param {Object} obj The object to get the unique ID for.
  * @return {number} The unique ID for the object.

--- a/test/spec/ol/index.test.js
+++ b/test/spec/ol/index.test.js
@@ -1,0 +1,23 @@
+goog.provide('ol.test');
+goog.require('ol');
+
+describe('getUid()', function() {
+  it('is constant once generated', function() {
+    var a = {};
+    expect(ol.getUid(a)).to.be(ol.getUid(a));
+  });
+
+  it('generates a strictly increasing sequence', function() {
+    var a = {} , b = {}, c = {};
+    ol.getUid(a);
+    ol.getUid(c);
+    ol.getUid(b);
+
+    //uid order should be a < c < b
+    expect(ol.getUid(a)).to.be.lessThan(ol.getUid(c));
+    expect(ol.getUid(c)).to.be.lessThan(ol.getUid(b));
+    expect(ol.getUid(a)).to.be.lessThan(ol.getUid(b));
+  });
+});
+
+


### PR DESCRIPTION
@ahocevar mentioned (in the #5795 review) that we should document the fact that ol.getUid returns an increasing sequence of IDs. If that's still the policy, maybe this would be helpful.