### PR TITLE
Stop asserting that zero duration animations take time

### DIFF
--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -304,7 +304,7 @@ ol.View.prototype.updateAnimations_ = function() {
         continue;
       }
       var elapsed = now - animation.start;
-      var fraction = elapsed / animation.duration;
+      var fraction = animation.duration > 0 ? elapsed / animation.duration : 1;
       if (fraction >= 1) {
         animation.complete = true;
         fraction = 1;

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -379,7 +379,6 @@ describe('ol.View', function() {
         zoom: 4,
         duration: 0
       });
-      expect(view.getAnimating()).to.eql(true);
 
       setTimeout(function() {
         expect(view.getCenter()).to.eql([0, 0]);


### PR DESCRIPTION
A bad assertion snuck in with #6202.  When calling `view.animate()` with `duration: 0`, `view.getAnimating()` is `true` if called in the same millisecond as `view.animate()` (because `(0 / 0 >= 1) === false`).  However, it is `false` if called in the next millisecond (because `(1 / 0 >= 1) === true`).  We don't want to be testing whether a these calls occur in the same millisecond.

In addition to removing this bad assertion, this more explicitly guards against division by zero (treating zero duration animations as immediately complete).
