### PR TITLE
Fix changelog/upgrade-notes.md formating

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -1,6 +1,6 @@
 ## Upgrade notes
 
-#### ´goog.DEBUG´ define was renamed to ´ol.DEBUG´
+#### `goog.DEBUG` define was renamed to `ol.DEBUG`
 
 As last step in the removal of the dependency on Google Closure Library, the `goog.DEBUG` compiler define was renamed to `ol.DEBUG`. Please change accordingly in your custom build configuration json files.
 


### PR DESCRIPTION
See https://github.com/openlayers/ol3/blob/master/changelog/upgrade-notes.md#googdebug-define-was-renamed-to-oldebug 