### PR TITLE
Release v3.20.1

### DIFF
--- a/changelog/v3.20.1.md
+++ b/changelog/v3.20.1.md
@@ -1,0 +1,10 @@
+# v3.20.1
+
+## Summary
+
+The v3.19.1 release is a patch release that addresses two regressions in the v3.19.0 release. See the [v3.20.0 release notes](https://github.com/openlayers/ol3/releases/tag/v3.20.0) for details on upgrading from v3.19.x.
+
+## Fixes
+
+ * [#6280](https://github.com/openlayers/ol3/pull/6280) - Continue loading tiles when image is not ready yet ([@ahocevar](https://github.com/ahocevar))
+ * [#6283](https://github.com/openlayers/ol3/pull/6283) - Avoid modifying coordinate in forEachLayerAtCoordinate ([@tschaub](https://github.com/tschaub))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlayers",
-  "version": "3.20.0",
+  "version": "3.20.1",
   "description": "Build tools and sources for developing OpenLayers based mapping applications",
   "keywords": [
     "map",

--- a/src/ol/renderer/canvas/intermediatecanvas.js
+++ b/src/ol/renderer/canvas/intermediatecanvas.js
@@ -129,7 +129,7 @@ ol.renderer.canvas.IntermediateCanvas.prototype.forEachLayerAtCoordinate = funct
     // so that for example also transparent polygons are detected
     return ol.renderer.canvas.Layer.prototype.forEachLayerAtCoordinate.apply(this, arguments);
   } else {
-    var pixel = ol.transform.apply(this.coordinateToCanvasPixelTransform, coordinate);
+    var pixel = ol.transform.apply(this.coordinateToCanvasPixelTransform, coordinate.slice());
     ol.coordinate.scale(pixel, frameState.viewState.resolution / this.renderedResolution);
 
     if (!this.hitCanvasContext_) {

--- a/src/ol/source/raster.js
+++ b/src/ol/source/raster.js
@@ -287,16 +287,19 @@ ol.source.Raster.prototype.composeFrame_ = function(frameState, callback) {
       imageDatas[i] = imageData;
     } else {
       // image not yet ready
-      return;
+      imageDatas = null;
+      break;
     }
   }
 
-  var data = {};
-  this.dispatchEvent(new ol.source.Raster.Event(
-      ol.source.Raster.EventType.BEFOREOPERATIONS, frameState, data));
+  if (imageDatas) {
+    var data = {};
+    this.dispatchEvent(new ol.source.Raster.Event(
+        ol.source.Raster.EventType.BEFOREOPERATIONS, frameState, data));
 
-  this.worker_.process(imageDatas, data,
-      this.onWorkerComplete_.bind(this, frameState, callback));
+    this.worker_.process(imageDatas, data,
+        this.onWorkerComplete_.bind(this, frameState, callback));
+  }
 
   frameState.tileQueue.loadMoreTiles(16, 16);
 };

--- a/test/spec/ol/map.test.js
+++ b/test/spec/ol/map.test.js
@@ -132,6 +132,68 @@ describe('ol.Map', function() {
 
   });
 
+  describe('#forEachLayerAtPixel()', function()  {
+
+    var target, map, original, log;
+
+    beforeEach(function(done) {
+      log = [];
+      original = ol.renderer.canvas.IntermediateCanvas.prototype.forEachLayerAtCoordinate;
+      ol.renderer.canvas.IntermediateCanvas.prototype.forEachLayerAtCoordinate = function(coordinate) {
+        log.push(coordinate.slice());
+      };
+
+      target = document.createElement('div');
+      var style = target.style;
+      style.position = 'absolute';
+      style.left = '-1000px';
+      style.top = '-1000px';
+      style.width = '360px';
+      style.height = '180px';
+      document.body.appendChild(target);
+
+      map = new ol.Map({
+        target: target,
+        view: new ol.View({
+          center: [0, 0],
+          zoom: 1
+        }),
+        layers: [
+          new ol.layer.Tile({
+            source: new ol.source.XYZ()
+          }),
+          new ol.layer.Tile({
+            source: new ol.source.XYZ()
+          }),
+          new ol.layer.Tile({
+            source: new ol.source.XYZ()
+          })
+        ]
+      });
+
+      map.once('postrender', function() {
+        done();
+      });
+    });
+
+    afterEach(function() {
+      ol.renderer.canvas.IntermediateCanvas.prototype.forEachLayerAtCoordinate = original;
+      map.dispose();
+      document.body.removeChild(target);
+      log = null;
+    });
+
+    it('calls each layer renderer with the same coordinate', function() {
+      var pixel = [10, 20];
+      map.forEachLayerAtPixel(pixel, function() {});
+      expect(log.length).to.equal(3);
+      expect(log[0].length).to.equal(2);
+      expect(log[0]).to.eql(log[1]);
+      expect(log[1]).to.eql(log[2]);
+    });
+
+  });
+
   describe('#render()', function() {
 
     var target, map;


### PR DESCRIPTION
## Summary

The v3.20.1 release is a patch release that addresses two regressions in the v3.20.0 release. See the [v3.20.0 release notes](https://github.com/openlayers/ol3/releases/tag/v3.20.0) for details on upgrading from v3.19.x.

## Fixes

 * [#6280](https://github.com/openlayers/ol3/pull/6280) - Continue loading tiles when image is not ready yet ([@ahocevar](https://github.com/ahocevar))
 * [#6283](https://github.com/openlayers/ol3/pull/6283) - Avoid modifying coordinate in forEachLayerAtCoordinate ([@tschaub](https://github.com/tschaub))
