### PR TITLE
Add hit tolerance parameter to ol.Map#forEachFeatureAtPixel

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -15,16 +15,16 @@ Old syntax:
 
 New syntax:
 ```
-    map.forEachFeatureAtPixel(pixel, callback, callbackThis, {
-        layerFilter: layerFilterFn,
-        layerFilterThis: layerFilterThis
+    map.forEachFeatureAtPixel(pixel, callback, {
+        layerFilter: layerFilterFn
     });
     
     map.hasFeatureAtPixel(pixel, {
-        layerFilter: layerFilterFn,
-        layerFilterThis: layerFilterThis
+        layerFilter: layerFilterFn
     });
 ```
+
+To bind a function to a this, please use the bind method of the function (See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind).
 
 This change is due to the introduction of the `hitTolerance` parameter which can be passed in via this `ol.AtPixelOptions` object, too.
 

--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,6 +2,32 @@
 
 ### Next release
 
+#### `ol.Map#forEachFeatureAtPixel` and `ol.Map#hasFeatureAtPixel` parameters have changed
+ 
+If you are using the layer filter of one of these methods, please note that you now have to pass in the layer filter via an `ol.AtPixelOptions` object. If you are not using the layer filter the usage has not changed.
+
+Old syntax:
+```
+    map.forEachFeatureAtPixel(pixel, callback, callback_this, layerFilter_function, layerFilter_this);
+    
+    map.hasFeatureAtPixel(pixel, layerFilter_function, layerFilter_this);
+```
+
+New syntax:
+```
+    map.forEachFeatureAtPixel(pixel, callback, callback_this, {
+        layerFilter: layerFilter_function,
+        layerFilterThis: layerFilter_this
+    });
+    
+    map.hasFeatureAtPixel(pixel, {
+        layerFilter: layerFilter_function,
+        layerFilterThis: layerFilter_this
+    });
+```
+
+This change is due to the introduction of the `hitTolerance` parameter which can be passed in via this `ol.AtPixelOptions` object, too.
+
 #### Use `view.animate()` instead of `map.beforeRender()` and `ol.animation` functions
 
 The `map.beforeRender()` and `ol.animation` functions have been deprecated in favor of a new `view.animate()` function.  Use of the deprecated functions will result in a warning during development.  These functions are subject to removal in an upcoming release.
@@ -73,20 +99,6 @@ As last step in the removal of the dependency on Google Closure Library, the `go
 
 `ol.format.ogc.filter` was simplified to `ol.format.filter`; to upgrade your code, simply remove the `ogc` string from the name.
 For example: `ol.format.ogc.filter.and` to `ol.format.filter.and`.
-
-#### `ol.Map#forEachFeatureAtPixel` and `ol.Map#hasFeatureAtPixel` parameters have changed
- 
-If you are using the layer filter of one of these methods, please note that you now have to pass in the layer filter via an `ol.AtPixelOptions` object. If you are not using the layer filter the usage has not changed.
- 
-New syntax:
-```
-    map.forEachFeatureAtPixel(pixel, callback, callback_this, {
-        layerFilter: layerFilterFunction,
-        layerFilterThis: someObject
-    })
-```
-
-This change is due to the introduction of the `hitTolerance` parameter which can be passed in via this `ol.AtPixelOptions` object, too.
 
 #### Changes only relevant to those who compile their applications together with the Closure Compiler
 

--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -74,6 +74,20 @@ As last step in the removal of the dependency on Google Closure Library, the `go
 `ol.format.ogc.filter` was simplified to `ol.format.filter`; to upgrade your code, simply remove the `ogc` string from the name.
 For example: `ol.format.ogc.filter.and` to `ol.format.filter.and`.
 
+#### `ol.Map#forEachFeatureAtPixel` and `ol.Map#hasFeatureAtPixel` parameters have changed
+ 
+If you are using the layer filter of one of these methods, please note that you now have to pass in the layer filter via an `ol.AtPixelOptions` object. If you are not using the layer filter the usage has not changed.
+ 
+New syntax:
+```
+    map.forEachFeatureAtPixel(pixel, callback, callback_this, {
+        layerFilter: layerFilterFunction,
+        layerFilterThis: someObject
+    })
+```
+
+This change is due to the introduction of the `hitTolerance` parameter which can be passed in via this `ol.AtPixelOptions` object, too.
+
 #### Changes only relevant to those who compile their applications together with the Closure Compiler
 
 A number of internal types have been renamed.  This will not affect those who use the API provided by the library, but if you are compiling your application together with OpenLayers and using type names, you'll need to do the following:

--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -8,21 +8,21 @@ If you are using the layer filter of one of these methods, please note that you 
 
 Old syntax:
 ```
-    map.forEachFeatureAtPixel(pixel, callback, callback_this, layerFilter_function, layerFilter_this);
+    map.forEachFeatureAtPixel(pixel, callback, callbackThis, layerFilterFn, layerFilterThis);
     
-    map.hasFeatureAtPixel(pixel, layerFilter_function, layerFilter_this);
+    map.hasFeatureAtPixel(pixel, layerFilterFn, layerFilterThis);
 ```
 
 New syntax:
 ```
-    map.forEachFeatureAtPixel(pixel, callback, callback_this, {
-        layerFilter: layerFilter_function,
-        layerFilterThis: layerFilter_this
+    map.forEachFeatureAtPixel(pixel, callback, callbackThis, {
+        layerFilter: layerFilterFn,
+        layerFilterThis: layerFilterThis
     });
     
     map.hasFeatureAtPixel(pixel, {
-        layerFilter: layerFilter_function,
-        layerFilterThis: layerFilter_this
+        layerFilter: layerFilterFn,
+        layerFilterThis: layerFilterThis
     });
 ```
 

--- a/examples/select-features.html
+++ b/examples/select-features.html
@@ -18,5 +18,13 @@ tags: "select, vector"
       <option value="altclick">Alt+Click</option>
       <option value="none">None</option>
     </select>
-    <span id="status">&nbsp;0 selected features</span>
+  <span id="status">&nbsp;0 selected features</span>
+  <br />
+  <label>Hit tolerance for selecting features </label>
+    <select id="hitTolerance" class="form-control">
+      <option value="0" selected>0 Pixels</option>
+      <option value="5">5 Pixels</option>
+      <option value="10">10 Pixels</option>
+    </select>
+    <canvas id="circle" style="vertical-align: middle"/>
 </form>

