### PR TITLE
Use a https enabled GeoServer

### DIFF
--- a/examples/epsg-4326.js
+++ b/examples/epsg-4326.js
@@ -9,7 +9,7 @@ goog.require('ol.source.TileWMS');
 var layers = [
   new ol.layer.Tile({
     source: new ol.source.TileWMS({
-      url: 'http://demo.boundlessgeo.com/geoserver/wms',
+      url: 'https://ahocevar.com/geoserver/wms',
       params: {
         'LAYERS': 'ne:NE1_HR_LC_SR_W_DR'
       }

--- a/examples/getfeatureinfo-image.js
+++ b/examples/getfeatureinfo-image.js
@@ -5,7 +5,7 @@ goog.require('ol.source.ImageWMS');
 
 
 var wmsSource = new ol.source.ImageWMS({
-  url: 'http://demo.boundlessgeo.com/geoserver/wms',
+  url: 'https://ahocevar.com/geoserver/wms',
   params: {'LAYERS': 'ne:ne'},
   serverType: 'geoserver',
   crossOrigin: 'anonymous'

--- a/examples/getfeatureinfo-tile.js
+++ b/examples/getfeatureinfo-tile.js
@@ -5,7 +5,7 @@ goog.require('ol.source.TileWMS');
 
 
 var wmsSource = new ol.source.TileWMS({
-  url: 'http://demo.boundlessgeo.com/geoserver/wms',
+  url: 'https://ahocevar.com/geoserver/wms',
   params: {'LAYERS': 'ne:ne'},
   serverType: 'geoserver',
   crossOrigin: 'anonymous'

--- a/examples/image-load-events.js
+++ b/examples/image-load-events.js
@@ -78,7 +78,7 @@ Progress.prototype.hide = function() {
 var progress = new Progress(document.getElementById('progress'));
 
 var source = new ol.source.ImageWMS({
-  url: 'http://demo.boundlessgeo.com/geoserver/wms',
+  url: 'https://ahocevar.com/geoserver/wms',
   params: {'LAYERS': 'topp:states'},
   serverType: 'geoserver'
 });

--- a/examples/reprojection.js
+++ b/examples/reprojection.js
@@ -69,7 +69,7 @@ layers['osm'] = new ol.layer.Tile({
 
 layers['wms4326'] = new ol.layer.Tile({
   source: new ol.source.TileWMS({
-    url: 'http://demo.boundlessgeo.com/geoserver/wms',
+    url: 'https://ahocevar.com/geoserver/wms',
     crossOrigin: '',
     params: {
       'LAYERS': 'ne:NE1_HR_LC_SR_W_DR'
@@ -129,7 +129,7 @@ for (var i = 0, ii = resolutions.length; i < ii; ++i) {
 
 layers['states'] = new ol.layer.Tile({
   source: new ol.source.TileWMS({
-    url: 'http://demo.boundlessgeo.com/geoserver/wms',
+    url: 'https://ahocevar.com/geoserver/wms',
     crossOrigin: '',
     params: {'LAYERS': 'topp:states', 'TILED': true},
     serverType: 'geoserver',

--- a/examples/tissot.js
+++ b/examples/tissot.js
@@ -20,7 +20,7 @@ var map4326 = new ol.Map({
   layers: [
     new ol.layer.Tile({
       source: new ol.source.TileWMS({
-        url: 'http://demo.boundlessgeo.com/geoserver/wms',
+        url: 'https://ahocevar.com/geoserver/wms',
         params: {
           'LAYERS': 'ne:NE1_HR_LC_SR_W_DR'
         }
@@ -40,7 +40,7 @@ var map3857 = new ol.Map({
   layers: [
     new ol.layer.Tile({
       source: new ol.source.TileWMS({
-        url: 'http://demo.boundlessgeo.com/geoserver/wms',
+        url: 'https://ahocevar.com/geoserver/wms',
         params: {
           'LAYERS': 'ne:NE1_HR_LC_SR_W_DR'
         }

--- a/examples/vector-wfs-getfeature.js
+++ b/examples/vector-wfs-getfeature.js
@@ -53,7 +53,7 @@ var featureRequest = new ol.format.WFS().writeGetFeature({
 });
 
 // then post the request and add the received features to a layer
-fetch('http://demo.boundlessgeo.com/geoserver/wfs', {
+fetch('https://ahocevar.com/geoserver/wfs', {
   method: 'POST',
   body: new XMLSerializer().serializeToString(featureRequest)
 }).then(function(response) {

--- a/examples/vector-wfs.js
+++ b/examples/vector-wfs.js
@@ -13,7 +13,7 @@ goog.require('ol.style.Style');
 var vectorSource = new ol.source.Vector({
   format: new ol.format.GeoJSON(),
   url: function(extent) {
-    return 'http://demo.boundlessgeo.com/geoserver/wfs?service=WFS&' +
+    return 'https://ahocevar.com/geoserver/wfs?service=WFS&' +
         'version=1.1.0&request=GetFeature&typename=osm:water_areas&' +
         'outputFormat=application/json&srsname=EPSG:3857&' +
         'bbox=' + extent.join(',') + ',EPSG:3857';

--- a/examples/wms-custom-tilegrid-512x256.js
+++ b/examples/wms-custom-tilegrid-512x256.js
@@ -26,7 +26,7 @@ var layers = [
   }),
   new ol.layer.Tile({
     source: new ol.source.TileWMS({
-      url: 'http://demo.boundlessgeo.com/geoserver/wms',
+      url: 'https://ahocevar.com/geoserver/wms',
       params: {'LAYERS': 'topp:states', 'TILED': true},
       serverType: 'geoserver',
       tileGrid: tileGrid

--- a/examples/wms-image.js
+++ b/examples/wms-image.js
@@ -13,7 +13,7 @@ var layers = [
   new ol.layer.Image({
     extent: [-13884991, 2870341, -7455066, 6338219],
     source: new ol.source.ImageWMS({
-      url: 'http://demo.boundlessgeo.com/geoserver/wms',
+      url: 'https://ahocevar.com/geoserver/wms',
       params: {'LAYERS': 'topp:states'},
       serverType: 'geoserver'
     })

--- a/examples/wms-tiled-wrap-180.js
+++ b/examples/wms-tiled-wrap-180.js
@@ -11,7 +11,7 @@ var layers = [
   }),
   new ol.layer.Tile({
     source: new ol.source.TileWMS({
-      url: 'http://demo.boundlessgeo.com/geoserver/ne/wms',
+      url: 'https://ahocevar.com/geoserver/ne/wms',
       params: {'LAYERS': 'ne:ne_10m_admin_0_countries', 'TILED': true},
       serverType: 'geoserver'
     })

--- a/examples/wms-tiled.js
+++ b/examples/wms-tiled.js
@@ -12,7 +12,7 @@ var layers = [
   new ol.layer.Tile({
     extent: [-13884991, 2870341, -7455066, 6338219],
     source: new ol.source.TileWMS({
-      url: 'http://demo.boundlessgeo.com/geoserver/wms',
+      url: 'https://ahocevar.com/geoserver/wms',
       params: {'LAYERS': 'topp:states', 'TILED': true},
       serverType: 'geoserver'
     })


### PR DESCRIPTION
Until https://demo.boundlessgeo.com/geoserver is available, I stood up a GeoServer instance that serves everything we use from that server. We can either keep this one, or switch back to demo.boundlessgeo.com when SSL is enabled there.