### PR TITLE
Continue loading tiles when image is not ready yet

### DIFF
--- a/src/ol/source/raster.js
+++ b/src/ol/source/raster.js
@@ -287,16 +287,19 @@ ol.source.Raster.prototype.composeFrame_ = function(frameState, callback) {
       imageDatas[i] = imageData;
     } else {
       // image not yet ready
-      return;
+      imageDatas = null;
+      break;
     }
   }
 
-  var data = {};
-  this.dispatchEvent(new ol.source.Raster.Event(
-      ol.source.Raster.EventType.BEFOREOPERATIONS, frameState, data));
+  if (imageDatas) {
+    var data = {};
+    this.dispatchEvent(new ol.source.Raster.Event(
+        ol.source.Raster.EventType.BEFOREOPERATIONS, frameState, data));
 
-  this.worker_.process(imageDatas, data,
-      this.onWorkerComplete_.bind(this, frameState, callback));
+    this.worker_.process(imageDatas, data,
+        this.onWorkerComplete_.bind(this, frameState, callback));
+  }
 
   frameState.tileQueue.loadMoreTiles(16, 16);
 };


### PR DESCRIPTION
When the image of a raster source's source is not available, one of the reasons can be that no tiles are loaded yet. So we need to instruct the tile queue to load more tiles also in this case.

(This problem is another reason why we should rethink or get rid of our tile queue)

Fixes #6279.