### PR TITLE
Remove ol.global

### DIFF
--- a/src/ol/color.js
+++ b/src/ol/color.js
@@ -1,6 +1,5 @@
 goog.provide('ol.color');
 
-goog.require('ol');
 goog.require('ol.asserts');
 goog.require('ol.math');
 
@@ -83,7 +82,7 @@ ol.color.fromNamed = function(color) {
   var el = document.createElement('div');
   el.style.color = color;
   document.body.appendChild(el);
-  var rgb = ol.global.getComputedStyle(el).color;
+  var rgb = getComputedStyle(el).color;
   document.body.removeChild(el);
   return rgb;
 };

--- a/src/ol/control/fullscreen.js
+++ b/src/ol/control/fullscreen.js
@@ -158,10 +158,9 @@ ol.control.FullScreen.prototype.handleFullScreenChange_ = function() {
  * @api stable
  */
 ol.control.FullScreen.prototype.setMap = function(map) {
-  var global = ol.global;
   ol.control.Control.prototype.setMap.call(this, map);
   if (map) {
-    this.listenerKeys.push(ol.events.listen(global.document,
+    this.listenerKeys.push(ol.events.listen(document,
         ol.control.FullScreen.getChangeType_(),
         this.handleFullScreenChange_, this)
     );

--- a/src/ol/control/zoomslider.js
+++ b/src/ol/control/zoomslider.js
@@ -181,14 +181,13 @@ ol.control.ZoomSlider.prototype.setMap = function(map) {
  * @private
  */
 ol.control.ZoomSlider.prototype.initSlider_ = function() {
-  var global = ol.global;
   var container = this.element;
   var containerSize = {
     width: container.offsetWidth, height: container.offsetHeight
   };
 
   var thumb = container.firstElementChild;
-  var computedStyle = global.getComputedStyle(thumb);
+  var computedStyle = getComputedStyle(thumb);
   var thumbWidth = thumb.offsetWidth +
       parseFloat(computedStyle['marginRight']) +
       parseFloat(computedStyle['marginLeft']);

--- a/src/ol/deviceorientation.js
+++ b/src/ol/deviceorientation.js
@@ -194,7 +194,7 @@ ol.DeviceOrientation.prototype.handleTrackingChanged_ = function() {
   if (ol.has.DEVICE_ORIENTATION) {
     var tracking = this.getTracking();
     if (tracking && !this.listenerKey_) {
-      this.listenerKey_ = ol.events.listen(ol.global, 'deviceorientation',
+      this.listenerKey_ = ol.events.listen(window, 'deviceorientation',
           this.orientationChange_, this);
     } else if (!tracking && this.listenerKey_ !== null) {
       ol.events.unlistenByKey(this.listenerKey_);

--- a/src/ol/dom.js
+++ b/src/ol/dom.js
@@ -1,7 +1,5 @@
 goog.provide('ol.dom');
 
-goog.require('ol');
-
 
 /**
  * Create an html canvas element and returns its 2d context.
@@ -29,9 +27,8 @@ ol.dom.createCanvasContext2D = function(opt_width, opt_height) {
  * @return {number} The width.
  */
 ol.dom.outerWidth = function(element) {
-  var global = ol.global;
   var width = element.offsetWidth;
-  var style = element.currentStyle || global.getComputedStyle(element);
+  var style = element.currentStyle || getComputedStyle(element);
   width += parseInt(style.marginLeft, 10) + parseInt(style.marginRight, 10);
 
   return width;
@@ -46,9 +43,8 @@ ol.dom.outerWidth = function(element) {
  * @return {number} The height.
  */
 ol.dom.outerHeight = function(element) {
-  var global = ol.global;
   var height = element.offsetHeight;
-  var style = element.currentStyle || global.getComputedStyle(element);
+  var style = element.currentStyle || getComputedStyle(element);
   height += parseInt(style.marginTop, 10) + parseInt(style.marginBottom, 10);
 
   return height;

--- a/src/ol/geolocation.js
+++ b/src/ol/geolocation.js
@@ -113,9 +113,7 @@ ol.Geolocation.prototype.handleProjectionChanged_ = function() {
  * @private
  */
 ol.Geolocation.prototype.handleTrackingChanged_ = function() {
-  var global = ol.global;
   if (ol.has.GEOLOCATION) {
-    var navigator = global.navigator;
     var tracking = this.getTracking();
     if (tracking && this.watchId_ === undefined) {
       this.watchId_ = navigator.geolocation.watchPosition(

--- a/src/ol/has.js
+++ b/src/ol/has.js
@@ -3,7 +3,6 @@ goog.provide('ol.has');
 goog.require('ol');
 goog.require('ol.webgl');
 
-var olGlobal = ol.global;
 var ua = typeof navigator !== 'undefined' ?
     navigator.userAgent.toLowerCase() : '';
 
@@ -39,7 +38,7 @@ ol.has.MAC = ua.indexOf('macintosh') !== -1;
  * @type {number}
  * @api stable
  */
-ol.has.DEVICE_PIXEL_RATIO = olGlobal.devicePixelRatio || 1;
+ol.has.DEVICE_PIXEL_RATIO = window.devicePixelRatio || 1;
 
 
 /**
@@ -61,7 +60,7 @@ ol.has.CANVAS = ol.ENABLE_CANVAS && (
      * @return {boolean} Canvas supported.
      */
     function() {
-      if (!('HTMLCanvasElement' in olGlobal)) {
+      if (!('HTMLCanvasElement' in window)) {
         return false;
       }
       try {
@@ -86,7 +85,7 @@ ol.has.CANVAS = ol.ENABLE_CANVAS && (
  * @type {boolean}
  * @api stable
  */
-ol.has.DEVICE_ORIENTATION = 'DeviceOrientationEvent' in olGlobal;
+ol.has.DEVICE_ORIENTATION = 'DeviceOrientationEvent' in window;
 
 
 /**
@@ -95,7 +94,7 @@ ol.has.DEVICE_ORIENTATION = 'DeviceOrientationEvent' in olGlobal;
  * @type {boolean}
  * @api stable
  */
-ol.has.GEOLOCATION = 'geolocation' in olGlobal.navigator;
+ol.has.GEOLOCATION = 'geolocation' in navigator;
 
 
 /**
@@ -104,7 +103,7 @@ ol.has.GEOLOCATION = 'geolocation' in olGlobal.navigator;
  * @type {boolean}
  * @api stable
  */
-ol.has.TOUCH = ol.ASSUME_TOUCH || 'ontouchstart' in olGlobal;
+ol.has.TOUCH = ol.ASSUME_TOUCH || 'ontouchstart' in window;
 
 
 /**
@@ -112,7 +111,7 @@ ol.has.TOUCH = ol.ASSUME_TOUCH || 'ontouchstart' in olGlobal;
  * @const
  * @type {boolean}
  */
-ol.has.POINTER = 'PointerEvent' in olGlobal;
+ol.has.POINTER = 'PointerEvent' in window;
 
 
 /**
@@ -120,7 +119,7 @@ ol.has.POINTER = 'PointerEvent' in olGlobal;
  * @const
  * @type {boolean}
  */
-ol.has.MSPOINTER = !!(olGlobal.navigator.msPointerEnabled);
+ol.has.MSPOINTER = !!(navigator.msPointerEnabled);
 
 
 /**
@@ -139,7 +138,7 @@ ol.has.WEBGL;
     var textureSize;
     var /** @type {Array.<string>} */ extensions = [];
 
-    if ('WebGLRenderingContext' in olGlobal) {
+    if ('WebGLRenderingContext' in window) {
       try {
         var canvas = /** @type {HTMLCanvasElement} */
             (document.createElement('CANVAS'));

--- a/src/ol/index.js
+++ b/src/ol/index.js
@@ -288,15 +288,3 @@ ol.getUid = function(obj) {
  * @private
  */
 ol.uidCounter_ = 0;
-
-
-/**
- * @see https://github.com/tc39/proposal-global
- */
-if (typeof window !== 'undefined') {
-  ol.global = window;
-} else if (typeof global !== 'undefined') {
-  ol.global = global;
-} else if (typeof self !== 'undefined') {
-  ol.global = self;
-}

--- a/src/ol/interaction/mousewheelzoom.js
+++ b/src/ol/interaction/mousewheelzoom.js
@@ -87,8 +87,6 @@ ol.interaction.MouseWheelZoom.handleEvent = function(mapBrowserEvent) {
     // https://github.com/mapbox/mapbox-gl-js/blob/001c7b9/js/ui/handler/scroll_zoom.js
     //TODO There's more good stuff in there for inspiration to improve this interaction.
     var delta;
-    var global = ol.global;
-    var WheelEvent = global.WheelEvent;
     if (mapBrowserEvent.type == ol.events.EventType.WHEEL) {
       delta = wheelEvent.deltaY;
       if (ol.has.FIREFOX &&
@@ -114,8 +112,8 @@ ol.interaction.MouseWheelZoom.handleEvent = function(mapBrowserEvent) {
     var duration = ol.MOUSEWHEELZOOM_TIMEOUT_DURATION;
     var timeLeft = Math.max(duration - (Date.now() - this.startTime_), 0);
 
-    global.clearTimeout(this.timeoutId_);
-    this.timeoutId_ = global.setTimeout(
+    clearTimeout(this.timeoutId_);
+    this.timeoutId_ = setTimeout(
         this.doZoom_.bind(this, map), timeLeft);
 
     mapBrowserEvent.preventDefault();

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -550,7 +550,6 @@ ol.Map.prototype.removePreRenderFunction = function(preRenderFunction) {
  * @inheritDoc
  */
 ol.Map.prototype.disposeInternal = function() {
-  var global = ol.global;
   this.mapBrowserEventHandler_.dispose();
   this.renderer_.dispose();
   ol.events.unlisten(this.viewport_, ol.events.EventType.WHEEL,
@@ -558,12 +557,12 @@ ol.Map.prototype.disposeInternal = function() {
   ol.events.unlisten(this.viewport_, ol.events.EventType.MOUSEWHEEL,
       this.handleBrowserEvent, this);
   if (this.handleResize_ !== undefined) {
-    global.removeEventListener(ol.events.EventType.RESIZE,
+    window.removeEventListener(ol.events.EventType.RESIZE,
         this.handleResize_, false);
     this.handleResize_ = undefined;
   }
   if (this.animationDelayKey_) {
-    global.cancelAnimationFrame(this.animationDelayKey_);
+    cancelAnimationFrame(this.animationDelayKey_);
     this.animationDelayKey_ = undefined;
   }
   this.setTarget(null);
@@ -1037,7 +1036,6 @@ ol.Map.prototype.handleSizeChanged_ = function() {
  * @private
  */
 ol.Map.prototype.handleTargetChanged_ = function() {
-  var global = ol.global;
   // target may be undefined, null, a string or an Element.
   // If it's a string we convert it to an Element before proceeding.
   // If it's not now an Element we remove the viewport from the DOM.
@@ -1060,7 +1058,7 @@ ol.Map.prototype.handleTargetChanged_ = function() {
   if (!targetElement) {
     ol.dom.removeNode(this.viewport_);
     if (this.handleResize_ !== undefined) {
-      global.removeEventListener(ol.events.EventType.RESIZE,
+      window.removeEventListener(ol.events.EventType.RESIZE,
           this.handleResize_, false);
       this.handleResize_ = undefined;
     }
@@ -1078,7 +1076,7 @@ ol.Map.prototype.handleTargetChanged_ = function() {
 
     if (!this.handleResize_) {
       this.handleResize_ = this.updateSize.bind(this);
-      global.addEventListener(ol.events.EventType.RESIZE,
+      window.addEventListener(ol.events.EventType.RESIZE,
           this.handleResize_, false);
     }
   }
@@ -1159,9 +1157,8 @@ ol.Map.prototype.isRendered = function() {
  * @api stable
  */
 ol.Map.prototype.renderSync = function() {
-  var global = ol.global;
   if (this.animationDelayKey_) {
-    global.cancelAnimationFrame(this.animationDelayKey_);
+    cancelAnimationFrame(this.animationDelayKey_);
   }
   this.animationDelay_();
 };
@@ -1172,9 +1169,8 @@ ol.Map.prototype.renderSync = function() {
  * @api stable
  */
 ol.Map.prototype.render = function() {
-  var global = ol.global;
   if (this.animationDelayKey_ === undefined) {
-    this.animationDelayKey_ = global.requestAnimationFrame(
+    this.animationDelayKey_ = requestAnimationFrame(
         this.animationDelay_);
   }
 };
@@ -1314,7 +1310,7 @@ ol.Map.prototype.renderFrame_ = function(time) {
   this.dispatchEvent(
       new ol.MapEvent(ol.MapEventType.POSTRENDER, this, frameState));
 
-  ol.global.setTimeout(this.handlePostRender.bind(this), 0);
+  setTimeout(this.handlePostRender.bind(this), 0);
 
 };
 
@@ -1381,13 +1377,12 @@ ol.Map.prototype.skipFeature = function(feature) {
  * @api stable
  */
 ol.Map.prototype.updateSize = function() {
-  var global = ol.global;
   var targetElement = this.getTargetElement();
 
   if (!targetElement) {
     this.setSize(undefined);
   } else {
-    var computedStyle = global.getComputedStyle(targetElement);
+    var computedStyle = getComputedStyle(targetElement);
     this.setSize([
       targetElement.offsetWidth -
           parseFloat(computedStyle['borderLeftWidth']) -

--- a/src/ol/mapbrowserevent.js
+++ b/src/ol/mapbrowserevent.js
@@ -214,9 +214,6 @@ ol.inherits(ol.MapBrowserEventHandler, ol.events.EventTarget);
  * @private
  */
 ol.MapBrowserEventHandler.prototype.emulateClick_ = function(pointerEvent) {
-  var global = ol.global;
-  var clearTimeout = global.clearTimeout;
-  var setTimeout = global.setTimeout;
   var newEvent = new ol.MapBrowserPointerEvent(
       ol.MapBrowserEvent.EventType.CLICK, this.map_, pointerEvent);
   this.dispatchEvent(newEvent);

--- a/src/ol/net.js
+++ b/src/ol/net.js
@@ -15,24 +15,23 @@ goog.require('ol');
  *     callback. Default is 'callback'.
  */
 ol.net.jsonp = function(url, callback, opt_errback, opt_callbackParam) {
-  var global = ol.global;
-  var script = global.document.createElement('script');
+  var script = document.createElement('script');
   var key = 'olc_' + ol.getUid(callback);
   function cleanup() {
-    delete global[key];
+    delete window[key];
     script.parentNode.removeChild(script);
   }
   script.async = true;
   script.src = url + (url.indexOf('?') == -1 ? '?' : '&') +
       (opt_callbackParam || 'callback') + '=' + key;
-  var timer = global.setTimeout(function() {
+  var timer = setTimeout(function() {
     cleanup();
     if (opt_errback) {
       opt_errback();
     }
   }, 10000);
-  global[key] = function(data) {
-    global.clearTimeout(timer);
+  window[key] = function(data) {
+    clearTimeout(timer);
     cleanup();
     callback(data);
   };

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -398,10 +398,9 @@ ol.Overlay.prototype.panIntoView_ = function() {
  * @private
  */
 ol.Overlay.prototype.getRect_ = function(element, size) {
-  var global = ol.global;
   var box = element.getBoundingClientRect();
-  var offsetX = box.left + global.pageXOffset;
-  var offsetY = box.top + global.pageYOffset;
+  var offsetX = box.left + window.pageXOffset;
+  var offsetY = box.top + window.pageYOffset;
   return [
     offsetX,
     offsetY,

--- a/src/ol/pointer/touchsource.js
+++ b/src/ol/pointer/touchsource.js
@@ -148,8 +148,7 @@ ol.pointer.TouchSource.prototype.removePrimaryPointer_ = function(inPointer) {
  * @private
  */
 ol.pointer.TouchSource.prototype.resetClickCount_ = function() {
-  var global = ol.global;
-  this.resetId_ = global.setTimeout(
+  this.resetId_ = setTimeout(
       this.resetClickCountHandler_.bind(this),
       ol.pointer.TouchSource.CLICK_COUNT_TIMEOUT);
 };
@@ -168,9 +167,8 @@ ol.pointer.TouchSource.prototype.resetClickCountHandler_ = function() {
  * @private
  */
 ol.pointer.TouchSource.prototype.cancelResetClickCount_ = function() {
-  var global = ol.global;
   if (this.resetId_ !== undefined) {
-    global.clearTimeout(this.resetId_);
+    clearTimeout(this.resetId_);
   }
 };
 
@@ -442,8 +440,7 @@ ol.pointer.TouchSource.prototype.dedupSynthMouse_ = function(inEvent) {
     var lt = [t.clientX, t.clientY];
     lts.push(lt);
 
-    var global = ol.global;
-    global.setTimeout(function() {
+    setTimeout(function() {
       // remove touch after timeout
       ol.array.remove(lts, lt);
     }, ol.pointer.TouchSource.DEDUP_TIMEOUT);

--- a/src/ol/proj/index.js
+++ b/src/ol/proj/index.js
@@ -139,7 +139,7 @@ ol.proj.Projection = function(options) {
   ol.DEBUG && console.assert(code !== undefined,
       'Option "code" is required for constructing instance');
   if (ol.ENABLE_PROJ4JS) {
-    var proj4js = ol.proj.proj4_ || ol.global['proj4'];
+    var proj4js = ol.proj.proj4_ || window['proj4'];
     if (typeof proj4js == 'function' && projections[code] === undefined) {
       var def = proj4js.defs(code);
       if (def !== undefined) {
@@ -668,7 +668,7 @@ ol.proj.get = function(projectionLike) {
     var code = projectionLike;
     projection = ol.proj.projections_[code];
     if (ol.ENABLE_PROJ4JS) {
-      var proj4js = ol.proj.proj4_ || ol.global['proj4'];
+      var proj4js = ol.proj.proj4_ || window['proj4'];
       if (projection === undefined && typeof proj4js == 'function' &&
           proj4js.defs(code) !== undefined) {
         projection = new ol.proj.Projection({code: code});

--- a/src/ol/reproj/index.js
+++ b/src/ol/reproj/index.js
@@ -17,18 +17,18 @@ goog.require('ol.proj');
  * @type {boolean}
  * @private
  */
-ol.reproj.browserAntialiasesClip_ = (function(global) {
+ol.reproj.browserAntialiasesClip_ = (function() {
   // Adapted from http://stackoverflow.com/questions/4565112/javascript-how-to-find-out-if-the-user-browser-is-chrome
-  var isOpera = global.navigator.userAgent.indexOf('OPR') > -1;
-  var isIEedge = global.navigator.userAgent.indexOf('Edge') > -1;
+  var isOpera = navigator.userAgent.indexOf('OPR') > -1;
+  var isIEedge = navigator.userAgent.indexOf('Edge') > -1;
   return !(
-    !global.navigator.userAgent.match('CriOS') &&  // Not Chrome on iOS
-    global.chrome !== null && global.chrome !== undefined && // Has chrome in window
-    global.navigator.vendor === 'Google Inc.' && // Vendor is Google.
+    !navigator.userAgent.match('CriOS') &&  // Not Chrome on iOS
+    'chrome' in window && // Has chrome in window
+    navigator.vendor === 'Google Inc.' && // Vendor is Google.
     isOpera == false && // Not Opera
     isIEedge == false // Not Edge
   );
-})(ol.global);
+})();
 
 
 /**

--- a/src/ol/reproj/tile.js
+++ b/src/ol/reproj/tile.js
@@ -300,8 +300,7 @@ ol.reproj.Tile.prototype.load = function() {
     });
 
     if (leftToLoad === 0) {
-      var global = ol.global;
-      global.setTimeout(this.reproject_.bind(this), 0);
+      setTimeout(this.reproject_.bind(this), 0);
     }
   }
 };

--- a/src/ol/source/tileutfgrid.js
+++ b/src/ol/source/tileutfgrid.js
@@ -139,7 +139,7 @@ ol.source.TileUTFGrid.prototype.forDataAtCoordinateAndResolution = function(
     tile.forDataAtCoordinate(coordinate, callback, opt_this, opt_request);
   } else {
     if (opt_request === true) {
-      ol.global.setTimeout(function() {
+      setTimeout(function() {
         callback.call(opt_this, null);
       }, 0);
     } else {
@@ -389,7 +389,7 @@ ol.source.TileUTFGrid.Tile_.prototype.forDataAtCoordinate = function(coordinate,
     this.loadInternal_();
   } else {
     if (opt_request === true) {
-      ol.global.setTimeout(function() {
+      setTimeout(function() {
         callback.call(opt_this, this.getData(coordinate));
       }.bind(this), 0);
     } else {

--- a/test/spec/ol/interaction/draganddrop.test.js
+++ b/test/spec/ol/interaction/draganddrop.test.js
@@ -10,7 +10,6 @@ goog.require('ol.interaction.DragAndDrop');
 
 describe('ol.interaction.DragAndDrop', function() {
   var viewport, map, interaction;
-  var global = ol.global;
 
   beforeEach(function() {
     viewport = new ol.events.EventTarget();
@@ -71,7 +70,7 @@ describe('ol.interaction.DragAndDrop', function() {
   });
 
   describe('#handleDrop_', function() {
-    var origFileReader = global.FileReader;
+    var OrigFileReader = FileReader;
 
     beforeEach(function() {
       FileReader = function() {
@@ -85,7 +84,7 @@ describe('ol.interaction.DragAndDrop', function() {
     });
 
     afterEach(function() {
-      global.FileReader = origFileReader;
+      FileReader = OrigFileReader;
     });
 
     it('reads dropped files', function(done) {

--- a/test/spec/ol/net.test.js
+++ b/test/spec/ol/net.test.js
@@ -5,13 +5,11 @@ goog.require('ol.net');
 
 describe('ol.net', function() {
 
-  var global = ol.global;
-
   describe('jsonp()', function() {
-    var head = global.document.getElementsByTagName('head')[0];
+    var head = document.getElementsByTagName('head')[0];
     var origAppendChild = head.appendChild;
     var origCreateElement = document.createElement;
-    var origSetTimeout = global.setTimeout;
+    var origSetTimeout = setTimeout;
     var key, removeChild;
 
     function createCallback(url, done) {
@@ -31,7 +29,7 @@ describe('ol.net', function() {
         if (arg == 'script') {
           return element;
         } else {
-          return origCreateElement.apply(global.document, arguments);
+          return origCreateElement.apply(document, arguments);
         }
       };
       head.appendChild = function(el) {
@@ -40,13 +38,13 @@ describe('ol.net', function() {
             removeChild: removeChild
           };
           origSetTimeout(function() {
-            global[key](element.src);
+            window[key](element.src);
           }, 0);
         } else {
           origAppendChild.apply(head, arguments);
         }
       };
-      global.setTimeout = function(fn, time) {
+      setTimeout = function(fn, time) {
         origSetTimeout(fn, 100);
       };
     });
@@ -54,7 +52,7 @@ describe('ol.net', function() {
     afterEach(function() {
       document.createElement = origCreateElement;
       head.appendChild = origAppendChild;
-      global.setTimeout = origSetTimeout;
+      setTimeout = origSetTimeout;
     });
 
     it('appends callback param to url, cleans up after call', function(done) {
@@ -74,7 +72,7 @@ describe('ol.net', function() {
         expect.fail();
       }
       function errback() {
-        expect(global[key]).to.be(undefined);
+        expect(window[key]).to.be(undefined);
         expect(removeChild.called).to.be(true);
         done();
       }


### PR DESCRIPTION
The use of `ol.global` was very inconsistent (sometimes `setTimeout`, sometimes, `ol.global.setTimeout` - same for `navigator`, `document`, etc.).  This change removes `ol.global` in favor of relying on regular scoping behavior and using `window` where needed.  To run OpenLayers outside of a browser, `window` and browser globals must be provided.

Fixes #5814.