### PR TITLE
Make modify interaction more robust

### DIFF
--- a/src/ol/interaction/modify.js
+++ b/src/ol/interaction/modify.js
@@ -198,7 +198,7 @@ ol.interaction.Modify.prototype.addFeature_ = function(feature) {
     this.SEGMENT_WRITERS_[geometry.getType()].call(this, feature, geometry);
   }
   var map = this.getMap();
-  if (map) {
+  if (map && map.isRendered()) {
     this.handlePointerAtPixel_(this.lastPixel_, map);
   }
   ol.events.listen(feature, ol.events.EventType.CHANGE,


### PR DESCRIPTION
When the map has not been rendered yet, adding a feature should not
trigger coordinate related functions as they make use of the framestate.