### PR TITLE
Setup a loaded image with src for TileLayer test

### DIFF
--- a/test/spec/ol/renderer/canvas/tilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/tilelayer.test.js
@@ -8,6 +8,18 @@ goog.require('ol.source.XYZ');
 
 
 describe('ol.renderer.canvas.TileLayer', function() {
+  var img = null;
+  beforeEach(function(done) {
+    img = new Image(1, 1);
+    img.onload = function() {
+      done();
+    };
+    img.src = 'data:image/gif;base64,' +
+      'R0lGODlhAQABAPAAAP8AAP///yH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==';
+  });
+  afterEach(function() {
+    img = null;
+  });
 
   describe('#composeFrame()', function() {
     it('uses correct draw scale when rotating (HiDPI)', function() {
@@ -45,7 +57,7 @@ describe('ol.renderer.canvas.TileLayer', function() {
           return [0, 0, 0];
         },
         getImage: function() {
-          return new Image();
+          return img;
         }
       }];
       renderer.composeFrame(frameState, layerState, context);


### PR DESCRIPTION
This PR suggests to change the test for the `canvas.TileLayer` to use a `<img>` with a loaded blank image data-URI to return when `getImage` is called.

This change removes the `"Component is not available"`-error from #5993, effectively making the complete testsuite pass for me in FF on Windows and Linux:

![linux-ff-49-all-ok](https://cloud.githubusercontent.com/assets/227934/19510286/dc420ddc-95e2-11e6-87e8-de7eefbd56b6.png)

![win-ff-49-all-ok](https://cloud.githubusercontent.com/assets/227934/19510290/e058b79a-95e2-11e6-984e-d44aff406200.png)

Please review.

Fixes #5993.