### PR TITLE
Properly complete multiple parallel animations

### DIFF
--- a/src/ol/control/zoom.js
+++ b/src/ol/control/zoom.js
@@ -106,6 +106,9 @@ ol.control.Zoom.prototype.zoomByDelta_ = function(delta) {
   if (currentResolution) {
     var newResolution = view.constrainResolution(currentResolution, delta);
     if (this.duration_ > 0) {
+      if (view.getAnimating()) {
+        view.cancelAnimations();
+      }
       view.animate({
         resolution: newResolution,
         duration: this.duration_,

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -271,7 +271,7 @@ ol.View.prototype.getAnimating = function() {
 /**
  * Cancel any ongoing animations.
  */
-ol.View.prototype.cancelAnimations_ = function() {
+ol.View.prototype.cancelAnimations = function() {
   for (var i = 0, ii = this.animations_.length; i < ii; ++i) {
     var series = this.animations_[i];
     if (series[0].callback) {
@@ -809,7 +809,7 @@ ol.View.prototype.rotate = function(rotation, opt_anchor) {
 ol.View.prototype.setCenter = function(center) {
   this.set(ol.View.Property.CENTER, center);
   if (this.getAnimating()) {
-    this.cancelAnimations_();
+    this.cancelAnimations();
   }
 };
 
@@ -838,7 +838,7 @@ ol.View.prototype.setHint = function(hint, delta) {
 ol.View.prototype.setResolution = function(resolution) {
   this.set(ol.View.Property.RESOLUTION, resolution);
   if (this.getAnimating()) {
-    this.cancelAnimations_();
+    this.cancelAnimations();
   }
 };
 
@@ -852,7 +852,7 @@ ol.View.prototype.setResolution = function(resolution) {
 ol.View.prototype.setRotation = function(rotation) {
   this.set(ol.View.Property.ROTATION, rotation);
   if (this.getAnimating()) {
-    this.cancelAnimations_();
+    this.cancelAnimations();
   }
 };
 

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -305,7 +305,7 @@ ol.View.prototype.updateAnimations_ = function() {
       }
       var elapsed = now - animation.start;
       var fraction = elapsed / animation.duration;
-      if (fraction > 1) {
+      if (fraction >= 1) {
         animation.complete = true;
         fraction = 1;
       } else {
@@ -345,14 +345,16 @@ ol.View.prototype.updateAnimations_ = function() {
       }
     }
     if (seriesComplete) {
+      this.animations_[i] = null;
       this.setHint(ol.View.Hint.ANIMATING, -1);
-      var completed = this.animations_.pop();
-      var callback = completed[0].callback;
+      var callback = series[0].callback;
       if (callback) {
         callback(true);
       }
     }
   }
+  // prune completed series
+  this.animations_ = this.animations_.filter(Boolean);
   if (more && this.updateAnimationKey_ === undefined) {
     this.updateAnimationKey_ = requestAnimationFrame(this.updateAnimations_);
   }

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -484,6 +484,39 @@ describe('ol.View', function() {
 
     });
 
+    it('completes multiple staggered animations run in parallel', function(done) {
+
+      var view = new ol.View({
+        center: [0, 0],
+        zoom: 0
+      });
+
+      var calls = 0;
+
+      view.animate({
+        zoom: 1,
+        duration: 25
+      }, function() {
+        ++calls;
+      });
+
+      setTimeout(function() {
+        expect(view.getZoom() > 0).to.be(true);
+        expect(view.getZoom() < 1).to.be(true);
+        expect(view.getAnimating()).to.be(true);
+        view.animate({
+          zoom: 2,
+          duration: 25
+        }, function() {
+          expect(calls).to.be(1);
+          expect(view.getZoom()).to.roughlyEqual(2, 1e-8);
+          expect(view.getAnimating()).to.be(false);
+          done();
+        });
+      }, 10);
+
+    });
+
   });
 
   describe('#getResolutions', function() {


### PR DESCRIPTION
Prior to this change, when multiple animations were run in parallel, we were not removing the correct series on completion.  A symptom of this is #6102.  Here is what was happening:

 * click zoom, start one animation series
 * before the first animation completes click zoom again
 * first animation completes, we pop a series from the stack (unfortunately, this is the newly pushed one instead of the completed one)
 * next animation frame, all series are complete, we decrement the animation hint and pop the last series from the stack, but because the animation was already complete, there was no view modification, we don't get another render, so no postrender functions are called, and hence no tile loading

The right thing to do (obviously) is to correctly remove the completed series (instead of just popping).  This is done in 97d942c8e2ef93121f5d257304cca1538150e634.

The change in 291766c48debad3f585a55be874576f2fb8e9ebb makes it so when you click the zoom button, any ongoing animations are cancelled, and we start a new one.  I think this is the expected behavior.  If you click a lot, you zoom a lot.

Because we can explicitly test whether the view is animating and we can cancel any running animations, interactions or controls can also do nothing if there is a current animation.  The change in #6101 takes the opposite approach of 291766c48debad3f585a55be874576f2fb8e9ebb, doing nothing until the current animations complete.  We could do the same thing with the mouse wheel zoom interaction (cancel any running animations and start a new one) - but I didn't yet do this because our mouse wheel handling is so crazy, and the result is that you end up zooming the map way too far (unless you are a seasoned OL dev who is used to the touchy interaction).  When we rework this interaction to better deal with trackpads, we can use a similar approach to the zoom control here.

Fixes #6102.