### PR TITLE
Remove getRendererFromQueryString from examples

### DIFF
--- a/examples/accessible.js
+++ b/examples/accessible.js
@@ -11,7 +11,6 @@ var map = new ol.Map({
       source: new ol.source.OSM()
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   controls: ol.control.defaults({
     attributionOptions: /** @type {olx.control.AttributionOptions} */ ({

--- a/examples/animation.js
+++ b/examples/animation.js
@@ -54,7 +54,6 @@ var map = new ol.Map({
       source: new ol.source.OSM()
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   // Improve user experience by loading tiles while animating. Will make
   // animations stutter on mobile or slow devices.
   loadTilesWhileAnimating: true,

--- a/examples/attributions.js
+++ b/examples/attributions.js
@@ -15,7 +15,6 @@ var map = new ol.Map({
     })
   ],
   controls: ol.control.defaults({attribution: false}).extend([attribution]),
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     center: [0, 0],

--- a/examples/bing-maps.js
+++ b/examples/bing-maps.js
@@ -28,7 +28,6 @@ for (i = 0, ii = styles.length; i < ii; ++i) {
 }
 var map = new ol.Map({
   layers: layers,
-  renderer: common.getRendererFromQueryString(),
   // Improve user experience by loading tiles while dragging/zooming. Will make
   // zooming choppy on mobile or slow devices.
   loadTilesWhileInteracting: true,

--- a/examples/button-title.js
+++ b/examples/button-title.js
@@ -9,7 +9,6 @@ var map = new ol.Map({
       source: new ol.source.OSM()
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     center: [-8730000, 5930000],

--- a/examples/canvas-tiles.js
+++ b/examples/canvas-tiles.js
@@ -20,7 +20,6 @@ var map = new ol.Map({
       })
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   controls: ol.control.defaults({
     attributionOptions: /** @type {olx.control.AttributionOptions} */ ({

--- a/examples/custom-controls.js
+++ b/examples/custom-controls.js
@@ -70,7 +70,6 @@ var map = new ol.Map({
       source: new ol.source.OSM()
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     center: [0, 0],

--- a/examples/device-orientation.js
+++ b/examples/device-orientation.js
@@ -19,7 +19,6 @@ var map = new ol.Map({
       source: new ol.source.OSM()
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   controls: ol.control.defaults({
     attributionOptions: /** @type {olx.control.AttributionOptions} */ ({

--- a/examples/drag-and-drop-image-vector.js
+++ b/examples/drag-and-drop-image-vector.js
@@ -104,7 +104,6 @@ var map = new ol.Map({
       })
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     center: [0, 0],

--- a/examples/drag-rotate-and-zoom.js
+++ b/examples/drag-rotate-and-zoom.js
@@ -15,7 +15,6 @@ var map = new ol.Map({
       source: new ol.source.OSM()
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     center: [0, 0],

--- a/examples/draw-features.js
+++ b/examples/draw-features.js
@@ -38,7 +38,6 @@ var vector = new ol.layer.Vector({
 
 var map = new ol.Map({
   layers: [raster, vector],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     center: [-11000000, 4600000],

--- a/examples/dynamic-data.js
+++ b/examples/dynamic-data.js
@@ -16,7 +16,6 @@ var map = new ol.Map({
       source: new ol.source.OSM()
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     center: [0, 0],

--- a/examples/feature-animation.js
+++ b/examples/feature-animation.js
@@ -28,7 +28,6 @@ var map = new ol.Map({
       collapsible: false
     })
   }),
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     center: [0, 0],

--- a/examples/full-screen-source.js
+++ b/examples/full-screen-source.js
@@ -22,7 +22,6 @@ var map = new ol.Map({
       source: new ol.source.OSM()
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: view
 });

--- a/examples/full-screen.js
+++ b/examples/full-screen.js
@@ -23,7 +23,6 @@ var map = new ol.Map({
       })
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: view
 });

--- a/examples/getfeatureinfo-image.js
+++ b/examples/getfeatureinfo-image.js
@@ -21,7 +21,6 @@ var view = new ol.View({
 });
 
 var map = new ol.Map({
-  renderer: common.getRendererFromQueryString(),
   layers: [wmsLayer],
   target: 'map',
   view: view

--- a/examples/getfeatureinfo-tile.js
+++ b/examples/getfeatureinfo-tile.js
@@ -21,7 +21,6 @@ var view = new ol.View({
 });
 
 var map = new ol.Map({
-  renderer: common.getRendererFromQueryString(),
   layers: [wmsLayer],
   target: 'map',
   view: view

--- a/examples/here-maps.js
+++ b/examples/here-maps.js
@@ -69,7 +69,6 @@ for (i = 0, ii = hereLayers.length; i < ii; ++i) {
 
 var map = new ol.Map({
   layers: layers,
-  renderer: common.getRendererFromQueryString(),
   // Improve user experience by loading tiles while dragging/zooming. Will make
   // zooming choppy on mobile or slow devices.
   loadTilesWhileInteracting: true,

--- a/examples/icon-color.js
+++ b/examples/icon-color.js
@@ -61,7 +61,6 @@ var rasterLayer = new ol.layer.Tile({
 });
 
 var map = new ol.Map({
-  renderer: common.getRendererFromQueryString(),
   layers: [rasterLayer, vectorLayer],
   target: document.getElementById('map'),
   view: new ol.View({

--- a/examples/icon-sprite-webgl.js
+++ b/examples/icon-sprite-webgl.js
@@ -79,7 +79,7 @@ var vector = new ol.layer.Vector({
 });
 
 var map = new ol.Map({
-  renderer: common.getRendererFromQueryString('webgl'),
+  renderer: 'webgl',
   layers: [vector],
   target: document.getElementById('map'),
   view: new ol.View({

--- a/examples/icon.js
+++ b/examples/icon.js
@@ -45,7 +45,6 @@ var rasterLayer = new ol.layer.Tile({
 });
 
 var map = new ol.Map({
-  renderer: common.getRendererFromQueryString(),
   layers: [rasterLayer, vectorLayer],
   target: document.getElementById('map'),
   view: new ol.View({

--- a/examples/image-load-events.js
+++ b/examples/image-load-events.js
@@ -99,7 +99,6 @@ var map = new ol.Map({
   layers: [
     new ol.layer.Image({source: source})
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     center: [-10997148, 4569099],

--- a/examples/layer-extent.js
+++ b/examples/layer-extent.js
@@ -32,7 +32,6 @@ var overlay = new ol.layer.Tile({
 
 var map = new ol.Map({
   layers: [base, overlay],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     center: [0, 0],

--- a/examples/layer-group.js
+++ b/examples/layer-group.js
@@ -27,7 +27,6 @@ var map = new ol.Map({
       ]
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     center: ol.proj.fromLonLat([37.40570, 8.81566]),

--- a/examples/lazy-source.js
+++ b/examples/lazy-source.js
@@ -9,7 +9,6 @@ var layer = new ol.layer.Tile();
 
 var map = new ol.Map({
   layers: [layer],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     center: [0, 0],

--- a/examples/line-arrows.js
+++ b/examples/line-arrows.js
@@ -53,7 +53,6 @@ var vector = new ol.layer.Vector({
 
 var map = new ol.Map({
   layers: [raster, vector],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     center: [-11000000, 4600000],

--- a/examples/min-max-resolution.js
+++ b/examples/min-max-resolution.js
@@ -25,7 +25,6 @@ var map = new ol.Map({
       maxResolution: 20000
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   controls: ol.control.defaults({
     attributionOptions: /** @type {olx.control.AttributionOptions} */ ({

--- a/examples/mobile-full-screen.js
+++ b/examples/mobile-full-screen.js
@@ -19,7 +19,6 @@ var map = new ol.Map({
       })
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: view
 });

--- a/examples/mouse-position.js
+++ b/examples/mouse-position.js
@@ -28,7 +28,6 @@ var map = new ol.Map({
       source: new ol.source.OSM()
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     center: [0, 0],

--- a/examples/moveend.js
+++ b/examples/moveend.js
@@ -13,7 +13,6 @@ var map = new ol.Map({
       source: new ol.source.OSM()
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   controls: ol.control.defaults({
     attributionOptions: /** @type {olx.control.AttributionOptions} */ ({

--- a/examples/navigation-controls.js
+++ b/examples/navigation-controls.js
@@ -24,7 +24,6 @@ var map = new ol.Map({
       source: new ol.source.OSM()
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     center: [0, 0],

--- a/examples/overlay.js
+++ b/examples/overlay.js
@@ -13,7 +13,6 @@ var layer = new ol.layer.Tile({
 
 var map = new ol.Map({
   layers: [layer],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     center: [0, 0],

--- a/examples/popup.js
+++ b/examples/popup.js
@@ -50,7 +50,6 @@ var map = new ol.Map({
       })
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   overlays: [overlay],
   target: 'map',
   view: new ol.View({

--- a/examples/preload.js
+++ b/examples/preload.js
@@ -19,7 +19,6 @@ var map1 = new ol.Map({
       })
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map1',
   view: view
 });
@@ -34,7 +33,6 @@ var map2 = new ol.Map({
       })
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map2',
   view: view
 });

--- a/examples/reprojection-by-code.js
+++ b/examples/reprojection-by-code.js
@@ -13,7 +13,6 @@ var map = new ol.Map({
       source: new ol.source.OSM()
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     projection: 'EPSG:3857',

--- a/examples/reprojection-image.js
+++ b/examples/reprojection-image.js
@@ -29,7 +29,6 @@ var map = new ol.Map({
       })
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     center: ol.proj.transform(

--- a/examples/reprojection-wgs84.js
+++ b/examples/reprojection-wgs84.js
@@ -9,7 +9,6 @@ var map = new ol.Map({
       source: new ol.source.OSM()
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     projection: 'EPSG:4326',

--- a/examples/reprojection.js
+++ b/examples/reprojection.js
@@ -148,7 +148,6 @@ var map = new ol.Map({
     layers['osm'],
     layers['bng']
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     projection: 'EPSG:3857',

--- a/examples/resources/common.js
+++ b/examples/resources/common.js
@@ -79,24 +79,3 @@
 
   container.appendChild(form);
 })();
-
-var common = {};
-
-common.getRendererFromQueryString = function(opt_default) {
-  var obj = {};
-  var queryString = location.search.slice(1);
-  var re = /([^&=]+)=([^&]*)/g;
-
-  var m = re.exec(queryString);
-  while (m) {
-    obj[decodeURIComponent(m[1])] = decodeURIComponent(m[2]);
-    m = re.exec(queryString);
-  }
-  if ('renderers' in obj) {
-    return obj['renderers'].split(',');
-  } else if ('renderer' in obj) {
-    return [obj['renderer']];
-  } else {
-    return opt_default;
-  }
-};

--- a/examples/rotation.js
+++ b/examples/rotation.js
@@ -11,7 +11,6 @@ var map = new ol.Map({
       source: new ol.source.OSM()
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   controls: ol.control.defaults({
     attributionOptions: /** @type {olx.control.AttributionOptions} */ ({

--- a/examples/scale-line.js
+++ b/examples/scale-line.js
@@ -21,7 +21,6 @@ var map = new ol.Map({
       source: new ol.source.OSM()
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     center: [0, 0],

--- a/examples/semi-transparent-layer.js
+++ b/examples/semi-transparent-layer.js
@@ -18,7 +18,6 @@ var map = new ol.Map({
       })
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     center: ol.proj.fromLonLat([-77.93255, 37.9555]),

--- a/examples/stamen.js
+++ b/examples/stamen.js
@@ -18,7 +18,6 @@ var map = new ol.Map({
       })
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     center: ol.proj.transform(

--- a/examples/symbol-atlas-webgl.js
+++ b/examples/symbol-atlas-webgl.js
@@ -107,7 +107,7 @@ var vector = new ol.layer.Vector({
 });
 
 var map = new ol.Map({
-  renderer: common.getRendererFromQueryString('webgl'),
+  renderer: 'webgl',
   layers: [vector],
   target: document.getElementById('map'),
   view: new ol.View({

--- a/examples/teleport.js
+++ b/examples/teleport.js
@@ -11,7 +11,6 @@ var map = new ol.Map({
       source: new ol.source.OSM()
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   controls: ol.control.defaults({
     attributionOptions: /** @type {olx.control.AttributionOptions} */ ({
       collapsible: false

--- a/examples/tile-load-events.js
+++ b/examples/tile-load-events.js
@@ -98,7 +98,6 @@ var map = new ol.Map({
   layers: [
     new ol.layer.Tile({source: source})
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     center: [0, 0],

--- a/examples/tilejson.js
+++ b/examples/tilejson.js
@@ -13,7 +13,6 @@ var map = new ol.Map({
       })
     })
   ],
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     center: [0, 0],

--- a/examples/wms-custom-proj.js
+++ b/examples/wms-custom-proj.js
@@ -76,7 +76,6 @@ var map = new ol.Map({
     })
   ]),
   layers: layers,
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     projection: projection,

--- a/examples/wms-image-custom-proj.js
+++ b/examples/wms-image-custom-proj.js
@@ -62,7 +62,6 @@ var map = new ol.Map({
     new ol.control.ScaleLine()
   ]),
   layers: layers,
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     projection: projection,

--- a/examples/wms-image.js
+++ b/examples/wms-image.js
@@ -22,7 +22,6 @@ var layers = [
 var map = new ol.Map({
   layers: layers,
   target: 'map',
-  renderer: common.getRendererFromQueryString(),
   view: new ol.View({
     center: [-10997148, 4569099],
     zoom: 4

--- a/examples/wms-no-proj.js
+++ b/examples/wms-no-proj.js
@@ -44,7 +44,6 @@ var projection = new ol.proj.Projection({
 
 var map = new ol.Map({
   layers: layers,
-  renderer: common.getRendererFromQueryString(),
   target: 'map',
   view: new ol.View({
     center: [660000, 190000],

--- a/tasks/build-examples.js
+++ b/tasks/build-examples.js
@@ -7,7 +7,7 @@ var marked = require('marked');
 var pkg = require('../package.json');
 
 var markupRegEx = /([^\/^\.]*)\.html$/;
-var cleanupJSRegEx = /.*(\/\/ NOCOMPILE|goog\.require\(.*\);|.*renderer: common\..*,?)[\n]*/g;
+var cleanupJSRegEx = /.*(\/\/ NOCOMPILE|goog\.require\(.*\);)[\n]*/g;
 var requiresRegEx = /.*goog\.require\('(ol\.\S*)'\);/g;
 var isCssRegEx = /\.css$/;
 var isJsRegEx = /\.js$/;


### PR DESCRIPTION
as discussed in #5726. Have I forgotten anything?

Once this is merged, I'll submit another PR to deal with the random string in the renderer option.