### PR TITLE
Update Mapzen urls to new scheme

### DIFF
--- a/examples/osm-vector-tiles.js
+++ b/examples/osm-vector-tiles.js
@@ -42,7 +42,7 @@ var map = new ol.Map({
         attributions: attribution,
         format: format,
         tileGrid: tileGrid,
-        url: 'https://vector.mapzen.com/osm/water/{z}/{x}/{y}.topojson?api_key=' + key
+        url: 'https://tile.mapzen.com/mapzen/vector/v1/water/{z}/{x}/{y}.topojson?api_key=' + key
       }),
       style: new ol.style.Style({
         fill: new ol.style.Fill({
@@ -55,7 +55,7 @@ var map = new ol.Map({
         attributions: attribution,
         format: format,
         tileGrid: tileGrid,
-        url: 'https://vector.mapzen.com/osm/roads/{z}/{x}/{y}.topojson?api_key=' + key
+        url: 'https://tile.mapzen.com/mapzen/vector/v1/roads/{z}/{x}/{y}.topojson?api_key=' + key
       }),
       style: function(feature) {
         var kind = feature.get('kind');
@@ -89,7 +89,7 @@ var map = new ol.Map({
         attributions: attribution,
         format: format,
         tileGrid: tileGrid,
-        url: 'https://vector.mapzen.com/osm/buildings/{z}/{x}/{y}.topojson?api_key=' + key
+        url: 'https://tile.mapzen.com/mapzen/vector/v1/buildings/{z}/{x}/{y}.topojson?api_key=' + key
       }),
       style: function(f, resolution) {
         return (resolution < 10) ? buildingStyle : null;


### PR DESCRIPTION
Mapzen have changed their tile urls, and it seems the old urls were phased out earlier than planned. Essentially, this broke the osm-vector-tiles example, which is fixed by this pull request.