### PR TITLE
Combine standard coverage and rendering coverage

### DIFF
--- a/test_rendering/test.js
+++ b/test_rendering/test.js
@@ -19,8 +19,23 @@ page.open(url).then(function(status) {
         }
         console.error(failedTests.length + ' test(s) failed.');
       } else {
+        // check for cov here
+        var coverage = page.evaluate(function() {
+          return window.__coverage__;
+        });
+
+        if (coverage) {
+          console.log('Writing coverage to coverage/coverage-rendering.json');
+          var fs = require('fs');
+          fs.write(
+            fs.workingDirectory + '/coverage/coverage-rendering.json',
+            JSON.stringify(coverage),
+            'w'
+          );
+        }
         console.log('All tests passed.');
       }
+
       page.close();
       phantom.exit(failedTests.length === 0 ? 0 : 1);
     };


### PR DESCRIPTION
This is open for discussion.

Wouldn't it be nice if we knew the code coverage of our rendering tests? And wouldn't it even be better if we knew the combined coverage of standard-tests and coverage ones?

This PR contains a commit that does that, it is open for your input. Just share what you think.

(PS: with rendering tests participating in the total coverage percentage, we're at ~86%, plus ~4.8%)