### PR TITLE
Hint change means view change

### DIFF
--- a/src/ol/interaction/dragpan.js
+++ b/src/ol/interaction/dragpan.js
@@ -110,9 +110,6 @@ ol.interaction.DragPan.handleUpEvent_ = function(mapBrowserEvent) {
         duration: 500,
         easing: ol.easing.easeOut
       });
-    } else {
-      // the view is not updated, force a render
-      map.render();
     }
     view.setHint(ol.View.Hint.INTERACTING, -1);
     return false;

--- a/src/ol/interaction/mousewheelzoom.js
+++ b/src/ol/interaction/mousewheelzoom.js
@@ -223,7 +223,6 @@ ol.interaction.MouseWheelZoom.prototype.decrementInteractingHint_ = function() {
   this.trackpadTimeoutId_ = undefined;
   var view = this.getMap().getView();
   view.setHint(ol.View.Hint.INTERACTING, -1);
-  view.changed(); // notify listeners of the hint change
 };
 
 

--- a/src/ol/interaction/pinchrotate.js
+++ b/src/ol/interaction/pinchrotate.js
@@ -157,7 +157,6 @@ ol.interaction.PinchRotate.handleDownEvent_ = function(mapBrowserEvent) {
     if (!this.handlingDownUpSequence) {
       map.getView().setHint(ol.View.Hint.INTERACTING, 1);
     }
-    map.render();
     return true;
   } else {
     return false;

--- a/src/ol/interaction/pinchzoom.js
+++ b/src/ol/interaction/pinchzoom.js
@@ -140,7 +140,6 @@ ol.interaction.PinchZoom.handleDownEvent_ = function(mapBrowserEvent) {
     if (!this.handlingDownUpSequence) {
       map.getView().setHint(ol.View.Hint.INTERACTING, 1);
     }
-    map.render();
     return true;
   } else {
     return false;

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -826,6 +826,7 @@ ol.View.prototype.setHint = function(hint, delta) {
   this.hints_[hint] += delta;
   ol.DEBUG && console.assert(this.hints_[hint] >= 0,
       'Hint at %s must be positive, was %s', hint, this.hints_[hint]);
+  this.changed();
   return this.hints_[hint];
 };
 

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -280,7 +280,6 @@ ol.View.prototype.cancelAnimations = function() {
     }
   }
   this.animations_.length = 0;
-  this.changed(); // notify that the hint changed
 };
 
 /**

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -301,6 +301,35 @@ describe('ol.View', function() {
 
   });
 
+  describe('#setHint()', function() {
+
+    it('changes a view hint', function() {
+      var view = new ol.View({
+        center: [0, 0],
+        zoom: 0
+      });
+
+      expect(view.getHints()).to.eql([0, 0]);
+
+      view.setHint(ol.View.Hint.INTERACTING, 1);
+      expect(view.getHints()).to.eql([0, 1]);
+    });
+
+    it('triggers the change event', function(done) {
+      var view = new ol.View({
+        center: [0, 0],
+        zoom: 0
+      });
+
+      view.on('change', function() {
+        expect(view.getHints()).to.eql([0, 1]);
+        done();
+      });
+      view.setHint(ol.View.Hint.INTERACTING, 1);
+    });
+
+  });
+
   describe('#animate()', function() {
 
     var originalRequestAnimationFrame = window.requestAnimationFrame;


### PR DESCRIPTION
This makes it so `view.setHint()` triggers `CHANGE`.  This includes the changes from #6120, which makes it so the map schedules a render on view changes.  The result is that when the view goes from interacting to not interacting or animating to not animating, we do what needs to be done post-render (e.g. load tiles).

Fixes #6118.
