### PR TITLE
Remove carriage return after goog.require in examples

### DIFF
--- a/tasks/build-examples.js
+++ b/tasks/build-examples.js
@@ -7,7 +7,7 @@ var marked = require('marked');
 var pkg = require('../package.json');
 
 var markupRegEx = /([^\/^\.]*)\.html$/;
-var cleanupJSRegEx = /.*(\/\/ NOCOMPILE|goog\.require\(.*\);)[\n]*/g;
+var cleanupJSRegEx = /.*(\/\/ NOCOMPILE|goog\.require\(.*\);)[\r\n]*/g;
 var requiresRegEx = /.*goog\.require\('(ol\.\S*)'\);/g;
 var isCssRegEx = /\.css$/;
 var isJsRegEx = /\.js$/;


### PR DESCRIPTION
On Windows, removes lot of empty lines in examples in the beginning of the script