### PR TITLE
Match equivalent projections from WMTS caps

### DIFF
--- a/src/ol/source/wmts.js
+++ b/src/ol/source/wmts.js
@@ -317,9 +317,14 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
             var tileMatrixSet = ol.array.find(tileMatrixSets, function(el) {
               return el['Identifier'] == elt['TileMatrixSet'];
             });
-            return tileMatrixSet['SupportedCRS'].replace(
-                /urn:ogc:def:crs:(\w+):(.*:)?(\w+)$/, '$1:$3'
-                   ) == config['projection'];
+            var supportedCRS = tileMatrixSet['SupportedCRS'].replace(/urn:ogc:def:crs:(\w+):(.*:)?(\w+)$/, '$1:$3');
+            var proj1 = ol.proj.get(supportedCRS);
+            var proj2 = ol.proj.get(config['projection']);
+            if (proj1 && proj2) {
+              return ol.proj.equivalent(proj1, proj2);
+            } else {
+              return supportedCRS == config['projection'];
+            }
           });
     } else {
       idx = ol.array.findIndex(l['TileMatrixSetLink'],

--- a/test/spec/ol/source/wmts.test.js
+++ b/test/spec/ol/source/wmts.test.js
@@ -95,6 +95,16 @@ describe('ol.source.WMTS', function() {
       expect(options.matrixSet).to.be.eql('google3857');
     });
 
+    it('can find a MatrixSet by equivalent SRS identifier', function() {
+      var options = ol.source.WMTS.optionsFromCapabilities(capabilities, {
+        layer: 'BlueMarbleNextGeneration',
+        projection: 'EPSG:900913',
+        requestEncoding: 'REST'
+      });
+
+      expect(options.matrixSet).to.be.eql('google3857');
+    });
+
   });
 
   describe('when creating tileUrlFunction', function() {


### PR DESCRIPTION
Currently, if there is a matrixSet with EPSG:900913, it will not get matched when asking for projection EPSG:3857, we should match equivalent projections when possible and fall-back to the current behaviour if the projections are not known.