--- a/examples/select-features.js
+++ b/examples/select-features.js
@@ -31,23 +31,28 @@ var map = new ol.Map({
 var select = null;  // ref to currently selected interaction
 
 // select interaction working on "singleclick"
-var selectSingleClick = new ol.interaction.Select();
+var selectSingleClick = new ol.interaction.Select({
+  multi: true // multi is used in this example if hitTolerance > 0
+});
 
 // select interaction working on "click"
 var selectClick = new ol.interaction.Select({
-  condition: ol.events.condition.click
+  condition: ol.events.condition.click,
+  multi: true
 });
 
 // select interaction working on "pointermove"
 var selectPointerMove = new ol.interaction.Select({
-  condition: ol.events.condition.pointerMove
+  condition: ol.events.condition.pointerMove,
+  multi: true
 });
 
 var selectAltClick = new ol.interaction.Select({
   condition: function(mapBrowserEvent) {
     return ol.events.condition.click(mapBrowserEvent) &&
         ol.events.condition.altKeyOnly(mapBrowserEvent);
-  }
+  },
+  multi: true
 });
 
 var selectElement = document.getElementById('type');
@@ -85,3 +90,27 @@ var changeInteraction = function() {
  */
 selectElement.onchange = changeInteraction;
 changeInteraction();
+
+var selectHitToleranceElement = document.getElementById('hitTolerance');
+var circleCanvas = document.getElementById('circle');
+
+var changeHitTolerance = function() {
+  var value = parseInt(selectHitToleranceElement.value, 10);
+  selectSingleClick.setHitTolerance(value);
+  selectClick.setHitTolerance(value);
+  selectPointerMove.setHitTolerance(value);
+  selectAltClick.setHitTolerance(value);
+
+  var size = 2 * value + 2;
+  circleCanvas.width = size;
+  circleCanvas.height = size;
+  var ctx = circleCanvas.getContext('2d');
+  ctx.clearRect(0, 0, size, size);
+  ctx.beginPath();
+  ctx.arc(value + 1, value + 1, value + 0.5, 0, 2 * Math.PI);
+  ctx.fill();
+  ctx.stroke();
+};
+
+selectHitToleranceElement.onchange = changeHitTolerance;
+changeHitTolerance();

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -2910,7 +2910,8 @@ olx.interaction.ExtentOptions.prototype.wrapX;
 /**
  * @typedef {{
  *     features: (ol.Collection.<ol.Feature>|undefined),
- *     layers: (undefined|Array.<ol.layer.Layer>|function(ol.layer.Layer): boolean)
+ *     layers: (undefined|Array.<ol.layer.Layer>|function(ol.layer.Layer): boolean),
+ *     hitTolerance: (number|undefined)
  * }}
  */
 olx.interaction.TranslateOptions;
@@ -2935,6 +2936,16 @@ olx.interaction.TranslateOptions.prototype.features;
  * @api
  */
 olx.interaction.TranslateOptions.prototype.layers;
+
+
+/**
+ * Hit-detection tolerance. Pixels inside the radius around the given position
+ * will be checked for features. This only works for the canvas renderer and
+ * not for WebGL.
+ * @type {number|undefined}
+ * @api
+ */
+olx.interaction.TranslateOptions.prototype.hitTolerance;
 
 
 /**

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -301,6 +301,49 @@ olx.MapOptions.prototype.target;
  */
 olx.MapOptions.prototype.view;
 
+/**
+ * The filter function will receive one argument, the
+ * {@link ol.layer.Layer layer-candidate} and it should return a boolean
+ * value.
+ * @typedef {(function(ol.layer.Layer): boolean)}
+ */
+olx.LayerFilterFunction;
+
+/**
+ * Object literal with options for the forEachFeatureAtCoordinate methods.
+ * @typedef {{layerFilter: (olx.LayerFilterFunction|undefined),
+ *    layerFilterThis: (Object|undefined),
+ *    hitTolerance: (number|undefined)}}
+ */
+olx.ForEachFeatureOptions;
+
+
+/**
+ * Layer filter function. Only layers which are visible and for which this function returns
+ * `true` will be tested for features. By default, all visible layers will
+ * be tested.
+ * @type {olx.LayerFilterFunction|undefined}
+ * @api stable
+ */
+olx.ForEachFeatureOptions.prototype.layerFilter;
+
+
+/**
+ * Value to use as `this` when executing `layerFilter`.
+ * @type {Object}
+ * @api stable
+ */
+olx.ForEachFeatureOptions.prototype.layerFilterThis;
+
+
+/**
+ * Value of a radius in whichs area around the given coordinate features are
+ *    called.
+ * @type {number}
+ * @api stable
+ */
+olx.ForEachFeatureOptions.prototype.hitTolerance;
+
 
 /**
  * Object literal with config options for the overlay.

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -309,7 +309,7 @@ olx.MapOptions.prototype.view;
  *    layerFilterThis: (Object|undefined),
  *    hitTolerance: (number|undefined)}}
  */
-olx.FeatureAtPixelOptions;
+olx.AtPixelOptions;
 
 
 /**
@@ -320,7 +320,7 @@ olx.FeatureAtPixelOptions;
  * @type {((function(ol.layer.Layer): boolean)|undefined)}
  * @api stable
  */
-olx.FeatureAtPixelOptions.prototype.layerFilter;
+olx.AtPixelOptions.prototype.layerFilter;
 
 
 /**
@@ -328,7 +328,7 @@ olx.FeatureAtPixelOptions.prototype.layerFilter;
  * @type {Object|undefined}
  * @api stable
  */
-olx.FeatureAtPixelOptions.prototype.layerFilterThis;
+olx.AtPixelOptions.prototype.layerFilterThis;
 
 
 /**
@@ -338,7 +338,7 @@ olx.FeatureAtPixelOptions.prototype.layerFilterThis;
  * @type {number|undefined}
  * @api
  */
-olx.FeatureAtPixelOptions.prototype.hitTolerance;
+olx.AtPixelOptions.prototype.hitTolerance;
 
 
 /**

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -3212,7 +3212,8 @@ olx.interaction.PointerOptions.prototype.handleUpEvent;
  *     multi: (boolean|undefined),
  *     features: (ol.Collection.<ol.Feature>|undefined),
  *     filter: (ol.SelectFilterFunction|undefined),
- *     wrapX: (boolean|undefined)}}
+ *     wrapX: (boolean|undefined),
+ *     hitTolerance: (number|undefined)}}
  */
 olx.interaction.SelectOptions;
 
@@ -3324,6 +3325,16 @@ olx.interaction.SelectOptions.prototype.filter;
  * @api
  */
 olx.interaction.SelectOptions.prototype.wrapX;
+
+
+/**
+ * Hit-detection tolerance. Pixels inside the radius around the given position
+ * will be checked for features. This only works for the canvas renderer and
+ * not for WebGL.
+ * @type {number|undefined}
+ * @api
+ */
+olx.interaction.SelectOptions.prototype.hitTolerance;
 
 
 /**

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -303,39 +303,42 @@ olx.MapOptions.prototype.view;
 
 
 /**
- * Object literal with options for the forEachFeatureAtCoordinate methods.
+ * Object literal with options for the forEachFeatureAtPixel and
+ * hasFeatureAtPixel methods.
  * @typedef {{layerFilter: ((function(ol.layer.Layer): boolean)|undefined),
  *    layerFilterThis: (Object|undefined),
  *    hitTolerance: (number|undefined)}}
  */
-olx.ForEachFeatureOptions;
+olx.FeatureAtPixelOptions;
 
 
 /**
- * Layer filter function. Only layers which are visible and for which this function returns
- * `true` will be tested for features. By default, all visible layers will
- * be tested.
+ * Layer filter function. The filter function will receive one argument, the
+ * {@link ol.layer.Layer layer-candidate} and it should return a boolean value.
+ * Only layers which are visible and for which this function returns `true`
+ * will be tested for features. By default, all visible layers will be tested.
  * @type {((function(ol.layer.Layer): boolean)|undefined)}
  * @api stable
  */
-olx.ForEachFeatureOptions.prototype.layerFilter;
+olx.FeatureAtPixelOptions.prototype.layerFilter;
 
 
 /**
  * Value to use as `this` when executing `layerFilter`.
- * @type {Object}
+ * @type {Object|undefined}
  * @api stable
  */
-olx.ForEachFeatureOptions.prototype.layerFilterThis;
+olx.FeatureAtPixelOptions.prototype.layerFilterThis;
 
 
 /**
- * Value of a radius in whichs area around the given coordinate features are
- *    called.
- * @type {number}
- * @api stable
+ * Hit-detection tolerance. Pixels inside the radius around the given position
+ * will be checked for features. This only works for the canvas renderer and
+ * not for WebGL.
+ * @type {number|undefined}
+ * @api
  */
-olx.ForEachFeatureOptions.prototype.hitTolerance;
+olx.FeatureAtPixelOptions.prototype.hitTolerance;
 
 
 /**

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -301,17 +301,10 @@ olx.MapOptions.prototype.target;
  */
 olx.MapOptions.prototype.view;
 
-/**
- * The filter function will receive one argument, the
- * {@link ol.layer.Layer layer-candidate} and it should return a boolean
- * value.
- * @typedef {(function(ol.layer.Layer): boolean)}
- */
-olx.LayerFilterFunction;
 
 /**
  * Object literal with options for the forEachFeatureAtCoordinate methods.
- * @typedef {{layerFilter: (olx.LayerFilterFunction|undefined),
+ * @typedef {{layerFilter: ((function(ol.layer.Layer): boolean)|undefined),
  *    layerFilterThis: (Object|undefined),
  *    hitTolerance: (number|undefined)}}
  */
@@ -322,7 +315,7 @@ olx.ForEachFeatureOptions;
  * Layer filter function. Only layers which are visible and for which this function returns
  * `true` will be tested for features. By default, all visible layers will
  * be tested.
- * @type {olx.LayerFilterFunction|undefined}
+ * @type {((function(ol.layer.Layer): boolean)|undefined)}
  * @api stable
  */
 olx.ForEachFeatureOptions.prototype.layerFilter;

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -303,8 +303,8 @@ olx.MapOptions.prototype.view;
 
 
 /**
- * Object literal with options for the forEachFeatureAtPixel and
- * hasFeatureAtPixel methods.
+ * Object literal with options for the {@link ol.Map#forEachFeatureAtPixel} and
+ * {@link ol.Map#hasFeatureAtPixel} methods.
  * @typedef {{layerFilter: ((function(ol.layer.Layer): boolean)|undefined),
  *    layerFilterThis: (Object|undefined),
  *    hitTolerance: (number|undefined)}}

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -306,7 +306,6 @@ olx.MapOptions.prototype.view;
  * Object literal with options for the {@link ol.Map#forEachFeatureAtPixel} and
  * {@link ol.Map#hasFeatureAtPixel} methods.
  * @typedef {{layerFilter: ((function(ol.layer.Layer): boolean)|undefined),
- *    layerFilterThis: (Object|undefined),
  *    hitTolerance: (number|undefined)}}
  */
 olx.AtPixelOptions;
@@ -321,14 +320,6 @@ olx.AtPixelOptions;
  * @api stable
  */
 olx.AtPixelOptions.prototype.layerFilter;
-
-
-/**
- * Value to use as `this` when executing `layerFilter`.
- * @type {Object|undefined}
- * @api stable
- */
-olx.AtPixelOptions.prototype.layerFilterThis;
 
 
 /**
@@ -7684,7 +7675,7 @@ olx.view.FitOptions.prototype.maxZoom;
 
 
 /**
- * The duration of the animation in milliseconds. By default, there is no 
+ * The duration of the animation in milliseconds. By default, there is no
  * animations.
  * @type {number|undefined}
  * @api

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -323,7 +323,7 @@ olx.AtPixelOptions.prototype.layerFilter;
 
 
 /**
- * Hit-detection tolerance. Pixels inside the radius around the given position
+ * Hit-detection tolerance in pixels. Pixels inside the radius around the given position
  * will be checked for features. This only works for the canvas renderer and
  * not for WebGL.
  * @type {number|undefined}

--- a/src/ol/interaction/select.js
+++ b/src/ol/interaction/select.js
@@ -217,7 +217,7 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
     // the pixel.
     ol.obj.clear(this.featureLayerAssociation_);
     map.forEachFeatureAtPixel(mapBrowserEvent.pixel,
-        /**
+      (/**
          * @param {ol.Feature|ol.render.Feature} feature Feature.
          * @param {ol.layer.Layer} layer Layer.
          * @return {boolean|undefined} Continue to iterate over the features.
@@ -228,7 +228,7 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
             this.addFeatureLayerAssociation_(feature, layer);
             return !this.multi_;
           }
-        }, this, {
+        }).bind(this), {
           layerFilter: this.layerFilter_,
           hitTolerance: this.hitTolerance_
         });
@@ -250,7 +250,7 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
   } else {
     // Modify the currently selected feature(s).
     map.forEachFeatureAtPixel(mapBrowserEvent.pixel,
-        /**
+      (/**
          * @param {ol.Feature|ol.render.Feature} feature Feature.
          * @param {ol.layer.Layer} layer Layer.
          * @return {boolean|undefined} Continue to iterate over the features.
@@ -268,7 +268,7 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
             }
             return !this.multi_;
           }
-        }, this, {
+        }).bind(this), {
           layerFilter: this.layerFilter_,
           hitTolerance: this.hitTolerance_
         });

--- a/src/ol/interaction/select.js
+++ b/src/ol/interaction/select.js
@@ -82,6 +82,8 @@ ol.interaction.Select = function(opt_options) {
   this.filter_ = options.filter ? options.filter :
       ol.functions.TRUE;
 
+  this.hitTolerance_ = options.hitTolerance ? options.hitTolerance : 0;
+
   var featureOverlay = new ol.layer.Vector({
     source: new ol.source.Vector({
       useSpatialIndex: false,
@@ -161,6 +163,16 @@ ol.interaction.Select.prototype.getFeatures = function() {
 
 
 /**
+ * Returns the Hit-detection tolerance.
+ * @returns {number} Hit tolerance.
+ * @api
+ */
+ol.interaction.Select.prototype.getHitTolerance = function() {
+  return this.hitTolerance_;
+};
+
+
+/**
  * Returns the associated {@link ol.layer.Vector vectorlayer} of
  * the (last) selected feature. Note that this will not work with any
  * programmatic method like pushing features to
@@ -212,7 +224,10 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
             this.addFeatureLayerAssociation_(feature, layer);
             return !this.multi_;
           }
-        }, this, {layerFilter: this.layerFilter_});
+        }, this, {
+          layerFilter: this.layerFilter_,
+          hitTolerance: this.hitTolerance_
+        });
     var i;
     for (i = features.getLength() - 1; i >= 0; --i) {
       var feature = features.item(i);
@@ -249,7 +264,10 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
             }
             return !this.multi_;
           }
-        }, this, {layerFilter: this.layerFilter_});
+        }, this, {
+          layerFilter: this.layerFilter_,
+          hitTolerance: this.hitTolerance_
+        });
     var j;
     for (j = deselected.length - 1; j >= 0; --j) {
       features.remove(deselected[j]);
@@ -262,6 +280,18 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
             selected, deselected, mapBrowserEvent));
   }
   return ol.events.condition.pointerMove(mapBrowserEvent);
+};
+
+
+/**
+ * Hit-detection tolerance. Pixels inside the radius around the given position
+ * will be checked for features. This only works for the canvas renderer and
+ * not for WebGL.
+ * @param {number} hitTolerance Hit tolerance.
+ * @api
+ */
+ol.interaction.Select.prototype.setHitTolerance = function(hitTolerance) {
+  this.hitTolerance_ = hitTolerance;
 };
 
 

--- a/src/ol/interaction/select.js
+++ b/src/ol/interaction/select.js
@@ -168,7 +168,7 @@ ol.interaction.Select.prototype.getFeatures = function() {
 
 /**
  * Returns the Hit-detection tolerance.
- * @returns {number} Hit tolerance.
+ * @returns {number} Hit tolerance in pixels.
  * @api
  */
 ol.interaction.Select.prototype.getHitTolerance = function() {
@@ -291,7 +291,7 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
  * Hit-detection tolerance. Pixels inside the radius around the given position
  * will be checked for features. This only works for the canvas renderer and
  * not for WebGL.
- * @param {number} hitTolerance Hit tolerance.
+ * @param {number} hitTolerance Hit tolerance in pixels.
  * @api
  */
 ol.interaction.Select.prototype.setHitTolerance = function(hitTolerance) {

--- a/src/ol/interaction/select.js
+++ b/src/ol/interaction/select.js
@@ -82,6 +82,10 @@ ol.interaction.Select = function(opt_options) {
   this.filter_ = options.filter ? options.filter :
       ol.functions.TRUE;
 
+  /**
+   * @private
+   * @type {number}
+   */
   this.hitTolerance_ = options.hitTolerance ? options.hitTolerance : 0;
 
   var featureOverlay = new ol.layer.Vector({

--- a/src/ol/interaction/select.js
+++ b/src/ol/interaction/select.js
@@ -200,9 +200,7 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
     // pixel, or clear the selected feature(s) if there is no feature at
     // the pixel.
     ol.obj.clear(this.featureLayerAssociation_);
-    map.forEachFeatureAtPixel(mapBrowserEvent.pixel, {
-          layerFilter: this.layerFilter_
-        },
+    map.forEachFeatureAtPixel(mapBrowserEvent.pixel,
         /**
          * @param {ol.Feature|ol.render.Feature} feature Feature.
          * @param {ol.layer.Layer} layer Layer.
@@ -214,7 +212,7 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
             this.addFeatureLayerAssociation_(feature, layer);
             return !this.multi_;
           }
-        }, this);
+        }, this, {layerFilter: this.layerFilter_});
     var i;
     for (i = features.getLength() - 1; i >= 0; --i) {
       var feature = features.item(i);
@@ -232,9 +230,7 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
     }
   } else {
     // Modify the currently selected feature(s).
-    map.forEachFeatureAtPixel(mapBrowserEvent.pixel, {
-          layerFilter: this.layerFilter_
-        },
+    map.forEachFeatureAtPixel(mapBrowserEvent.pixel,
         /**
          * @param {ol.Feature|ol.render.Feature} feature Feature.
          * @param {ol.layer.Layer} layer Layer.
@@ -253,7 +249,7 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
             }
             return !this.multi_;
           }
-        }, this);
+        }, this, {layerFilter: this.layerFilter_});
     var j;
     for (j = deselected.length - 1; j >= 0; --j) {
       features.remove(deselected[j]);

--- a/src/ol/interaction/select.js
+++ b/src/ol/interaction/select.js
@@ -200,7 +200,9 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
     // pixel, or clear the selected feature(s) if there is no feature at
     // the pixel.
     ol.obj.clear(this.featureLayerAssociation_);
-    map.forEachFeatureAtPixel(mapBrowserEvent.pixel,
+    map.forEachFeatureAtPixel(mapBrowserEvent.pixel, {
+          layerFilter: this.layerFilter_
+        },
         /**
          * @param {ol.Feature|ol.render.Feature} feature Feature.
          * @param {ol.layer.Layer} layer Layer.
@@ -212,7 +214,7 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
             this.addFeatureLayerAssociation_(feature, layer);
             return !this.multi_;
           }
-        }, this, this.layerFilter_);
+        }, this);
     var i;
     for (i = features.getLength() - 1; i >= 0; --i) {
       var feature = features.item(i);
@@ -230,7 +232,9 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
     }
   } else {
     // Modify the currently selected feature(s).
-    map.forEachFeatureAtPixel(mapBrowserEvent.pixel,
+    map.forEachFeatureAtPixel(mapBrowserEvent.pixel, {
+          layerFilter: this.layerFilter_
+        },
         /**
          * @param {ol.Feature|ol.render.Feature} feature Feature.
          * @param {ol.layer.Layer} layer Layer.
@@ -249,7 +253,7 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
             }
             return !this.multi_;
           }
-        }, this, this.layerFilter_);
+        }, this);
     var j;
     for (j = deselected.length - 1; j >= 0; --j) {
       features.remove(deselected[j]);

--- a/src/ol/interaction/translate.js
+++ b/src/ol/interaction/translate.js
@@ -197,7 +197,9 @@ ol.interaction.Translate.prototype.featuresAtPixel_ = function(pixel, map) {
             ol.array.includes(this.features_.getArray(), feature)) {
           return feature;
         }
-      }, this, this.layerFilter_);
+      }, this, {
+        layerFilter: this.layerFilter_
+      });
 };
 
 

--- a/src/ol/interaction/translate.js
+++ b/src/ol/interaction/translate.js
@@ -203,7 +203,7 @@ ol.interaction.Translate.prototype.featuresAtPixel_ = function(pixel, map) {
             ol.array.includes(this.features_.getArray(), feature)) {
           return feature;
         }
-      }, this, {
+      }.bind(this), {
         layerFilter: this.layerFilter_,
         hitTolerance: this.hitTolerance_
       });

--- a/src/ol/interaction/translate.js
+++ b/src/ol/interaction/translate.js
@@ -212,7 +212,7 @@ ol.interaction.Translate.prototype.featuresAtPixel_ = function(pixel, map) {
 
 /**
  * Returns the Hit-detection tolerance.
- * @returns {number} Hit tolerance.
+ * @returns {number} Hit tolerance in pixels.
  * @api
  */
 ol.interaction.Translate.prototype.getHitTolerance = function() {
@@ -224,7 +224,7 @@ ol.interaction.Translate.prototype.getHitTolerance = function() {
  * Hit-detection tolerance. Pixels inside the radius around the given position
  * will be checked for features. This only works for the canvas renderer and
  * not for WebGL.
- * @param {number} hitTolerance Hit tolerance.
+ * @param {number} hitTolerance Hit tolerance in pixels.
  * @api
  */
 ol.interaction.Translate.prototype.setHitTolerance = function(hitTolerance) {

--- a/src/ol/interaction/translate.js
+++ b/src/ol/interaction/translate.js
@@ -71,6 +71,12 @@ ol.interaction.Translate = function(opt_options) {
   this.layerFilter_ = layerFilter;
 
   /**
+   * @private
+   * @type {number}
+   */
+  this.hitTolerance_ = options.hitTolerance ? options.hitTolerance : 0;
+
+  /**
    * @type {ol.Feature}
    * @private
    */
@@ -198,8 +204,31 @@ ol.interaction.Translate.prototype.featuresAtPixel_ = function(pixel, map) {
           return feature;
         }
       }, this, {
-        layerFilter: this.layerFilter_
+        layerFilter: this.layerFilter_,
+        hitTolerance: this.hitTolerance_
       });
+};
+
+
+/**
+ * Returns the Hit-detection tolerance.
+ * @returns {number} Hit tolerance.
+ * @api
+ */
+ol.interaction.Translate.prototype.getHitTolerance = function() {
+  return this.hitTolerance_;
+};
+
+
+/**
+ * Hit-detection tolerance. Pixels inside the radius around the given position
+ * will be checked for features. This only works for the canvas renderer and
+ * not for WebGL.
+ * @param {number} hitTolerance Hit tolerance.
+ * @api
+ */
+ol.interaction.Translate.prototype.setHitTolerance = function(hitTolerance) {
+  this.hitTolerance_ = hitTolerance;
 };
 
 

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -568,7 +568,7 @@ ol.Map.prototype.disposeInternal = function() {
  *     unmanaged layers. To stop detection, callback functions can return a
  *     truthy value.
  * @param {S=} opt_this Value to use as this when executing callback.
- * @param {olx.FeatureAtPixelOptions=} opt_options Optional options.
+ * @param {olx.AtPixelOptions=} opt_options Optional options.
  * @return {T|undefined} Callback result, i.e. the return value of last
  * callback execution, or the first truthy callback return value.
  * @template S,T
@@ -632,7 +632,7 @@ ol.Map.prototype.forEachLayerAtPixel = function(pixel, callback, opt_this, opt_l
  * Detect if features intersect a pixel on the viewport. Layers included in the
  * detection can be configured through `opt_layerFilter`.
  * @param {ol.Pixel} pixel Pixel.
- * @param {olx.FeatureAtPixelOptions=} opt_options Optional options.
+ * @param {olx.AtPixelOptions=} opt_options Optional options.
  * @return {boolean} Is there a feature at the given pixel?
  * @template U
  * @api

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -581,7 +581,7 @@ ol.Map.prototype.forEachFeatureAtPixel = function(pixel, callback, opt_this, opt
   var coordinate = this.getCoordinateFromPixel(pixel);
   opt_options = opt_options !== undefined ? opt_options : {};
   var hitTolerance = opt_options.hitTolerance !== undefined ?
-    opt_options.hitTolerance : 0;
+    opt_options.hitTolerance * this.frameState_.pixelRatio : 0;
   var thisArg = opt_this !== undefined ? opt_this : null;
   var layerFilter = opt_options.layerFilter !== undefined ?
     opt_options.layerFilter : ol.functions.TRUE;
@@ -651,7 +651,7 @@ ol.Map.prototype.hasFeatureAtPixel = function(pixel, opt_options) {
   var thisArg = opt_options.layerFilterThis !== undefined ?
     opt_options.layerFilterThis : null;
   var hitTolerance = opt_options.hitTolerance !== undefined ?
-    opt_options.hitTolerance : 0;
+    opt_options.hitTolerance * this.frameState_.pixelRatio : 0;
   return this.renderer_.hasFeatureAtCoordinate(
       coordinate, this.frameState_, hitTolerance, layerFilter, thisArg);
 };

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -568,7 +568,7 @@ ol.Map.prototype.disposeInternal = function() {
  *     unmanaged layers. To stop detection, callback functions can return a
  *     truthy value.
  * @param {S=} opt_this Value to use as this when executing callback.
- * @param {olx.ForEachFeatureOptions=} opt_options Optional options.
+ * @param {olx.FeatureAtPixelOptions=} opt_options Optional options.
  * @return {T|undefined} Callback result, i.e. the return value of last
  * callback execution, or the first truthy callback return value.
  * @template S,T
@@ -632,27 +632,22 @@ ol.Map.prototype.forEachLayerAtPixel = function(pixel, callback, opt_this, opt_l
  * Detect if features intersect a pixel on the viewport. Layers included in the
  * detection can be configured through `opt_layerFilter`.
  * @param {ol.Pixel} pixel Pixel.
- * @param {(function(this: U, ol.layer.Layer): boolean)=} opt_layerFilter Layer
- *     filter function. The filter function will receive one argument, the
- *     {@link ol.layer.Layer layer-candidate} and it should return a boolean
- *     value. Only layers which are visible and for which this function returns
- *     `true` will be tested for features. By default, all visible layers will
- *     be tested.
- * @param {U=} opt_this Value to use as `this` when executing `layerFilter`.
+ * @param {olx.FeatureAtPixelOptions=} opt_options Optional options.
  * @return {boolean} Is there a feature at the given pixel?
  * @template U
  * @api
  */
-ol.Map.prototype.hasFeatureAtPixel = function(pixel, opt_layerFilter, opt_this) {
+ol.Map.prototype.hasFeatureAtPixel = function(pixel, opt_options) {
+  opt_options = opt_options !== undefined ? opt_options : {};
   if (!this.frameState_) {
     return false;
   }
   var coordinate = this.getCoordinateFromPixel(pixel);
-  var layerFilter = opt_layerFilter !== undefined ?
-      opt_layerFilter : ol.functions.TRUE;
-  var thisArg = opt_this !== undefined ? opt_this : null;
+  var layerFilter = opt_options.layerFilter !== undefined ?
+      opt_options.layerFilter : ol.functions.TRUE;
+  var thisArg = opt_options.layerFilterThis !== undefined ? opt_options.layerFilterThis : null;
   return this.renderer_.hasFeatureAtCoordinate(
-      coordinate, this.frameState_, layerFilter, thisArg);
+      coordinate, this.frameState_, opt_options.hitTolerance || 0, layerFilter, thisArg);
 };
 
 

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -555,25 +555,10 @@ ol.Map.prototype.disposeInternal = function() {
 
 
 /**
- * @typedef {object} ol.MapForEachFeatureOptions
- * @property {(function(this: U, ol.layer.Layer): boolean)=} layerFilter Layer
- *     filter function. The filter function will receive one argument, the
- *     {@link ol.layer.Layer layer-candidate} and it should return a boolean
- *     value. Only layers which are visible and for which this function returns
- *     `true` will be tested for features. By default, all visible layers will
- *     be tested.
- * @property {U=} layerFilterThis Value to use as `this` when executing `layerFilter`.
- * @property {number=} hitTolerance the hitTolerance in pixels in which features
- *     get hit.
- */
-
-
-/**
  * Detect features that intersect a pixel on the viewport, and execute a
  * callback with each intersecting feature. Layers included in the detection can
  * be configured through `opt_layerFilter`.
  * @param {ol.Pixel} pixel Pixel.
- * @param {ol.MapForEachFeatureOptions=} opt_options
  * @param {function(this: S, (ol.Feature|ol.render.Feature),
  *     ol.layer.Layer): T} callback Feature callback. The callback will be
  *     called with two arguments. The first argument is one
@@ -582,27 +567,25 @@ ol.Map.prototype.disposeInternal = function() {
  *     the {@link ol.layer.Layer layer} of the feature and will be null for
  *     unmanaged layers. To stop detection, callback functions can return a
  *     truthy value.
- * @param {S=} opt_this
+ * @param {S=} opt_this Value to use as this when executing callback.
+ * @param {olx.ForEachFeatureOptions=} opt_options Optional options.
  * @return {T|undefined} Callback result, i.e. the return value of last
  * callback execution, or the first truthy callback return value.
- * @template S,T,U
+ * @template S,T
  * @api stable
  */
-ol.Map.prototype.forEachFeatureAtPixel = function(pixel, opt_options, callback, opt_this) {
-  if (typeof opt_options !== 'object') {
-    opt_this = callback;
-    callback = opt_options;
-    opt_options = {};
-  }
+ol.Map.prototype.forEachFeatureAtPixel = function(pixel, callback, opt_this, opt_options) {
+  opt_options = opt_options !== undefined ? opt_options : {};
   if (!this.frameState_) {
     return;
   }
   var coordinate = this.getCoordinateFromPixel(pixel);
+  var hitTolerance = opt_options.hitTolerance || 0;
   var thisArg = opt_this !== undefined ? opt_this : null;
   var layerFilter = opt_options.layerFilter || ol.functions.TRUE;
   var thisArg2 = opt_options.layerFilterThis || null;
   return this.renderer_.forEachFeatureAtCoordinate(
-      coordinate, this.frameState_, opt_options.hitTolerance || 0, callback, thisArg,
+      coordinate, this.frameState_, hitTolerance, callback, thisArg,
       layerFilter, thisArg2);
 };
 

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -567,14 +567,13 @@ ol.Map.prototype.disposeInternal = function() {
  *     the {@link ol.layer.Layer layer} of the feature and will be null for
  *     unmanaged layers. To stop detection, callback functions can return a
  *     truthy value.
- * @param {S=} opt_this Value to use as this when executing callback.
  * @param {olx.AtPixelOptions=} opt_options Optional options.
  * @return {T|undefined} Callback result, i.e. the return value of last
  * callback execution, or the first truthy callback return value.
  * @template S,T
  * @api stable
  */
-ol.Map.prototype.forEachFeatureAtPixel = function(pixel, callback, opt_this, opt_options) {
+ol.Map.prototype.forEachFeatureAtPixel = function(pixel, callback, opt_options) {
   if (!this.frameState_) {
     return;
   }
@@ -582,14 +581,11 @@ ol.Map.prototype.forEachFeatureAtPixel = function(pixel, callback, opt_this, opt
   opt_options = opt_options !== undefined ? opt_options : {};
   var hitTolerance = opt_options.hitTolerance !== undefined ?
     opt_options.hitTolerance * this.frameState_.pixelRatio : 0;
-  var thisArg = opt_this !== undefined ? opt_this : null;
   var layerFilter = opt_options.layerFilter !== undefined ?
     opt_options.layerFilter : ol.functions.TRUE;
-  var thisArg2 = opt_options.layerFilterThis !== undefined ?
-    opt_options.layerFilterThis : null;
   return this.renderer_.forEachFeatureAtCoordinate(
-      coordinate, this.frameState_, hitTolerance, callback, thisArg,
-      layerFilter, thisArg2);
+      coordinate, this.frameState_, hitTolerance, callback, null,
+      layerFilter, null);
 };
 
 
@@ -648,12 +644,10 @@ ol.Map.prototype.hasFeatureAtPixel = function(pixel, opt_options) {
   opt_options = opt_options !== undefined ? opt_options : {};
   var layerFilter = opt_options.layerFilter !== undefined ?
       opt_options.layerFilter : ol.functions.TRUE;
-  var thisArg = opt_options.layerFilterThis !== undefined ?
-    opt_options.layerFilterThis : null;
   var hitTolerance = opt_options.hitTolerance !== undefined ?
     opt_options.hitTolerance * this.frameState_.pixelRatio : 0;
   return this.renderer_.hasFeatureAtCoordinate(
-      coordinate, this.frameState_, hitTolerance, layerFilter, thisArg);
+      coordinate, this.frameState_, hitTolerance, layerFilter, null);
 };
 
 

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -574,7 +574,7 @@ ol.Map.prototype.disposeInternal = function() {
  * @template S,T
  * @api stable
  */
-ol.Map.prototype.forEachFeatureAtPixel = function(pixel, callback, opt_this,opt_options) {
+ol.Map.prototype.forEachFeatureAtPixel = function(pixel, callback, opt_this, opt_options) {
   if (!this.frameState_) {
     return;
   }

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -555,10 +555,25 @@ ol.Map.prototype.disposeInternal = function() {
 
 
 /**
+ * @typedef {object} ol.MapForEachFeatureOptions
+ * @property {(function(this: U, ol.layer.Layer): boolean)=} layerFilter Layer
+ *     filter function. The filter function will receive one argument, the
+ *     {@link ol.layer.Layer layer-candidate} and it should return a boolean
+ *     value. Only layers which are visible and for which this function returns
+ *     `true` will be tested for features. By default, all visible layers will
+ *     be tested.
+ * @property {U=} layerFilterThis Value to use as `this` when executing `layerFilter`.
+ * @property {number=} hitTolerance the hitTolerance in pixels in which features
+ *     get hit.
+ */
+
+
+/**
  * Detect features that intersect a pixel on the viewport, and execute a
  * callback with each intersecting feature. Layers included in the detection can
  * be configured through `opt_layerFilter`.
  * @param {ol.Pixel} pixel Pixel.
+ * @param {ol.MapForEachFeatureOptions=} opt_options
  * @param {function(this: S, (ol.Feature|ol.render.Feature),
  *     ol.layer.Layer): T} callback Feature callback. The callback will be
  *     called with two arguments. The first argument is one
@@ -567,30 +582,27 @@ ol.Map.prototype.disposeInternal = function() {
  *     the {@link ol.layer.Layer layer} of the feature and will be null for
  *     unmanaged layers. To stop detection, callback functions can return a
  *     truthy value.
- * @param {S=} opt_this Value to use as `this` when executing `callback`.
- * @param {(function(this: U, ol.layer.Layer): boolean)=} opt_layerFilter Layer
- *     filter function. The filter function will receive one argument, the
- *     {@link ol.layer.Layer layer-candidate} and it should return a boolean
- *     value. Only layers which are visible and for which this function returns
- *     `true` will be tested for features. By default, all visible layers will
- *     be tested.
- * @param {U=} opt_this2 Value to use as `this` when executing `layerFilter`.
+ * @param {S=} opt_this
  * @return {T|undefined} Callback result, i.e. the return value of last
  * callback execution, or the first truthy callback return value.
  * @template S,T,U
  * @api stable
  */
-ol.Map.prototype.forEachFeatureAtPixel = function(pixel, callback, opt_this, opt_layerFilter, opt_this2) {
+ol.Map.prototype.forEachFeatureAtPixel = function(pixel, opt_options, callback, opt_this) {
+  if (typeof opt_options !== 'object') {
+    opt_this = callback;
+    callback = opt_options;
+    opt_options = {};
+  }
   if (!this.frameState_) {
     return;
   }
   var coordinate = this.getCoordinateFromPixel(pixel);
   var thisArg = opt_this !== undefined ? opt_this : null;
-  var layerFilter = opt_layerFilter !== undefined ?
-      opt_layerFilter : ol.functions.TRUE;
-  var thisArg2 = opt_this2 !== undefined ? opt_this2 : null;
+  var layerFilter = opt_options.layerFilter || ol.functions.TRUE;
+  var thisArg2 = opt_options.layerFilterThis || null;
   return this.renderer_.forEachFeatureAtCoordinate(
-      coordinate, this.frameState_, callback, thisArg,
+      coordinate, this.frameState_, opt_options.hitTolerance || 0, callback, thisArg,
       layerFilter, thisArg2);
 };
 

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -574,16 +574,19 @@ ol.Map.prototype.disposeInternal = function() {
  * @template S,T
  * @api stable
  */
-ol.Map.prototype.forEachFeatureAtPixel = function(pixel, callback, opt_this, opt_options) {
-  opt_options = opt_options !== undefined ? opt_options : {};
+ol.Map.prototype.forEachFeatureAtPixel = function(pixel, callback, opt_this,opt_options) {
   if (!this.frameState_) {
     return;
   }
   var coordinate = this.getCoordinateFromPixel(pixel);
-  var hitTolerance = opt_options.hitTolerance || 0;
+  opt_options = opt_options !== undefined ? opt_options : {};
+  var hitTolerance = opt_options.hitTolerance !== undefined ?
+    opt_options.hitTolerance : 0;
   var thisArg = opt_this !== undefined ? opt_this : null;
-  var layerFilter = opt_options.layerFilter || ol.functions.TRUE;
-  var thisArg2 = opt_options.layerFilterThis || null;
+  var layerFilter = opt_options.layerFilter !== undefined ?
+    opt_options.layerFilter : ol.functions.TRUE;
+  var thisArg2 = opt_options.layerFilterThis !== undefined ?
+    opt_options.layerFilterThis : null;
   return this.renderer_.forEachFeatureAtCoordinate(
       coordinate, this.frameState_, hitTolerance, callback, thisArg,
       layerFilter, thisArg2);
@@ -638,16 +641,19 @@ ol.Map.prototype.forEachLayerAtPixel = function(pixel, callback, opt_this, opt_l
  * @api
  */
 ol.Map.prototype.hasFeatureAtPixel = function(pixel, opt_options) {
-  opt_options = opt_options !== undefined ? opt_options : {};
   if (!this.frameState_) {
     return false;
   }
   var coordinate = this.getCoordinateFromPixel(pixel);
+  opt_options = opt_options !== undefined ? opt_options : {};
   var layerFilter = opt_options.layerFilter !== undefined ?
       opt_options.layerFilter : ol.functions.TRUE;
-  var thisArg = opt_options.layerFilterThis !== undefined ? opt_options.layerFilterThis : null;
+  var thisArg = opt_options.layerFilterThis !== undefined ?
+    opt_options.layerFilterThis : null;
+  var hitTolerance = opt_options.hitTolerance !== undefined ?
+    opt_options.hitTolerance : 0;
   return this.renderer_.hasFeatureAtCoordinate(
-      coordinate, this.frameState_, opt_options.hitTolerance || 0, layerFilter, thisArg);
+      coordinate, this.frameState_, hitTolerance, layerFilter, thisArg);
 };
 
 

--- a/src/ol/render/canvas/replaygroup.js
+++ b/src/ol/render/canvas/replaygroup.js
@@ -204,7 +204,7 @@ ol.render.canvas.ReplayGroup.prototype.forEachFeatureAtCoordinate = function(
   if (this.renderBuffer_ !== undefined) {
     hitExtent = ol.extent.createEmpty();
     ol.extent.extendCoordinate(hitExtent, coordinate);
-    ol.extent.buffer(hitExtent, resolution * this.renderBuffer_, hitExtent);
+    ol.extent.buffer(hitExtent, resolution * (this.renderBuffer_ + hitTolerance), hitExtent);
   }
 
   var mask = ol.render.canvas.ReplayGroup.getCircleArray_(hitTolerance);

--- a/src/ol/render/canvas/replaygroup.js
+++ b/src/ol/render/canvas/replaygroup.js
@@ -71,6 +71,12 @@ ol.render.canvas.ReplayGroup = function(
    * @type {CanvasRenderingContext2D}
    */
   this.hitDetectionContext_ = ol.dom.createCanvasContext2D(1, 1);
+
+  /**
+   * @private
+   * @type {ol.Transform}
+   */
+  this.hitDetectionTransform_ = ol.transform.create();
 };
 ol.inherits(ol.render.canvas.ReplayGroup, ol.render.ReplayGroup);
 
@@ -174,7 +180,7 @@ ol.render.canvas.ReplayGroup.prototype.finish = function() {
  * @param {ol.Coordinate} coordinate Coordinate.
  * @param {number} resolution Resolution.
  * @param {number} rotation Rotation.
- * @param {number} hitTolerance Hit tolerance.
+ * @param {number} hitTolerance Hit tolerance in pixels.
  * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features
  *     to skip.
  * @param {function((ol.Feature|ol.render.Feature)): T} callback Feature
@@ -187,15 +193,19 @@ ol.render.canvas.ReplayGroup.prototype.forEachFeatureAtCoordinate = function(
 
   hitTolerance = Math.round(hitTolerance);
   var contextSize = hitTolerance * 2 + 1;
-  var transform = ol.transform.compose(ol.transform.create(),
+  var transform = ol.transform.compose(this.hitDetectionTransform_,
       hitTolerance + 0.5, hitTolerance + 0.5,
       1 / resolution, -1 / resolution,
       -rotation,
       -coordinate[0], -coordinate[1]);
   var context = this.hitDetectionContext_;
-  context.canvas.width = contextSize;
-  context.canvas.height = contextSize;
-  context.clearRect(0, 0, contextSize, contextSize);
+
+  if (context.canvas.width !== contextSize || context.canvas.height !== contextSize) {
+    context.canvas.width = contextSize;
+    context.canvas.height = contextSize;
+  } else {
+    context.clearRect(0, 0, contextSize, contextSize);
+  }
 
   /**
    * @type {ol.Extent}

--- a/src/ol/render/canvas/replaygroup.js
+++ b/src/ol/render/canvas/replaygroup.js
@@ -76,6 +76,8 @@ ol.inherits(ol.render.canvas.ReplayGroup, ol.render.ReplayGroup);
 
 
 /**
+ * This cache is used for storing calculated pixel circles for increasing performance.
+ * It is a static property to allow each Replaygroup to access it.
  * @type {Object.<number, Array.<Array.<(boolean|undefined)>>>}
  * @private
  */
@@ -111,6 +113,7 @@ ol.render.canvas.ReplayGroup.fillCircleArrayRowToMiddle_ = function(array, x, y)
  * This methods creates a circle inside a fitting array. Points inside the
  * circle are marked by true, points on the outside are undefined.
  * It uses the midpoint circle algorithm.
+ * A cache is used to increase performance.
  * @param {number} radius Radius.
  * @returns {Array.<Array.<(boolean|undefined)>>} An array with marked circle points.
  * @private

--- a/src/ol/render/canvas/replaygroup.js
+++ b/src/ol/render/canvas/replaygroup.js
@@ -69,29 +69,32 @@ ol.render.canvas.ReplayGroup = function(
 ol.inherits(ol.render.canvas.ReplayGroup, ol.render.ReplayGroup);
 
 /**
- * This methods creates a circle inside an exactly fitting array. Points inside the circle are marked by true, points
- * on the outside are marked with false.
- * This method uses the midpoint circle algorithm.
- * @param {Number} radius
- * @returns {Boolean[][]}
+ * This methods creates a circle inside a fitting array. Points inside the
+ * circle are marked by true, points on the outside are marked with false.
+ * It uses the midpoint circle algorithm.
+ * @param {number} radius Radius.
+ * @returns {Array.<Array.<Boolean>>} an array with marked circel points.
  * @private
  */
 ol.render.canvas.ReplayGroup.createPixelCircle_ = function(radius) {
   var arraySize = radius * 2 + 1;
   var arr = new Array(arraySize);
   for (var i = 0; i < arraySize; i++) {
-    arr[i] = (new Array(arraySize)).fill(false);
+    arr[i] = new Array(arraySize);
+    for (var j = 0; j < arraySize; j++) {
+      arr[i][j] = false;
+    }
   }
 
   function fillRowToMiddle(x, y) {
     var i;
     if (x >= radius) {
       for (i = radius; i < x; i++) {
-        arr[i][y] = true
+        arr[i][y] = true;
       }
     } else if (x < radius) {
       for (i = x + 1; i < radius; i++) {
-        arr[i][y] = true
+        arr[i][y] = true;
       }
     }
   }
@@ -112,8 +115,7 @@ ol.render.canvas.ReplayGroup.createPixelCircle_ = function(radius) {
 
     y++;
     error += 1 + 2 * y;
-    if (2 * (error - x) + 1 > 0)
-    {
+    if (2 * (error - x) + 1 > 0) {
       x -= 1;
       error += 1 - 2 * x;
     }
@@ -175,7 +177,12 @@ ol.render.canvas.ReplayGroup.prototype.forEachFeatureAtCoordinate = function(
     ol.extent.buffer(hitExtent, resolution * this.renderBuffer_, hitExtent);
   }
 
-  var mask = ol.render.canvas.ReplayGroup.createPixelCircle_(hitTolerance);
+  var mask;
+  if (hitTolerance === 0) {
+    mask = [[true]];
+  } else {
+    mask = ol.render.canvas.ReplayGroup.createPixelCircle_(hitTolerance);
+  }
 
   return this.replayHitDetection_(context, transform, rotation,
       skippedFeaturesHash,

--- a/src/ol/render/canvas/replaygroup.js
+++ b/src/ol/render/canvas/replaygroup.js
@@ -88,6 +88,7 @@ ol.render.canvas.ReplayGroup.prototype.finish = function() {
  * @param {ol.Coordinate} coordinate Coordinate.
  * @param {number} resolution Resolution.
  * @param {number} rotation Rotation.
+ * @param {number} hitTolerance hit tolerance.
  * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features
  *     to skip.
  * @param {function((ol.Feature|ol.render.Feature)): T} callback Feature
@@ -96,9 +97,8 @@ ol.render.canvas.ReplayGroup.prototype.finish = function() {
  * @template T
  */
 ol.render.canvas.ReplayGroup.prototype.forEachFeatureAtCoordinate = function(
-    coordinate, resolution, rotation, skippedFeaturesHash, callback) {
+    coordinate, resolution, rotation, hitTolerance, skippedFeaturesHash, callback) {
 
-  var hitTolerance = 10;
   var contextSize = hitTolerance * 2 + 1;
 
   var transform = ol.transform.compose(ol.transform.create(),

--- a/src/ol/renderer/canvas/intermediatecanvas.js
+++ b/src/ol/renderer/canvas/intermediatecanvas.js
@@ -98,14 +98,14 @@ ol.renderer.canvas.IntermediateCanvas.prototype.getImageTransform = function() {
 /**
  * @inheritDoc
  */
-ol.renderer.canvas.IntermediateCanvas.prototype.forEachFeatureAtCoordinate = function(coordinate, frameState, callback, thisArg) {
+ol.renderer.canvas.IntermediateCanvas.prototype.forEachFeatureAtCoordinate = function(coordinate, frameState, hitTolerance, callback, thisArg) {
   var layer = this.getLayer();
   var source = layer.getSource();
   var resolution = frameState.viewState.resolution;
   var rotation = frameState.viewState.rotation;
   var skippedFeatureUids = frameState.skippedFeatureUids;
   return source.forEachFeatureAtCoordinate(
-      coordinate, resolution, rotation, skippedFeatureUids,
+      coordinate, resolution, rotation, hitTolerance, skippedFeatureUids,
       /**
        * @param {ol.Feature|ol.render.Feature} feature Feature.
        * @return {?} Callback result.

--- a/src/ol/renderer/canvas/layer.js
+++ b/src/ol/renderer/canvas/layer.js
@@ -106,7 +106,7 @@ ol.renderer.canvas.Layer.prototype.dispatchComposeEvent_ = function(type, contex
  */
 ol.renderer.canvas.Layer.prototype.forEachLayerAtCoordinate = function(coordinate, frameState, callback, thisArg) {
   var hasFeature = this.forEachFeatureAtCoordinate(
-      coordinate, frameState, ol.functions.TRUE, this);
+      coordinate, frameState, 0, ol.functions.TRUE, this);
 
   if (hasFeature) {
     return callback.call(thisArg, this.getLayer(), null);

--- a/src/ol/renderer/canvas/vectorlayer.js
+++ b/src/ol/renderer/canvas/vectorlayer.js
@@ -177,7 +177,7 @@ ol.renderer.canvas.VectorLayer.prototype.composeFrame = function(frameState, lay
 /**
  * @inheritDoc
  */
-ol.renderer.canvas.VectorLayer.prototype.forEachFeatureAtCoordinate = function(coordinate, frameState, callback, thisArg) {
+ol.renderer.canvas.VectorLayer.prototype.forEachFeatureAtCoordinate = function(coordinate, frameState, hitTolerance, callback, thisArg) {
   if (!this.replayGroup_) {
     return undefined;
   } else {
@@ -187,7 +187,7 @@ ol.renderer.canvas.VectorLayer.prototype.forEachFeatureAtCoordinate = function(c
     /** @type {Object.<string, boolean>} */
     var features = {};
     return this.replayGroup_.forEachFeatureAtCoordinate(coordinate, resolution,
-        rotation, {},
+        rotation, hitTolerance, {},
         /**
          * @param {ol.Feature|ol.render.Feature} feature Feature.
          * @return {?} Callback result.

--- a/src/ol/renderer/canvas/vectortilelayer.js
+++ b/src/ol/renderer/canvas/vectortilelayer.js
@@ -191,13 +191,12 @@ ol.renderer.canvas.VectorTileLayer.prototype.forEachFeatureAtCoordinate = functi
   var tileGrid = source.getTileGrid();
   var found, tileSpaceCoordinate;
   var i, ii, origin, replayGroup;
-  var tile, tileCoord, tileExtent, tilePixelRatio, tileResolution, pointResolution;
+  var tile, tileCoord, tileExtent, tilePixelRatio, tileResolution;
   for (i = 0, ii = replayables.length; i < ii; ++i) {
     tile = replayables[i];
     tileCoord = tile.tileCoord;
     tileExtent = source.getTileGrid().getTileCoordExtent(tileCoord, this.tmpExtent);
-    pointResolution = tile.getProjection().getPointResolution(resolution, coordinate);
-    if (!ol.extent.containsCoordinate(ol.extent.buffer(tileExtent, hitTolerance * pointResolution), coordinate)) {
+    if (!ol.extent.containsCoordinate(ol.extent.buffer(tileExtent, hitTolerance * resolution), coordinate)) {
       continue;
     }
     if (tile.getProjection().getUnits() === ol.proj.Units.TILE_PIXELS) {

--- a/src/ol/renderer/canvas/vectortilelayer.js
+++ b/src/ol/renderer/canvas/vectortilelayer.js
@@ -176,7 +176,7 @@ ol.renderer.canvas.VectorTileLayer.prototype.drawTileImage = function(
 /**
  * @inheritDoc
  */
-ol.renderer.canvas.VectorTileLayer.prototype.forEachFeatureAtCoordinate = function(coordinate, frameState, callback, thisArg) {
+ol.renderer.canvas.VectorTileLayer.prototype.forEachFeatureAtCoordinate = function(coordinate, frameState, hitTolerance, callback, thisArg) {
   var resolution = frameState.viewState.resolution;
   var rotation = frameState.viewState.rotation;
   var layer = this.getLayer();
@@ -212,7 +212,7 @@ ol.renderer.canvas.VectorTileLayer.prototype.forEachFeatureAtCoordinate = functi
     }
     replayGroup = tile.getReplayState().replayGroup;
     found = found || replayGroup.forEachFeatureAtCoordinate(
-        tileSpaceCoordinate, resolution, rotation, {},
+        tileSpaceCoordinate, resolution, rotation, hitTolerance, {},
         /**
          * @param {ol.Feature|ol.render.Feature} feature Feature.
          * @return {?} Callback result.

--- a/src/ol/renderer/canvas/vectortilelayer.js
+++ b/src/ol/renderer/canvas/vectortilelayer.js
@@ -179,6 +179,7 @@ ol.renderer.canvas.VectorTileLayer.prototype.drawTileImage = function(
 ol.renderer.canvas.VectorTileLayer.prototype.forEachFeatureAtCoordinate = function(coordinate, frameState, hitTolerance, callback, thisArg) {
   var resolution = frameState.viewState.resolution;
   var rotation = frameState.viewState.rotation;
+  hitTolerance = hitTolerance == undefined ? 0 : hitTolerance;
   var layer = this.getLayer();
   /** @type {Object.<string, boolean>} */
   var features = {};
@@ -190,12 +191,13 @@ ol.renderer.canvas.VectorTileLayer.prototype.forEachFeatureAtCoordinate = functi
   var tileGrid = source.getTileGrid();
   var found, tileSpaceCoordinate;
   var i, ii, origin, replayGroup;
-  var tile, tileCoord, tileExtent, tilePixelRatio, tileResolution;
+  var tile, tileCoord, tileExtent, tilePixelRatio, tileResolution, pointResolution;
   for (i = 0, ii = replayables.length; i < ii; ++i) {
     tile = replayables[i];
     tileCoord = tile.tileCoord;
     tileExtent = source.getTileGrid().getTileCoordExtent(tileCoord, this.tmpExtent);
-    if (!ol.extent.containsCoordinate(tileExtent, coordinate)) {
+    pointResolution = tile.getProjection().getPointResolution(resolution, coordinate);
+    if (!ol.extent.containsCoordinate(ol.extent.buffer(tileExtent, hitTolerance * pointResolution), coordinate)) {
       continue;
     }
     if (tile.getProjection().getUnits() === ol.proj.Units.TILE_PIXELS) {

--- a/src/ol/renderer/layer.js
+++ b/src/ol/renderer/layer.js
@@ -35,7 +35,7 @@ ol.inherits(ol.renderer.Layer, ol.Observable);
 /**
  * @param {ol.Coordinate} coordinate Coordinate.
  * @param {olx.FrameState} frameState Frame state.
- * @param {number} hitTolerance Hit tolerance.
+ * @param {number} hitTolerance Hit tolerance in pixels.
  * @param {function(this: S, (ol.Feature|ol.render.Feature), ol.layer.Layer): T}
  *     callback Feature callback.
  * @param {S} thisArg Value to use as `this` when executing `callback`.

--- a/src/ol/renderer/layer.js
+++ b/src/ol/renderer/layer.js
@@ -35,7 +35,7 @@ ol.inherits(ol.renderer.Layer, ol.Observable);
 /**
  * @param {ol.Coordinate} coordinate Coordinate.
  * @param {olx.FrameState} frameState Frame state.
- * @param {number} hitTolerance hit tolerance.
+ * @param {number} hitTolerance Hit tolerance.
  * @param {function(this: S, (ol.Feature|ol.render.Feature), ol.layer.Layer): T}
  *     callback Feature callback.
  * @param {S} thisArg Value to use as `this` when executing `callback`.

--- a/src/ol/renderer/layer.js
+++ b/src/ol/renderer/layer.js
@@ -35,6 +35,7 @@ ol.inherits(ol.renderer.Layer, ol.Observable);
 /**
  * @param {ol.Coordinate} coordinate Coordinate.
  * @param {olx.FrameState} frameState Frame state.
+ * @param {number} hitTolerance hit tolerance.
  * @param {function(this: S, (ol.Feature|ol.render.Feature), ol.layer.Layer): T}
  *     callback Feature callback.
  * @param {S} thisArg Value to use as `this` when executing `callback`.

--- a/src/ol/renderer/map.js
+++ b/src/ol/renderer/map.js
@@ -189,6 +189,7 @@ ol.renderer.Map.prototype.forEachLayerAtPixel = function(pixel, frameState, call
 /**
  * @param {ol.Coordinate} coordinate Coordinate.
  * @param {olx.FrameState} frameState FrameState.
+ * @param {number} hitTolerance HitTolerance.
  * @param {function(this: U, ol.layer.Layer): boolean} layerFilter Layer filter
  *     function, only layers which are visible and for which this function
  *     returns `true` will be tested for features.  By default, all visible
@@ -197,9 +198,9 @@ ol.renderer.Map.prototype.forEachLayerAtPixel = function(pixel, frameState, call
  * @return {boolean} Is there a feature at the given coordinate?
  * @template U
  */
-ol.renderer.Map.prototype.hasFeatureAtCoordinate = function(coordinate, frameState, layerFilter, thisArg) {
+ol.renderer.Map.prototype.hasFeatureAtCoordinate = function(coordinate, frameState, hitTolerance, layerFilter, thisArg) {
   var hasFeature = this.forEachFeatureAtCoordinate(
-      coordinate, frameState, 0, ol.functions.TRUE, this, layerFilter, thisArg);
+      coordinate, frameState, hitTolerance, ol.functions.TRUE, this, layerFilter, thisArg);
 
   return hasFeature !== undefined;
 };

--- a/src/ol/renderer/map.js
+++ b/src/ol/renderer/map.js
@@ -100,7 +100,7 @@ ol.renderer.Map.expireIconCache_ = function(map, frameState) {
 /**
  * @param {ol.Coordinate} coordinate Coordinate.
  * @param {olx.FrameState} frameState FrameState.
- * @param {number} hitTolerance hit tolerance.
+ * @param {number} hitTolerance Hit tolerance.
  * @param {function(this: S, (ol.Feature|ol.render.Feature),
  *     ol.layer.Layer): T} callback Feature callback.
  * @param {S} thisArg Value to use as `this` when executing `callback`.
@@ -189,7 +189,7 @@ ol.renderer.Map.prototype.forEachLayerAtPixel = function(pixel, frameState, call
 /**
  * @param {ol.Coordinate} coordinate Coordinate.
  * @param {olx.FrameState} frameState FrameState.
- * @param {number} hitTolerance HitTolerance.
+ * @param {number} hitTolerance Hit tolerance.
  * @param {function(this: U, ol.layer.Layer): boolean} layerFilter Layer filter
  *     function, only layers which are visible and for which this function
  *     returns `true` will be tested for features.  By default, all visible

--- a/src/ol/renderer/map.js
+++ b/src/ol/renderer/map.js
@@ -100,6 +100,7 @@ ol.renderer.Map.expireIconCache_ = function(map, frameState) {
 /**
  * @param {ol.Coordinate} coordinate Coordinate.
  * @param {olx.FrameState} frameState FrameState.
+ * @param {number} hitTolerance hit tolerance.
  * @param {function(this: S, (ol.Feature|ol.render.Feature),
  *     ol.layer.Layer): T} callback Feature callback.
  * @param {S} thisArg Value to use as `this` when executing `callback`.
@@ -111,7 +112,7 @@ ol.renderer.Map.expireIconCache_ = function(map, frameState) {
  * @return {T|undefined} Callback result.
  * @template S,T,U
  */
-ol.renderer.Map.prototype.forEachFeatureAtCoordinate = function(coordinate, frameState, callback, thisArg,
+ol.renderer.Map.prototype.forEachFeatureAtCoordinate = function(coordinate, frameState, hitTolerance, callback, thisArg,
         layerFilter, thisArg2) {
   var result;
   var viewState = frameState.viewState;
@@ -155,7 +156,7 @@ ol.renderer.Map.prototype.forEachFeatureAtCoordinate = function(coordinate, fram
       if (layer.getSource()) {
         result = layerRenderer.forEachFeatureAtCoordinate(
             layer.getSource().getWrapX() ? translatedCoordinate : coordinate,
-            frameState, forEachFeatureAtCoordinate, thisArg);
+            frameState, hitTolerance, forEachFeatureAtCoordinate, thisArg);
       }
       if (result) {
         return result;

--- a/src/ol/renderer/map.js
+++ b/src/ol/renderer/map.js
@@ -100,7 +100,7 @@ ol.renderer.Map.expireIconCache_ = function(map, frameState) {
 /**
  * @param {ol.Coordinate} coordinate Coordinate.
  * @param {olx.FrameState} frameState FrameState.
- * @param {number} hitTolerance Hit tolerance.
+ * @param {number} hitTolerance Hit tolerance in pixels.
  * @param {function(this: S, (ol.Feature|ol.render.Feature),
  *     ol.layer.Layer): T} callback Feature callback.
  * @param {S} thisArg Value to use as `this` when executing `callback`.
@@ -189,7 +189,7 @@ ol.renderer.Map.prototype.forEachLayerAtPixel = function(pixel, frameState, call
 /**
  * @param {ol.Coordinate} coordinate Coordinate.
  * @param {olx.FrameState} frameState FrameState.
- * @param {number} hitTolerance Hit tolerance.
+ * @param {number} hitTolerance Hit tolerance in pixels.
  * @param {function(this: U, ol.layer.Layer): boolean} layerFilter Layer filter
  *     function, only layers which are visible and for which this function
  *     returns `true` will be tested for features.  By default, all visible

--- a/src/ol/renderer/map.js
+++ b/src/ol/renderer/map.js
@@ -199,7 +199,7 @@ ol.renderer.Map.prototype.forEachLayerAtPixel = function(pixel, frameState, call
  */
 ol.renderer.Map.prototype.hasFeatureAtCoordinate = function(coordinate, frameState, layerFilter, thisArg) {
   var hasFeature = this.forEachFeatureAtCoordinate(
-      coordinate, frameState, ol.functions.TRUE, this, layerFilter, thisArg);
+      coordinate, frameState, 0, ol.functions.TRUE, this, layerFilter, thisArg);
 
   return hasFeature !== undefined;
 };

--- a/src/ol/renderer/webgl/imagelayer.js
+++ b/src/ol/renderer/webgl/imagelayer.js
@@ -68,14 +68,14 @@ ol.renderer.webgl.ImageLayer.prototype.createTexture_ = function(image) {
 /**
  * @inheritDoc
  */
-ol.renderer.webgl.ImageLayer.prototype.forEachFeatureAtCoordinate = function(coordinate, frameState, callback, thisArg) {
+ol.renderer.webgl.ImageLayer.prototype.forEachFeatureAtCoordinate = function(coordinate, frameState, hitTolerance, callback, thisArg) {
   var layer = this.getLayer();
   var source = layer.getSource();
   var resolution = frameState.viewState.resolution;
   var rotation = frameState.viewState.rotation;
   var skippedFeatureUids = frameState.skippedFeatureUids;
   return source.forEachFeatureAtCoordinate(
-      coordinate, resolution, rotation, skippedFeatureUids,
+      coordinate, resolution, rotation, hitTolerance, skippedFeatureUids,
 
       /**
        * @param {ol.Feature|ol.render.Feature} feature Feature.

--- a/src/ol/renderer/webgl/imagelayer.js
+++ b/src/ol/renderer/webgl/imagelayer.js
@@ -213,7 +213,7 @@ ol.renderer.webgl.ImageLayer.prototype.updateProjectionMatrix_ = function(canvas
  */
 ol.renderer.webgl.ImageLayer.prototype.hasFeatureAtCoordinate = function(coordinate, frameState) {
   var hasFeature = this.forEachFeatureAtCoordinate(
-      coordinate, frameState, ol.functions.TRUE, this);
+      coordinate, frameState, 0, ol.functions.TRUE, this);
   return hasFeature !== undefined;
 };
 
@@ -232,7 +232,7 @@ ol.renderer.webgl.ImageLayer.prototype.forEachLayerAtPixel = function(pixel, fra
     var coordinate = ol.transform.apply(
         frameState.pixelToCoordinateTransform, pixel.slice());
     var hasFeature = this.forEachFeatureAtCoordinate(
-        coordinate, frameState, ol.functions.TRUE, this);
+        coordinate, frameState, 0, ol.functions.TRUE, this);
 
     if (hasFeature) {
       return callback.call(thisArg, this.getLayer(), null);

--- a/src/ol/renderer/webgl/map.js
+++ b/src/ol/renderer/webgl/map.js
@@ -502,7 +502,7 @@ ol.renderer.webgl.Map.prototype.renderFrame = function(frameState) {
 /**
  * @inheritDoc
  */
-ol.renderer.webgl.Map.prototype.forEachFeatureAtCoordinate = function(coordinate, frameState, callback, thisArg,
+ol.renderer.webgl.Map.prototype.forEachFeatureAtCoordinate = function(coordinate, frameState, hitTolerance, callback, thisArg,
         layerFilter, thisArg2) {
   var result;
 
@@ -522,7 +522,7 @@ ol.renderer.webgl.Map.prototype.forEachFeatureAtCoordinate = function(coordinate
         layerFilter.call(thisArg2, layer)) {
       var layerRenderer = this.getLayerRenderer(layer);
       result = layerRenderer.forEachFeatureAtCoordinate(
-          coordinate, frameState, callback, thisArg);
+          coordinate, frameState, hitTolerance, callback, thisArg);
       if (result) {
         return result;
       }

--- a/src/ol/renderer/webgl/map.js
+++ b/src/ol/renderer/webgl/map.js
@@ -535,7 +535,7 @@ ol.renderer.webgl.Map.prototype.forEachFeatureAtCoordinate = function(coordinate
 /**
  * @inheritDoc
  */
-ol.renderer.webgl.Map.prototype.hasFeatureAtCoordinate = function(coordinate, frameState, layerFilter, thisArg) {
+ol.renderer.webgl.Map.prototype.hasFeatureAtCoordinate = function(coordinate, frameState, hitTolerance, layerFilter, thisArg) {
   var hasFeature = false;
 
   if (this.getGL().isContextLost()) {

--- a/src/ol/renderer/webgl/vectorlayer.js
+++ b/src/ol/renderer/webgl/vectorlayer.js
@@ -106,7 +106,7 @@ ol.renderer.webgl.VectorLayer.prototype.disposeInternal = function() {
 /**
  * @inheritDoc
  */
-ol.renderer.webgl.VectorLayer.prototype.forEachFeatureAtCoordinate = function(coordinate, frameState, callback, thisArg) {
+ol.renderer.webgl.VectorLayer.prototype.forEachFeatureAtCoordinate = function(coordinate, frameState, hitTolerance, callback, thisArg) {
   if (!this.replayGroup_ || !this.layerState_) {
     return undefined;
   } else {

--- a/src/ol/source/imagevector.js
+++ b/src/ol/source/imagevector.js
@@ -155,14 +155,14 @@ ol.source.ImageVector.prototype.canvasFunctionInternal_ = function(extent, resol
  * @inheritDoc
  */
 ol.source.ImageVector.prototype.forEachFeatureAtCoordinate = function(
-    coordinate, resolution, rotation, skippedFeatureUids, callback) {
+    coordinate, resolution, rotation, hitTolerance, skippedFeatureUids, callback) {
   if (!this.replayGroup_) {
     return undefined;
   } else {
     /** @type {Object.<string, boolean>} */
     var features = {};
     return this.replayGroup_.forEachFeatureAtCoordinate(
-        coordinate, resolution, 0, skippedFeatureUids,
+        coordinate, resolution, 0, hitTolerance, skippedFeatureUids,
         /**
          * @param {ol.Feature|ol.render.Feature} feature Feature.
          * @return {?} Callback result.

--- a/src/ol/source/source.js
+++ b/src/ol/source/source.js
@@ -94,6 +94,7 @@ ol.source.Source.toAttributionsArray_ = function(attributionLike) {
  * @param {ol.Coordinate} coordinate Coordinate.
  * @param {number} resolution Resolution.
  * @param {number} rotation Rotation.
+ * @param {number} hitTolerance Hit tolerance.
  * @param {Object.<string, boolean>} skippedFeatureUids Skipped feature uids.
  * @param {function((ol.Feature|ol.render.Feature)): T} callback Feature
  *     callback.

--- a/src/ol/source/source.js
+++ b/src/ol/source/source.js
@@ -94,7 +94,7 @@ ol.source.Source.toAttributionsArray_ = function(attributionLike) {
  * @param {ol.Coordinate} coordinate Coordinate.
  * @param {number} resolution Resolution.
  * @param {number} rotation Rotation.
- * @param {number} hitTolerance Hit tolerance.
+ * @param {number} hitTolerance Hit tolerance in pixels.
  * @param {Object.<string, boolean>} skippedFeatureUids Skipped feature uids.
  * @param {function((ol.Feature|ol.render.Feature)): T} callback Feature
  *     callback.

--- a/test/spec/ol/render/canvas/replaygroup.test.js
+++ b/test/spec/ol/render/canvas/replaygroup.test.js
@@ -1,0 +1,33 @@
+goog.provide('ol.test.render.canvas.ReplayGroup');
+
+goog.require('ol.render.canvas.ReplayGroup');
+
+
+describe('ol.render.canvas.ReplayGroup', function() {
+
+  describe('#getCircleArray_', function() {
+    it('creates an array with a pixelated circle marked with true', function() {
+      var radius = 10;
+      var minRadiusSq = Math.pow(radius - Math.SQRT2, 2);
+      var maxRadiusSq = Math.pow(radius + Math.SQRT2, 2);
+      var circleArray = ol.render.canvas.ReplayGroup.getCircleArray_(radius);
+      var size = radius * 2 + 1;
+      expect(circleArray.length).to.be(size);
+
+      for (var i = 0; i < size; i++) {
+        expect(circleArray[i].length).to.be(size);
+        for (var j = 0; j < size; j++) {
+          var dx = Math.abs(radius - i);
+          var dy = Math.abs(radius - j);
+          var distanceSq = Math.pow(dx, 2) + Math.pow(dy, 2);
+          if (circleArray[i][j] === true) {
+            expect(distanceSq).to.be.within(0, maxRadiusSq);
+          } else {
+            expect(distanceSq).to.be.within(minRadiusSq, Infinity);
+          }
+        }
+      }
+    });
+  });
+
+});

--- a/test/spec/ol/renderer/canvas/map.test.js
+++ b/test/spec/ol/renderer/canvas/map.test.js
@@ -111,7 +111,7 @@ describe('ol.renderer.canvas.Map', function() {
       map.addLayer(layer);
       map.renderSync();
       var cb = sinon.spy();
-      map.forEachFeatureAtPixel(map.getPixelFromCoordinate([0, 0]), cb, null, {
+      map.forEachFeatureAtPixel(map.getPixelFromCoordinate([0, 0]), cb, {
         layerFilter: function() {
           return false;
         }
@@ -151,13 +151,13 @@ describe('ol.renderer.canvas.Map', function() {
       ];
 
       for (var i = 0; i < 4; i++) {
-        map.forEachFeatureAtPixel(pixelsInside[i], cb1, null, {hitTolerance:10});
+        map.forEachFeatureAtPixel(pixelsInside[i], cb1, {hitTolerance:10});
       }
       expect(cb1.callCount).to.be(4);
       expect(cb1.firstCall.args[1]).to.be(layer);
 
       for (var j = 0; j < 4; j++) {
-        map.forEachFeatureAtPixel(pixelsOutside[j], cb2, null, {hitTolerance:10});
+        map.forEachFeatureAtPixel(pixelsOutside[j], cb2, {hitTolerance:10});
       }
       expect(cb2).not.to.be.called();
     });

--- a/test/spec/ol/renderer/canvas/map.test.js
+++ b/test/spec/ol/renderer/canvas/map.test.js
@@ -30,7 +30,7 @@ describe('ol.renderer.canvas.Map', function() {
 
     var layer, map, target;
 
-    beforeEach(function() {
+    beforeEach(function(done) {
       target = document.createElement('div');
       target.style.width = '100px';
       target.style.height = '100px';
@@ -42,6 +42,14 @@ describe('ol.renderer.canvas.Map', function() {
           zoom: 0
         })
       });
+
+      // 1 x 1 pixel black icon
+      var img = document.createElement('img');
+      img.onload = function() {
+        done();
+      };
+      img.src = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNiAAAABgADNjd8qAAAAABJRU5ErkJggg==';
+
       layer = new ol.layer.Vector({
         source: new ol.source.Vector({
           features: [
@@ -49,6 +57,12 @@ describe('ol.renderer.canvas.Map', function() {
               geometry: new ol.geom.Point([0, 0])
             })
           ]
+        }),
+        style: new ol.style.Style({
+          image: new ol.style.Icon({
+            img : img,
+            imgSize: [1, 1]
+          })
         })
       });
     });
@@ -113,6 +127,39 @@ describe('ol.renderer.canvas.Map', function() {
       }).to.not.throwException();
     });
 
+    it('calls callback for clicks inside of the hitTolerance', function() {
+      map.addLayer(layer);
+      map.renderSync();
+      var cb1 = sinon.spy();
+      var cb2 = sinon.spy();
+
+      var pixel = map.getPixelFromCoordinate([0, 0]);
+
+      var pixelsInside = [
+        [pixel[0] + 9, pixel[1]],
+        [pixel[0] - 9, pixel[1]],
+        [pixel[0], pixel[1] + 9],
+        [pixel[0], pixel[1] - 9]
+      ];
+
+      var pixelsOutside = [
+        [pixel[0] + 9, pixel[1] + 9],
+        [pixel[0] - 9, pixel[1] + 9],
+        [pixel[0] + 9, pixel[1] - 9],
+        [pixel[0] - 9, pixel[1] - 9]
+      ];
+
+      for (var i = 0; i < 4; i++) {
+        map.forEachFeatureAtPixel(pixelsInside[i], {hitTolerance:10}, cb1);
+      }
+      expect(cb1.callCount).to.be(4);
+      expect(cb1.firstCall.args[1]).to.be(layer);
+
+      for (var j = 0; j < 4; j++) {
+        map.forEachFeatureAtPixel(pixelsOutside[j], {hitTolerance:10}, cb2);
+      }
+      expect(cb2).not.to.be.called();
+    });
   });
 
   describe('#renderFrame()', function() {

--- a/test/spec/ol/renderer/canvas/map.test.js
+++ b/test/spec/ol/renderer/canvas/map.test.js
@@ -111,11 +111,11 @@ describe('ol.renderer.canvas.Map', function() {
       map.addLayer(layer);
       map.renderSync();
       var cb = sinon.spy();
-      map.forEachFeatureAtPixel(map.getPixelFromCoordinate([0, 0]), {
-          layerFilter: function() {
-            return false;
-          }
-        }, cb);
+      map.forEachFeatureAtPixel(map.getPixelFromCoordinate([0, 0]), cb, null, {
+        layerFilter: function() {
+          return false;
+        }
+      });
       expect(cb).to.not.be.called();
     });
 
@@ -151,13 +151,13 @@ describe('ol.renderer.canvas.Map', function() {
       ];
 
       for (var i = 0; i < 4; i++) {
-        map.forEachFeatureAtPixel(pixelsInside[i], {hitTolerance:10}, cb1);
+        map.forEachFeatureAtPixel(pixelsInside[i], cb1, null, {hitTolerance:10});
       }
       expect(cb1.callCount).to.be(4);
       expect(cb1.firstCall.args[1]).to.be(layer);
 
       for (var j = 0; j < 4; j++) {
-        map.forEachFeatureAtPixel(pixelsOutside[j], {hitTolerance:10}, cb2);
+        map.forEachFeatureAtPixel(pixelsOutside[j], cb2, null, {hitTolerance:10});
       }
       expect(cb2).not.to.be.called();
     });

--- a/test/spec/ol/renderer/canvas/map.test.js
+++ b/test/spec/ol/renderer/canvas/map.test.js
@@ -111,10 +111,11 @@ describe('ol.renderer.canvas.Map', function() {
       map.addLayer(layer);
       map.renderSync();
       var cb = sinon.spy();
-      map.forEachFeatureAtPixel(map.getPixelFromCoordinate([0, 0]), cb, null,
-          function() {
+      map.forEachFeatureAtPixel(map.getPixelFromCoordinate([0, 0]), {
+          layerFilter: function() {
             return false;
-          });
+          }
+        }, cb);
       expect(cb).to.not.be.called();
     });
 

--- a/test/spec/ol/renderer/canvas/vectorlayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectorlayer.test.js
@@ -79,7 +79,7 @@ describe('ol.renderer.canvas.VectorLayer', function() {
       var replayGroup = {};
       renderer.replayGroup_ = replayGroup;
       replayGroup.forEachFeatureAtCoordinate = function(coordinate,
-          resolution, rotation, skippedFeaturesUids, callback) {
+          resolution, rotation, hitTolerance, skippedFeaturesUids, callback) {
         var feature = new ol.Feature();
         callback(feature);
         callback(feature);
@@ -99,7 +99,7 @@ describe('ol.renderer.canvas.VectorLayer', function() {
       };
       frameState.layerStates[ol.getUid(layer)] = {};
       renderer.forEachFeatureAtCoordinate(
-          coordinate, frameState, spy, undefined);
+          coordinate, frameState, 0, spy, undefined);
       expect(spy.callCount).to.be(1);
       expect(spy.getCall(0).args[1]).to.equal(layer);
     });

--- a/test/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -169,7 +169,7 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
       });
       renderer = new ol.renderer.canvas.VectorTileLayer(layer);
       replayGroup.forEachFeatureAtCoordinate = function(coordinate,
-          resolution, rotation, skippedFeaturesUids, callback) {
+          resolution, rotation, hitTolerance, skippedFeaturesUids, callback) {
         var feature = new ol.Feature();
         callback(feature);
         callback(feature);
@@ -190,7 +190,7 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
       frameState.layerStates[ol.getUid(layer)] = {};
       renderer.renderedTiles = [new TileClass([0, 0, -1])];
       renderer.forEachFeatureAtCoordinate(
-          coordinate, frameState, spy, undefined);
+          coordinate, frameState, 0, spy, undefined);
       expect(spy.callCount).to.be(1);
       expect(spy.getCall(0).args[1]).to.equal(layer);
     });


### PR DESCRIPTION
TODO:
- [X] Write a test
- [X] Change the signature of map.forEachFeatureAtCoordinate and map.forEachFeatureAtPixel in the source code, the examples and the tests
- [X] Add a hitTolerance parameter to all internal forEachFeatureAtCoordinate methods of the renderer
- [X] Make ol.render.canvas.ReplayGroup.prototype.forEachFeatureAtCoordinate work with a hitContext of variable size
- [x] Implement the midpoint circle algorithm and checking only pixels inside the circle
- [x] Update documentation
- [X] hitTolerance should also be added to ol.Map#hasFeatureAtPixel.
- [X] example
- [X] caching
- [x] Test with retina screens (devicePixelRatio > 1)
- [X] Handle VectorTiles.
~Write a test for VectorTiles.~
- [x] Update changelog.
- [x] Created test for ol.render.canvas.ReplayGroup#getCircleArray_

See discussion: #5862
