### PR TITLE
Ignore duplicated attributions

### DIFF
--- a/src/ol/control/attribution.js
+++ b/src/ol/control/attribution.js
@@ -182,11 +182,21 @@ ol.control.Attribution.prototype.getSourceAttributions = function(frameState) {
       } else {
         intersectsTileRange = false;
       }
+      var attributionAlreadyAdded = false;
       if (intersectsTileRange) {
         if (sourceAttributionKey in hiddenAttributions) {
           delete hiddenAttributions[sourceAttributionKey];
         }
-        attributions[sourceAttributionKey] = sourceAttribution;
+        for (var existingKey in attributions) {
+          if (attributions.hasOwnProperty(existingKey)) {
+            if (attributions[existingKey].getHTML() === sourceAttribution.getHTML()) {
+              attributionAlreadyAdded = true;
+            }
+          }
+        }
+        if (!attributionAlreadyAdded) {
+          attributions[sourceAttributionKey] = sourceAttribution;
+        }
       } else {
         hiddenAttributions[sourceAttributionKey] = sourceAttribution;
       }

--- a/src/ol/control/attribution.js
+++ b/src/ol/control/attribution.js
@@ -157,6 +157,7 @@ ol.control.Attribution.prototype.getSourceAttributions = function(frameState) {
   var attributions = ol.obj.assign({}, frameState.attributions);
   /** @type {Object.<string, ol.Attribution>} */
   var hiddenAttributions = {};
+  var uniqueAttributions = {};
   var projection = /** @type {!ol.proj.Projection} */ (frameState.viewState.projection);
   for (i = 0, ii = layerStatesArray.length; i < ii; i++) {
     source = layerStatesArray[i].layer.getSource();
@@ -182,19 +183,13 @@ ol.control.Attribution.prototype.getSourceAttributions = function(frameState) {
       } else {
         intersectsTileRange = false;
       }
-      var attributionAlreadyAdded = false;
       if (intersectsTileRange) {
         if (sourceAttributionKey in hiddenAttributions) {
           delete hiddenAttributions[sourceAttributionKey];
         }
-        for (var existingKey in attributions) {
-          if (attributions.hasOwnProperty(existingKey)) {
-            if (attributions[existingKey].getHTML() === sourceAttribution.getHTML()) {
-              attributionAlreadyAdded = true;
-            }
-          }
-        }
-        if (!attributionAlreadyAdded) {
+        var html = sourceAttribution.getHTML();
+        if (!(html in uniqueAttributions)) {
+          uniqueAttributions[html] = true;
           attributions[sourceAttributionKey] = sourceAttribution;
         }
       } else {

--- a/test/spec/ol/control/attribution.test.js
+++ b/test/spec/ol/control/attribution.test.js
@@ -1,0 +1,76 @@
+goog.provide('ol.test.control.Attribution');
+
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.control.Attribution');
+goog.require('ol.layer.Tile');
+goog.require('ol.source.Tile');
+
+describe('ol.control.Attribution', function() {
+
+  var map, target;
+  beforeEach(function() {
+    target = document.createElement('div');
+    target.style.width = target.style.height = '100px';
+    document.body.appendChild(target);
+    map = new ol.Map({
+      target: target,
+      controls: [new ol.control.Attribution({
+        collapsed: false,
+        collapsible: false
+      })],
+      layers: [
+        new ol.layer.Tile({
+          source: new ol.source.Tile({
+            projection: 'EPSG:3857',
+            tileGrid: ol.tilegrid.createXYZ(),
+            attributions: 'foo'
+          })
+        }),
+        new ol.layer.Tile({
+          source: new ol.source.Tile({
+            projection: 'EPSG:3857',
+            tileGrid: ol.tilegrid.createXYZ(),
+            attributions: 'bar'
+          })
+        }),
+        new ol.layer.Tile({
+          source: new ol.source.Tile({
+            projection: 'EPSG:3857',
+            tileGrid: ol.tilegrid.createXYZ(),
+            attributions: 'foo'
+          })
+        })
+      ],
+      view: new ol.View({
+        center: [0, 0],
+        zoom: 0
+      })
+    });
+    map.getLayers().forEach(function(layer) {
+      var source = layer.getSource();
+      source.getTile = function() {
+        var tile = new ol.Tile([0, 0, -1], 2 /* LOADED */);
+        tile.getImage = function() {
+          var image = new Image();
+          image.width = 256;
+          image.height = 256;
+          return image;
+        };
+        return tile;
+      };
+    });
+  });
+
+  afterEach(function() {
+    map.setTarget(null);
+    document.body.removeChild(target);
+  });
+
+  it('does not add duplicate attributions', function() {
+    map.renderSync();
+    var attribution = document.querySelectorAll('.ol-attribution li');
+    expect(attribution.length).to.be(3); // first <li> is the logo
+  });
+
+});


### PR DESCRIPTION
This is a rebased/squashed version of @aberenyi's work in #6185.  I added one additional commit to avoid looping through all attributions for each source.