### PR TITLE
Rename source.VectorEvent(*) to source.Vector.Event(*)

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -20,6 +20,8 @@ A number of internal types have been renamed.  This will not affect those who us
  * rename `ol.layer.VectorTileRenderType` to `ol.layer.VectorTile.RenderType`
  * rename `ol.source.TileEvent` to `ol.source.Tile.Event`
  * rename `ol.source.TileEventType` to `ol.source.Tile.EventType`
+ * rename `ol.source.VectorEvent` to `ol.source.Vector.Event`
+ * rename `ol.source.VectorEventType` to `ol.source.Vector.EventType`
  * rename `ol.source.WMTSRequestEncoding` to `ol.source.WMTS.RequestEncoding`
  * rename `ol.style.IconAnchorUnits` to `ol.style.Icon.AnchorUnits`
  * rename `ol.style.IconOrigin` to `ol.style.Icon.Origin`

--- a/doc/tutorials/custom-builds.md
+++ b/doc/tutorials/custom-builds.md
@@ -190,7 +190,7 @@ Now let's try a more complicated example: [`heatmaps-earthquakes`](http://openla
     "ol.format.KML",
     "ol.layer.Heatmap#getSource",
     "ol.source.Vector#on",
-    "ol.source.VectorEvent#feature",
+    "ol.source.Vector.Event#feature",
     "ol.Feature#get",
     "ol.Feature#set",
     "ol.layer.Tile",
