### PR TITLE
Allow animation duration to be zero

### DIFF
--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -222,7 +222,7 @@ ol.View.prototype.animate = function(var_args) {
       start: start,
       complete: false,
       anchor: options.anchor,
-      duration: options.duration || 1000,
+      duration: options.duration !== undefined ? options.duration : 1000,
       easing: options.easing || ol.easing.inAndOut
     });
 

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -369,6 +369,26 @@ describe('ol.View', function() {
       }, 50);
     });
 
+    it('allows duration to be zero', function(done) {
+      var view = new ol.View({
+        center: [0, 0],
+        zoom: 5
+      });
+
+      view.animate({
+        zoom: 4,
+        duration: 0
+      });
+      expect(view.getAnimating()).to.eql(true);
+
+      setTimeout(function() {
+        expect(view.getCenter()).to.eql([0, 0]);
+        expect(view.getZoom()).to.eql(4);
+        expect(view.getAnimating()).to.eql(false);
+        done();
+      }, 10);
+    });
+
     it('prefers zoom over resolution', function(done) {
       var view = new ol.View({
         center: [0, 0],


### PR DESCRIPTION
I'll admit I don't see a good use case for this, but the old animation system allowed for it.

Fixes #6191.