### PR TITLE
Refactored proj modules

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -35,6 +35,22 @@ view.animate({
 });
 ```
 
+#### Use `ol.proj.getPointResolution()` instead of `projection.getPointResolution()`
+
+The experimental `getPointResolution` method has been removed from `ol.Projection` instances.  Since the implementation of this method required an inverse transform (function for transforming projected coordinates to geographic coordinates) and `ol.Projection` instances are not constructed with forward or inverse transforms, it does not make sense that a projection instance can always calculate the point resolution.
+
+As a substitute for the `projection.getPointResolution()` function, a `ol.proj.getPointResolution()` function has been added.  To upgrade, you will need to change things like this:
+```js
+projection.getPointResolution(resolution, point);
+```
+
+into this:
+```js
+ol.proj.getPointResolution(projection, resolution, point);
+```
+
+Note that if you were previously creating a projection with a `getPointResolution` function in the constructor (or calling `projection.setGetPointResolution()` after construction), this function will be used by `ol.proj.getPointResolution()`.
+
 ### v3.19.1
 
 #### `ol.style.Fill` with `CanvasGradient` or `CanvasPattern`

--- a/src/ol/control/scaleline.js
+++ b/src/ol/control/scaleline.js
@@ -6,6 +6,7 @@ goog.require('ol.asserts');
 goog.require('ol.control.Control');
 goog.require('ol.css');
 goog.require('ol.events');
+goog.require('ol.proj');
 goog.require('ol.proj.METERS_PER_UNIT');
 goog.require('ol.proj.Units');
 
@@ -169,7 +170,7 @@ ol.control.ScaleLine.prototype.updateElement_ = function() {
   var projection = viewState.projection;
   var metersPerUnit = projection.getMetersPerUnit();
   var pointResolution =
-      projection.getPointResolution(viewState.resolution, center) *
+      ol.proj.getPointResolution(projection, viewState.resolution, center) *
       metersPerUnit;
 
   var nominalCount = this.minWidth_ * pointResolution;

--- a/src/ol/control/scaleline.js
+++ b/src/ol/control/scaleline.js
@@ -7,7 +7,6 @@ goog.require('ol.control.Control');
 goog.require('ol.css');
 goog.require('ol.events');
 goog.require('ol.proj');
-goog.require('ol.proj.METERS_PER_UNIT');
 goog.require('ol.proj.Units');
 
 

--- a/src/ol/proj/epsg3857.js
+++ b/src/ol/proj/epsg3857.js
@@ -22,18 +22,13 @@ ol.proj.EPSG3857_ = function(code) {
     units: ol.proj.Units.METERS,
     extent: ol.proj.EPSG3857.EXTENT,
     global: true,
-    worldExtent: ol.proj.EPSG3857.WORLD_EXTENT
+    worldExtent: ol.proj.EPSG3857.WORLD_EXTENT,
+    getPointResolution: function(resolution, point) {
+      return resolution / ol.math.cosh(point[1] / ol.proj.EPSG3857.RADIUS);
+    }
   });
 };
 ol.inherits(ol.proj.EPSG3857_, ol.proj.Projection);
-
-
-/**
- * @inheritDoc
- */
-ol.proj.EPSG3857_.prototype.getPointResolution = function(resolution, point) {
-  return resolution / ol.math.cosh(point[1] / ol.proj.EPSG3857.RADIUS);
-};
 
 
 /**

--- a/src/ol/proj/epsg4326.js
+++ b/src/ol/proj/epsg4326.js
@@ -36,14 +36,6 @@ ol.inherits(ol.proj.EPSG4326_, ol.proj.Projection);
 
 
 /**
- * @inheritDoc
- */
-ol.proj.EPSG4326_.prototype.getPointResolution = function(resolution, point) {
-  return resolution;
-};
-
-
-/**
  * Extent of the EPSG:4326 projection which is the whole world.
  *
  * @const

--- a/src/ol/proj/index.js
+++ b/src/ol/proj/index.js
@@ -5,6 +5,7 @@ goog.provide('ol.proj.Projection');
 goog.require('ol');
 goog.require('ol.extent');
 goog.require('ol.proj.Units');
+goog.require('ol.proj.proj4');
 goog.require('ol.proj.projections');
 goog.require('ol.proj.transforms');
 goog.require('ol.sphere.NORMAL');
@@ -24,13 +25,6 @@ ol.proj.METERS_PER_UNIT[ol.proj.Units.METERS] = 1;
 ol.proj.METERS_PER_UNIT[ol.proj.Units.USFEET] = 1200 / 3937;
 
 
-/**
- * @private
- * @type {proj4}
- */
-ol.proj.proj4_ = null;
-
-
 if (ol.ENABLE_PROJ4JS) {
   /**
    * Register proj4. If not explicitly registered, it will be assumed that
@@ -47,7 +41,7 @@ if (ol.ENABLE_PROJ4JS) {
   ol.proj.setProj4 = function(proj4) {
     ol.DEBUG && console.assert(typeof proj4 == 'function',
         'proj4 argument should be a function');
-    ol.proj.proj4_ = proj4;
+    ol.proj.proj4.set(proj4);
   };
 }
 
@@ -151,7 +145,7 @@ ol.proj.Projection = function(options) {
   ol.DEBUG && console.assert(code !== undefined,
       'Option "code" is required for constructing instance');
   if (ol.ENABLE_PROJ4JS) {
-    var proj4js = ol.proj.proj4_ || window['proj4'];
+    var proj4js = ol.proj.proj4.get();
     if (typeof proj4js == 'function' && !ol.proj.projections.get(code)) {
       var def = proj4js.defs(code);
       if (def !== undefined) {
@@ -579,7 +573,7 @@ ol.proj.get = function(projectionLike) {
     var code = projectionLike;
     projection = ol.proj.projections.get(code);
     if (ol.ENABLE_PROJ4JS) {
-      var proj4js = ol.proj.proj4_ || window['proj4'];
+      var proj4js = ol.proj.proj4.get();
       if (!projection && typeof proj4js == 'function' &&
           proj4js.defs(code) !== undefined) {
         projection = new ol.proj.Projection({code: code});
@@ -648,7 +642,7 @@ ol.proj.getTransformFromProjections = function(sourceProjection, destinationProj
   var destinationCode = destinationProjection.getCode();
   var transform = ol.proj.transforms.get(sourceCode, destinationCode);
   if (ol.ENABLE_PROJ4JS && !transform) {
-    var proj4js = ol.proj.proj4_ || window['proj4'];
+    var proj4js = ol.proj.proj4.get();
     if (typeof proj4js == 'function') {
       var sourceDef = proj4js.defs(sourceCode);
       var destinationDef = proj4js.defs(destinationCode);

--- a/src/ol/proj/index.js
+++ b/src/ol/proj/index.js
@@ -1,27 +1,12 @@
 goog.provide('ol.proj');
 goog.provide('ol.proj.METERS_PER_UNIT');
 goog.provide('ol.proj.Projection');
-goog.provide('ol.proj.Units');
 
 goog.require('ol');
 goog.require('ol.extent');
 goog.require('ol.obj');
+goog.require('ol.proj.Units');
 goog.require('ol.sphere.NORMAL');
-
-
-/**
- * Projection units: `'degrees'`, `'ft'`, `'m'`, `'pixels'`, `'tile-pixels'` or
- * `'us-ft'`.
- * @enum {string}
- */
-ol.proj.Units = {
-  DEGREES: 'degrees',
-  FEET: 'ft',
-  METERS: 'm',
-  PIXELS: 'pixels',
-  TILE_PIXELS: 'tile-pixels',
-  USFEET: 'us-ft'
-};
 
 
 /**

--- a/src/ol/proj/index.js
+++ b/src/ol/proj/index.js
@@ -1,5 +1,4 @@
 goog.provide('ol.proj');
-goog.provide('ol.proj.METERS_PER_UNIT');
 
 goog.require('ol');
 goog.require('ol.extent');

--- a/src/ol/proj/proj4.js
+++ b/src/ol/proj/proj4.js
@@ -1,0 +1,26 @@
+goog.provide('ol.proj.proj4');
+
+
+/**
+ * @private
+ * @type {proj4}
+ */
+ol.proj.proj4.cache_ = null;
+
+
+/**
+ * Store the proj4 function.
+ * @param {proj4} proj4 The proj4 function.
+ */
+ol.proj.proj4.set = function(proj4) {
+  ol.proj.proj4.cache_ = proj4;
+};
+
+
+/**
+ * Get proj4.
+ * @return {proj4} The proj4 function set above or available globally.
+ */
+ol.proj.proj4.get = function() {
+  return ol.proj.proj4.cache_ || window['proj4'];
+};

--- a/src/ol/proj/projection.js
+++ b/src/ol/proj/projection.js
@@ -1,0 +1,277 @@
+goog.provide('ol.proj.Projection');
+
+goog.require('ol');
+goog.require('ol.proj.Units');
+goog.require('ol.proj.proj4');
+
+
+/**
+ * @classdesc
+ * Projection definition class. One of these is created for each projection
+ * supported in the application and stored in the {@link ol.proj} namespace.
+ * You can use these in applications, but this is not required, as API params
+ * and options use {@link ol.ProjectionLike} which means the simple string
+ * code will suffice.
+ *
+ * You can use {@link ol.proj.get} to retrieve the object for a particular
+ * projection.
+ *
+ * The library includes definitions for `EPSG:4326` and `EPSG:3857`, together
+ * with the following aliases:
+ * * `EPSG:4326`: CRS:84, urn:ogc:def:crs:EPSG:6.6:4326,
+ *     urn:ogc:def:crs:OGC:1.3:CRS84, urn:ogc:def:crs:OGC:2:84,
+ *     http://www.opengis.net/gml/srs/epsg.xml#4326,
+ *     urn:x-ogc:def:crs:EPSG:4326
+ * * `EPSG:3857`: EPSG:102100, EPSG:102113, EPSG:900913,
+ *     urn:ogc:def:crs:EPSG:6.18:3:3857,
+ *     http://www.opengis.net/gml/srs/epsg.xml#3857
+ *
+ * If you use proj4js, aliases can be added using `proj4.defs()`; see
+ * [documentation](https://github.com/proj4js/proj4js). To set an alternative
+ * namespace for proj4, use {@link ol.proj.setProj4}.
+ *
+ * @constructor
+ * @param {olx.ProjectionOptions} options Projection options.
+ * @struct
+ * @api stable
+ */
+ol.proj.Projection = function(options) {
+
+  /**
+   * @private
+   * @type {string}
+   */
+  this.code_ = options.code;
+
+  /**
+   * @private
+   * @type {ol.proj.Units}
+   */
+  this.units_ = /** @type {ol.proj.Units} */ (options.units);
+
+  /**
+   * @private
+   * @type {ol.Extent}
+   */
+  this.extent_ = options.extent !== undefined ? options.extent : null;
+
+  /**
+   * @private
+   * @type {ol.Extent}
+   */
+  this.worldExtent_ = options.worldExtent !== undefined ?
+      options.worldExtent : null;
+
+  /**
+   * @private
+   * @type {string}
+   */
+  this.axisOrientation_ = options.axisOrientation !== undefined ?
+      options.axisOrientation : 'enu';
+
+  /**
+   * @private
+   * @type {boolean}
+   */
+  this.global_ = options.global !== undefined ? options.global : false;
+
+  /**
+   * @private
+   * @type {boolean}
+   */
+  this.canWrapX_ = !!(this.global_ && this.extent_);
+
+  /**
+  * @private
+  * @type {function(number, ol.Coordinate):number|undefined}
+  */
+  this.getPointResolutionFunc_ = options.getPointResolution;
+
+  /**
+   * @private
+   * @type {ol.tilegrid.TileGrid}
+   */
+  this.defaultTileGrid_ = null;
+
+  /**
+   * @private
+   * @type {number|undefined}
+   */
+  this.metersPerUnit_ = options.metersPerUnit;
+
+  var code = options.code;
+  ol.DEBUG && console.assert(code !== undefined,
+      'Option "code" is required for constructing instance');
+  if (ol.ENABLE_PROJ4JS) {
+    var proj4js = ol.proj.proj4.get();
+    if (typeof proj4js == 'function') {
+      var def = proj4js.defs(code);
+      if (def !== undefined) {
+        if (def.axis !== undefined && options.axisOrientation === undefined) {
+          this.axisOrientation_ = def.axis;
+        }
+        if (options.metersPerUnit === undefined) {
+          this.metersPerUnit_ = def.to_meter;
+        }
+        if (options.units === undefined) {
+          this.units_ = def.units;
+        }
+      }
+    }
+  }
+
+};
+
+
+/**
+ * @return {boolean} The projection is suitable for wrapping the x-axis
+ */
+ol.proj.Projection.prototype.canWrapX = function() {
+  return this.canWrapX_;
+};
+
+
+/**
+ * Get the code for this projection, e.g. 'EPSG:4326'.
+ * @return {string} Code.
+ * @api stable
+ */
+ol.proj.Projection.prototype.getCode = function() {
+  return this.code_;
+};
+
+
+/**
+ * Get the validity extent for this projection.
+ * @return {ol.Extent} Extent.
+ * @api stable
+ */
+ol.proj.Projection.prototype.getExtent = function() {
+  return this.extent_;
+};
+
+
+/**
+ * Get the units of this projection.
+ * @return {ol.proj.Units} Units.
+ * @api stable
+ */
+ol.proj.Projection.prototype.getUnits = function() {
+  return this.units_;
+};
+
+
+/**
+ * Get the amount of meters per unit of this projection.  If the projection is
+ * not configured with `metersPerUnit` or a units identifier, the return is
+ * `undefined`.
+ * @return {number|undefined} Meters.
+ * @api stable
+ */
+ol.proj.Projection.prototype.getMetersPerUnit = function() {
+  return this.metersPerUnit_ || ol.proj.Units.METERS_PER_UNIT[this.units_];
+};
+
+
+/**
+ * Get the world extent for this projection.
+ * @return {ol.Extent} Extent.
+ * @api
+ */
+ol.proj.Projection.prototype.getWorldExtent = function() {
+  return this.worldExtent_;
+};
+
+
+/**
+ * Get the axis orientation of this projection.
+ * Example values are:
+ * enu - the default easting, northing, elevation.
+ * neu - northing, easting, up - useful for "lat/long" geographic coordinates,
+ *     or south orientated transverse mercator.
+ * wnu - westing, northing, up - some planetary coordinate systems have
+ *     "west positive" coordinate systems
+ * @return {string} Axis orientation.
+ */
+ol.proj.Projection.prototype.getAxisOrientation = function() {
+  return this.axisOrientation_;
+};
+
+
+/**
+ * Is this projection a global projection which spans the whole world?
+ * @return {boolean} Whether the projection is global.
+ * @api stable
+ */
+ol.proj.Projection.prototype.isGlobal = function() {
+  return this.global_;
+};
+
+
+/**
+* Set if the projection is a global projection which spans the whole world
+* @param {boolean} global Whether the projection is global.
+* @api stable
+*/
+ol.proj.Projection.prototype.setGlobal = function(global) {
+  this.global_ = global;
+  this.canWrapX_ = !!(global && this.extent_);
+};
+
+
+/**
+ * @return {ol.tilegrid.TileGrid} The default tile grid.
+ */
+ol.proj.Projection.prototype.getDefaultTileGrid = function() {
+  return this.defaultTileGrid_;
+};
+
+
+/**
+ * @param {ol.tilegrid.TileGrid} tileGrid The default tile grid.
+ */
+ol.proj.Projection.prototype.setDefaultTileGrid = function(tileGrid) {
+  this.defaultTileGrid_ = tileGrid;
+};
+
+
+/**
+ * Set the validity extent for this projection.
+ * @param {ol.Extent} extent Extent.
+ * @api stable
+ */
+ol.proj.Projection.prototype.setExtent = function(extent) {
+  this.extent_ = extent;
+  this.canWrapX_ = !!(this.global_ && extent);
+};
+
+
+/**
+ * Set the world extent for this projection.
+ * @param {ol.Extent} worldExtent World extent
+ *     [minlon, minlat, maxlon, maxlat].
+ * @api
+ */
+ol.proj.Projection.prototype.setWorldExtent = function(worldExtent) {
+  this.worldExtent_ = worldExtent;
+};
+
+
+/**
+ * Set the getPointResolution function for this projection.
+ * @param {function(number, ol.Coordinate):number} func Function
+ * @api
+ */
+ol.proj.Projection.prototype.setGetPointResolution = function(func) {
+  this.getPointResolutionFunc_ = func;
+};
+
+
+/**
+ * Get the custom point resolution function for this projection (if set).
+ * @return {function(number, ol.Coordinate):number|undefined} The custom point
+ * resolution function (if set).
+ */
+ol.proj.Projection.prototype.getPointResolutionFunc = function() {
+  return this.getPointResolutionFunc_;
+};

--- a/src/ol/proj/projections.js
+++ b/src/ol/proj/projections.js
@@ -1,0 +1,38 @@
+goog.provide('ol.proj.projections');
+
+
+/**
+ * @private
+ * @type {Object.<string, ol.proj.Projection>}
+ */
+ol.proj.projections.cache_ = {};
+
+
+/**
+ * Clear the projections cache.
+ */
+ol.proj.projections.clear = function() {
+  ol.proj.projections.cache_ = {};
+};
+
+
+/**
+ * Get a cached projection by code.
+ * @param {string} code The code for the projection.
+ * @return {ol.proj.Projection} The projection (if cached).
+ */
+ol.proj.projections.get = function(code) {
+  var projections = ol.proj.projections.cache_;
+  return projections[code] || null;
+};
+
+
+/**
+ * Add a projection to the cache.
+ * @param {string} code The projection code.
+ * @param {ol.proj.Projection} projection The projection to cache.
+ */
+ol.proj.projections.add = function(code, projection) {
+  var projections = ol.proj.projections.cache_;
+  projections[code] = projection;
+};

--- a/src/ol/proj/transforms.js
+++ b/src/ol/proj/transforms.js
@@ -1,0 +1,80 @@
+goog.provide('ol.proj.transforms');
+
+goog.require('ol');
+goog.require('ol.obj');
+
+
+/**
+ * @private
+ * @type {Object.<string, Object.<string, ol.TransformFunction>>}
+ */
+ol.proj.transforms.cache_ = {};
+
+
+/**
+ * Clear the transform cache.
+ */
+ol.proj.transforms.clear = function() {
+  ol.proj.transforms.cache_ = {};
+};
+
+
+/**
+ * Registers a conversion function to convert coordinates from the source
+ * projection to the destination projection.
+ *
+ * @param {ol.proj.Projection} source Source.
+ * @param {ol.proj.Projection} destination Destination.
+ * @param {ol.TransformFunction} transformFn Transform.
+ */
+ol.proj.transforms.add = function(source, destination, transformFn) {
+  var sourceCode = source.getCode();
+  var destinationCode = destination.getCode();
+  var transforms = ol.proj.transforms.cache_;
+  if (!(sourceCode in transforms)) {
+    transforms[sourceCode] = {};
+  }
+  transforms[sourceCode][destinationCode] = transformFn;
+};
+
+
+/**
+ * Unregisters the conversion function to convert coordinates from the source
+ * projection to the destination projection.  This method is used to clean up
+ * cached transforms during testing.
+ *
+ * @param {ol.proj.Projection} source Source projection.
+ * @param {ol.proj.Projection} destination Destination projection.
+ * @return {ol.TransformFunction} transformFn The unregistered transform.
+ */
+ol.proj.transforms.remove = function(source, destination) {
+  var sourceCode = source.getCode();
+  var destinationCode = destination.getCode();
+  var transforms = ol.proj.transforms.cache_;
+  ol.DEBUG && console.assert(sourceCode in transforms,
+      'sourceCode should be in transforms');
+  ol.DEBUG && console.assert(destinationCode in transforms[sourceCode],
+      'destinationCode should be in transforms of sourceCode');
+  var transform = transforms[sourceCode][destinationCode];
+  delete transforms[sourceCode][destinationCode];
+  if (ol.obj.isEmpty(transforms[sourceCode])) {
+    delete transforms[sourceCode];
+  }
+  return transform;
+};
+
+
+/**
+ * Get a transform given a source code and a destination code.
+ * @param {string} sourceCode The code for the source projection.
+ * @param {string} destinationCode The code for the destination projection.
+ * @return {?ol.TransformFunction} The transform function (if found).
+ */
+ol.proj.transforms.get = function(sourceCode, destinationCode) {
+  var transform = null;
+  var transforms = ol.proj.transforms.cache_;
+  if (sourceCode in transforms && destinationCode in transforms[sourceCode]) {
+    transform = transforms[sourceCode][destinationCode];
+  }
+  return transform;
+};

--- a/src/ol/proj/transforms.js
+++ b/src/ol/proj/transforms.js
@@ -68,10 +68,10 @@ ol.proj.transforms.remove = function(source, destination) {
  * Get a transform given a source code and a destination code.
  * @param {string} sourceCode The code for the source projection.
  * @param {string} destinationCode The code for the destination projection.
- * @return {?ol.TransformFunction} The transform function (if found).
+ * @return {ol.TransformFunction|undefined} The transform function (if found).
  */
 ol.proj.transforms.get = function(sourceCode, destinationCode) {
-  var transform = null;
+  var transform;
   var transforms = ol.proj.transforms.cache_;
   if (sourceCode in transforms && destinationCode in transforms[sourceCode]) {
     transform = transforms[sourceCode][destinationCode];

--- a/src/ol/proj/units.js
+++ b/src/ol/proj/units.js
@@ -1,0 +1,16 @@
+goog.provide('ol.proj.Units');
+
+
+/**
+ * Projection units: `'degrees'`, `'ft'`, `'m'`, `'pixels'`, `'tile-pixels'` or
+ * `'us-ft'`.
+ * @enum {string}
+ */
+ol.proj.Units = {
+  DEGREES: 'degrees',
+  FEET: 'ft',
+  METERS: 'm',
+  PIXELS: 'pixels',
+  TILE_PIXELS: 'tile-pixels',
+  USFEET: 'us-ft'
+};

--- a/src/ol/proj/units.js
+++ b/src/ol/proj/units.js
@@ -1,5 +1,7 @@
 goog.provide('ol.proj.Units');
 
+goog.require('ol.sphere.NORMAL');
+
 
 /**
  * Projection units: `'degrees'`, `'ft'`, `'m'`, `'pixels'`, `'tile-pixels'` or
@@ -14,3 +16,17 @@ ol.proj.Units = {
   TILE_PIXELS: 'tile-pixels',
   USFEET: 'us-ft'
 };
+
+
+/**
+ * Meters per unit lookup table.
+ * @const
+ * @type {Object.<ol.proj.Units, number>}
+ * @api stable
+ */
+ol.proj.Units.METERS_PER_UNIT = {};
+ol.proj.Units.METERS_PER_UNIT[ol.proj.Units.DEGREES] =
+    2 * Math.PI * ol.sphere.NORMAL.radius / 360;
+ol.proj.Units.METERS_PER_UNIT[ol.proj.Units.FEET] = 0.3048;
+ol.proj.Units.METERS_PER_UNIT[ol.proj.Units.METERS] = 1;
+ol.proj.Units.METERS_PER_UNIT[ol.proj.Units.USFEET] = 1200 / 3937;

--- a/src/ol/reproj/index.js
+++ b/src/ol/reproj/index.js
@@ -50,7 +50,7 @@ ol.reproj.calculateSourceResolution = function(sourceProj, targetProj,
 
   // calculate the ideal resolution of the source data
   var sourceResolution =
-      targetProj.getPointResolution(targetResolution, targetCenter);
+      ol.proj.getPointResolution(targetProj, targetResolution, targetCenter);
 
   var targetMetersPerUnit = targetProj.getMetersPerUnit();
   if (targetMetersPerUnit !== undefined) {
@@ -66,7 +66,7 @@ ol.reproj.calculateSourceResolution = function(sourceProj, targetProj,
   // in order to achieve optimal results.
 
   var compensationFactor =
-      sourceProj.getPointResolution(sourceResolution, sourceCenter) /
+      ol.proj.getPointResolution(sourceProj, sourceResolution, sourceCenter) /
       sourceResolution;
 
   if (isFinite(compensationFactor) && compensationFactor > 0) {

--- a/src/ol/tilegrid/index.js
+++ b/src/ol/tilegrid/index.js
@@ -6,7 +6,6 @@ goog.require('ol.extent');
 goog.require('ol.extent.Corner');
 goog.require('ol.obj');
 goog.require('ol.proj');
-goog.require('ol.proj.METERS_PER_UNIT');
 goog.require('ol.proj.Units');
 goog.require('ol.tilegrid.TileGrid');
 

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -14,7 +14,6 @@ goog.require('ol.extent');
 goog.require('ol.geom.Polygon');
 goog.require('ol.geom.SimpleGeometry');
 goog.require('ol.proj');
-goog.require('ol.proj.METERS_PER_UNIT');
 goog.require('ol.proj.Units');
 
 

--- a/test/spec/ol/format/kml.test.js
+++ b/test/spec/ol/format/kml.test.js
@@ -17,6 +17,7 @@ goog.require('ol.style.Fill');
 goog.require('ol.style.Icon');
 goog.require('ol.proj');
 goog.require('ol.proj.Projection');
+goog.require('ol.proj.transforms');
 goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
 goog.require('ol.style.Text');
@@ -358,9 +359,9 @@ describe('ol.format.KML', function() {
               '</kml>';
           expect(node).to.xmleql(ol.xml.parse(text));
 
-          ol.proj.removeTransform(
+          ol.proj.transforms.remove(
               ol.proj.get('EPSG:4326'), ol.proj.get('double'));
-          ol.proj.removeTransform(
+          ol.proj.transforms.remove(
               ol.proj.get('double'), ol.proj.get('EPSG:4326'));
         });
 

--- a/test/spec/ol/proj/epsg3857.test.js
+++ b/test/spec/ol/proj/epsg3857.test.js
@@ -49,7 +49,7 @@ describe('ol.proj.EPSG3857', function() {
       var epsg3857 = ol.proj.get('EPSG:3857');
       var resolution = 19.11;
       var point = [0, 0];
-      expect(epsg3857.getPointResolution(resolution, point)).
+      expect(ol.proj.getPointResolution(epsg3857, resolution, point)).
           to.roughlyEqual(19.11, 1e-1);
     });
 
@@ -60,7 +60,7 @@ describe('ol.proj.EPSG3857', function() {
           var epsg4326 = ol.proj.get('EPSG:4326');
           var resolution = 19.11;
           var point = ol.proj.transform([0, 43.65], epsg4326, epsg3857);
-          expect(epsg3857.getPointResolution(resolution, point)).
+          expect(ol.proj.getPointResolution(epsg3857, resolution, point)).
               to.roughlyEqual(19.11 * Math.cos(Math.PI * 43.65 / 180), 1e-9);
         });
 
@@ -72,7 +72,7 @@ describe('ol.proj.EPSG3857', function() {
       var latitude;
       for (latitude = 0; latitude <= 85; ++latitude) {
         var point = ol.proj.transform([0, latitude], epsg4326, epsg3857);
-        expect(epsg3857.getPointResolution(resolution, point)).
+        expect(ol.proj.getPointResolution(epsg3857, resolution, point)).
             to.roughlyEqual(19.11 * Math.cos(Math.PI * latitude / 180), 1e-9);
       }
     });

--- a/test/spec/ol/proj/index.test.js
+++ b/test/spec/ol/proj/index.test.js
@@ -310,7 +310,7 @@ describe('ol.proj', function() {
 
     it('numerically estimates point scale at the equator', function() {
       var googleProjection = ol.proj.get('GOOGLE');
-      expect(googleProjection.getPointResolution(1, [0, 0])).
+      expect(ol.proj.getPointResolution(googleProjection, 1, [0, 0])).
           to.roughlyEqual(1, 1e-1);
     });
 
@@ -320,8 +320,8 @@ describe('ol.proj', function() {
       var point, y;
       for (y = -20; y <= 20; ++y) {
         point = [0, 1000000 * y];
-        expect(googleProjection.getPointResolution(1, point)).to.roughlyEqual(
-            epsg3857Projection.getPointResolution(1, point), 1e-1);
+        expect(ol.proj.getPointResolution(googleProjection, 1, point)).to.roughlyEqual(
+            ol.proj.getPointResolution(epsg3857Projection, 1, point), 1e-1);
       }
     });
 
@@ -332,8 +332,8 @@ describe('ol.proj', function() {
       for (x = -20; x <= 20; x += 2) {
         for (y = -20; y <= 20; y += 2) {
           point = [1000000 * x, 1000000 * y];
-          expect(googleProjection.getPointResolution(1, point)).to.roughlyEqual(
-              epsg3857Projection.getPointResolution(1, point), 1e-1);
+          expect(ol.proj.getPointResolution(googleProjection, 1, point)).to.roughlyEqual(
+              ol.proj.getPointResolution(epsg3857Projection, 1, point), 1e-1);
         }
       }
     });

--- a/test/spec/ol/proj/index.test.js
+++ b/test/spec/ol/proj/index.test.js
@@ -451,37 +451,6 @@ describe('ol.proj', function() {
     });
   });
 
-  describe('ol.proj.removeTransform()', function() {
-
-    var extent = [180, -90, 180, 90];
-    var units = 'degrees';
-
-    it('removes functions cached by addTransform', function() {
-      var foo = new ol.proj.Projection({
-        code: 'foo',
-        units: units,
-        extent: extent
-      });
-      var bar = new ol.proj.Projection({
-        code: 'bar',
-        units: units,
-        extent: extent
-      });
-      var transform = function(input, output, dimension) {
-        return input;
-      };
-      ol.proj.addTransform(foo, bar, transform);
-      expect(ol.proj.transforms_).not.to.be(undefined);
-      expect(ol.proj.transforms_.foo).not.to.be(undefined);
-      expect(ol.proj.transforms_.foo.bar).to.be(transform);
-
-      var removed = ol.proj.removeTransform(foo, bar);
-      expect(removed).to.be(transform);
-      expect(ol.proj.transforms_.foo).to.be(undefined);
-    });
-
-  });
-
   describe('ol.proj.transform()', function() {
 
     it('transforms a 2d coordinate', function() {

--- a/test/spec/ol/proj/transforms.test.js
+++ b/test/spec/ol/proj/transforms.test.js
@@ -1,0 +1,36 @@
+goog.provide('ol.test.proj.transforms');
+
+goog.require('ol.proj.Projection');
+goog.require('ol.proj.transforms');
+
+
+describe('ol.proj.transforms.remove()', function() {
+
+  var extent = [180, -90, 180, 90];
+  var units = 'degrees';
+
+  it('removes functions cached by ol.proj.transforms.add()', function() {
+    var foo = new ol.proj.Projection({
+      code: 'foo',
+      units: units,
+      extent: extent
+    });
+    var bar = new ol.proj.Projection({
+      code: 'bar',
+      units: units,
+      extent: extent
+    });
+    var transform = function(input, output, dimension) {
+      return input;
+    };
+    ol.proj.transforms.add(foo, bar, transform);
+    expect(ol.proj.transforms.cache_).not.to.be(undefined);
+    expect(ol.proj.transforms.cache_.foo).not.to.be(undefined);
+    expect(ol.proj.transforms.cache_.foo.bar).to.be(transform);
+
+    var removed = ol.proj.transforms.remove(foo, bar);
+    expect(removed).to.be(transform);
+    expect(ol.proj.transforms.cache_.foo).to.be(undefined);
+  });
+
+});

--- a/test/spec/ol/tilegrid/tilegrid.test.js
+++ b/test/spec/ol/tilegrid/tilegrid.test.js
@@ -5,7 +5,6 @@ goog.require('ol.TileRange');
 goog.require('ol.extent');
 goog.require('ol.proj');
 goog.require('ol.proj.EPSG3857');
-goog.require('ol.proj.METERS_PER_UNIT');
 goog.require('ol.proj.Projection');
 goog.require('ol.tilegrid');
 goog.require('ol.tilegrid.TileGrid');


### PR DESCRIPTION
This reworks the modules in `ol/proj` so we have one provide per module.

The one resulting API change is that we have `ol.proj.getPointResolution()` instead of `projection.getPointResolution()`.  The `getPointResolution` function requires the use of an inverse transform (from projected coordinates to geographic coordinates).  Our `ol.proj.Projection` instances are not constructed or otherwise provided with inverse or forward transforms, so it doesn't make sense to have this function be a method of a projection instance.  Instead, the function is available in the `ol/proj` module, where the registry of transforms is available.
