### PR TITLE
Allow readFeature and readFeatures to be called with GeoJSON geometries

### DIFF
--- a/src/ol/format/geojson.js
+++ b/src/ol/format/geojson.js
@@ -357,8 +357,9 @@ ol.format.GeoJSON.prototype.getExtensions = function() {
 
 
 /**
- * Read a feature from a GeoJSON Feature source.  Only works for Feature,
- * use `readFeatures` to read FeatureCollection source.
+ * Read a feature from a GeoJSON Feature source.  Only works for Feature or
+ * geometry types.  Use {@link ol.format.GeoJSON#readFeatures} to read
+ * FeatureCollection source.
  *
  * @function
  * @param {Document|Node|Object|string} source Source.
@@ -370,8 +371,9 @@ ol.format.GeoJSON.prototype.readFeature;
 
 
 /**
- * Read all features from a GeoJSON source.  Works with both Feature and
- * FeatureCollection sources.
+ * Read all features from a GeoJSON source.  Works for all GeoJSON types.
+ * If the source includes only geometries, features will be created with those
+ * geometries.
  *
  * @function
  * @param {Document|Node|Object|string} source Source.
@@ -387,11 +389,23 @@ ol.format.GeoJSON.prototype.readFeatures;
  */
 ol.format.GeoJSON.prototype.readFeatureFromObject = function(
     object, opt_options) {
-  var geoJSONFeature = /** @type {GeoJSONFeature} */ (object);
-  ol.DEBUG && console.assert(geoJSONFeature.type == 'Feature',
-      'geoJSONFeature.type should be Feature');
-  var geometry = ol.format.GeoJSON.readGeometry_(geoJSONFeature.geometry,
-      opt_options);
+
+  ol.DEBUG && console.assert(object.type !== 'FeatureCollection', 'Expected a Feature or geometry');
+
+  /**
+   * @type {GeoJSONFeature}
+   */
+  var geoJSONFeature = null;
+  if (object.type === 'Feature') {
+    geoJSONFeature = /** @type {GeoJSONFeature} */ (object);
+  } else {
+    geoJSONFeature = /** @type {GeoJSONFeature} */ ({
+      type: 'Feature',
+      geometry: /** @type {GeoJSONGeometry|GeoJSONGeometryCollection} */ (object)
+    });
+  }
+
+  var geometry = ol.format.GeoJSON.readGeometry_(geoJSONFeature.geometry, opt_options);
   var feature = new ol.Feature();
   if (this.geometryName_) {
     feature.setGeometryName(this.geometryName_);
@@ -414,10 +428,8 @@ ol.format.GeoJSON.prototype.readFeaturesFromObject = function(
     object, opt_options) {
   var geoJSONObject = /** @type {GeoJSONObject} */ (object);
   /** @type {Array.<ol.Feature>} */
-  var features;
-  if (geoJSONObject.type == 'Feature') {
-    features = [this.readFeatureFromObject(object, opt_options)];
-  } else if (geoJSONObject.type == 'FeatureCollection') {
+  var features = null;
+  if (geoJSONObject.type === 'FeatureCollection') {
     var geoJSONFeatureCollection = /** @type {GeoJSONFeatureCollection} */
         (object);
     features = [];
@@ -428,9 +440,9 @@ ol.format.GeoJSON.prototype.readFeaturesFromObject = function(
           opt_options));
     }
   } else {
-    ol.asserts.assert(false, 35); // Unknown GeoJSON object type
+    features = [this.readFeatureFromObject(object, opt_options)];
   }
-  return /** Array.<ol.Feature> */ (features);
+  return features;
 };
 
 

--- a/test/spec/ol/format/geojson.test.js
+++ b/test/spec/ol/format/geojson.test.js
@@ -154,6 +154,14 @@ describe('ol.format.GeoJSON', function() {
       expect(feature.get('prop0')).to.be('value0');
     });
 
+    it('can read a single point geometry as a feature feature', function() {
+      var feature = format.readFeature(pointGeoJSON.geometry);
+      expect(feature).to.be.an(ol.Feature);
+      var geometry = feature.getGeometry();
+      expect(geometry).to.be.an(ol.geom.Point);
+      expect(geometry.getCoordinates()).to.eql([102.0, 0.5]);
+    });
+
     it('can read a single line string feature', function() {
       var feature = format.readFeature(lineStringGeoJSON);
       expect(feature).to.be.an(ol.Feature);
@@ -275,6 +283,14 @@ describe('ol.format.GeoJSON', function() {
       expect(second.get('ST_NAME')).to.be('BRUNNSGATAN');
       var secondGeom = second.getGeometry();
       expect(secondGeom).to.be.a(ol.geom.LineString);
+    });
+
+    it('can parse a polygon geometry as an array of one feature', function() {
+      var features = format.readFeatures(polygonGeoJSON);
+      expect(features).to.be.an(Array);
+      expect(features).to.have.length(1);
+      var geometry = features[0].getGeometry();
+      expect(geometry).to.be.an(ol.geom.Polygon);
     });
 
     it('parses countries.geojson', function(done) {

--- a/test/spec/ol/format/geojson.test.js
+++ b/test/spec/ol/format/geojson.test.js
@@ -154,7 +154,7 @@ describe('ol.format.GeoJSON', function() {
       expect(feature.get('prop0')).to.be('value0');
     });
 
-    it('can read a single point geometry as a feature feature', function() {
+    it('can read a single point geometry as a feature', function() {
       var feature = format.readFeature(pointGeoJSON.geometry);
       expect(feature).to.be.an(ol.Feature);
       var geometry = feature.getGeometry();


### PR DESCRIPTION
We allow `format.readFeatures()` to be called with a GeoJSON Feature or FeatureCollection.  It would be convenient to also allow it to be called with geometries.  For example, when writing an application with drag-and-drop support, it would be nice not to inspect the dropped data, switch on the type, and call different methods.
