### PR TITLE
Remove plain string from Map renderer option

### DIFF
--- a/examples/box-selection.js
+++ b/examples/box-selection.js
@@ -25,7 +25,6 @@ var map = new ol.Map({
       source: vectorSource
     })
   ],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View({
     center: [0, 0],

--- a/examples/cluster.js
+++ b/examples/cluster.js
@@ -69,7 +69,6 @@ var raster = new ol.layer.Tile({
 
 var map = new ol.Map({
   layers: [raster, clusters],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View({
     center: [0, 0],

--- a/examples/extent-interaction.js
+++ b/examples/extent-interaction.js
@@ -22,7 +22,6 @@ var map = new ol.Map({
       source: vectorSource
     })
   ],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View({
     center: [0, 0],

--- a/examples/graticule.js
+++ b/examples/graticule.js
@@ -13,7 +13,6 @@ var map = new ol.Map({
       source: new ol.source.OSM()
     })
   ],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View({
     center: ol.proj.fromLonLat([4.8, 47.75]),

--- a/examples/icon-sprite-webgl.js
+++ b/examples/icon-sprite-webgl.js
@@ -79,7 +79,7 @@ var vector = new ol.layer.Vector({
 });
 
 var map = new ol.Map({
-  renderer: 'webgl',
+  renderer: /** @type {ol.renderer.Type} */ ('webgl'),
   layers: [vector],
   target: document.getElementById('map'),
   view: new ol.View({

--- a/examples/layer-clipping-webgl.js
+++ b/examples/layer-clipping-webgl.js
@@ -19,7 +19,7 @@ if (!ol.has.WEBGL) {
 
   var map = new ol.Map({
     layers: [osm],
-    renderer: 'webgl',
+    renderer: /** @type {ol.renderer.Type} */ ('webgl'),
     target: 'map',
     controls: ol.control.defaults({
       attributionOptions: /** @type {olx.control.AttributionOptions} */ ({

--- a/examples/side-by-side.js
+++ b/examples/side-by-side.js
@@ -22,7 +22,7 @@ var map1 = new ol.Map({
 if (ol.has.WEBGL) {
   var map2 = new ol.Map({
     target: 'webglMap',
-    renderer: 'webgl',
+    renderer: /** @type {ol.renderer.Type} */ ('webgl'),
     layers: [layer],
     view: view
   });

--- a/examples/sphere-mollweide.js
+++ b/examples/sphere-mollweide.js
@@ -29,7 +29,6 @@ var map = new ol.Map({
       })
     })
   ],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View({
     center: [0, 0],

--- a/examples/symbol-atlas-webgl.js
+++ b/examples/symbol-atlas-webgl.js
@@ -107,7 +107,7 @@ var vector = new ol.layer.Vector({
 });
 
 var map = new ol.Map({
-  renderer: 'webgl',
+  renderer: /** @type {ol.renderer.Type} */ ('webgl'),
   layers: [vector],
   target: document.getElementById('map'),
   view: new ol.View({

--- a/examples/tissot.js
+++ b/examples/tissot.js
@@ -28,7 +28,6 @@ var map4326 = new ol.Map({
     }),
     vectorLayer4326
   ],
-  renderer: 'canvas',
   target: 'map4326',
   view: new ol.View({
     projection: 'EPSG:4326',
@@ -49,7 +48,6 @@ var map3857 = new ol.Map({
     }),
     vectorLayer3857
   ],
-  renderer: 'canvas',
   target: 'map3857',
   view: new ol.View({
     center: [0, 0],

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -171,7 +171,7 @@ olx.interaction.InteractionOptions.prototype.handleEvent;
  *     loadTilesWhileInteracting: (boolean|undefined),
  *     logo: (boolean|string|olx.LogoOptions|Element|undefined),
  *     overlays: (ol.Collection.<ol.Overlay>|Array.<ol.Overlay>|undefined),
- *     renderer: (ol.renderer.Type|Array.<ol.renderer.Type|string>|string|undefined),
+ *     renderer: (ol.renderer.Type|Array.<ol.renderer.Type>|undefined),
  *     target: (Element|string|undefined),
  *     view: (ol.View|undefined)}}
  */
@@ -277,7 +277,7 @@ olx.MapOptions.prototype.overlays;
  * {@link ol.renderer.Type} here to use a specific renderer.
  * Note that the Canvas renderer fully supports vector data, but WebGL can only
  * render Point geometries.
- * @type {ol.renderer.Type|Array.<ol.renderer.Type|string>|string|undefined}
+ * @type {ol.renderer.Type|Array.<ol.renderer.Type>|undefined}
  * @api stable
  */
 olx.MapOptions.prototype.renderer;


### PR DESCRIPTION
Fixes #5726. So the examples continue to compile, I removed those with `renderer: 'canvas'`, which is the default anyway, and added a typecast to those with `renderer: 'webgl'`.