### PR TITLE
Use tile image dimensions in rendering

### DIFF
--- a/src/ol/renderer/canvas/tilelayer.js
+++ b/src/ol/renderer/canvas/tilelayer.js
@@ -360,9 +360,8 @@ ol.renderer.canvas.TileLayer.prototype.renderTileImages = function(context, fram
       }
       pixelExtents.push(pixelExtent);
     }
-    var tilePixelSize = source.getTilePixelSize(currentZ, pixelRatio, projection);
     renderContext.drawImage(tile.getImage(), tileGutter, tileGutter,
-        tilePixelSize[0], tilePixelSize[1], left, top, w, h);
+         tile.getImage().width, tile.getImage().height, left, top, w,h);
     if (!opaque) {
       renderContext.restore();
     }


### PR DESCRIPTION
Some servers sometimes return tiles that do not match the tile size
specification (e.g. it can return a 1x1 blank tile where there's no
data). This can cause an out-of-bound error in drawImage - at least in ie 10+11.

See the discussion in #5936, this patch stems from the comment by @tschaub.
