### PR TITLE
Add a freehand option to the draw interaction

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -2582,6 +2582,7 @@ olx.interaction.DragZoomOptions.prototype.out;
  *     geometryFunction: (ol.DrawGeometryFunctionType|undefined),
  *     geometryName: (string|undefined),
  *     condition: (ol.EventsConditionType|undefined),
+ *     freehand: (boolean|undefined),
  *     freehandCondition: (ol.EventsConditionType|undefined),
  *     wrapX: (boolean|undefined)}}
  */

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -2696,6 +2696,16 @@ olx.interaction.DrawOptions.prototype.condition;
 
 
 /**
+ * Operate in freehand mode for lines, polygons, and circles.  This makes the
+ * interaction always operate in freehand mode and takes precedence over any
+ * `freehandCondition` option.
+ * @type {boolean|undefined}
+ * @api
+ */
+olx.interaction.DrawOptions.prototype.freehand;
+
+
+/**
  * Condition that activates freehand drawing for lines and polygons. This
  * function takes an {@link ol.MapBrowserEvent} and returns a boolean to
  * indicate whether that event should be handled. The default is

--- a/src/ol/interaction/draw.js
+++ b/src/ol/interaction/draw.js
@@ -251,8 +251,13 @@ ol.interaction.Draw = function(options) {
    * @private
    * @type {ol.EventsConditionType}
    */
-  this.freehandCondition_ = options.freehandCondition ?
-      options.freehandCondition : ol.events.condition.shiftKeyOnly;
+  this.freehandCondition_;
+  if (options.freehand) {
+    this.freehandCondition_ = ol.events.condition.always;
+  } else {
+    this.freehandCondition_ = options.freehandCondition ?
+        options.freehandCondition : ol.events.condition.shiftKeyOnly;
+  }
 
   ol.events.listen(this,
       ol.Object.getChangeEventType(ol.interaction.Interaction.Property.ACTIVE),
@@ -319,14 +324,14 @@ ol.interaction.Draw.handleEvent = function(mapBrowserEvent) {
  * @private
  */
 ol.interaction.Draw.handleDownEvent_ = function(event) {
-  if (this.condition_(event)) {
-    this.downPx_ = event.pixel;
-    return true;
-  } else if (this.freehand_) {
+  if (this.freehand_) {
     this.downPx_ = event.pixel;
     if (!this.finishCoordinate_) {
       this.startDrawing_(event);
     }
+    return true;
+  } else if (this.condition_(event)) {
+    this.downPx_ = event.pixel;
     return true;
   } else {
     return false;

--- a/test/spec/ol/interaction/draw.test.js
+++ b/test/spec/ol/interaction/draw.test.js
@@ -88,6 +88,22 @@ describe('ol.interaction.Draw', function() {
       expect(draw).to.be.a(ol.interaction.Interaction);
     });
 
+    it('accepts a freehand option', function() {
+      var draw = new ol.interaction.Draw({
+        source: source,
+        type: 'LineString',
+        freehand: true
+      });
+
+      var event = new ol.pointer.PointerEvent('pointerdown', {
+        clientX: 0,
+        clientY: 0,
+        shiftKey: false
+      });
+
+      expect(draw.freehandCondition_(event)).to.be(true);
+    });
+
   });
 
   describe('specifying a geometryName', function() {


### PR DESCRIPTION
This makes it possible to create a draw interaction that is always in freehand mode.
