### PR TITLE
Add getters to BingMaps source for api key and imagerySet

### DIFF
--- a/src/ol/source/bingmaps.js
+++ b/src/ol/source/bingmaps.js
@@ -46,9 +46,21 @@ ol.source.BingMaps = function(options) {
    */
   this.maxZoom_ = options.maxZoom !== undefined ? options.maxZoom : -1;
 
+  /**
+   * @private
+   * @type {string}
+   */
+  this.apiKey_ = options.key;
+
+  /**
+   * @private
+   * @type {string}
+   */
+  this.imagerySet_ = options.imagerySet;
+
   var url = 'https://dev.virtualearth.net/REST/v1/Imagery/Metadata/' +
-      options.imagerySet +
-      '?uriScheme=https&include=ImageryProviders&key=' + options.key;
+      this.imagerySet_ +
+      '?uriScheme=https&include=ImageryProviders&key=' + this.apiKey_;
 
   ol.net.jsonp(url, this.handleImageryMetadataResponse.bind(this), undefined,
       'jsonp');
@@ -69,6 +81,28 @@ ol.source.BingMaps.TOS_ATTRIBUTION = new ol.Attribution({
       'href="http://www.microsoft.com/maps/product/terms.html">' +
       'Terms of Use</a>'
 });
+
+
+/**
+ * Get the api key used for this source.
+ *
+ * @return {string} The api key.
+ * @api
+ */
+ol.source.BingMaps.prototype.getApiKey = function() {
+  return this.apiKey_;
+};
+
+
+/**
+ * Get the imagery set associated with this source.
+ *
+ * @return {string} The imagery set.
+ * @api
+ */
+ol.source.BingMaps.prototype.getImagerySet = function() {
+  return this.imagerySet_;
+};
 
 
 /**

--- a/test/spec/ol/source/bingmaps.test.js
+++ b/test/spec/ol/source/bingmaps.test.js
@@ -37,6 +37,14 @@ describe('ol.source.BingMaps', function() {
       });
     });
 
+    it('getImagerySet works correctly', function() {
+      expect(source.getImagerySet()).to.equal('AerialWithLabels');
+    });
+
+    it('getApiKey works correctly', function() {
+      expect(source.getApiKey()).to.equal('');
+    });
+
     it('returns the expected URL', function() {
 
       var coordinate = [829330.2064098881, 5933916.615134273];


### PR DESCRIPTION
These options can be passed into the source constructor, but cannot be retrieved after construction. This is useful for serialising state.