### PR TITLE
Fix API docs of ol.Feature#getStyle

### DIFF
--- a/src/ol/feature.js
+++ b/src/ol/feature.js
@@ -170,8 +170,8 @@ ol.Feature.prototype.getGeometryName = function() {
 
 
 /**
- * Get the feature's style.  This return for this method depends on what was
- * provided to the {@link ol.Feature#setStyle} method.
+ * Get the feature's style. Will return what was provided to the
+ * {@link ol.Feature#setStyle} method.
  * @return {ol.style.Style|Array.<ol.style.Style>|
  *     ol.FeatureStyleFunction} The feature style.
  * @api stable


### PR DESCRIPTION
The `ol.Feature#getStyle` prose doc was:

> Get the feature's style. This return for this method depends on what was provided …

This PR suggests to reword this as follows:

> Get the feature's style. Will return what was provided …

Please review.