### PR TITLE
Move vector tile loader functions into vector tile module

### DIFF
--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -1,7 +1,6 @@
 goog.provide('ol.featureloader');
 
 goog.require('ol');
-goog.require('ol.Tile');
 goog.require('ol.format.FormatType');
 goog.require('ol.xml');
 
@@ -66,35 +65,6 @@ ol.featureloader.loadFeaturesXhr = function(url, format, success, failure) {
           }
         }.bind(this);
         xhr.send();
-      });
-};
-
-
-/**
- * Create an XHR feature loader for a `url` and `format`. The feature loader
- * loads features (with XHR), parses the features, and adds them to the
- * vector tile.
- * @param {string|ol.FeatureUrlFunction} url Feature URL service.
- * @param {ol.format.Feature} format Feature format.
- * @return {ol.FeatureLoader} The feature loader.
- * @api
- */
-ol.featureloader.tile = function(url, format) {
-  return ol.featureloader.loadFeaturesXhr(url, format,
-      /**
-       * @param {Array.<ol.Feature>} features The loaded features.
-       * @param {ol.proj.Projection} dataProjection Data projection.
-       * @this {ol.VectorTile}
-       */
-      function(features, dataProjection) {
-        this.setProjection(dataProjection);
-        this.setFeatures(features);
-      },
-      /**
-       * @this {ol.VectorTile}
-       */
-      function() {
-        this.setState(ol.Tile.State.ERROR);
       });
 };
 

--- a/src/ol/source/vectortile.js
+++ b/src/ol/source/vectortile.js
@@ -5,7 +5,6 @@ goog.require('ol.Tile');
 goog.require('ol.VectorTile');
 goog.require('ol.events');
 goog.require('ol.events.EventType');
-goog.require('ol.featureloader');
 goog.require('ol.size');
 goog.require('ol.source.UrlTile');
 
@@ -38,7 +37,7 @@ ol.source.VectorTile = function(options) {
     state: options.state,
     tileGrid: options.tileGrid,
     tileLoadFunction: options.tileLoadFunction ?
-        options.tileLoadFunction : ol.source.VectorTile.defaultTileLoadFunction,
+        options.tileLoadFunction : ol.VectorTile.defaultLoadFunction,
     tileUrlFunction: options.tileUrlFunction,
     tilePixelRatio: options.tilePixelRatio,
     url: options.url,
@@ -120,13 +119,4 @@ ol.source.VectorTile.prototype.getTilePixelRatio = function(opt_pixelRatio) {
 ol.source.VectorTile.prototype.getTilePixelSize = function(z, pixelRatio, projection) {
   var tileSize = ol.size.toSize(this.tileGrid.getTileSize(z));
   return [Math.round(tileSize[0] * pixelRatio), Math.round(tileSize[1] * pixelRatio)];
-};
-
-
-/**
- * @param {ol.VectorTile} vectorTile Vector tile.
- * @param {string} url URL.
- */
-ol.source.VectorTile.defaultTileLoadFunction = function(vectorTile, url) {
-  vectorTile.setLoader(ol.featureloader.tile(url, vectorTile.getFormat()));
 };

--- a/src/ol/vectortile.js
+++ b/src/ol/vectortile.js
@@ -151,6 +151,25 @@ ol.VectorTile.prototype.load = function() {
 
 
 /**
+ * Handler for successful tile load.
+ * @param {Array.<ol.Feature>} features The loaded features.
+ * @param {ol.proj.Projection} dataProjection Data projection.
+ */
+ol.VectorTile.prototype.onLoad_ = function(features, dataProjection) {
+  this.setProjection(dataProjection);
+  this.setFeatures(features);
+};
+
+
+/**
+ * Handler for tile load errors.
+ */
+ol.VectorTile.prototype.onError_ = function() {
+  this.setState(ol.Tile.State.ERROR);
+};
+
+
+/**
  * @param {Array.<ol.Feature>} features Features.
  * @api
  */
@@ -190,9 +209,13 @@ ol.VectorTile.prototype.setLoader = function(loader) {
 
 
 /**
+ * Sets the loader for a tile.
  * @param {ol.VectorTile} tile Vector tile.
  * @param {string} url URL.
  */
 ol.VectorTile.defaultLoadFunction = function(tile, url) {
-  tile.setLoader(ol.featureloader.tile(url, tile.getFormat()));
+  var loader = ol.featureloader.loadFeaturesXhr(
+      url, tile.getFormat(), tile.onLoad_.bind(tile), tile.onError_.bind(tile));
+
+  tile.setLoader(loader);
 };

--- a/src/ol/vectortile.js
+++ b/src/ol/vectortile.js
@@ -3,6 +3,7 @@ goog.provide('ol.VectorTile');
 goog.require('ol');
 goog.require('ol.Tile');
 goog.require('ol.dom');
+goog.require('ol.featureloader');
 
 
 /**
@@ -185,4 +186,13 @@ ol.VectorTile.prototype.setState = function(tileState) {
  */
 ol.VectorTile.prototype.setLoader = function(loader) {
   this.loader_ = loader;
+};
+
+
+/**
+ * @param {ol.VectorTile} tile Vector tile.
+ * @param {string} url URL.
+ */
+ol.VectorTile.defaultLoadFunction = function(tile, url) {
+  tile.setLoader(ol.featureloader.tile(url, tile.getFormat()));
 };

--- a/test/spec/ol/featureloader.test.js
+++ b/test/spec/ol/featureloader.test.js
@@ -1,12 +1,7 @@
 goog.provide('ol.test.featureloader');
 
-goog.require('ol.events');
-goog.require('ol.VectorTile');
-goog.require('ol.Feature');
 goog.require('ol.featureloader');
 goog.require('ol.format.GeoJSON');
-goog.require('ol.format.TextFeature');
-goog.require('ol.proj');
 goog.require('ol.source.Vector');
 
 
@@ -62,50 +57,6 @@ describe('ol.featureloader', function() {
         loader = ol.featureloader.xhr(url, format);
         loader.call(source, [], 1, 'EPSG:3857');
       });
-    });
-
-  });
-
-  describe('ol.featureloader.tile', function() {
-    var loader;
-    var tile;
-
-    beforeEach(function() {
-      tile = new ol.VectorTile([0, 0, 0]);
-    });
-
-    it('sets features on the tile', function(done) {
-      var url = 'spec/ol/data/point.json';
-      var format = new ol.format.GeoJSON();
-      loader = ol.featureloader.tile(url, format);
-      ol.events.listen(tile, 'change', function(e) {
-        expect(tile.getFeatures().length).to.be.greaterThan(0);
-        done();
-      });
-      loader.call(tile, [], 1, ol.proj.get('EPSG:3857'));
-    });
-
-    it('sets features on the tile and updates proj units', function(done) {
-      // mock format that return a tile-pixels feature
-      var format = new ol.format.TextFeature();
-      format.readProjection = function(source) {
-        return new ol.proj.Projection({
-          code: '',
-          units: 'tile-pixels'
-        });
-      };
-      format.readFeatures = function(source, options) {
-        return [new ol.Feature()];
-      };
-
-      var url = 'spec/ol/data/point.json';
-      loader = ol.featureloader.tile(url, format);
-      ol.events.listen(tile, 'change', function(e) {
-        expect(tile.getFeatures().length).to.be.greaterThan(0);
-        expect(tile.getProjection().getUnits()).to.be('tile-pixels');
-        done();
-      });
-      loader.call(tile, [], 1, ol.proj.get('EPSG:3857'));
     });
 
   });