@@ -217,7 +217,7 @@ Now let's try a more complicated example: [`heatmaps-earthquakes`](http://openla
 }
 ```
 
-The exports are given here in the order in which they occur in the `heatmaps-earthquakes` example's JavaScript code. In this example we not only use the `ol.` functions and constructors, but also `prototype` methods where the `ol` namespace is not directly used. In the code, we have for example `vector.getSource().on()`. This means we are using the `getSource` method of `layer.Heatmap` and the `on` method of `source.KML`, so this is what has to be exported. Similarly, `event.feature.get()` means we are using the `feature` property of `source.VectorEvent` and the `get` method of `Feature`. If any of these names are left out, the compile will complete successfully, but the missing names will be obfuscated and you will get a 'property undefined' error when you try and run the script.
+The exports are given here in the order in which they occur in the `heatmaps-earthquakes` example's JavaScript code. In this example we not only use the `ol.` functions and constructors, but also `prototype` methods where the `ol` namespace is not directly used. In the code, we have for example `vector.getSource().on()`. This means we are using the `getSource` method of `layer.Heatmap` and the `on` method of `source.KML`, so this is what has to be exported. Similarly, `event.feature.get()` means we are using the `feature` property of `source.Vector.Event` and the `get` method of `Feature`. If any of these names are left out, the compile will complete successfully, but the missing names will be obfuscated and you will get a 'property undefined' error when you try and run the script.
 
 As this example uses a vector layer it is necessary to remove `"ol.ENABLE_VECTOR=false"` in the `define` section of the configuration.
 

--- a/externs/oli.js
+++ b/externs/oli.js
@@ -359,10 +359,10 @@ oli.source.Tile.Event.prototype.tile;
 /**
  * @interface
  */
-oli.source.VectorEvent = function() {};
+oli.source.Vector.Event = function() {};
 
 
 /**
  * @type {ol.Feature|undefined}
  */
-oli.source.VectorEvent.prototype.feature;
+oli.source.Vector.Event.prototype.feature;

--- a/src/ol/interaction/snap.js
+++ b/src/ol/interaction/snap.js
@@ -11,8 +11,7 @@ goog.require('ol.extent');
 goog.require('ol.interaction.Pointer');
 goog.require('ol.functions');
 goog.require('ol.obj');
-goog.require('ol.source.VectorEvent');
-goog.require('ol.source.VectorEventType');
+goog.require('ol.source.Vector');
 goog.require('ol.structs.RBush');
 
 
@@ -226,12 +225,12 @@ ol.interaction.Snap.prototype.getFeatures_ = function() {
 
 
 /**
- * @param {ol.source.VectorEvent|ol.Collection.Event} evt Event.
+ * @param {ol.source.Vector.Event|ol.Collection.Event} evt Event.
  * @private
  */
 ol.interaction.Snap.prototype.handleFeatureAdd_ = function(evt) {
   var feature;
-  if (evt instanceof ol.source.VectorEvent) {
+  if (evt instanceof ol.source.Vector.Event) {
     feature = evt.feature;
   } else if (evt instanceof ol.Collection.Event) {
     feature = evt.element;
@@ -241,12 +240,12 @@ ol.interaction.Snap.prototype.handleFeatureAdd_ = function(evt) {
 
 
 /**
- * @param {ol.source.VectorEvent|ol.Collection.Event} evt Event.
+ * @param {ol.source.Vector.Event|ol.Collection.Event} evt Event.
  * @private
  */
 ol.interaction.Snap.prototype.handleFeatureRemove_ = function(evt) {
   var feature;
-  if (evt instanceof ol.source.VectorEvent) {
+  if (evt instanceof ol.source.Vector.Event) {
     feature = evt.feature;
   } else if (evt instanceof ol.Collection.Event) {
     feature = evt.element;
@@ -343,9 +342,9 @@ ol.interaction.Snap.prototype.setMap = function(map) {
       );
     } else if (this.source_) {
       keys.push(
-        ol.events.listen(this.source_, ol.source.VectorEventType.ADDFEATURE,
+        ol.events.listen(this.source_, ol.source.Vector.EventType.ADDFEATURE,
             this.handleFeatureAdd_, this),
-        ol.events.listen(this.source_, ol.source.VectorEventType.REMOVEFEATURE,
+        ol.events.listen(this.source_, ol.source.Vector.EventType.REMOVEFEATURE,
             this.handleFeatureRemove_, this)
       );
     }

--- a/src/ol/source/vector.js
+++ b/src/ol/source/vector.js
@@ -2,8 +2,6 @@
 // FIXME make change-detection more refined (notably, geometry hint)
 
 goog.provide('ol.source.Vector');
-goog.provide('ol.source.VectorEvent');
-goog.provide('ol.source.VectorEventType');
 
 goog.require('ol');
 goog.require('ol.Collection');
@@ -24,41 +22,6 @@ goog.require('ol.structs.RBush');
 
 
 /**
- * @enum {string}
- */
-ol.source.VectorEventType = {
-  /**
-   * Triggered when a feature is added to the source.
-   * @event ol.source.VectorEvent#addfeature
-   * @api stable
-   */
-  ADDFEATURE: 'addfeature',
-
-  /**
-   * Triggered when a feature is updated.
-   * @event ol.source.VectorEvent#changefeature
-   * @api
-   */
-  CHANGEFEATURE: 'changefeature',
-
-  /**
-   * Triggered when the clear method is called on the source.
-   * @event ol.source.VectorEvent#clear
-   * @api
-   */
-  CLEAR: 'clear',
-
-  /**
-   * Triggered when a feature is removed from the source.
-   * See {@link ol.source.Vector#clear source.clear()} for exceptions.
-   * @event ol.source.VectorEvent#removefeature
-   * @api stable
-   */
-  REMOVEFEATURE: 'removefeature'
-};
-
-
-/**
  * @classdesc
  * Provides a source of features for vector layers. Vector features provided
  * by this source are suitable for editing. See {@link ol.source.VectorTile} for
@@ -66,7 +29,7 @@ ol.source.VectorEventType = {
  *
  * @constructor
  * @extends {ol.source.Source}
- * @fires ol.source.VectorEvent
+ * @fires ol.source.Vector.Event
  * @param {olx.source.VectorOptions=} opt_options Vector source options.
  * @api stable
  */
@@ -227,7 +190,7 @@ ol.source.Vector.prototype.addFeatureInternal = function(feature) {
   }
 
   this.dispatchEvent(
-      new ol.source.VectorEvent(ol.source.VectorEventType.ADDFEATURE, feature));
+      new ol.source.Vector.Event(ol.source.Vector.EventType.ADDFEATURE, feature));
 };
 
 
@@ -323,8 +286,8 @@ ol.source.Vector.prototype.addFeaturesInternal = function(features) {
   }
 
   for (i = 0, length = newFeatures.length; i < length; i++) {
-    this.dispatchEvent(new ol.source.VectorEvent(
-        ol.source.VectorEventType.ADDFEATURE, newFeatures[i]));
+    this.dispatchEvent(new ol.source.Vector.Event(
+        ol.source.Vector.EventType.ADDFEATURE, newFeatures[i]));
   }
 };
 
@@ -337,7 +300,7 @@ ol.source.Vector.prototype.bindFeaturesCollection_ = function(collection) {
   ol.DEBUG && console.assert(!this.featuresCollection_,
       'bindFeaturesCollection can only be called once');
   var modifyingCollection = false;
-  ol.events.listen(this, ol.source.VectorEventType.ADDFEATURE,
+  ol.events.listen(this, ol.source.Vector.EventType.ADDFEATURE,
       function(evt) {
         if (!modifyingCollection) {
           modifyingCollection = true;
@@ -345,7 +308,7 @@ ol.source.Vector.prototype.bindFeaturesCollection_ = function(collection) {
           modifyingCollection = false;
         }
       });
-  ol.events.listen(this, ol.source.VectorEventType.REMOVEFEATURE,
+  ol.events.listen(this, ol.source.Vector.EventType.REMOVEFEATURE,
       function(evt) {
         if (!modifyingCollection) {
           modifyingCollection = true;
@@ -413,7 +376,7 @@ ol.source.Vector.prototype.clear = function(opt_fast) {
   this.loadedExtentsRtree_.clear();
   this.nullGeometryFeatures_ = {};
 
-  var clearEvent = new ol.source.VectorEvent(ol.source.VectorEventType.CLEAR);
+  var clearEvent = new ol.source.Vector.Event(ol.source.Vector.EventType.CLEAR);
   this.dispatchEvent(clearEvent);
   this.changed();
 };
@@ -775,8 +738,8 @@ ol.source.Vector.prototype.handleFeatureChange_ = function(event) {
     }
   }
   this.changed();
-  this.dispatchEvent(new ol.source.VectorEvent(
-      ol.source.VectorEventType.CHANGEFEATURE, feature));
+  this.dispatchEvent(new ol.source.Vector.Event(
+      ol.source.Vector.EventType.CHANGEFEATURE, feature));
 };
 
 
@@ -855,8 +818,8 @@ ol.source.Vector.prototype.removeFeatureInternal = function(feature) {
   } else {
     delete this.undefIdIndex_[featureKey];
   }
-  this.dispatchEvent(new ol.source.VectorEvent(
-      ol.source.VectorEventType.REMOVEFEATURE, feature));
+  this.dispatchEvent(new ol.source.Vector.Event(
+      ol.source.Vector.EventType.REMOVEFEATURE, feature));
 };
 
 
@@ -887,11 +850,11 @@ ol.source.Vector.prototype.removeFromIdIndex_ = function(feature) {
  *
  * @constructor
  * @extends {ol.events.Event}
- * @implements {oli.source.VectorEvent}
+ * @implements {oli.source.Vector.Event}
  * @param {string} type Type.
  * @param {ol.Feature=} opt_feature Feature.
  */
-ol.source.VectorEvent = function(type, opt_feature) {
+ol.source.Vector.Event = function(type, opt_feature) {
 
   ol.events.Event.call(this, type);
 
@@ -903,4 +866,39 @@ ol.source.VectorEvent = function(type, opt_feature) {
   this.feature = opt_feature;
 
 };
-ol.inherits(ol.source.VectorEvent, ol.events.Event);
+ol.inherits(ol.source.Vector.Event, ol.events.Event);
+
+
+/**
+ * @enum {string}
+ */
+ol.source.Vector.EventType = {
+  /**
+   * Triggered when a feature is added to the source.
+   * @event ol.source.Vector.Event#addfeature
+   * @api stable
+   */
+  ADDFEATURE: 'addfeature',
+
+  /**
+   * Triggered when a feature is updated.
+   * @event ol.source.Vector.Event#changefeature
+   * @api
+   */
+  CHANGEFEATURE: 'changefeature',
+
+  /**
+   * Triggered when the clear method is called on the source.
+   * @event ol.source.Vector.Event#clear
+   * @api
+   */
+  CLEAR: 'clear',
+
+  /**
+   * Triggered when a feature is removed from the source.
+   * See {@link ol.source.Vector#clear source.clear()} for exceptions.
+   * @event ol.source.Vector.Event#removefeature
+   * @api stable
+   */
+  REMOVEFEATURE: 'removefeature'
+};


### PR DESCRIPTION
In order to have only one provide per file, this PR suggests renaming

* `ol.source.VectorEvent` => `ol.source.Vector.Event`
* `ol.source.VectorEventType` => `ol.source.Vector.EventType`

It is basically the same as we did for `ol.source.TileEvent` in 74047e747d8c016644780a3dc0193ee9eddafa17 (part of #5794)

Please review.