### PR TITLE
Improve the headers styles in the api doc

### DIFF
--- a/config/jsdoc/api/template/static/styles/jaguar.css
+++ b/config/jsdoc/api/template/static/styles/jaguar.css
@@ -45,9 +45,11 @@
 body {
   padding-top: 50px;
 }
-.nameContainer .name, .prettyprint.source .pln {
+.nameContainer .anchor {
   padding-top: 50px;
   margin-top: -50px;
+  width: 0px;
+  height: 0px;
 }
 a {
   position: relative;
@@ -294,6 +296,7 @@ span.type-signature.static {
   color: gray;
 }
 .main .nameContainer h4 {
+  margin-top: 0px;
   margin-right: 150px;
   line-height: 1.3;
 }

--- a/config/jsdoc/api/template/tmpl/members.tmpl
+++ b/config/jsdoc/api/template/tmpl/members.tmpl
@@ -11,7 +11,9 @@ if (data.type && data.type.names) {
 ?>
 <dt class="<?js= (data.stability && data.stability !== 'stable') ? 'unstable' : '' ?>">
     <div class="nameContainer">
-        <h4 class="name" id="<?js= id ?>">
+        <div class="anchor" id="<?js= id ?>">
+        </div>
+        <h4 class="name">
             <?js= data.attribs + (data.scope === 'static' ? longname : name)  + typeSignature ?>
             <?js= this.partial('stability.tmpl', data) ?>
         </h4>

--- a/config/jsdoc/api/template/tmpl/method.tmpl
+++ b/config/jsdoc/api/template/tmpl/method.tmpl
@@ -5,7 +5,9 @@ var self = this;
 <dt class="<?js= (data.stability && data.stability !== 'stable') ? 'unstable' : '' ?>">
     <div class="nameContainer<?js if (data.inherited) { ?> inherited<?js } ?>">
         <?js if (data.stability || kind !== 'class') { ?>
-        <h4 class="name" id="<?js= id ?>">
+        <div class="anchor" id="<?js= id ?>">
+        </div>
+        <h4 class="name">
             <?js= data.attribs + (kind === 'class' ? 'new ' : '') + (data.scope === 'static' ? longname : name) + (kind !== 'event' ? data.signature : '') ?>
             <?js if (data.inherited || data.inherits) { ?>
                 <span class="inherited"><?js= this.linkto(data.inherits, 'inherited') ?></span>


### PR DESCRIPTION
Fix #5093

To clarify the problem, it's impossible to select the last line (in the issue, the first line happens to be the last) of any members or methods (except the very last one) because the next header use a big padding-top that cover that last line.

To correct the problem, I moved the anchor (id=".name-of-prop") to an empty div with no width.