### PR TITLE
Add a reference to the French translation of the workshop

### DIFF
--- a/doc/index.hbs
+++ b/doc/index.hbs
@@ -9,7 +9,7 @@ If you're eager to get your first OpenLayers 3 map on a page, dive into the [qui
 
 For a more in-depth overview of OpenLayers 3 core concepts, check out the [tutorials](tutorials/).
 
-Make sure to also check out the [OpenLayers 3 workshop](/workshop/en/).
+Make sure to also check out the [OpenLayers 3 workshop](/workshop/en/). If your native language is French, you can look at the French version of the workshop.
 
 Find additional reference material in the [API docs](../apidoc).
 


### PR DESCRIPTION
The link has been changed with https://github.com/openlayers/ol3/commit/ede6fc6e013a3ebf74ad31034dff9161b945be79 as we assumed most readers are speaking English but it completely hides the French version.

This PR adds a sentence for at least mention the availability of the French version of the workshop.