### PR TITLE
Updated linter config and curly conditional blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "coveralls": "2.11.15",
     "debounce": "^1.0.0",
     "eslint": "3.10.0",
-    "eslint-config-openlayers": "5.0.0",
+    "eslint-config-openlayers": "6.0.0",
     "eslint-plugin-openlayers-internal": "2.2.0",
     "expect.js": "0.3.1",
     "gaze": "^1.0.0",

--- a/src/ol/string.js
+++ b/src/ol/string.js
@@ -27,8 +27,12 @@ ol.string.compareVersions = function(v1, v2) {
     var n1 = parseInt(s1[i] || '0', 10);
     var n2 = parseInt(s2[i] || '0', 10);
 
-    if (n1 > n2) return 1;
-    if (n2 > n1) return -1;
+    if (n1 > n2) {
+      return 1;
+    }
+    if (n2 > n1) {
+      return -1;
+    }
   }
 
   return 0;


### PR DESCRIPTION
Our style convention has always been to enclose single line conditional blocks in curly braces.  This makes the linter enforce it.
