### PR TITLE
Simplify Zoomify example

### DIFF
--- a/examples/zoomify.js
+++ b/examples/zoomify.js
@@ -1,22 +1,10 @@
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.layer.Tile');
-goog.require('ol.proj.Projection');
 goog.require('ol.source.Zoomify');
 
 var imgWidth = 9911;
 var imgHeight = 6100;
-
-var imgCenter = [imgWidth / 2, -imgHeight / 2];
-
-// Maps always need a projection, but Zoomify layers are not geo-referenced, and
-// are only measured in pixels.  So, we create a fake projection that the map
-// can use to properly display the layer.
-var proj = new ol.proj.Projection({
-  code: 'ZOOMIFY',
-  units: 'pixels',
-  extent: [0, 0, imgWidth, imgHeight]
-});
 
 var source = new ol.source.Zoomify({
   url: 'http://vips.vtech.fr/cgi-bin/iipsrv.fcgi?zoomify=' +
@@ -24,6 +12,7 @@ var source = new ol.source.Zoomify({
   size: [imgWidth, imgHeight],
   crossOrigin: 'anonymous'
 });
+var extent = [0, -imgHeight, imgWidth, 0];
 
 var map = new ol.Map({
   layers: [
@@ -33,11 +22,10 @@ var map = new ol.Map({
   ],
   target: 'map',
   view: new ol.View({
-    projection: proj,
-    center: imgCenter,
+    // adjust zoom levels to those provided by the source
+    resolutions: source.getTileGrid().getResolutions(),
     zoom: 2,
-    // constrain the center: center cannot be set outside
-    // this extent
-    extent: [0, -imgHeight, imgWidth, 0]
+    // constrain the center: center cannot be set outside this extent
+    extent: extent
   })
 });


### PR DESCRIPTION
There is no need to specify a projection with Zoomify layers. I think it makes it easier to understand for users if they do not have to deal with projections.