### PR TITLE
Remove unused goog.require('ol')

### DIFF
--- a/src/ol/asserts.js
+++ b/src/ol/asserts.js
@@ -1,6 +1,5 @@
 goog.provide('ol.asserts');
 
-goog.require('ol');
 goog.require('ol.AssertionError');
 
 


### PR DESCRIPTION
presumably, the linter rule is not catching these