### PR TITLE
Remove 'global' from externs/closure-compiler.js

### DIFF
--- a/externs/closure-compiler.js
+++ b/externs/closure-compiler.js
@@ -27,5 +27,3 @@ ArrayBuffer.isView = function(arg) {};
  * @see http://www.w3.org/TR/pointerevents/#the-touch-action-css-property
  */
 CSSProperties.prototype.touchAction;
-
-var global;


### PR DESCRIPTION
Leftover from #5837