### PR TITLE
Require ol where ol.DEBUG is being used

### DIFF
--- a/src/ol/array.js
+++ b/src/ol/array.js
@@ -1,5 +1,7 @@
 goog.provide('ol.array');
 
+goog.require('ol');
+
 
 /**
  * Performs a binary search on the provided sorted list and returns the index of the item if found. If it can't be found it'll return -1.

--- a/src/ol/extent.js
+++ b/src/ol/extent.js
@@ -2,6 +2,7 @@ goog.provide('ol.extent');
 goog.provide('ol.extent.Corner');
 goog.provide('ol.extent.Relationship');
 
+goog.require('ol');
 goog.require('ol.asserts');
 
 

--- a/src/ol/geom/flat/closest.js
+++ b/src/ol/geom/flat/closest.js
@@ -1,5 +1,6 @@
 goog.provide('ol.geom.flat.closest');
 
+goog.require('ol');
 goog.require('ol.math');
 
 

--- a/src/ol/geom/flat/contains.js
+++ b/src/ol/geom/flat/contains.js
@@ -1,5 +1,6 @@
 goog.provide('ol.geom.flat.contains');
 
+goog.require('ol');
 goog.require('ol.extent');
 
 

--- a/src/ol/geom/flat/deflate.js
+++ b/src/ol/geom/flat/deflate.js
@@ -1,5 +1,7 @@
 goog.provide('ol.geom.flat.deflate');
 
+goog.require('ol');
+
 
 /**
  * @param {Array.<number>} flatCoordinates Flat coordinates.

--- a/src/ol/geom/flat/geodesic.js
+++ b/src/ol/geom/flat/geodesic.js
@@ -1,5 +1,6 @@
 goog.provide('ol.geom.flat.geodesic');
 
+goog.require('ol');
 goog.require('ol.math');
 goog.require('ol.proj');
 

--- a/src/ol/geom/flat/interiorpoint.js
+++ b/src/ol/geom/flat/interiorpoint.js
@@ -1,5 +1,6 @@
 goog.provide('ol.geom.flat.interiorpoint');
 
+goog.require('ol');
 goog.require('ol.array');
 goog.require('ol.geom.flat.contains');
 

--- a/src/ol/geom/flat/interpolate.js
+++ b/src/ol/geom/flat/interpolate.js
@@ -1,5 +1,6 @@
 goog.provide('ol.geom.flat.interpolate');
 
+goog.require('ol');
 goog.require('ol.array');
 goog.require('ol.math');
 

--- a/src/ol/geom/flat/intersectsextent.js
+++ b/src/ol/geom/flat/intersectsextent.js
@@ -1,5 +1,6 @@
 goog.provide('ol.geom.flat.intersectsextent');
 
+goog.require('ol');
 goog.require('ol.extent');
 goog.require('ol.geom.flat.contains');
 goog.require('ol.geom.flat.segments');

--- a/src/ol/graticule.js
+++ b/src/ol/graticule.js
@@ -1,5 +1,6 @@
 goog.provide('ol.Graticule');
 
+goog.require('ol');
 goog.require('ol.extent');
 goog.require('ol.geom.GeometryLayout');
 goog.require('ol.geom.LineString');

--- a/src/ol/math.js
+++ b/src/ol/math.js
@@ -1,5 +1,6 @@
 goog.provide('ol.math');
 
+goog.require('ol');
 goog.require('ol.asserts');
 
 

--- a/src/ol/structs/lrucache.js
+++ b/src/ol/structs/lrucache.js
@@ -1,5 +1,6 @@
 goog.provide('ol.structs.LRUCache');
 
+goog.require('ol');
 goog.require('ol.asserts');
 goog.require('ol.obj');
 

--- a/src/ol/structs/priorityqueue.js
+++ b/src/ol/structs/priorityqueue.js
@@ -1,5 +1,6 @@
 goog.provide('ol.structs.PriorityQueue');
 
+goog.require('ol');
 goog.require('ol.asserts');
 goog.require('ol.obj');
 

--- a/src/ol/style/iconimagecache.js
+++ b/src/ol/style/iconimagecache.js
@@ -1,5 +1,6 @@
 goog.provide('ol.style.IconImageCache');
 
+goog.require('ol');
 goog.require('ol.color');
 
 

--- a/src/ol/tilecoord.js
+++ b/src/ol/tilecoord.js
@@ -1,5 +1,7 @@
 goog.provide('ol.tilecoord');
 
+goog.require('ol');
+
 
 /**
  * @param {string} str String that follows pattern “z/x/y” where x, y and z are

--- a/src/ol/tileurlfunction.js
+++ b/src/ol/tileurlfunction.js
@@ -1,5 +1,6 @@
 goog.provide('ol.TileUrlFunction');
 
+goog.require('ol');
 goog.require('ol.asserts');
 goog.require('ol.math');
 goog.require('ol.tilecoord');


### PR DESCRIPTION
This is a follow up in the work done in #5794.

It removes the eslint warnings

```
warning  Missing goog.require('ol.DEBUG') or goog.require('ol')  openlayers-internal/no-missing-requires
```

by adding

```js
goog.require('ol');
```

to the appropriate files.

I hope this is the right way to fix this.

Please review.