--- a/test/spec/ol/vectortile.test.js
+++ b/test/spec/ol/vectortile.test.js
@@ -1,0 +1,64 @@
+goog.provide('ol.test.VectorTile');
+
+goog.require('ol.events');
+goog.require('ol.VectorTile');
+goog.require('ol.Feature');
+goog.require('ol.format.GeoJSON');
+goog.require('ol.format.TextFeature');
+goog.require('ol.proj');
+
+
+describe('ol.VectorTile.defaultLoadFunction()', function() {
+
+  it('sets the loader function on the tile', function() {
+    var format = new ol.format.GeoJSON();
+    var tile = new ol.VectorTile([0, 0, 0], null, null, format);
+    var url = 'https://example.com/';
+
+    ol.VectorTile.defaultLoadFunction(tile, url);
+    var loader = tile.loader_;
+    expect(typeof loader).to.be('function');
+  });
+
+  it('loader sets features on the tile', function(done) {
+    var format = new ol.format.GeoJSON();
+    var tile = new ol.VectorTile([0, 0, 0], null, null, format);
+    var url = 'spec/ol/data/point.json';
+
+    ol.VectorTile.defaultLoadFunction(tile, url);
+    var loader = tile.loader_;
+
+    ol.events.listen(tile, 'change', function(e) {
+      expect(tile.getFeatures().length).to.be.greaterThan(0);
+      done();
+    });
+    loader.call(tile, [], 1, ol.proj.get('EPSG:3857'));
+  });
+
+  it('loader sets features on the tile and updates proj units', function(done) {
+    // mock format that return a tile-pixels feature
+    var format = new ol.format.TextFeature();
+    format.readProjection = function(source) {
+      return new ol.proj.Projection({
+        code: '',
+        units: 'tile-pixels'
+      });
+    };
+    format.readFeatures = function(source, options) {
+      return [new ol.Feature()];
+    };
+
+    var tile = new ol.VectorTile([0, 0, 0], null, null, format);
+    var url = 'spec/ol/data/point.json';
+
+    ol.VectorTile.defaultLoadFunction(tile, url);
+    var loader = tile.loader_;
+    ol.events.listen(tile, 'change', function(e) {
+      expect(tile.getFeatures().length).to.be.greaterThan(0);
+      expect(tile.getProjection().getUnits()).to.be('tile-pixels');
+      done();
+    });
+    loader.call(tile, [], 1, ol.proj.get('EPSG:3857'));
+  });
+
+});


### PR DESCRIPTION
This moves the feature loader function that is specific to vector tiles into `src/ol/vectortile.js`.  It also load success and failure handlers to the vector tile prototype.
