### PR TITLE
KML ExtendedData Export

### DIFF
--- a/src/ol/format/kml.js
+++ b/src/ol/format/kml.js
@@ -2558,7 +2558,8 @@ ol.format.KML.writePlacemark_ = function(node, feature, objectStack) {
 
   // don't export these to ExtendedData
   var filter = {'address': 1, 'description': 1, 'name': 1, 'open': 1,
-    'phoneNumber': 1, 'styleUrl': 1, 'visibility': 1, 'geometry': 1};
+    'phoneNumber': 1, 'styleUrl': 1, 'visibility': 1};
+  filter[feature.getGeometryName()] = 1;
   var keys = Object.keys(properties || {}).sort().filter(function(v) {
     return !filter[v];
   });

--- a/src/ol/format/xsd.js
+++ b/src/ol/format/xsd.js
@@ -115,6 +115,15 @@ ol.format.XSD.writeBooleanTextNode = function(node, bool) {
 
 
 /**
+ * @param {Node} node Node to append a CDATA Section with the string to.
+ * @param {string} string String.
+ */
+ol.format.XSD.writeCDATASection = function(node, string) {
+  node.appendChild(ol.xml.DOCUMENT.createCDATASection(string));
+};
+
+
+/**
  * @param {Node} node Node to append a TextNode with the dateTime to.
  * @param {number} dateTime DateTime in seconds.
  */

--- a/test/spec/ol/format/kml.test.js
+++ b/test/spec/ol/format/kml.test.js
@@ -1487,6 +1487,83 @@ describe('ol.format.KML', function() {
 
       describe('extended data', function() {
 
+        it('can write ExtendedData with no values', function() {
+          var feature = new ol.Feature();
+          feature.set('foo', null);
+          feature.set('bar', undefined);
+          var features = [feature];
+          var node = format.writeFeaturesNode(features);
+          var text =
+              '<kml xmlns="http://www.opengis.net/kml/2.2"' +
+              ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
+              ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"' +
+              ' xsi:schemaLocation="http://www.opengis.net/kml/2.2' +
+              ' https://developers.google.com/kml/schema/kml22gx.xsd">' +
+              '  <Placemark>' +
+              '    <ExtendedData>' +
+              '      <Data name="bar"/>' +
+              '      <Data name="foo"/>' +
+              '    </ExtendedData>' +
+              '  </Placemark>' +
+              '</kml>';
+          expect(node).to.xmleql(ol.xml.parse(text));
+        });
+
+        it('can write ExtendedData with values', function() {
+          var feature = new ol.Feature();
+          feature.set('foo', 'bar');
+          feature.set('aNumber', 1000);
+          var features = [feature];
+          var node = format.writeFeaturesNode(features);
+          var text =
+              '<kml xmlns="http://www.opengis.net/kml/2.2"' +
+              ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
+              ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"' +
+              ' xsi:schemaLocation="http://www.opengis.net/kml/2.2' +
+              ' https://developers.google.com/kml/schema/kml22gx.xsd">' +
+              '  <Placemark>' +
+              '    <ExtendedData>' +
+              '      <Data name="aNumber">' +
+              '        <value>1000</value>' +
+              '      </Data>' +
+              '      <Data name="foo">' +
+              '        <value>bar</value>' +
+              '      </Data>' +
+              '    </ExtendedData>' +
+              '  </Placemark>' +
+              '</kml>';
+          expect(node).to.xmleql(ol.xml.parse(text));
+        });
+
+        it('can write ExtendedData pair with displayName and value', function() {
+          var pair = {
+            value: 'bar',
+            displayName: 'display name'
+          };
+
+          var feature = new ol.Feature();
+          feature.set('foo', pair);
+
+          var features = [feature];
+          var node = format.writeFeaturesNode(features);
+          var text =
+              '<kml xmlns="http://www.opengis.net/kml/2.2"' +
+              ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
+              ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"' +
+              ' xsi:schemaLocation="http://www.opengis.net/kml/2.2' +
+              ' https://developers.google.com/kml/schema/kml22gx.xsd">' +
+              '  <Placemark>' +
+              '    <ExtendedData>' +
+              '      <Data name="foo">' +
+              '        <displayName><![CDATA[display name]]></displayName>' +
+              '        <value>bar</value>' +
+              '      </Data>' +
+              '    </ExtendedData>' +
+              '  </Placemark>' +
+              '</kml>';
+          expect(node).to.xmleql(ol.xml.parse(text));
+        });
+
         it('can read ExtendedData', function() {
           var text =
               '<kml xmlns="http://earth.google.com/kml/2.2">' +


### PR DESCRIPTION
ol.format.KML feature writers can now export ExtendedData

Keys in the properties object will be exported in the ExtendedData node unless they are part of another export method.

Support for [typed data](https://developers.google.com/kml/documentation/extendeddata#adding-typed-data-to-a-feature) and [arbitrary XML data](https://developers.google.com/kml/documentation/extendeddata#adding-arbitrary-xml-data-to-a-feature) should be added.