### PR TITLE
Use same proj4js version in examples and tests

### DIFF
--- a/examples/reprojection-by-code.html
+++ b/examples/reprojection-by-code.html
@@ -8,7 +8,7 @@ docs: >
   in <a href="http://epsg.io/">EPSG.io</a> database.
 tags: "reprojection, projection, proj4js, epsg.io"
 resources:
-  - https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.14/proj4.js
+  - https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.15/proj4.js
 ---
 <div id="map" class="map"></div>
 <form class="form-inline">

--- a/examples/reprojection-image.html
+++ b/examples/reprojection-image.html
@@ -6,6 +6,6 @@ docs: >
   This example shows client-side reprojection of single image source.
 tags: "reprojection, projection, proj4js, image, imagestatic"
 resources:
-  - https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.14/proj4.js
+  - https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.15/proj4.js
 ---
 <div id="map" class="map"></div>

--- a/examples/reprojection.html
+++ b/examples/reprojection.html
@@ -6,7 +6,7 @@ docs: >
   This example shows client-side raster reprojection between various projections.
 tags: "reprojection, projection, proj4js, osm, wms, wmts, hidpi"
 resources:
-  - https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.14/proj4.js
+  - https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.15/proj4.js
 ---
 <div id="map" class="map"></div>
 <form class="form-inline">

--- a/examples/scaleline-indiana-east.html
+++ b/examples/scaleline-indiana-east.html
@@ -6,6 +6,6 @@ docs: >
   This example shows client-side reprojection of OpenStreetMap to NAD83 Indiana East, including a ScaleLine control with US units.
 tags: "reprojection, projection, openstreetmap, nad83, tile, scaleline"
 resources:
-  - https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.14/proj4.js
+  - https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.15/proj4.js
 ---
 <div id="map" class="map"></div>

--- a/examples/sphere-mollweide.html
+++ b/examples/sphere-mollweide.html
@@ -6,6 +6,6 @@ docs: >
   Example of a Sphere Mollweide map with a Graticule component.
 tags: "graticule, Mollweide, projection, proj4js"
 resources:
-  - https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.14/proj4.js
+  - https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.15/proj4.js
 ---
 <div id="map" class="map"></div>

--- a/examples/wms-image-custom-proj.html
+++ b/examples/wms-image-custom-proj.html
@@ -6,7 +6,7 @@ docs: >
   With [Proj4js](http://proj4js.org/) integration, OpenLayers can transform coordinates between arbitrary projections.
 tags: "wms, single image, proj4js, projection"
 resources:
-  - https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.14/proj4.js
+  - https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.15/proj4.js
   - https://epsg.io/21781-1753.js
 ---
 <div id="map" class="map"></div>


### PR DESCRIPTION
The version was updated in package.json, but not in the examples. This pull request makes it so the same version is used everywhere.