### PR TITLE
Add missing goog.provide for several components

### DIFF
--- a/src/ol/control/scaleline.js
+++ b/src/ol/control/scaleline.js
@@ -1,4 +1,5 @@
 goog.provide('ol.control.ScaleLine');
+goog.provide('ol.control.ScaleLine.Units');
 
 goog.require('ol');
 goog.require('ol.Object');

--- a/src/ol/format/igc.js
+++ b/src/ol/format/igc.js
@@ -1,4 +1,5 @@
 goog.provide('ol.format.IGC');
+goog.provide('ol.format.IGC.Z');
 
 goog.require('ol');
 goog.require('ol.Feature');

--- a/src/ol/layer/vectortile.js
+++ b/src/ol/layer/vectortile.js
@@ -1,4 +1,5 @@
 goog.provide('ol.layer.VectorTile');
+goog.provide('ol.layer.VectorTile.RenderType');
 
 goog.require('ol');
 goog.require('ol.asserts');

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -1,4 +1,5 @@
 goog.provide('ol.Overlay');
+goog.provide('ol.Overlay.Positioning');
 
 goog.require('ol');
 goog.require('ol.MapEvent');

--- a/src/ol/source/wmts.js
+++ b/src/ol/source/wmts.js
@@ -1,4 +1,5 @@
 goog.provide('ol.source.WMTS');
+goog.provide('ol.source.WMTS.RequestEncoding');
 
 goog.require('ol');
 goog.require('ol.TileUrlFunction');

--- a/src/ol/style/icon.js
+++ b/src/ol/style/icon.js
@@ -1,4 +1,6 @@
 goog.provide('ol.style.Icon');
+goog.provide('ol.style.Icon.AnchorUnits');
+goog.provide('ol.style.Icon.Origin');
 
 goog.require('ol');
 goog.require('ol.asserts');

--- a/src/ol/tile.js
+++ b/src/ol/tile.js
@@ -1,4 +1,5 @@
 goog.provide('ol.Tile');
+goog.provide('ol.Tile.State');
 
 goog.require('ol');
 goog.require('ol.events.EventTarget');


### PR DESCRIPTION
This PR adds a missing provide for:
- ol.control.ScaleLines.Units
- ol.Overlay.Positioning
- ol.format.IGC.Z
- ol.source.WMTS.RequestEncoding
- ol.style.Icon.AnchorUnits
- ol.style.Icon.Origin
- ol.layer.VectorTile.RenderType
- ol.Tile.State

With or without this, the `build` works just fine.  However, when trying to use Closure-util unless we define those missing provide we get errors like these:

```
ERR! compile node_modules/openlayers/externs/olx.js:1263: ERROR - Bad type annotation. Unknown type ol.control.ScaleLine.Units
ERR! compile  *     units: (ol.control.ScaleLine.Units|string|undefined)}}
ERR! compile                ^
ERR! compile 
ERR! compile 
ERR! compile node_modules/openlayers/externs/olx.js:1303: ERROR - Bad type annotation. Unknown type ol.control.ScaleLine.Units
ERR! compile  * @type {ol.control.ScaleLine.Units|string|undefined}
ERR! compile           ^
ERR! compile 
ERR! compile 
ERR! compile 2 error(s), 0
ERR! compile  warning(s)
```

Ready for review.
