### PR TITLE
Do not fill when there is no fillStyle

### DIFF
--- a/src/ol/render/canvas/polygonreplay.js
+++ b/src/ol/render/canvas/polygonreplay.js
@@ -343,7 +343,7 @@ ol.render.canvas.PolygonReplay.prototype.setFillStrokeStyles_ = function(geometr
   var lineJoin = state.lineJoin;
   var lineWidth = state.lineWidth;
   var miterLimit = state.miterLimit;
-  if (typeof fillStyle !== 'string' || fillStyle !== undefined && state.currentFillStyle != fillStyle) {
+  if (fillStyle !== undefined && (typeof fillStyle !== 'string' || state.currentFillStyle != fillStyle)) {
     var fillInstruction = [ol.render.canvas.Instruction.SET_FILL_STYLE, fillStyle];
     if (typeof fillStyle !== 'string') {
       var fillExtent = geometry.getExtent();


### PR DESCRIPTION
This is a follow-up on #6034, which fixes the problem mentioned in https://github.com/openlayers/ol3/pull/6034#pullrequestreview-6202214.

Fixes #6038.