### PR TITLE
Add type annotations for vector tiles

### DIFF
--- a/src/ol/renderer/canvas/vectortilelayer.js
+++ b/src/ol/renderer/canvas/vectortilelayer.js
@@ -137,7 +137,9 @@ ol.renderer.canvas.VectorTileLayer.prototype.renderTileReplays_ = function(
   var alpha = replayContext.globalAlpha;
   replayContext.globalAlpha = layerState.opacity;
 
+  /** @type {Array.<ol.VectorTile>} */
   var tilesToDraw = this.renderedTiles;
+
   var tileGrid = source.getTileGrid();
 
   var currentZ, i, ii, offsetX, offsetY, origin, pixelSpace, replayState;
@@ -283,7 +285,9 @@ ol.renderer.canvas.VectorTileLayer.prototype.forEachFeatureAtCoordinate = functi
   /** @type {Object.<string, boolean>} */
   var features = {};
 
+  /** @type {Array.<ol.VectorTile>} */
   var replayables = this.renderedTiles;
+
   var source = /** @type {ol.source.VectorTile} */ (layer.getSource());
   var tileGrid = source.getTileGrid();
   var found, tileSpaceCoordinate;


### PR DESCRIPTION
Since `getProjection` and `getReplayState` are not defined for `ol.Tile`, the compiler needs to know we are talking about `ol.VectorTile` here.

See https://travis-ci.org/camptocamp/ngeo/jobs/174469862#L614-L631 for a related build failure.  It would be nice to know why the compiler doesn't warn of the same in our own build jobs.
