### PR TITLE
Smooth trackpad zooming

### DIFF
--- a/src/ol/interaction/mousewheelzoom.js
+++ b/src/ol/interaction/mousewheelzoom.js
@@ -116,7 +116,6 @@ ol.interaction.MouseWheelZoom.handleEvent = function(mapBrowserEvent) {
 
   // Delta normalisation inspired by
   // https://github.com/mapbox/mapbox-gl-js/blob/001c7b9/js/ui/handler/scroll_zoom.js
-  //TODO There's more good stuff in there for inspiration to improve this interaction.
   var delta;
   if (mapBrowserEvent.type == ol.events.EventType.WHEEL) {
     delta = wheelEvent.deltaY;

--- a/src/ol/interaction/mousewheelzoom.js
+++ b/src/ol/interaction/mousewheelzoom.js
@@ -192,8 +192,7 @@ ol.interaction.MouseWheelZoom.handleEvent = function(mapBrowserEvent) {
   var timeLeft = Math.max(this.timeout_ - (now - this.startTime_), 0);
 
   clearTimeout(this.timeoutId_);
-  this.timeoutId_ = setTimeout(
-      this.doZoom_.bind(this, map), timeLeft);
+  this.timeoutId_ = setTimeout(this.handleWheelZoom_.bind(this, map), timeLeft);
 
   return false;
 };
@@ -203,14 +202,15 @@ ol.interaction.MouseWheelZoom.handleEvent = function(mapBrowserEvent) {
  * @private
  * @param {ol.Map} map Map.
  */
-ol.interaction.MouseWheelZoom.prototype.doZoom_ = function(map) {
+ol.interaction.MouseWheelZoom.prototype.handleWheelZoom_ = function(map) {
   var view = map.getView();
-  if (!view.getAnimating()) {
-    var maxDelta = ol.MOUSEWHEELZOOM_MAXDELTA;
-    var delta = ol.math.clamp(this.delta_, -maxDelta, maxDelta);
-    ol.interaction.Interaction.zoomByDelta(map, view, -delta, this.lastAnchor_,
-        this.duration_);
+  if (view.getAnimating()) {
+    view.cancelAnimations();
   }
+  var maxDelta = ol.MOUSEWHEELZOOM_MAXDELTA;
+  var delta = ol.math.clamp(this.delta_, -maxDelta, maxDelta);
+  ol.interaction.Interaction.zoomByDelta(map, view, -delta, this.lastAnchor_,
+      this.duration_);
   this.mode_ = undefined;
   this.delta_ = 0;
   this.lastAnchor_ = null;

--- a/test/spec/ol/interaction/mousewheelzoom.test.js
+++ b/test/spec/ol/interaction/mousewheelzoom.test.js
@@ -7,14 +7,17 @@ goog.require('ol.View');
 goog.require('ol.events.Event');
 goog.require('ol.has');
 goog.require('ol.interaction.Interaction');
+goog.require('ol.interaction.MouseWheelZoom');
 
 
 describe('ol.interaction.MouseWheelZoom', function() {
-  var map;
+  var map, interaction;
 
   beforeEach(function() {
+    interaction = new ol.interaction.MouseWheelZoom();
     map = new ol.Map({
       target: createMapDiv(100, 100),
+      interactions: [interaction],
       view: new ol.View({
         center: [0, 0],
         resolutions: [2, 1, 0.5],
@@ -23,8 +26,11 @@ describe('ol.interaction.MouseWheelZoom', function() {
     });
     map.renderSync();
   });
+
   afterEach(function() {
     disposeMap(map);
+    map = null;
+    interaction = null;
   });
 
   describe('timeout duration', function() {
@@ -58,14 +64,12 @@ describe('ol.interaction.MouseWheelZoom', function() {
   });
 
   describe('handleEvent()', function() {
-    it('[wheel] works on Firefox in DOM_DELTA_PIXEL mode', function(done) {
+
+    it('works on Firefox in DOM_DELTA_PIXEL mode (trackpad)', function(done) {
       var origHasFirefox = ol.has.FIREFOX;
       ol.has.FIREFOX = true;
-      var spy = sinon.spy(ol.interaction.Interaction, 'zoomByDelta');
       map.once('postrender', function() {
-        expect(spy.getCall(0).args[2]).to.be(-1);
-        expect(spy.getCall(0).args[3]).to.eql([0, 0]);
-        ol.interaction.Interaction.zoomByDelta.restore();
+        expect(interaction.mode_).to.be(ol.interaction.MouseWheelZoom.Mode.TRACKPAD);
         ol.has.FIREFOX = origHasFirefox;
         done();
       });
@@ -79,14 +83,12 @@ describe('ol.interaction.MouseWheelZoom', function() {
       event.coordinate = [0, 0];
       map.handleMapBrowserEvent(event);
     });
-    it('[wheel] works in DOM_DELTA_PIXEL mode', function(done) {
+
+    it('works in DOM_DELTA_PIXEL mode (trackpad)', function(done) {
       var origHasFirefox = ol.has.FIREFOX;
       ol.has.FIREFOX = false;
-      var spy = sinon.spy(ol.interaction.Interaction, 'zoomByDelta');
       map.once('postrender', function() {
-        expect(spy.getCall(0).args[2]).to.be(-1);
-        expect(spy.getCall(0).args[3]).to.eql([0, 0]);
-        ol.interaction.Interaction.zoomByDelta.restore();
+        expect(interaction.mode_).to.be(ol.interaction.MouseWheelZoom.Mode.TRACKPAD);
         ol.has.FIREFOX = origHasFirefox;
         done();
       });
@@ -100,7 +102,8 @@ describe('ol.interaction.MouseWheelZoom', function() {
       event.coordinate = [0, 0];
       map.handleMapBrowserEvent(event);
     });
-    it('[wheel] works in DOM_DELTA_LINE mode', function(done) {
+
+    it('works in DOM_DELTA_LINE mode (wheel)', function(done) {
       var spy = sinon.spy(ol.interaction.Interaction, 'zoomByDelta');
       map.once('postrender', function() {
         expect(spy.getCall(0).args[2]).to.be(-1);
@@ -111,14 +114,15 @@ describe('ol.interaction.MouseWheelZoom', function() {
       var event = new ol.MapBrowserEvent('wheel', map, {
         type: 'wheel',
         deltaMode: WheelEvent.DOM_DELTA_LINE,
-        deltaY: 1 / 40,
+        deltaY: 3.714599609375,
         target: map.getViewport(),
         preventDefault: ol.events.Event.prototype.preventDefault
       });
       event.coordinate = [0, 0];
       map.handleMapBrowserEvent(event);
     });
-    it('[mousewheel] works on Safari', function(done) {
+
+    it('works on Safari (wheel)', function(done) {
       var origHasSafari = ol.has.SAFARI;
       ol.has.SAFARI = true;
       var spy = sinon.spy(ol.interaction.Interaction, 'zoomByDelta');
@@ -131,14 +135,15 @@ describe('ol.interaction.MouseWheelZoom', function() {
       });
       var event = new ol.MapBrowserEvent('mousewheel', map, {
         type: 'mousewheel',
-        wheelDeltaY: -3,
+        wheelDeltaY: -50,
         target: map.getViewport(),
         preventDefault: ol.events.Event.prototype.preventDefault
       });
       event.coordinate = [0, 0];
       map.handleMapBrowserEvent(event);
     });
-    it('[mousewheel] works on other browsers', function(done) {
+
+    it('works on other browsers (wheel)', function(done) {
       var origHasSafari = ol.has.SAFARI;
       ol.has.SAFARI = false;
       var spy = sinon.spy(ol.interaction.Interaction, 'zoomByDelta');
@@ -151,7 +156,7 @@ describe('ol.interaction.MouseWheelZoom', function() {
       });
       var event = new ol.MapBrowserEvent('mousewheel', map, {
         type: 'mousewheel',
-        wheelDeltaY: -1,
+        wheelDeltaY: -120,
         target: map.getViewport(),
         preventDefault: ol.events.Event.prototype.preventDefault
       });


### PR DESCRIPTION
This reworks the mousewheel zoom interaction for nicer trackpad zooming.

After trying a number of different strategies, by far the nicest interaction is to allow the view to settle at fractional zoom levels.  We could add an option to always end on an integer zoom level, but this makes for jumpier interaction, and I would prefer that it not be the default.

Fixes #6030.