### PR TITLE
Always use the frameState's extent

### DIFF
--- a/src/ol/renderer/canvas/tilelayer.js
+++ b/src/ol/renderer/canvas/tilelayer.js
@@ -90,15 +90,7 @@ ol.renderer.canvas.TileLayer.prototype.prepareFrame = function(
   var tileGrid = tileSource.getTileGridForProjection(projection);
   var z = tileGrid.getZForResolution(viewState.resolution, this.zDirection);
   var tileResolution = tileGrid.getResolution(z);
-  var center = viewState.center;
-  var extent;
-  if (tileResolution == viewState.resolution) {
-    center = this.snapCenterToPixel(center, tileResolution, frameState.size);
-    extent = ol.extent.getForViewAndSize(
-        center, tileResolution, viewState.rotation, frameState.size);
-  } else {
-    extent = frameState.extent;
-  }
+  var extent = frameState.extent;
 
   if (layerState.extent !== undefined) {
     extent = ol.extent.getIntersection(extent, layerState.extent);

--- a/src/ol/renderer/layer.js
+++ b/src/ol/renderer/layer.js
@@ -255,21 +255,6 @@ ol.renderer.Layer.prototype.updateUsedTiles = function(usedTiles, tileSource, z,
 
 
 /**
- * @param {ol.Coordinate} center Center.
- * @param {number} resolution Resolution.
- * @param {ol.Size} size Size.
- * @protected
- * @return {ol.Coordinate} Snapped center.
- */
-ol.renderer.Layer.prototype.snapCenterToPixel = function(center, resolution, size) {
-  return [
-    resolution * (Math.round(center[0] / resolution) + (size[0] % 2) / 2),
-    resolution * (Math.round(center[1] / resolution) + (size[1] % 2) / 2)
-  ];
-};
-
-
-/**
  * Manage tile pyramid.
  * This function performs a number of functions related to the tiles at the
  * current zoom and lower zoom levels:

--- a/src/ol/renderer/webgl/tilelayer.js
+++ b/src/ol/renderer/webgl/tilelayer.js
@@ -164,14 +164,7 @@ ol.renderer.webgl.TileLayer.prototype.prepareFrame = function(frameState, layerS
   var tileGutter = frameState.pixelRatio * tileSource.getGutter(projection);
 
   var center = viewState.center;
-  var extent;
-  if (tileResolution == viewState.resolution) {
-    center = this.snapCenterToPixel(center, tileResolution, frameState.size);
-    extent = ol.extent.getForViewAndSize(
-        center, tileResolution, viewState.rotation, frameState.size);
-  } else {
-    extent = frameState.extent;
-  }
+  var extent = frameState.extent;
   var tileRange = tileGrid.getTileRangeForExtentAndResolution(
       extent, tileResolution);
 
@@ -346,9 +339,9 @@ ol.renderer.webgl.TileLayer.prototype.prepareFrame = function(frameState, layerS
   var texCoordMatrix = this.texCoordMatrix;
   ol.transform.reset(texCoordMatrix);
   ol.transform.translate(texCoordMatrix,
-      (center[0] - framebufferExtent[0]) /
+      (Math.round(center[0] / tileResolution) * tileResolution - framebufferExtent[0]) /
           (framebufferExtent[2] - framebufferExtent[0]),
-      (center[1] - framebufferExtent[1]) /
+      (Math.round(center[1] / tileResolution) * tileResolution - framebufferExtent[1]) /
           (framebufferExtent[3] - framebufferExtent[1]));
   if (viewState.rotation !== 0) {
     ol.transform.rotate(texCoordMatrix, viewState.rotation);


### PR DESCRIPTION
Since the tile renderer aligns tiles to pixels anyway, we do not need to
modify the extent to make its center align with a pixel.