### PR TITLE
Remove assertion in TileArcGISRest source

### DIFF
--- a/src/ol/source/tilearcgisrest.js
+++ b/src/ol/source/tilearcgisrest.js
@@ -1,7 +1,6 @@
 goog.provide('ol.source.TileArcGISRest');
 
 goog.require('ol');
-goog.require('ol.asserts');
 goog.require('ol.extent');
 goog.require('ol.math');
 goog.require('ol.obj');
@@ -125,9 +124,6 @@ ol.source.TileArcGISRest.prototype.getRequestUrl_ = function(tileCoord, tileSize
   var modifiedUrl = url
       .replace(/MapServer\/?$/, 'MapServer/export')
       .replace(/ImageServer\/?$/, 'ImageServer/exportImage');
-  if (modifiedUrl == url) {
-    ol.asserts.assert(false, 50); // Cannot determine Rest Service from url
-  }
   return ol.uri.appendParams(modifiedUrl, params);
 };
 


### PR DESCRIPTION
This removes an assertion that causes URLs like `http://example.com/arcgis/rest/services/foo/ImageServer/exportImage` to break the TileArcGISRest source.

See https://github.com/openlayers/ol3/commit/cd2dfc7f108da15f3bc4a1ce15a85629e39b0e91#commitcomment-20055596
