### PR TITLE
Return the expected resolution and center from view.fit and view.centerOn

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -7558,11 +7558,27 @@ olx.view;
 
 /**
  * @typedef {{
+ *     apply: (boolean|undefined)}}
+ */
+olx.view.CenterOnOptions;
+
+
+/**
+ * Apply the new center directly. Default is `true`.
+ * @type {boolean|undefined}
+ * @api
+ */
+olx.view.CenterOnOptions.prototype.apply;
+
+
+/**
+ * @typedef {{
  *     padding: (!Array.<number>|undefined),
  *     constrainResolution: (boolean|undefined),
  *     nearest: (boolean|undefined),
  *     maxZoom: (number|undefined),
- *     minResolution: (number|undefined)}}
+ *     minResolution: (number|undefined),
+ *     apply: (boolean|undefined)}}
  */
 olx.view.FitOptions;
 
@@ -7607,6 +7623,14 @@ olx.view.FitOptions.prototype.minResolution;
  * @api
  */
 olx.view.FitOptions.prototype.maxZoom;
+
+
+/**
+ * Apply the new center and resolution directly. Default is `true`.
+ * @type {boolean|undefined}
+ * @api
+ */
+olx.view.FitOptions.prototype.apply;
 
 
 /* typedefs for object literals exposed by the library */

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -674,6 +674,8 @@ ol.View.prototype.getZoom = function() {
  * @param {ol.geom.SimpleGeometry|ol.Extent} geometry Geometry.
  * @param {ol.Size} size Box pixel size.
  * @param {olx.view.FitOptions=} opt_options Options.
+ * @return {olx.AnimationOptions} Object containing the new resolution and
+ * center, that can be used for animations.
  * @api
  */
 ol.View.prototype.fit = function(geometry, size, opt_options) {
@@ -735,7 +737,9 @@ ol.View.prototype.fit = function(geometry, size, opt_options) {
     }
     resolution = constrainedResolution;
   }
-  this.setResolution(resolution);
+  if (options.apply !== undefined ? options.apply : true) {
+    this.setResolution(resolution);
+  }
 
   // calculate center
   sinAngle = -sinAngle; // go back to original rotation
@@ -745,8 +749,16 @@ ol.View.prototype.fit = function(geometry, size, opt_options) {
   centerRotY += (padding[0] - padding[2]) / 2 * resolution;
   var centerX = centerRotX * cosAngle - centerRotY * sinAngle;
   var centerY = centerRotY * cosAngle + centerRotX * sinAngle;
+  var center = [centerX, centerY];
 
-  this.setCenter([centerX, centerY]);
+  if (options.apply !== undefined ? options.apply : true) {
+    this.setCenter(center);
+  }
+
+  return {
+    resolution: resolution,
+    center: center
+  };
 };
 
 
@@ -755,9 +767,14 @@ ol.View.prototype.fit = function(geometry, size, opt_options) {
  * @param {ol.Coordinate} coordinate Coordinate.
  * @param {ol.Size} size Box pixel size.
  * @param {ol.Pixel} position Position on the view to center on.
+ * @param {olx.view.CenterOnOptions=} opt_options Options.
+ * @return {olx.AnimationOptions} Object containing the new center that can be
+ * used for animations.
  * @api
  */
-ol.View.prototype.centerOn = function(coordinate, size, position) {
+ol.View.prototype.centerOn = function(coordinate, size, position, opt_options) {
+  var options = opt_options || {};
+
   // calculate rotated position
   var rotation = this.getRotation();
   var cosAngle = Math.cos(-rotation);
@@ -772,8 +789,15 @@ ol.View.prototype.centerOn = function(coordinate, size, position) {
   sinAngle = -sinAngle; // go back to original rotation
   var centerX = rotX * cosAngle - rotY * sinAngle;
   var centerY = rotY * cosAngle + rotX * sinAngle;
+  var center = [centerX, centerY];
 
-  this.setCenter([centerX, centerY]);
+  if (options.apply !== undefined ? options.apply : true) {
+    this.setCenter(center);
+  }
+
+  return {
+    center: center
+  };
 };
 
 

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -876,6 +876,29 @@ describe('ol.View', function() {
       expect(view.getCenter()[0]).to.be(1500);
       expect(view.getCenter()[1]).to.be(1500);
     });
+    it('returns the new center and resolution', function() {
+      var fitResult = view.fit(
+          new ol.geom.LineString([[6000, 46000], [6000, 47100], [7000, 46000]]),
+          [200, 200],
+          {padding: [100, 0, 0, 100], constrainResolution: false});
+
+      expect(fitResult.resolution).to.be(11);
+      expect(fitResult.center[0]).to.be(5950);
+      expect(fitResult.center[1]).to.be(47100);
+    });
+    it('does not apply if apply option is false', function() {
+      var fitResult = view.fit(
+          new ol.geom.LineString([[6000, 46000], [6000, 47100], [7000, 46000]]),
+          [200, 200],
+          {padding: [100, 0, 0, 100], constrainResolution: false, apply: false});
+
+      expect(view.getResolution()).to.be(undefined);
+      expect(view.getCenter()).to.be(null);
+
+      expect(fitResult.resolution).to.be(11);
+      expect(fitResult.center[0]).to.be(5950);
+      expect(fitResult.center[1]).to.be(47100);
+    });
     it('throws on invalid geometry/extent value', function() {
       expect(function() {
         view.fit(true, [200, 200]);
@@ -913,6 +936,31 @@ describe('ol.View', function() {
       );
       expect(view.getCenter()[0]).to.roughlyEqual(4585.78643762691, 1e-9);
       expect(view.getCenter()[1]).to.roughlyEqual(46000, 1e-9);
+    });
+    it('returns the new center', function() {
+      view.setResolution(10);
+      var centerOnResult = view.centerOn(
+          [6000, 46000],
+          [400, 400],
+          [300, 300]
+      );
+
+      expect(centerOnResult.center[0]).to.be(5000);
+      expect(centerOnResult.center[1]).to.be(47000);
+    });
+    it('does not apply if apply option is false', function() {
+      view.setResolution(10);
+      var centerOnResult = view.centerOn(
+          [6000, 46000],
+          [400, 400],
+          [300, 300],
+          {apply: false}
+      );
+
+      expect(view.getCenter()).to.be(null);
+
+      expect(centerOnResult.center[0]).to.be(5000);
+      expect(centerOnResult.center[1]).to.be(47000);
     });
   });
 });


### PR DESCRIPTION
... and add an apply option to prevent the application of the new resolution and center. That way, the result can be used in the animate method instead

Alternative fix for #6170 

Can be used that way : 
````js
var fitResult = view.fit(polygon, size, {apply: false});

// Can set a duration and/or easing :
fitResult.duration = 1000;

view.animate(fitResult);
````