### PR TITLE
Ensure correct type of event.element

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -455,7 +455,8 @@ ol.Map = function(options) {
        * @param {ol.Collection.Event} event Collection event.
        */
       function(event) {
-        var id = event.element.getId();
+        var overlay = /** @type {ol.Overlay} */ (event.element);
+        var id = overlay.getId();
         if (id !== undefined) {
           delete this.overlayIdIndex_[id.toString()];
         }


### PR DESCRIPTION
This PR adds a cast around a `event.element`, the event being a `ol.Collection.Event`.

I don't know why, but when I use Closure-util, the line returns an error:

```
info closure-util Reading build config
info closure-util Getting Closure dependencies
info closure-util Compiling 296 sources
ERR! compile 
node_modules/openlayers/src/ol/map.js:445: ERROR - Property getId never defined on ol.Collection.Event.element
ERR! compile         var id = event.element.getId();
```

The native build within ol3 works fine with or without casting the type of element.  I don't understand what's going on as I use the exact same configuration for the build.  Also, why only this line?  If you look just above, there are other places where `event.element` are used without casting the element and that works just fine.  This one is picky, so this PR fixes this.  It doesn't impact anyting from the actual code, just making Closure-util stop complaining about it.

Ready for review.