### PR TITLE
Doc clarification ol.MapBrowserEvent#pixel, ol.MapBrowserEvent#coordinate, ol.Map#getEventCoordinate

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -674,7 +674,7 @@ ol.Map.prototype.hasFeatureAtPixel = function(pixel, opt_layerFilter, opt_this) 
 
 
 /**
- * Returns the geographical coordinate for a browser event.
+ * Returns the coordinate in view projection for a browser event.
  * @param {Event} event Event.
  * @return {ol.Coordinate} Coordinate.
  * @api stable

--- a/src/ol/mapbrowserevent.js
+++ b/src/ol/mapbrowserevent.js
@@ -40,14 +40,14 @@ ol.MapBrowserEvent = function(type, map, browserEvent, opt_dragging,
   this.originalEvent = browserEvent;
 
   /**
-   * The pixel of the original browser event.
+   * The map pixel relative to the viewport corresponding to the original browser event.
    * @type {ol.Pixel}
    * @api stable
    */
   this.pixel = map.getEventPixel(browserEvent);
 
   /**
-   * The coordinate of the original browser event.
+   * The geographical coordinate corresponding the original browser event.
    * @type {ol.Coordinate}
    * @api stable
    */

--- a/src/ol/mapbrowserevent.js
+++ b/src/ol/mapbrowserevent.js
@@ -47,7 +47,7 @@ ol.MapBrowserEvent = function(type, map, browserEvent, opt_dragging,
   this.pixel = map.getEventPixel(browserEvent);
 
   /**
-   * The geographical coordinate corresponding the original browser event.
+   * The coordinate in view projection corresponding to the original browser event.
    * @type {ol.Coordinate}
    * @api stable
    */


### PR DESCRIPTION
Clarified the description of ol.MapBrowserEvent#pixel, ol.MapBrowserEvent#coordinate and ol.Map#getEventCoordinate.
The current description is somewhat misleading:
`pixel {ol.Pixel} The pixel of the original browser event.` could be understood as the pixel attribute having the value [e.clientX, e.clientY] of the original browser event.
Changed it to `The map pixel relative to the viewport corresponding to the original browser event.`

The corresponding change was made for the coordinate property and the description of getEventCoordinate was updated to the same text.