### PR TITLE
No gaps between tiles of different resolutions

### DIFF
--- a/test/spec/ol/renderer/canvas/tilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/tilelayer.test.js
@@ -40,6 +40,14 @@ describe('ol.renderer.canvas.TileLayer', function() {
         canvas: canvas,
         drawImage: sinon.spy()
       };
+      renderer.renderedTiles = [{
+        getTileCoord: function() {
+          return [0, 0, 0];
+        },
+        getImage: function() {
+          return new Image();
+        }
+      }];
       renderer.composeFrame(frameState, layerState, context);
       expect(context.drawImage.firstCall.args[0].width).to.be(112);
     });


### PR DESCRIPTION
When tiles of different resolutions are combined for a layer (which is the case before all tiles of the best resolution have been loaded), lower resolution tiles may not align with higher resolution tiles. Because OpenLayers supports arbitrary tile grids (not just grids where a tile is divided into 4 when increasing the zoom level by 1), we cannot solve the alignment problem with powers of 2 pyramids.

In the sketch below, we are looking at a map between zoom 11 and 12. The view is scaled by 0.69 during the zoom animation. When rounding to integers, a 256 pixel tile from zoom 12 will be 177 pixels. But a tile from zoom 11 will be 353 pixels, which is 1 less than 2*177. At each resolution, we stitch tiles with integer widths and heights together from a common origin so they align without gaps. In the sketch below, the origin for zoom 11 and 12 is the same and marked with `O` (but it could be different across resolutions in the current implementation). And because of rounding after scaling, tiles from zoom 12 will be 1 pixel short with each tile further away from the origin:
```
+---------+---------+                   +------
|         |         |----------------+  |
|         |         |                |  |
|         |         |    no higher   |  |
+---------+---------+    resolution  |  +------
|         |         |    available   |  |
|         |         |                |  |
|         |         |                |  |
+---------+---------O-------------------+------
|         |         |         |         |
|         |         |         |         |
```

To fix this issue, I took the following approach:

 1. Try to use the same origin across all resolutions. By using `ol.tilegrid.TileGrid#getTileCoordForCoordAndZ()` for the tile that contains the center at the lowest resolution, we get a coordinate that will also be a tile corner at higher resolutions for powers of 2 tile grids.
 1.  Calulate the tile size in pixels for the highest resolution tiles. By multiplying this size with the resolution factor (tile resolution divided by highest resolution) and taking into account possibly different tile sizes at different resolutions, we do not need to round tile sizes any more to get integer values for powers of 2 tile grids.

This approach won't change anything for tile grids that have no powers of 2 layout, but it will result in pixel perfect alignment for scaled tile sizes even across resolutions for powers of 2 tile grids.

Fixes #5690.