### PR TITLE
Always load a gated URL polyfill when testing

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -15,7 +15,9 @@
   <script type="text/javascript" src="../node_modules/mocha/mocha.js"></script>
   <script type="text/javascript" src="../node_modules/proj4/dist/proj4.js"></script>
   <script type="text/javascript" src="test-extensions.js"></script>
-  <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL"></script>
+  <!-- load polyfills: Always load the URL polyfill in a gated form so that
+       MS Edge has it -->
+  <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL|always|gated"></script>
   <script>
     if (typeof initMochaPhantomJS === 'function') {
       initMochaPhantomJS()


### PR DESCRIPTION
Otherwise the tests fail to run in MS Edge, whose user agent doesn't trigger the inclusion of the polyfill without `always` on `polyfill.io`.

With this in we are down from 45 failing tests in MS Edge to 1 remaining failure.

See also #5996

Please review.