### PR TITLE
Add getter for color property to ol.style.Icon

### DIFF
--- a/src/ol/style/icon.js
+++ b/src/ol/style/icon.js
@@ -260,6 +260,16 @@ ol.style.Icon.prototype.getAnchor = function() {
 
 
 /**
+ * Get the icon color.
+ * @return {ol.Color} Color.
+ * @api
+ */
+ol.style.Icon.prototype.getColor = function() {
+  return this.color_;
+};
+
+
+/**
  * Get the image icon.
  * @param {number} pixelRatio Pixel ratio.
  * @return {Image|HTMLCanvasElement} Image or Canvas element.

--- a/test/spec/ol/style/icon.test.js
+++ b/test/spec/ol/style/icon.test.js
@@ -75,7 +75,7 @@ describe('ol.style.Icon', function() {
       expect(original.anchorXUnits_).to.eql(clone.anchorXUnits_);
       expect(original.anchorYUnits_).to.eql(clone.anchorYUnits_);
       expect(original.crossOrigin_).to.eql(clone.crossOrigin_);
-      expect(original.color_).to.eql(clone.color_);
+      expect(original.getColor()).to.eql(clone.getColor());
       expect(original.getImage(1).src).to.eql(clone.getImage(1).src);
       expect(original.getImage(1).toDataURL()).to.eql(original.getImage(1).toDataURL());
       expect(original.offset_).to.eql(clone.offset_);
@@ -108,7 +108,7 @@ describe('ol.style.Icon', function() {
       expect(original.getAnchor()).not.to.be(clone.getAnchor());
       expect(original.getImage(1)).not.to.be(clone.getImage(1));
       expect(original.offset_).not.to.be(clone.offset_);
-      expect(original.color_).not.to.be(clone.color_);
+      expect(original.getColor()).not.to.be(clone.getColor());
       expect(original.getSize()).not.to.be(clone.getSize());
 
       clone.anchor_[0] = 0;


### PR DESCRIPTION
Added getColor() method to class ol.style.Icon similar like in ol.style.Fill and ol.style.Stroke

Fixes #6131.