### PR TITLE
Set interacting hint during trackpad scroll

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -218,6 +218,12 @@ ol.Map = function(options) {
 
   /**
    * @private
+   * @type {?ol.EventsKey}
+   */
+  this.viewChangeListenerKey_ = null;
+
+  /**
+   * @private
    * @type {Array.<ol.EventsKey>}
    */
   this.layerGroupPropertyListenerKeys_ = null;
@@ -1102,10 +1108,17 @@ ol.Map.prototype.handleViewChanged_ = function() {
     ol.events.unlistenByKey(this.viewPropertyListenerKey_);
     this.viewPropertyListenerKey_ = null;
   }
+  if (this.viewChangeListenerKey_) {
+    ol.events.unlistenByKey(this.viewChangeListenerKey_);
+    this.viewChangeListenerKey_ = null;
+  }
   var view = this.getView();
   if (view) {
     this.viewPropertyListenerKey_ = ol.events.listen(
         view, ol.ObjectEventType.PROPERTYCHANGE,
+        this.handleViewPropertyChanged_, this);
+    this.viewChangeListenerKey_ = ol.events.listen(
+        view, ol.events.EventType.CHANGE,
         this.handleViewPropertyChanged_, this);
   }
   this.render();
@@ -1221,7 +1234,6 @@ ol.Map.prototype.removeOverlay = function(overlay) {
  * @private
  */
 ol.Map.prototype.renderFrame_ = function(time) {
-
   var i, ii, viewState;
 
   var size = this.getSize();

--- a/test/spec/ol/map.test.js
+++ b/test/spec/ol/map.test.js
@@ -160,6 +160,23 @@ describe('ol.Map', function() {
       document.body.removeChild(target);
     });
 
+    it('is called when the view.changed() is called', function() {
+      var view = map.getView();
+
+      var spy = sinon.spy(map, 'render');
+      view.changed();
+      expect(spy.callCount).to.be(1);
+    });
+
+    it('is not called on view changes after the view has been removed', function() {
+      var view = map.getView();
+      map.setView(null);
+
+      var spy = sinon.spy(map, 'render');
+      view.changed();
+      expect(spy.callCount).to.be(0);
+    });
+
     it('calls renderFrame_ and results in an postrender event', function(done) {
 
       var spy = sinon.spy(map, 'renderFrame_');


### PR DESCRIPTION
This makes it so the interacting hint is set while scrolling with the trackpad.  This results in more consistent `moveend` handling (this will be fired at the end of a scroll) and let's people control tile loading during interaction (with `loadTilesWhileInteracting`).

The map doesn't currently re-render on generic `CHANGE` events from the view.  5b85f8ecc993367e1a1fb476b6278fed3fda255a makes it so the map also listens for this event.