### PR TITLE
Dedicated modules for shared enums

### DIFF
--- a/config/jsdoc/api/readme.md
+++ b/config/jsdoc/api/readme.md
@@ -34,7 +34,7 @@ Events are documented using `@fires` and `@event` annotations:
  * Constants for event names.
  * @enum {string}
  */
-ol.MapBrowserEvent.EventType = {
+ol.MapBrowserEventType = {
   /**
    * A true single click with no dragging and no double click. Note that this
    * event is delayed by 250 ms to ensure that it is not a double click.

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -1391,7 +1391,7 @@ olx.control.OverviewMapOptions.prototype.view;
  *     minWidth: (number|undefined),
  *     render: (function(ol.MapEvent)|undefined),
  *     target: (Element|undefined),
- *     units: (ol.control.ScaleLine.Units|string|undefined)}}
+ *     units: (ol.control.ScaleLineUnits|string|undefined)}}
  */
 olx.control.ScaleLineOptions;
 
@@ -1431,7 +1431,7 @@ olx.control.ScaleLineOptions.prototype.target;
 
 /**
  * Units. Default is `metric`.
- * @type {ol.control.ScaleLine.Units|string|undefined}
+ * @type {ol.control.ScaleLineUnits|string|undefined}
  * @api stable
  */
 olx.control.ScaleLineOptions.prototype.units;

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -4014,7 +4014,7 @@ olx.layer.VectorOptions.prototype.visible;
  *     opacity: (number|undefined),
  *     preload: (number|undefined),
  *     renderBuffer: (number|undefined),
- *     renderMode: (ol.layer.VectorTile.RenderType|string|undefined),
+ *     renderMode: (ol.layer.VectorTileRenderType|string|undefined),
  *     renderOrder: (function(ol.Feature, ol.Feature):number|undefined),
  *     source: (ol.source.VectorTile|undefined),
  *     style: (ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined),
@@ -4049,7 +4049,7 @@ olx.layer.VectorTileOptions.prototype.renderBuffer;
  *  * `'vector'`: Vector tiles are rendered as vectors. Most accurate rendering
  *    even during animations, but slower performance than the other options.
  *  The default is `'hybrid'`.
- * @type {ol.layer.VectorTile.RenderType|string|undefined}
+ * @type {ol.layer.VectorTileRenderType|string|undefined}
  * @api
  */
 olx.layer.VectorTileOptions.prototype.renderMode;

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -338,7 +338,7 @@ olx.AtPixelOptions.prototype.hitTolerance;
  *     element: (Element|undefined),
  *     offset: (Array.<number>|undefined),
  *     position: (ol.Coordinate|undefined),
- *     positioning: (ol.Overlay.Positioning|string|undefined),
+ *     positioning: (ol.OverlayPositioning|string|undefined),
  *     stopEvent: (boolean|undefined),
  *     insertFirst: (boolean|undefined),
  *     autoPan: (boolean|undefined),
@@ -389,7 +389,7 @@ olx.OverlayOptions.prototype.position;
  * property. Possible values are `'bottom-left'`, `'bottom-center'`,
  * `'bottom-right'`, `'center-left'`, `'center-center'`, `'center-right'`,
  * `'top-left'`, `'top-center'`, and `'top-right'`. Default is `'top-left'`.
- * @type {ol.Overlay.Positioning|string|undefined}
+ * @type {ol.OverlayPositioning|string|undefined}
  * @api stable
  */
 olx.OverlayOptions.prototype.positioning;

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -6194,7 +6194,7 @@ olx.source.VectorOptions.prototype.wrapX;
  *     tileGrid: ol.tilegrid.WMTS,
  *     projection: ol.ProjectionLike,
  *     reprojectionErrorThreshold: (number|undefined),
- *     requestEncoding: (ol.source.WMTS.RequestEncoding|string|undefined),
+ *     requestEncoding: (ol.source.WMTSRequestEncoding|string|undefined),
  *     layer: string,
  *     style: string,
  *     tilePixelRatio: (number|undefined),
@@ -6276,7 +6276,7 @@ olx.source.WMTSOptions.prototype.reprojectionErrorThreshold;
 
 /**
  * Request encoding. Default is `KVP`.
- * @type {ol.source.WMTS.RequestEncoding|string|undefined}
+ * @type {ol.source.WMTSRequestEncoding|string|undefined}
  * @api stable
  */
 olx.source.WMTSOptions.prototype.requestEncoding;

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -1932,7 +1932,7 @@ olx.format.TopoJSONOptions.prototype.defaultDataProjection;
 
 
 /**
- * @typedef {{altitudeMode: (ol.format.IGC.Z|undefined)}}
+ * @typedef {{altitudeMode: (ol.format.IGCZ|undefined)}}
  */
 olx.format.IGCOptions;
 
@@ -1940,7 +1940,7 @@ olx.format.IGCOptions;
 /**
  * Altitude mode. Possible values are `barometric`, `gps`, and `none`. Default
  * is `none`.
- * @type {ol.format.IGC.Z|undefined}
+ * @type {ol.format.IGCZ|undefined}
  * @api
  */
 olx.format.IGCOptions.prototype.altitudeMode;

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -5326,7 +5326,7 @@ olx.source.ImageVectorOptions.prototype.style;
  *     operation: (ol.RasterOperation|undefined),
  *     lib: (Object|undefined),
  *     threads: (number|undefined),
- *     operationType: (ol.source.Raster.OperationType|undefined)}}
+ *     operationType: (ol.source.RasterOperationType|undefined)}}
  * @api
  */
 olx.source.RasterOptions;
@@ -5374,7 +5374,7 @@ olx.source.RasterOptions.prototype.threads;
  * `'pixel'` operations are assumed, and operations will be called with an
  * array of pixels from input sources.  If set to `'image'`, operations will
  * be called with an array of ImageData objects from input sources.
- * @type {ol.source.Raster.OperationType|undefined}
+ * @type {ol.source.RasterOperationType|undefined}
  * @api
  */
 olx.source.RasterOptions.prototype.operationType;

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "debounce": "^1.0.0",
     "eslint": "3.12.1",
     "eslint-config-openlayers": "6.0.0",
-    "eslint-plugin-openlayers-internal": "^3.0.0",
+    "eslint-plugin-openlayers-internal": "^3.1.0",
     "expect.js": "0.3.1",
     "gaze": "^1.0.0",
     "istanbul": "0.4.5",
@@ -97,6 +97,7 @@
         }
       ],
       "no-constant-condition": 0,
+      "openlayers-internal/enum": 2,
       "openlayers-internal/no-duplicate-requires": 2,
       "openlayers-internal/no-missing-requires": 1,
       "openlayers-internal/no-unused-requires": 2,

--- a/src/ol/collection.js
+++ b/src/ol/collection.js
@@ -6,8 +6,9 @@
 goog.provide('ol.Collection');
 
 goog.require('ol');
-goog.require('ol.events.Event');
+goog.require('ol.CollectionEventType');
 goog.require('ol.Object');
+goog.require('ol.events.Event');
 
 
 /**
@@ -127,7 +128,7 @@ ol.Collection.prototype.insertAt = function(index, elem) {
   this.array_.splice(index, 0, elem);
   this.updateLength_();
   this.dispatchEvent(
-      new ol.Collection.Event(ol.Collection.EventType.ADD, elem));
+      new ol.Collection.Event(ol.CollectionEventType.ADD, elem));
 };
 
 
@@ -185,7 +186,7 @@ ol.Collection.prototype.removeAt = function(index) {
   this.array_.splice(index, 1);
   this.updateLength_();
   this.dispatchEvent(
-      new ol.Collection.Event(ol.Collection.EventType.REMOVE, prev));
+      new ol.Collection.Event(ol.CollectionEventType.REMOVE, prev));
   return prev;
 };
 
@@ -202,9 +203,9 @@ ol.Collection.prototype.setAt = function(index, elem) {
     var prev = this.array_[index];
     this.array_[index] = elem;
     this.dispatchEvent(
-        new ol.Collection.Event(ol.Collection.EventType.REMOVE, prev));
+        new ol.Collection.Event(ol.CollectionEventType.REMOVE, prev));
     this.dispatchEvent(
-        new ol.Collection.Event(ol.Collection.EventType.ADD, elem));
+        new ol.Collection.Event(ol.CollectionEventType.ADD, elem));
   } else {
     var j;
     for (j = n; j < index; ++j) {
@@ -232,25 +233,6 @@ ol.Collection.Property = {
 
 
 /**
- * @enum {string}
- */
-ol.Collection.EventType = {
-  /**
-   * Triggered when an item is added to the collection.
-   * @event ol.Collection.Event#add
-   * @api stable
-   */
-  ADD: 'add',
-  /**
-   * Triggered when an item is removed from the collection.
-   * @event ol.Collection.Event#remove
-   * @api stable
-   */
-  REMOVE: 'remove'
-};
-
-
-/**
  * @classdesc
  * Events emitted by {@link ol.Collection} instances are instances of this
  * type.
@@ -258,7 +240,7 @@ ol.Collection.EventType = {
  * @constructor
  * @extends {ol.events.Event}
  * @implements {oli.Collection.Event}
- * @param {ol.Collection.EventType} type Type.
+ * @param {ol.CollectionEventType} type Type.
  * @param {*=} opt_element Element.
  */
 ol.Collection.Event = function(type, opt_element) {

--- a/src/ol/collection.js
+++ b/src/ol/collection.js
@@ -114,7 +114,7 @@ ol.Collection.prototype.item = function(index) {
  * @api stable
  */
 ol.Collection.prototype.getLength = function() {
-  return /** @type {number} */ (this.get(ol.Collection.Property.LENGTH));
+  return /** @type {number} */ (this.get(ol.Collection.Property_.LENGTH));
 };
 
 
@@ -220,14 +220,15 @@ ol.Collection.prototype.setAt = function(index, elem) {
  * @private
  */
 ol.Collection.prototype.updateLength_ = function() {
-  this.set(ol.Collection.Property.LENGTH, this.array_.length);
+  this.set(ol.Collection.Property_.LENGTH, this.array_.length);
 };
 
 
 /**
  * @enum {string}
+ * @private
  */
-ol.Collection.Property = {
+ol.Collection.Property_ = {
   LENGTH: 'length'
 };
 

--- a/src/ol/collectioneventtype.js
+++ b/src/ol/collectioneventtype.js
@@ -1,0 +1,19 @@
+goog.provide('ol.CollectionEventType');
+
+/**
+ * @enum {string}
+ */
+ol.CollectionEventType = {
+  /**
+   * Triggered when an item is added to the collection.
+   * @event ol.Collection.Event#add
+   * @api stable
+   */
+  ADD: 'add',
+  /**
+   * Triggered when an item is removed from the collection.
+   * @event ol.Collection.Event#remove
+   * @api stable
+   */
+  REMOVE: 'remove'
+};

--- a/src/ol/control/control.js
+++ b/src/ol/control/control.js
@@ -1,10 +1,10 @@
 goog.provide('ol.control.Control');
 
-goog.require('ol.events');
 goog.require('ol');
-goog.require('ol.MapEvent');
+goog.require('ol.MapEventType');
 goog.require('ol.Object');
 goog.require('ol.dom');
+goog.require('ol.events');
 
 
 /**
@@ -118,7 +118,7 @@ ol.control.Control.prototype.setMap = function(map) {
     target.appendChild(this.element);
     if (this.render !== ol.nullFunction) {
       this.listenerKeys.push(ol.events.listen(map,
-          ol.MapEvent.Type.POSTRENDER, this.render, this));
+          ol.MapEventType.POSTRENDER, this.render, this));
     }
     map.render();
   }

--- a/src/ol/control/mouseposition.js
+++ b/src/ol/control/mouseposition.js
@@ -40,7 +40,7 @@ ol.control.MousePosition = function(opt_options) {
   });
 
   ol.events.listen(this,
-      ol.Object.getChangeEventType(ol.control.MousePosition.Property.PROJECTION),
+      ol.Object.getChangeEventType(ol.control.MousePosition.Property_.PROJECTION),
       this.handleProjectionChanged_, this);
 
   if (options.coordinateFormat) {
@@ -122,7 +122,7 @@ ol.control.MousePosition.prototype.handleProjectionChanged_ = function() {
  */
 ol.control.MousePosition.prototype.getCoordinateFormat = function() {
   return /** @type {ol.CoordinateFormatType|undefined} */ (
-      this.get(ol.control.MousePosition.Property.COORDINATE_FORMAT));
+      this.get(ol.control.MousePosition.Property_.COORDINATE_FORMAT));
 };
 
 
@@ -135,7 +135,7 @@ ol.control.MousePosition.prototype.getCoordinateFormat = function() {
  */
 ol.control.MousePosition.prototype.getProjection = function() {
   return /** @type {ol.proj.Projection|undefined} */ (
-      this.get(ol.control.MousePosition.Property.PROJECTION));
+      this.get(ol.control.MousePosition.Property_.PROJECTION));
 };
 
 
@@ -186,7 +186,7 @@ ol.control.MousePosition.prototype.setMap = function(map) {
  * @api stable
  */
 ol.control.MousePosition.prototype.setCoordinateFormat = function(format) {
-  this.set(ol.control.MousePosition.Property.COORDINATE_FORMAT, format);
+  this.set(ol.control.MousePosition.Property_.COORDINATE_FORMAT, format);
 };
 
 
@@ -198,7 +198,7 @@ ol.control.MousePosition.prototype.setCoordinateFormat = function(format) {
  * @api stable
  */
 ol.control.MousePosition.prototype.setProjection = function(projection) {
-  this.set(ol.control.MousePosition.Property.PROJECTION, projection);
+  this.set(ol.control.MousePosition.Property_.PROJECTION, projection);
 };
 
 
@@ -239,8 +239,9 @@ ol.control.MousePosition.prototype.updateHTML_ = function(pixel) {
 
 /**
  * @enum {string}
+ * @private
  */
-ol.control.MousePosition.Property = {
+ol.control.MousePosition.Property_ = {
   PROJECTION: 'projection',
   COORDINATE_FORMAT: 'coordinateFormat'
 };

--- a/src/ol/control/overviewmap.js
+++ b/src/ol/control/overviewmap.js
@@ -8,6 +8,7 @@ goog.require('ol.MapProperty');
 goog.require('ol.Object');
 goog.require('ol.ObjectEventType');
 goog.require('ol.Overlay');
+goog.require('ol.OverlayPositioning');
 goog.require('ol.ViewProperty');
 goog.require('ol.control.Control');
 goog.require('ol.coordinate');
@@ -123,7 +124,7 @@ ol.control.OverviewMap = function(opt_options) {
    */
   this.boxOverlay_ = new ol.Overlay({
     position: [0, 0],
-    positioning: ol.Overlay.Positioning.BOTTOM_LEFT,
+    positioning: ol.OverlayPositioning.BOTTOM_LEFT,
     element: box
   });
   this.ovmap_.addOverlay(this.boxOverlay_);

--- a/src/ol/control/overviewmap.js
+++ b/src/ol/control/overviewmap.js
@@ -6,6 +6,7 @@ goog.require('ol.Map');
 goog.require('ol.MapEventType');
 goog.require('ol.MapProperty');
 goog.require('ol.Object');
+goog.require('ol.ObjectEventType');
 goog.require('ol.Overlay');
 goog.require('ol.ViewProperty');
 goog.require('ol.control.Control');
@@ -166,7 +167,7 @@ ol.control.OverviewMap.prototype.setMap = function(map) {
 
   if (map) {
     this.listenerKeys.push(ol.events.listen(
-        map, ol.Object.EventType.PROPERTYCHANGE,
+        map, ol.ObjectEventType.PROPERTYCHANGE,
         this.handleMapPropertyChange_, this));
 
     // TODO: to really support map switching, this would need to be reworked

--- a/src/ol/control/overviewmap.js
+++ b/src/ol/control/overviewmap.js
@@ -3,7 +3,7 @@ goog.provide('ol.control.OverviewMap');
 goog.require('ol');
 goog.require('ol.Collection');
 goog.require('ol.Map');
-goog.require('ol.MapEvent');
+goog.require('ol.MapEventType');
 goog.require('ol.MapProperty');
 goog.require('ol.Object');
 goog.require('ol.Overlay');
@@ -443,7 +443,7 @@ ol.control.OverviewMap.prototype.handleToggle_ = function() {
   if (!this.collapsed_ && !ovmap.isRendered()) {
     ovmap.updateSize();
     this.resetExtent_();
-    ol.events.listenOnce(ovmap, ol.MapEvent.Type.POSTRENDER,
+    ol.events.listenOnce(ovmap, ol.MapEventType.POSTRENDER,
         function(event) {
           this.updateBox_();
         },

--- a/src/ol/control/scaleline.js
+++ b/src/ol/control/scaleline.js
@@ -85,7 +85,7 @@ ol.control.ScaleLine = function(opt_options) {
   });
 
   ol.events.listen(
-      this, ol.Object.getChangeEventType(ol.control.ScaleLine.Property.UNITS),
+      this, ol.Object.getChangeEventType(ol.control.ScaleLine.Property_.UNITS),
       this.handleUnitsChanged_, this);
 
   this.setUnits(/** @type {ol.control.ScaleLine.Units} */ (options.units) ||
@@ -111,7 +111,7 @@ ol.control.ScaleLine.LEADING_DIGITS = [1, 2, 5];
  */
 ol.control.ScaleLine.prototype.getUnits = function() {
   return /** @type {ol.control.ScaleLine.Units|undefined} */ (
-      this.get(ol.control.ScaleLine.Property.UNITS));
+      this.get(ol.control.ScaleLine.Property_.UNITS));
 };
 
 
@@ -147,7 +147,7 @@ ol.control.ScaleLine.prototype.handleUnitsChanged_ = function() {
  * @api stable
  */
 ol.control.ScaleLine.prototype.setUnits = function(units) {
-  this.set(ol.control.ScaleLine.Property.UNITS, units);
+  this.set(ol.control.ScaleLine.Property_.UNITS, units);
 };
 
 
@@ -264,9 +264,9 @@ ol.control.ScaleLine.prototype.updateElement_ = function() {
 
 /**
  * @enum {string}
- * @api
+ * @private
  */
-ol.control.ScaleLine.Property = {
+ol.control.ScaleLine.Property_ = {
   UNITS: 'units'
 };
 

--- a/src/ol/control/scaleline.js
+++ b/src/ol/control/scaleline.js
@@ -4,6 +4,7 @@ goog.require('ol');
 goog.require('ol.Object');
 goog.require('ol.asserts');
 goog.require('ol.control.Control');
+goog.require('ol.control.ScaleLineUnits');
 goog.require('ol.css');
 goog.require('ol.events');
 goog.require('ol.proj');
@@ -88,8 +89,8 @@ ol.control.ScaleLine = function(opt_options) {
       this, ol.Object.getChangeEventType(ol.control.ScaleLine.Property_.UNITS),
       this.handleUnitsChanged_, this);
 
-  this.setUnits(/** @type {ol.control.ScaleLine.Units} */ (options.units) ||
-      ol.control.ScaleLine.Units.METRIC);
+  this.setUnits(/** @type {ol.control.ScaleLineUnits} */ (options.units) ||
+      ol.control.ScaleLineUnits.METRIC);
 
 };
 ol.inherits(ol.control.ScaleLine, ol.control.Control);
@@ -104,13 +105,13 @@ ol.control.ScaleLine.LEADING_DIGITS = [1, 2, 5];
 
 /**
  * Return the units to use in the scale line.
- * @return {ol.control.ScaleLine.Units|undefined} The units to use in the scale
+ * @return {ol.control.ScaleLineUnits|undefined} The units to use in the scale
  *     line.
  * @observable
  * @api stable
  */
 ol.control.ScaleLine.prototype.getUnits = function() {
-  return /** @type {ol.control.ScaleLine.Units|undefined} */ (
+  return /** @type {ol.control.ScaleLineUnits|undefined} */ (
       this.get(ol.control.ScaleLine.Property_.UNITS));
 };
 
@@ -142,7 +143,7 @@ ol.control.ScaleLine.prototype.handleUnitsChanged_ = function() {
 
 /**
  * Set the units to use in the scale line.
- * @param {ol.control.ScaleLine.Units} units The units to use in the scale line.
+ * @param {ol.control.ScaleLineUnits} units The units to use in the scale line.
  * @observable
  * @api stable
  */
@@ -175,7 +176,7 @@ ol.control.ScaleLine.prototype.updateElement_ = function() {
   var nominalCount = this.minWidth_ * pointResolution;
   var suffix = '';
   var units = this.getUnits();
-  if (units == ol.control.ScaleLine.Units.DEGREES) {
+  if (units == ol.control.ScaleLineUnits.DEGREES) {
     var metersPerDegree = ol.proj.METERS_PER_UNIT[ol.proj.Units.DEGREES];
     pointResolution /= metersPerDegree;
     if (nominalCount < metersPerDegree / 60) {
@@ -187,7 +188,7 @@ ol.control.ScaleLine.prototype.updateElement_ = function() {
     } else {
       suffix = '\u00b0'; // degrees
     }
-  } else if (units == ol.control.ScaleLine.Units.IMPERIAL) {
+  } else if (units == ol.control.ScaleLineUnits.IMPERIAL) {
     if (nominalCount < 0.9144) {
       suffix = 'in';
       pointResolution /= 0.0254;
@@ -198,10 +199,10 @@ ol.control.ScaleLine.prototype.updateElement_ = function() {
       suffix = 'mi';
       pointResolution /= 1609.344;
     }
-  } else if (units == ol.control.ScaleLine.Units.NAUTICAL) {
+  } else if (units == ol.control.ScaleLineUnits.NAUTICAL) {
     pointResolution /= 1852;
     suffix = 'nm';
-  } else if (units == ol.control.ScaleLine.Units.METRIC) {
+  } else if (units == ol.control.ScaleLineUnits.METRIC) {
     if (nominalCount < 1) {
       suffix = 'mm';
       pointResolution *= 1000;
@@ -211,7 +212,7 @@ ol.control.ScaleLine.prototype.updateElement_ = function() {
       suffix = 'km';
       pointResolution /= 1000;
     }
-  } else if (units == ol.control.ScaleLine.Units.US) {
+  } else if (units == ol.control.ScaleLineUnits.US) {
     if (nominalCount < 0.9144) {
       suffix = 'in';
       pointResolution *= 39.37;
@@ -268,18 +269,4 @@ ol.control.ScaleLine.prototype.updateElement_ = function() {
  */
 ol.control.ScaleLine.Property_ = {
   UNITS: 'units'
-};
-
-
-/**
- * Units for the scale line. Supported values are `'degrees'`, `'imperial'`,
- * `'nautical'`, `'metric'`, `'us'`.
- * @enum {string}
- */
-ol.control.ScaleLine.Units = {
-  DEGREES: 'degrees',
-  IMPERIAL: 'imperial',
-  NAUTICAL: 'nautical',
-  METRIC: 'metric',
-  US: 'us'
 };

--- a/src/ol/control/scalelineunits.js
+++ b/src/ol/control/scalelineunits.js
@@ -1,0 +1,14 @@
+goog.provide('ol.control.ScaleLineUnits');
+
+/**
+ * Units for the scale line. Supported values are `'degrees'`, `'imperial'`,
+ * `'nautical'`, `'metric'`, `'us'`.
+ * @enum {string}
+ */
+ol.control.ScaleLineUnits = {
+  DEGREES: 'degrees',
+  IMPERIAL: 'imperial',
+  NAUTICAL: 'nautical',
+  METRIC: 'metric',
+  US: 'us'
+};

--- a/src/ol/control/zoomslider.js
+++ b/src/ol/control/zoomslider.js
@@ -42,12 +42,12 @@ ol.control.ZoomSlider = function(opt_options) {
 
   /**
    * The direction of the slider. Will be determined from actual display of the
-   * container and defaults to ol.control.ZoomSlider.direction.VERTICAL.
+   * container and defaults to ol.control.ZoomSlider.Direction_.VERTICAL.
    *
-   * @type {ol.control.ZoomSlider.direction}
+   * @type {ol.control.ZoomSlider.Direction_}
    * @private
    */
-  this.direction_ = ol.control.ZoomSlider.direction.VERTICAL;
+  this.direction_ = ol.control.ZoomSlider.Direction_.VERTICAL;
 
   /**
    * @type {boolean}
@@ -154,8 +154,9 @@ ol.control.ZoomSlider.prototype.disposeInternal = function() {
  * The enum for available directions.
  *
  * @enum {number}
+ * @private
  */
-ol.control.ZoomSlider.direction = {
+ol.control.ZoomSlider.Direction_ = {
   VERTICAL: 0,
   HORIZONTAL: 1
 };
@@ -196,10 +197,10 @@ ol.control.ZoomSlider.prototype.initSlider_ = function() {
   this.thumbSize_ = [thumbWidth, thumbHeight];
 
   if (containerSize.width > containerSize.height) {
-    this.direction_ = ol.control.ZoomSlider.direction.HORIZONTAL;
+    this.direction_ = ol.control.ZoomSlider.Direction_.HORIZONTAL;
     this.widthLimit_ = containerSize.width - thumbWidth;
   } else {
-    this.direction_ = ol.control.ZoomSlider.direction.VERTICAL;
+    this.direction_ = ol.control.ZoomSlider.Direction_.VERTICAL;
     this.heightLimit_ = containerSize.height - thumbHeight;
   }
   this.sliderInitialized_ = true;
@@ -333,7 +334,7 @@ ol.control.ZoomSlider.prototype.setThumbPosition_ = function(res) {
   var position = this.getPositionForResolution_(res);
   var thumb = this.element.firstElementChild;
 
-  if (this.direction_ == ol.control.ZoomSlider.direction.HORIZONTAL) {
+  if (this.direction_ == ol.control.ZoomSlider.Direction_.HORIZONTAL) {
     thumb.style.left = this.widthLimit_ * position + 'px';
   } else {
     thumb.style.top = this.heightLimit_ * position + 'px';
@@ -353,7 +354,7 @@ ol.control.ZoomSlider.prototype.setThumbPosition_ = function(res) {
  */
 ol.control.ZoomSlider.prototype.getRelativePosition_ = function(x, y) {
   var amount;
-  if (this.direction_ === ol.control.ZoomSlider.direction.HORIZONTAL) {
+  if (this.direction_ === ol.control.ZoomSlider.Direction_.HORIZONTAL) {
     amount = x / this.widthLimit_;
   } else {
     amount = y / this.heightLimit_;

--- a/src/ol/deviceorientation.js
+++ b/src/ol/deviceorientation.js
@@ -75,7 +75,7 @@ ol.DeviceOrientation = function(opt_options) {
   this.listenerKey_ = null;
 
   ol.events.listen(this,
-      ol.Object.getChangeEventType(ol.DeviceOrientation.Property.TRACKING),
+      ol.Object.getChangeEventType(ol.DeviceOrientation.Property_.TRACKING),
       this.handleTrackingChanged_, this);
 
   this.setTracking(options.tracking !== undefined ? options.tracking : false);
@@ -101,22 +101,22 @@ ol.DeviceOrientation.prototype.orientationChange_ = function(originalEvent) {
   var event = /** @type {DeviceOrientationEvent} */ (originalEvent);
   if (event.alpha !== null) {
     var alpha = ol.math.toRadians(event.alpha);
-    this.set(ol.DeviceOrientation.Property.ALPHA, alpha);
+    this.set(ol.DeviceOrientation.Property_.ALPHA, alpha);
     // event.absolute is undefined in iOS.
     if (typeof event.absolute === 'boolean' && event.absolute) {
-      this.set(ol.DeviceOrientation.Property.HEADING, alpha);
+      this.set(ol.DeviceOrientation.Property_.HEADING, alpha);
     } else if (typeof event.webkitCompassHeading === 'number' &&
                event.webkitCompassAccuracy != -1) {
       var heading = ol.math.toRadians(event.webkitCompassHeading);
-      this.set(ol.DeviceOrientation.Property.HEADING, heading);
+      this.set(ol.DeviceOrientation.Property_.HEADING, heading);
     }
   }
   if (event.beta !== null) {
-    this.set(ol.DeviceOrientation.Property.BETA,
+    this.set(ol.DeviceOrientation.Property_.BETA,
         ol.math.toRadians(event.beta));
   }
   if (event.gamma !== null) {
-    this.set(ol.DeviceOrientation.Property.GAMMA,
+    this.set(ol.DeviceOrientation.Property_.GAMMA,
         ol.math.toRadians(event.gamma));
   }
   this.changed();
@@ -132,7 +132,7 @@ ol.DeviceOrientation.prototype.orientationChange_ = function(originalEvent) {
  */
 ol.DeviceOrientation.prototype.getAlpha = function() {
   return /** @type {number|undefined} */ (
-      this.get(ol.DeviceOrientation.Property.ALPHA));
+      this.get(ol.DeviceOrientation.Property_.ALPHA));
 };
 
 
@@ -145,7 +145,7 @@ ol.DeviceOrientation.prototype.getAlpha = function() {
  */
 ol.DeviceOrientation.prototype.getBeta = function() {
   return /** @type {number|undefined} */ (
-      this.get(ol.DeviceOrientation.Property.BETA));
+      this.get(ol.DeviceOrientation.Property_.BETA));
 };
 
 
@@ -158,7 +158,7 @@ ol.DeviceOrientation.prototype.getBeta = function() {
  */
 ol.DeviceOrientation.prototype.getGamma = function() {
   return /** @type {number|undefined} */ (
-      this.get(ol.DeviceOrientation.Property.GAMMA));
+      this.get(ol.DeviceOrientation.Property_.GAMMA));
 };
 
 
@@ -171,7 +171,7 @@ ol.DeviceOrientation.prototype.getGamma = function() {
  */
 ol.DeviceOrientation.prototype.getHeading = function() {
   return /** @type {number|undefined} */ (
-      this.get(ol.DeviceOrientation.Property.HEADING));
+      this.get(ol.DeviceOrientation.Property_.HEADING));
 };
 
 
@@ -183,7 +183,7 @@ ol.DeviceOrientation.prototype.getHeading = function() {
  */
 ol.DeviceOrientation.prototype.getTracking = function() {
   return /** @type {boolean} */ (
-      this.get(ol.DeviceOrientation.Property.TRACKING));
+      this.get(ol.DeviceOrientation.Property_.TRACKING));
 };
 
 
@@ -212,14 +212,15 @@ ol.DeviceOrientation.prototype.handleTrackingChanged_ = function() {
  * @api
  */
 ol.DeviceOrientation.prototype.setTracking = function(tracking) {
-  this.set(ol.DeviceOrientation.Property.TRACKING, tracking);
+  this.set(ol.DeviceOrientation.Property_.TRACKING, tracking);
 };
 
 
 /**
  * @enum {string}
+ * @private
  */
-ol.DeviceOrientation.Property = {
+ol.DeviceOrientation.Property_ = {
   ALPHA: 'alpha',
   BETA: 'beta',
   GAMMA: 'gamma',

--- a/src/ol/events/condition.js
+++ b/src/ol/events/condition.js
@@ -1,6 +1,6 @@
 goog.provide('ol.events.condition');
 
-goog.require('ol.MapBrowserEvent');
+goog.require('ol.MapBrowserEventType');
 goog.require('ol.asserts');
 goog.require('ol.functions');
 goog.require('ol.has');
@@ -59,7 +59,7 @@ ol.events.condition.always = ol.functions.TRUE;
  * @api stable
  */
 ol.events.condition.click = function(mapBrowserEvent) {
-  return mapBrowserEvent.type == ol.MapBrowserEvent.EventType.CLICK;
+  return mapBrowserEvent.type == ol.MapBrowserEventType.CLICK;
 };
 
 
@@ -111,7 +111,7 @@ ol.events.condition.pointerMove = function(mapBrowserEvent) {
  * @api stable
  */
 ol.events.condition.singleClick = function(mapBrowserEvent) {
-  return mapBrowserEvent.type == ol.MapBrowserEvent.EventType.SINGLECLICK;
+  return mapBrowserEvent.type == ol.MapBrowserEventType.SINGLECLICK;
 };
 
 
@@ -123,7 +123,7 @@ ol.events.condition.singleClick = function(mapBrowserEvent) {
  * @api stable
  */
 ol.events.condition.doubleClick = function(mapBrowserEvent) {
-  return mapBrowserEvent.type == ol.MapBrowserEvent.EventType.DBLCLICK;
+  return mapBrowserEvent.type == ol.MapBrowserEventType.DBLCLICK;
 };
 
 

--- a/src/ol/format/igc.js
+++ b/src/ol/format/igc.js
@@ -3,6 +3,7 @@ goog.provide('ol.format.IGC');
 goog.require('ol');
 goog.require('ol.Feature');
 goog.require('ol.format.Feature');
+goog.require('ol.format.IGCZ');
 goog.require('ol.format.TextFeature');
 goog.require('ol.geom.GeometryLayout');
 goog.require('ol.geom.LineString');
@@ -31,10 +32,10 @@ ol.format.IGC = function(opt_options) {
 
   /**
    * @private
-   * @type {ol.format.IGC.Z}
+   * @type {ol.format.IGCZ}
    */
   this.altitudeMode_ = options.altitudeMode ?
-      options.altitudeMode : ol.format.IGC.Z.NONE;
+      options.altitudeMode : ol.format.IGCZ.NONE;
 
 };
 ol.inherits(ol.format.IGC, ol.format.TextFeature);
@@ -135,11 +136,11 @@ ol.format.IGC.prototype.readFeatureFromText = function(text, opt_options) {
           x = -x;
         }
         flatCoordinates.push(x, y);
-        if (altitudeMode != ol.format.IGC.Z.NONE) {
+        if (altitudeMode != ol.format.IGCZ.NONE) {
           var z;
-          if (altitudeMode == ol.format.IGC.Z.GPS) {
+          if (altitudeMode == ol.format.IGCZ.GPS) {
             z = parseInt(m[11], 10);
-          } else if (altitudeMode == ol.format.IGC.Z.BAROMETRIC) {
+          } else if (altitudeMode == ol.format.IGCZ.BAROMETRIC) {
             z = parseInt(m[12], 10);
           } else {
             ol.DEBUG && console.assert(false, 'Unknown altitude mode.');
@@ -173,7 +174,7 @@ ol.format.IGC.prototype.readFeatureFromText = function(text, opt_options) {
     return null;
   }
   var lineString = new ol.geom.LineString(null);
-  var layout = altitudeMode == ol.format.IGC.Z.NONE ?
+  var layout = altitudeMode == ol.format.IGCZ.NONE ?
       ol.geom.GeometryLayout.XYM : ol.geom.GeometryLayout.XYZM;
   lineString.setFlatCoordinates(layout, flatCoordinates);
   var feature = new ol.Feature(ol.format.Feature.transformWithOptions(
@@ -218,14 +219,3 @@ ol.format.IGC.prototype.readFeaturesFromText = function(text, opt_options) {
  * @api
  */
 ol.format.IGC.prototype.readProjection;
-
-
-/**
- * IGC altitude/z. One of 'barometric', 'gps', 'none'.
- * @enum {string}
- */
-ol.format.IGC.Z = {
-  BAROMETRIC: 'barometric',
-  GPS: 'gps',
-  NONE: 'none'
-};

--- a/src/ol/format/igcz.js
+++ b/src/ol/format/igcz.js
@@ -1,0 +1,11 @@
+goog.provide('ol.format.IGCZ');
+
+/**
+ * IGC altitude/z. One of 'barometric', 'gps', 'none'.
+ * @enum {string}
+ */
+ol.format.IGCZ = {
+  BAROMETRIC: 'barometric',
+  GPS: 'gps',
+  NONE: 'none'
+};

--- a/src/ol/format/wkt.js
+++ b/src/ol/format/wkt.js
@@ -413,8 +413,9 @@ ol.format.WKT.prototype.writeGeometryText = function(geometry, opt_options) {
 /**
  * @const
  * @enum {number}
+ * @private
  */
-ol.format.WKT.TokenType = {
+ol.format.WKT.TokenType_ = {
   TEXT: 1,
   LEFT_PAREN: 2,
   RIGHT_PAREN: 3,
@@ -496,21 +497,21 @@ ol.format.WKT.Lexer.prototype.nextToken = function() {
   var token = {position: this.index_, value: c};
 
   if (c == '(') {
-    token.type = ol.format.WKT.TokenType.LEFT_PAREN;
+    token.type = ol.format.WKT.TokenType_.LEFT_PAREN;
   } else if (c == ',') {
-    token.type = ol.format.WKT.TokenType.COMMA;
+    token.type = ol.format.WKT.TokenType_.COMMA;
   } else if (c == ')') {
-    token.type = ol.format.WKT.TokenType.RIGHT_PAREN;
+    token.type = ol.format.WKT.TokenType_.RIGHT_PAREN;
   } else if (this.isNumeric_(c) || c == '-') {
-    token.type = ol.format.WKT.TokenType.NUMBER;
+    token.type = ol.format.WKT.TokenType_.NUMBER;
     token.value = this.readNumber_();
   } else if (this.isAlpha_(c)) {
-    token.type = ol.format.WKT.TokenType.TEXT;
+    token.type = ol.format.WKT.TokenType_.TEXT;
     token.value = this.readText_();
   } else if (this.isWhiteSpace_(c)) {
     return this.nextToken();
   } else if (c === '') {
-    token.type = ol.format.WKT.TokenType.EOF;
+    token.type = ol.format.WKT.TokenType_.EOF;
   } else {
     throw new Error('Unexpected character: ' + c);
   }
@@ -598,7 +599,7 @@ ol.format.WKT.Parser.prototype.consume_ = function() {
 
 /**
  * Tests if the given type matches the type of the current token.
- * @param {ol.format.WKT.TokenType} type Token type.
+ * @param {ol.format.WKT.TokenType_} type Token type.
  * @return {boolean} Whether the token matches the given type.
  */
 ol.format.WKT.Parser.prototype.isTokenType = function(type) {
@@ -609,7 +610,7 @@ ol.format.WKT.Parser.prototype.isTokenType = function(type) {
 
 /**
  * If the given type matches the current token, consume it.
- * @param {ol.format.WKT.TokenType} type Token type.
+ * @param {ol.format.WKT.TokenType_} type Token type.
  * @return {boolean} Whether the token matches the given type.
  */
 ol.format.WKT.Parser.prototype.match = function(type) {
@@ -628,7 +629,7 @@ ol.format.WKT.Parser.prototype.match = function(type) {
 ol.format.WKT.Parser.prototype.parse = function() {
   this.consume_();
   var geometry = this.parseGeometry_();
-  ol.DEBUG && console.assert(this.token_.type == ol.format.WKT.TokenType.EOF,
+  ol.DEBUG && console.assert(this.token_.type == ol.format.WKT.TokenType_.EOF,
       'token type should be end of file');
   return geometry;
 };
@@ -642,7 +643,7 @@ ol.format.WKT.Parser.prototype.parse = function() {
 ol.format.WKT.Parser.prototype.parseGeometryLayout_ = function() {
   var layout = ol.geom.GeometryLayout.XY;
   var dimToken = this.token_;
-  if (this.isTokenType(ol.format.WKT.TokenType.TEXT)) {
+  if (this.isTokenType(ol.format.WKT.TokenType_.TEXT)) {
     var dimInfo = dimToken.value;
     if (dimInfo === ol.format.WKT.Z) {
       layout = ol.geom.GeometryLayout.XYZ;
@@ -665,7 +666,7 @@ ol.format.WKT.Parser.prototype.parseGeometryLayout_ = function() {
  */
 ol.format.WKT.Parser.prototype.parseGeometry_ = function() {
   var token = this.token_;
-  if (this.match(ol.format.WKT.TokenType.TEXT)) {
+  if (this.match(ol.format.WKT.TokenType_.TEXT)) {
     var geomType = token.value;
     this.layout_ = this.parseGeometryLayout_();
     if (geomType == ol.geom.GeometryType.GEOMETRY_COLLECTION.toUpperCase()) {
@@ -690,12 +691,12 @@ ol.format.WKT.Parser.prototype.parseGeometry_ = function() {
  * @private
  */
 ol.format.WKT.Parser.prototype.parseGeometryCollectionText_ = function() {
-  if (this.match(ol.format.WKT.TokenType.LEFT_PAREN)) {
+  if (this.match(ol.format.WKT.TokenType_.LEFT_PAREN)) {
     var geometries = [];
     do {
       geometries.push(this.parseGeometry_());
-    } while (this.match(ol.format.WKT.TokenType.COMMA));
-    if (this.match(ol.format.WKT.TokenType.RIGHT_PAREN)) {
+    } while (this.match(ol.format.WKT.TokenType_.COMMA));
+    if (this.match(ol.format.WKT.TokenType_.RIGHT_PAREN)) {
       return geometries;
     }
   } else if (this.isEmptyGeometry_()) {
@@ -710,9 +711,9 @@ ol.format.WKT.Parser.prototype.parseGeometryCollectionText_ = function() {
  * @private
  */
 ol.format.WKT.Parser.prototype.parsePointText_ = function() {
-  if (this.match(ol.format.WKT.TokenType.LEFT_PAREN)) {
+  if (this.match(ol.format.WKT.TokenType_.LEFT_PAREN)) {
     var coordinates = this.parsePoint_();
-    if (this.match(ol.format.WKT.TokenType.RIGHT_PAREN)) {
+    if (this.match(ol.format.WKT.TokenType_.RIGHT_PAREN)) {
       return coordinates;
     }
   } else if (this.isEmptyGeometry_()) {
@@ -727,9 +728,9 @@ ol.format.WKT.Parser.prototype.parsePointText_ = function() {
  * @private
  */
 ol.format.WKT.Parser.prototype.parseLineStringText_ = function() {
-  if (this.match(ol.format.WKT.TokenType.LEFT_PAREN)) {
+  if (this.match(ol.format.WKT.TokenType_.LEFT_PAREN)) {
     var coordinates = this.parsePointList_();
-    if (this.match(ol.format.WKT.TokenType.RIGHT_PAREN)) {
+    if (this.match(ol.format.WKT.TokenType_.RIGHT_PAREN)) {
       return coordinates;
     }
   } else if (this.isEmptyGeometry_()) {
@@ -744,9 +745,9 @@ ol.format.WKT.Parser.prototype.parseLineStringText_ = function() {
  * @private
  */
 ol.format.WKT.Parser.prototype.parsePolygonText_ = function() {
-  if (this.match(ol.format.WKT.TokenType.LEFT_PAREN)) {
+  if (this.match(ol.format.WKT.TokenType_.LEFT_PAREN)) {
     var coordinates = this.parseLineStringTextList_();
-    if (this.match(ol.format.WKT.TokenType.RIGHT_PAREN)) {
+    if (this.match(ol.format.WKT.TokenType_.RIGHT_PAREN)) {
       return coordinates;
     }
   } else if (this.isEmptyGeometry_()) {
@@ -761,14 +762,14 @@ ol.format.WKT.Parser.prototype.parsePolygonText_ = function() {
  * @private
  */
 ol.format.WKT.Parser.prototype.parseMultiPointText_ = function() {
-  if (this.match(ol.format.WKT.TokenType.LEFT_PAREN)) {
+  if (this.match(ol.format.WKT.TokenType_.LEFT_PAREN)) {
     var coordinates;
-    if (this.token_.type == ol.format.WKT.TokenType.LEFT_PAREN) {
+    if (this.token_.type == ol.format.WKT.TokenType_.LEFT_PAREN) {
       coordinates = this.parsePointTextList_();
     } else {
       coordinates = this.parsePointList_();
     }
-    if (this.match(ol.format.WKT.TokenType.RIGHT_PAREN)) {
+    if (this.match(ol.format.WKT.TokenType_.RIGHT_PAREN)) {
       return coordinates;
     }
   } else if (this.isEmptyGeometry_()) {
@@ -784,9 +785,9 @@ ol.format.WKT.Parser.prototype.parseMultiPointText_ = function() {
  * @private
  */
 ol.format.WKT.Parser.prototype.parseMultiLineStringText_ = function() {
-  if (this.match(ol.format.WKT.TokenType.LEFT_PAREN)) {
+  if (this.match(ol.format.WKT.TokenType_.LEFT_PAREN)) {
     var coordinates = this.parseLineStringTextList_();
-    if (this.match(ol.format.WKT.TokenType.RIGHT_PAREN)) {
+    if (this.match(ol.format.WKT.TokenType_.RIGHT_PAREN)) {
       return coordinates;
     }
   } else if (this.isEmptyGeometry_()) {
@@ -801,9 +802,9 @@ ol.format.WKT.Parser.prototype.parseMultiLineStringText_ = function() {
  * @private
  */
 ol.format.WKT.Parser.prototype.parseMultiPolygonText_ = function() {
-  if (this.match(ol.format.WKT.TokenType.LEFT_PAREN)) {
+  if (this.match(ol.format.WKT.TokenType_.LEFT_PAREN)) {
     var coordinates = this.parsePolygonTextList_();
-    if (this.match(ol.format.WKT.TokenType.RIGHT_PAREN)) {
+    if (this.match(ol.format.WKT.TokenType_.RIGHT_PAREN)) {
       return coordinates;
     }
   } else if (this.isEmptyGeometry_()) {
@@ -822,7 +823,7 @@ ol.format.WKT.Parser.prototype.parsePoint_ = function() {
   var dimensions = this.layout_.length;
   for (var i = 0; i < dimensions; ++i) {
     var token = this.token_;
-    if (this.match(ol.format.WKT.TokenType.NUMBER)) {
+    if (this.match(ol.format.WKT.TokenType_.NUMBER)) {
       coordinates.push(token.value);
     } else {
       break;
@@ -841,7 +842,7 @@ ol.format.WKT.Parser.prototype.parsePoint_ = function() {
  */
 ol.format.WKT.Parser.prototype.parsePointList_ = function() {
   var coordinates = [this.parsePoint_()];
-  while (this.match(ol.format.WKT.TokenType.COMMA)) {
+  while (this.match(ol.format.WKT.TokenType_.COMMA)) {
     coordinates.push(this.parsePoint_());
   }
   return coordinates;
@@ -854,7 +855,7 @@ ol.format.WKT.Parser.prototype.parsePointList_ = function() {
  */
 ol.format.WKT.Parser.prototype.parsePointTextList_ = function() {
   var coordinates = [this.parsePointText_()];
-  while (this.match(ol.format.WKT.TokenType.COMMA)) {
+  while (this.match(ol.format.WKT.TokenType_.COMMA)) {
     coordinates.push(this.parsePointText_());
   }
   return coordinates;
@@ -867,7 +868,7 @@ ol.format.WKT.Parser.prototype.parsePointTextList_ = function() {
  */
 ol.format.WKT.Parser.prototype.parseLineStringTextList_ = function() {
   var coordinates = [this.parseLineStringText_()];
-  while (this.match(ol.format.WKT.TokenType.COMMA)) {
+  while (this.match(ol.format.WKT.TokenType_.COMMA)) {
     coordinates.push(this.parseLineStringText_());
   }
   return coordinates;
@@ -880,7 +881,7 @@ ol.format.WKT.Parser.prototype.parseLineStringTextList_ = function() {
  */
 ol.format.WKT.Parser.prototype.parsePolygonTextList_ = function() {
   var coordinates = [this.parsePolygonText_()];
-  while (this.match(ol.format.WKT.TokenType.COMMA)) {
+  while (this.match(ol.format.WKT.TokenType_.COMMA)) {
     coordinates.push(this.parsePolygonText_());
   }
   return coordinates;
@@ -892,7 +893,7 @@ ol.format.WKT.Parser.prototype.parsePolygonTextList_ = function() {
  * @private
  */
 ol.format.WKT.Parser.prototype.isEmptyGeometry_ = function() {
-  var isEmpty = this.isTokenType(ol.format.WKT.TokenType.TEXT) &&
+  var isEmpty = this.isTokenType(ol.format.WKT.TokenType_.TEXT) &&
       this.token_.value == ol.format.WKT.EMPTY;
   if (isEmpty) {
     this.consume_();

--- a/src/ol/geolocation.js
+++ b/src/ol/geolocation.js
@@ -65,10 +65,10 @@ ol.Geolocation = function(opt_options) {
   this.watchId_ = undefined;
 
   ol.events.listen(
-      this, ol.Object.getChangeEventType(ol.Geolocation.Property.PROJECTION),
+      this, ol.Object.getChangeEventType(ol.Geolocation.Property_.PROJECTION),
       this.handleProjectionChanged_, this);
   ol.events.listen(
-      this, ol.Object.getChangeEventType(ol.Geolocation.Property.TRACKING),
+      this, ol.Object.getChangeEventType(ol.Geolocation.Property_.TRACKING),
       this.handleTrackingChanged_, this);
 
   if (options.projection !== undefined) {
@@ -103,7 +103,7 @@ ol.Geolocation.prototype.handleProjectionChanged_ = function() {
         ol.proj.get('EPSG:4326'), projection);
     if (this.position_) {
       this.set(
-          ol.Geolocation.Property.POSITION, this.transform_(this.position_));
+          ol.Geolocation.Property_.POSITION, this.transform_(this.position_));
     }
   }
 };
@@ -134,13 +134,13 @@ ol.Geolocation.prototype.handleTrackingChanged_ = function() {
  */
 ol.Geolocation.prototype.positionChange_ = function(position) {
   var coords = position.coords;
-  this.set(ol.Geolocation.Property.ACCURACY, coords.accuracy);
-  this.set(ol.Geolocation.Property.ALTITUDE,
+  this.set(ol.Geolocation.Property_.ACCURACY, coords.accuracy);
+  this.set(ol.Geolocation.Property_.ALTITUDE,
       coords.altitude === null ? undefined : coords.altitude);
-  this.set(ol.Geolocation.Property.ALTITUDE_ACCURACY,
+  this.set(ol.Geolocation.Property_.ALTITUDE_ACCURACY,
       coords.altitudeAccuracy === null ?
       undefined : coords.altitudeAccuracy);
-  this.set(ol.Geolocation.Property.HEADING, coords.heading === null ?
+  this.set(ol.Geolocation.Property_.HEADING, coords.heading === null ?
       undefined : ol.math.toRadians(coords.heading));
   if (!this.position_) {
     this.position_ = [coords.longitude, coords.latitude];
@@ -149,13 +149,13 @@ ol.Geolocation.prototype.positionChange_ = function(position) {
     this.position_[1] = coords.latitude;
   }
   var projectedPosition = this.transform_(this.position_);
-  this.set(ol.Geolocation.Property.POSITION, projectedPosition);
-  this.set(ol.Geolocation.Property.SPEED,
+  this.set(ol.Geolocation.Property_.POSITION, projectedPosition);
+  this.set(ol.Geolocation.Property_.SPEED,
       coords.speed === null ? undefined : coords.speed);
   var geometry = ol.geom.Polygon.circular(
       ol.sphere.WGS84, this.position_, coords.accuracy);
   geometry.applyTransform(this.transform_);
-  this.set(ol.Geolocation.Property.ACCURACY_GEOMETRY, geometry);
+  this.set(ol.Geolocation.Property_.ACCURACY_GEOMETRY, geometry);
   this.changed();
 };
 
@@ -185,7 +185,7 @@ ol.Geolocation.prototype.positionError_ = function(error) {
  */
 ol.Geolocation.prototype.getAccuracy = function() {
   return /** @type {number|undefined} */ (
-      this.get(ol.Geolocation.Property.ACCURACY));
+      this.get(ol.Geolocation.Property_.ACCURACY));
 };
 
 
@@ -197,7 +197,7 @@ ol.Geolocation.prototype.getAccuracy = function() {
  */
 ol.Geolocation.prototype.getAccuracyGeometry = function() {
   return /** @type {?ol.geom.Geometry} */ (
-      this.get(ol.Geolocation.Property.ACCURACY_GEOMETRY) || null);
+      this.get(ol.Geolocation.Property_.ACCURACY_GEOMETRY) || null);
 };
 
 
@@ -210,7 +210,7 @@ ol.Geolocation.prototype.getAccuracyGeometry = function() {
  */
 ol.Geolocation.prototype.getAltitude = function() {
   return /** @type {number|undefined} */ (
-      this.get(ol.Geolocation.Property.ALTITUDE));
+      this.get(ol.Geolocation.Property_.ALTITUDE));
 };
 
 
@@ -223,7 +223,7 @@ ol.Geolocation.prototype.getAltitude = function() {
  */
 ol.Geolocation.prototype.getAltitudeAccuracy = function() {
   return /** @type {number|undefined} */ (
-      this.get(ol.Geolocation.Property.ALTITUDE_ACCURACY));
+      this.get(ol.Geolocation.Property_.ALTITUDE_ACCURACY));
 };
 
 
@@ -235,7 +235,7 @@ ol.Geolocation.prototype.getAltitudeAccuracy = function() {
  */
 ol.Geolocation.prototype.getHeading = function() {
   return /** @type {number|undefined} */ (
-      this.get(ol.Geolocation.Property.HEADING));
+      this.get(ol.Geolocation.Property_.HEADING));
 };
 
 
@@ -248,7 +248,7 @@ ol.Geolocation.prototype.getHeading = function() {
  */
 ol.Geolocation.prototype.getPosition = function() {
   return /** @type {ol.Coordinate|undefined} */ (
-      this.get(ol.Geolocation.Property.POSITION));
+      this.get(ol.Geolocation.Property_.POSITION));
 };
 
 
@@ -261,7 +261,7 @@ ol.Geolocation.prototype.getPosition = function() {
  */
 ol.Geolocation.prototype.getProjection = function() {
   return /** @type {ol.proj.Projection|undefined} */ (
-      this.get(ol.Geolocation.Property.PROJECTION));
+      this.get(ol.Geolocation.Property_.PROJECTION));
 };
 
 
@@ -274,7 +274,7 @@ ol.Geolocation.prototype.getProjection = function() {
  */
 ol.Geolocation.prototype.getSpeed = function() {
   return /** @type {number|undefined} */ (
-      this.get(ol.Geolocation.Property.SPEED));
+      this.get(ol.Geolocation.Property_.SPEED));
 };
 
 
@@ -286,7 +286,7 @@ ol.Geolocation.prototype.getSpeed = function() {
  */
 ol.Geolocation.prototype.getTracking = function() {
   return /** @type {boolean} */ (
-      this.get(ol.Geolocation.Property.TRACKING));
+      this.get(ol.Geolocation.Property_.TRACKING));
 };
 
 
@@ -301,7 +301,7 @@ ol.Geolocation.prototype.getTracking = function() {
  */
 ol.Geolocation.prototype.getTrackingOptions = function() {
   return /** @type {GeolocationPositionOptions|undefined} */ (
-      this.get(ol.Geolocation.Property.TRACKING_OPTIONS));
+      this.get(ol.Geolocation.Property_.TRACKING_OPTIONS));
 };
 
 
@@ -313,7 +313,7 @@ ol.Geolocation.prototype.getTrackingOptions = function() {
  * @api stable
  */
 ol.Geolocation.prototype.setProjection = function(projection) {
-  this.set(ol.Geolocation.Property.PROJECTION, projection);
+  this.set(ol.Geolocation.Property_.PROJECTION, projection);
 };
 
 
@@ -324,7 +324,7 @@ ol.Geolocation.prototype.setProjection = function(projection) {
  * @api stable
  */
 ol.Geolocation.prototype.setTracking = function(tracking) {
-  this.set(ol.Geolocation.Property.TRACKING, tracking);
+  this.set(ol.Geolocation.Property_.TRACKING, tracking);
 };
 
 
@@ -338,14 +338,15 @@ ol.Geolocation.prototype.setTracking = function(tracking) {
  * @api stable
  */
 ol.Geolocation.prototype.setTrackingOptions = function(options) {
-  this.set(ol.Geolocation.Property.TRACKING_OPTIONS, options);
+  this.set(ol.Geolocation.Property_.TRACKING_OPTIONS, options);
 };
 
 
 /**
  * @enum {string}
+ * @private
  */
-ol.Geolocation.Property = {
+ol.Geolocation.Property_ = {
   ACCURACY: 'accuracy',
   ACCURACY_GEOMETRY: 'accuracyGeometry',
   ALTITUDE: 'altitude',

--- a/src/ol/interaction/doubleclickzoom.js
+++ b/src/ol/interaction/doubleclickzoom.js
@@ -1,7 +1,7 @@
 goog.provide('ol.interaction.DoubleClickZoom');
 
 goog.require('ol');
-goog.require('ol.MapBrowserEvent');
+goog.require('ol.MapBrowserEventType');
 goog.require('ol.interaction.Interaction');
 
 
@@ -49,7 +49,7 @@ ol.inherits(ol.interaction.DoubleClickZoom, ol.interaction.Interaction);
 ol.interaction.DoubleClickZoom.handleEvent = function(mapBrowserEvent) {
   var stopEvent = false;
   var browserEvent = mapBrowserEvent.originalEvent;
-  if (mapBrowserEvent.type == ol.MapBrowserEvent.EventType.DBLCLICK) {
+  if (mapBrowserEvent.type == ol.MapBrowserEventType.DBLCLICK) {
     var map = mapBrowserEvent.map;
     var anchor = mapBrowserEvent.coordinate;
     var delta = browserEvent.shiftKey ? -this.delta_ : this.delta_;

--- a/src/ol/interaction/draganddrop.js
+++ b/src/ol/interaction/draganddrop.js
@@ -118,7 +118,7 @@ ol.interaction.DragAndDrop.prototype.handleResult_ = function(file, event) {
   }
   this.dispatchEvent(
       new ol.interaction.DragAndDrop.Event(
-          ol.interaction.DragAndDrop.EventType.ADD_FEATURES, file,
+          ol.interaction.DragAndDrop.EventType_.ADD_FEATURES, file,
           features, projection));
 };
 
@@ -177,8 +177,9 @@ ol.interaction.DragAndDrop.prototype.tryReadFeatures_ = function(format, text, o
 
 /**
  * @enum {string}
+ * @private
  */
-ol.interaction.DragAndDrop.EventType = {
+ol.interaction.DragAndDrop.EventType_ = {
   /**
    * Triggered when features are added
    * @event ol.interaction.DragAndDrop.Event#addfeatures
@@ -196,7 +197,7 @@ ol.interaction.DragAndDrop.EventType = {
  * @constructor
  * @extends {ol.events.Event}
  * @implements {oli.interaction.DragAndDropEvent}
- * @param {ol.interaction.DragAndDrop.EventType} type Type.
+ * @param {ol.interaction.DragAndDrop.EventType_} type Type.
  * @param {File} file File.
  * @param {Array.<ol.Feature>=} opt_features Features.
  * @param {ol.proj.Projection=} opt_projection Projection.

--- a/src/ol/interaction/dragbox.js
+++ b/src/ol/interaction/dragbox.js
@@ -103,7 +103,7 @@ ol.interaction.DragBox.handleDragEvent_ = function(mapBrowserEvent) {
 
   this.box_.setPixels(this.startPixel_, mapBrowserEvent.pixel);
 
-  this.dispatchEvent(new ol.interaction.DragBox.Event(ol.interaction.DragBox.EventType.BOXDRAG,
+  this.dispatchEvent(new ol.interaction.DragBox.Event(ol.interaction.DragBox.EventType_.BOXDRAG,
     mapBrowserEvent.coordinate, mapBrowserEvent));
 };
 
@@ -143,7 +143,7 @@ ol.interaction.DragBox.handleUpEvent_ = function(mapBrowserEvent) {
   if (this.boxEndCondition_(mapBrowserEvent,
       this.startPixel_, mapBrowserEvent.pixel)) {
     this.onBoxEnd(mapBrowserEvent);
-    this.dispatchEvent(new ol.interaction.DragBox.Event(ol.interaction.DragBox.EventType.BOXEND,
+    this.dispatchEvent(new ol.interaction.DragBox.Event(ol.interaction.DragBox.EventType_.BOXEND,
         mapBrowserEvent.coordinate, mapBrowserEvent));
   }
   return false;
@@ -166,7 +166,7 @@ ol.interaction.DragBox.handleDownEvent_ = function(mapBrowserEvent) {
     this.startPixel_ = mapBrowserEvent.pixel;
     this.box_.setMap(mapBrowserEvent.map);
     this.box_.setPixels(this.startPixel_, this.startPixel_);
-    this.dispatchEvent(new ol.interaction.DragBox.Event(ol.interaction.DragBox.EventType.BOXSTART,
+    this.dispatchEvent(new ol.interaction.DragBox.Event(ol.interaction.DragBox.EventType_.BOXSTART,
         mapBrowserEvent.coordinate, mapBrowserEvent));
     return true;
   } else {
@@ -177,8 +177,9 @@ ol.interaction.DragBox.handleDownEvent_ = function(mapBrowserEvent) {
 
 /**
  * @enum {string}
+ * @private
  */
-ol.interaction.DragBox.EventType = {
+ol.interaction.DragBox.EventType_ = {
   /**
    * Triggered upon drag box start.
    * @event ol.interaction.DragBox.Event#boxstart

--- a/src/ol/interaction/draw.js
+++ b/src/ol/interaction/draw.js
@@ -484,7 +484,7 @@ ol.interaction.Draw.prototype.startDrawing_ = function(event) {
   this.sketchFeature_.setGeometry(geometry);
   this.updateSketchFeatures_();
   this.dispatchEvent(new ol.interaction.Draw.Event(
-      ol.interaction.Draw.EventType.DRAWSTART, this.sketchFeature_));
+      ol.interaction.Draw.EventType_.DRAWSTART, this.sketchFeature_));
 };
 
 
@@ -611,7 +611,7 @@ ol.interaction.Draw.prototype.removeLastPoint = function() {
 
 /**
  * Stop drawing and add the sketch feature to the target layer.
- * The {@link ol.interaction.Draw.EventType.DRAWEND} event is dispatched before
+ * The {@link ol.interaction.Draw.EventType_.DRAWEND} event is dispatched before
  * inserting the feature.
  * @api
  */
@@ -641,7 +641,7 @@ ol.interaction.Draw.prototype.finishDrawing = function() {
 
   // First dispatch event to allow full set up of feature
   this.dispatchEvent(new ol.interaction.Draw.Event(
-      ol.interaction.Draw.EventType.DRAWEND, sketchFeature));
+      ol.interaction.Draw.EventType_.DRAWEND, sketchFeature));
 
   // Then insert feature
   if (this.features_) {
@@ -692,7 +692,7 @@ ol.interaction.Draw.prototype.extend = function(feature) {
   this.sketchCoords_.push(last.slice());
   this.updateSketchFeatures_();
   this.dispatchEvent(new ol.interaction.Draw.Event(
-      ol.interaction.Draw.EventType.DRAWSTART, this.sketchFeature_));
+      ol.interaction.Draw.EventType_.DRAWSTART, this.sketchFeature_));
 };
 
 
@@ -848,7 +848,7 @@ ol.interaction.Draw.Mode_ = {
  * @constructor
  * @extends {ol.events.Event}
  * @implements {oli.DrawEvent}
- * @param {ol.interaction.Draw.EventType} type Type.
+ * @param {ol.interaction.Draw.EventType_} type Type.
  * @param {ol.Feature} feature The feature drawn.
  */
 ol.interaction.Draw.Event = function(type, feature) {
@@ -868,8 +868,9 @@ ol.inherits(ol.interaction.Draw.Event, ol.events.Event);
 
 /**
  * @enum {string}
+ * @private
  */
-ol.interaction.Draw.EventType = {
+ol.interaction.Draw.EventType_ = {
   /**
    * Triggered upon feature draw start
    * @event ol.interaction.Draw.Event#drawstart

--- a/src/ol/interaction/draw.js
+++ b/src/ol/interaction/draw.js
@@ -2,7 +2,7 @@ goog.provide('ol.interaction.Draw');
 
 goog.require('ol');
 goog.require('ol.Feature');
-goog.require('ol.MapBrowserEvent');
+goog.require('ol.MapBrowserEventType');
 goog.require('ol.Object');
 goog.require('ol.coordinate');
 goog.require('ol.events');
@@ -304,13 +304,13 @@ ol.interaction.Draw.handleEvent = function(event) {
   this.freehand_ = this.mode_ !== ol.interaction.Draw.Mode_.POINT && this.freehandCondition_(event);
   var pass = !this.freehand_;
   if (this.freehand_ &&
-      event.type === ol.MapBrowserEvent.EventType.POINTERDRAG && this.sketchFeature_ !== null) {
+      event.type === ol.MapBrowserEventType.POINTERDRAG && this.sketchFeature_ !== null) {
     this.addToDrawing_(event);
     pass = false;
   } else if (event.type ===
-      ol.MapBrowserEvent.EventType.POINTERMOVE) {
+      ol.MapBrowserEventType.POINTERMOVE) {
     pass = this.handlePointerMove_(event);
-  } else if (event.type === ol.MapBrowserEvent.EventType.DBLCLICK) {
+  } else if (event.type === ol.MapBrowserEventType.DBLCLICK) {
     pass = false;
   }
   return ol.interaction.Pointer.handleEvent.call(this, event) && pass;

--- a/src/ol/interaction/draw.js
+++ b/src/ol/interaction/draw.js
@@ -85,7 +85,7 @@ ol.interaction.Draw = function(options) {
 
   /**
    * Drawing mode (derived from geometry type.
-   * @type {ol.interaction.Draw.Mode}
+   * @type {ol.interaction.Draw.Mode_}
    * @private
    */
   this.mode_ = ol.interaction.Draw.getMode_(this.type_);
@@ -99,7 +99,7 @@ ol.interaction.Draw = function(options) {
    */
   this.minPoints_ = options.minPoints ?
       options.minPoints :
-      (this.mode_ === ol.interaction.Draw.Mode.POLYGON ? 3 : 2);
+      (this.mode_ === ol.interaction.Draw.Mode_.POLYGON ? 3 : 2);
 
   /**
    * The number of points that can be drawn before a polygon ring or line string
@@ -136,11 +136,11 @@ ol.interaction.Draw = function(options) {
     } else {
       var Constructor;
       var mode = this.mode_;
-      if (mode === ol.interaction.Draw.Mode.POINT) {
+      if (mode === ol.interaction.Draw.Mode_.POINT) {
         Constructor = ol.geom.Point;
-      } else if (mode === ol.interaction.Draw.Mode.LINE_STRING) {
+      } else if (mode === ol.interaction.Draw.Mode_.LINE_STRING) {
         Constructor = ol.geom.LineString;
-      } else if (mode === ol.interaction.Draw.Mode.POLYGON) {
+      } else if (mode === ol.interaction.Draw.Mode_.POLYGON) {
         Constructor = ol.geom.Polygon;
       }
       /**
@@ -152,7 +152,7 @@ ol.interaction.Draw = function(options) {
       geometryFunction = function(coordinates, opt_geometry) {
         var geometry = opt_geometry;
         if (geometry) {
-          if (mode === ol.interaction.Draw.Mode.POLYGON) {
+          if (mode === ol.interaction.Draw.Mode_.POLYGON) {
             geometry.setCoordinates([coordinates[0].concat([coordinates[0][0]])]);
           } else {
             geometry.setCoordinates(coordinates);
@@ -301,7 +301,7 @@ ol.interaction.Draw.prototype.setMap = function(map) {
  * @api
  */
 ol.interaction.Draw.handleEvent = function(event) {
-  this.freehand_ = this.mode_ !== ol.interaction.Draw.Mode.POINT && this.freehandCondition_(event);
+  this.freehand_ = this.mode_ !== ol.interaction.Draw.Mode_.POINT && this.freehandCondition_(event);
   var pass = !this.freehand_;
   if (this.freehand_ &&
       event.type === ol.MapBrowserEvent.EventType.POINTERDRAG && this.sketchFeature_ !== null) {
@@ -355,12 +355,12 @@ ol.interaction.Draw.handleUpEvent_ = function(event) {
   var shouldHandle = this.freehand_ ?
       squaredDistance > this.squaredClickTolerance_ :
       squaredDistance <= this.squaredClickTolerance_;
-  var circleMode = this.mode_ === ol.interaction.Draw.Mode.CIRCLE;
+  var circleMode = this.mode_ === ol.interaction.Draw.Mode_.CIRCLE;
   if (shouldHandle) {
     this.handlePointerMove_(event);
     if (!this.finishCoordinate_) {
       this.startDrawing_(event);
-      if (this.mode_ === ol.interaction.Draw.Mode.POINT) {
+      if (this.mode_ === ol.interaction.Draw.Mode_.POINT) {
         this.finishDrawing();
       }
     } else if (this.freehand_ || circleMode) {
@@ -407,9 +407,9 @@ ol.interaction.Draw.prototype.atFinish_ = function(event) {
   if (this.sketchFeature_) {
     var potentiallyDone = false;
     var potentiallyFinishCoordinates = [this.finishCoordinate_];
-    if (this.mode_ === ol.interaction.Draw.Mode.LINE_STRING) {
+    if (this.mode_ === ol.interaction.Draw.Mode_.LINE_STRING) {
       potentiallyDone = this.sketchCoords_.length > this.minPoints_;
-    } else if (this.mode_ === ol.interaction.Draw.Mode.POLYGON) {
+    } else if (this.mode_ === ol.interaction.Draw.Mode_.POLYGON) {
       potentiallyDone = this.sketchCoords_[0].length >
           this.minPoints_;
       potentiallyFinishCoordinates = [this.sketchCoords_[0][0],
@@ -460,14 +460,14 @@ ol.interaction.Draw.prototype.createOrUpdateSketchPoint_ = function(event) {
 ol.interaction.Draw.prototype.startDrawing_ = function(event) {
   var start = event.coordinate;
   this.finishCoordinate_ = start;
-  if (this.mode_ === ol.interaction.Draw.Mode.POINT) {
+  if (this.mode_ === ol.interaction.Draw.Mode_.POINT) {
     this.sketchCoords_ = start.slice();
-  } else if (this.mode_ === ol.interaction.Draw.Mode.POLYGON) {
+  } else if (this.mode_ === ol.interaction.Draw.Mode_.POLYGON) {
     this.sketchCoords_ = [[start.slice(), start.slice()]];
     this.sketchLineCoords_ = this.sketchCoords_[0];
   } else {
     this.sketchCoords_ = [start.slice(), start.slice()];
-    if (this.mode_ === ol.interaction.Draw.Mode.CIRCLE) {
+    if (this.mode_ === ol.interaction.Draw.Mode_.CIRCLE) {
       this.sketchLineCoords_ = this.sketchCoords_;
     }
   }
@@ -497,9 +497,9 @@ ol.interaction.Draw.prototype.modifyDrawing_ = function(event) {
   var coordinate = event.coordinate;
   var geometry = /** @type {ol.geom.SimpleGeometry} */ (this.sketchFeature_.getGeometry());
   var coordinates, last;
-  if (this.mode_ === ol.interaction.Draw.Mode.POINT) {
+  if (this.mode_ === ol.interaction.Draw.Mode_.POINT) {
     last = this.sketchCoords_;
-  } else if (this.mode_ === ol.interaction.Draw.Mode.POLYGON) {
+  } else if (this.mode_ === ol.interaction.Draw.Mode_.POLYGON) {
     coordinates = this.sketchCoords_[0];
     last = coordinates[coordinates.length - 1];
     if (this.atFinish_(event)) {
@@ -522,7 +522,7 @@ ol.interaction.Draw.prototype.modifyDrawing_ = function(event) {
   }
   var sketchLineGeom;
   if (geometry instanceof ol.geom.Polygon &&
-      this.mode_ !== ol.interaction.Draw.Mode.POLYGON) {
+      this.mode_ !== ol.interaction.Draw.Mode_.POLYGON) {
     if (!this.sketchLine_) {
       this.sketchLine_ = new ol.Feature(new ol.geom.LineString(null));
     }
@@ -548,7 +548,7 @@ ol.interaction.Draw.prototype.addToDrawing_ = function(event) {
   var geometry = /** @type {ol.geom.SimpleGeometry} */ (this.sketchFeature_.getGeometry());
   var done;
   var coordinates;
-  if (this.mode_ === ol.interaction.Draw.Mode.LINE_STRING) {
+  if (this.mode_ === ol.interaction.Draw.Mode_.LINE_STRING) {
     this.finishCoordinate_ = coordinate.slice();
     coordinates = this.sketchCoords_;
     if (coordinates.length >= this.maxPoints_) {
@@ -560,7 +560,7 @@ ol.interaction.Draw.prototype.addToDrawing_ = function(event) {
     }
     coordinates.push(coordinate.slice());
     this.geometryFunction_(coordinates, geometry);
-  } else if (this.mode_ === ol.interaction.Draw.Mode.POLYGON) {
+  } else if (this.mode_ === ol.interaction.Draw.Mode_.POLYGON) {
     coordinates = this.sketchCoords_[0];
     if (coordinates.length >= this.maxPoints_) {
       if (this.freehand_) {
@@ -589,11 +589,11 @@ ol.interaction.Draw.prototype.addToDrawing_ = function(event) {
 ol.interaction.Draw.prototype.removeLastPoint = function() {
   var geometry = /** @type {ol.geom.SimpleGeometry} */ (this.sketchFeature_.getGeometry());
   var coordinates, sketchLineGeom;
-  if (this.mode_ === ol.interaction.Draw.Mode.LINE_STRING) {
+  if (this.mode_ === ol.interaction.Draw.Mode_.LINE_STRING) {
     coordinates = this.sketchCoords_;
     coordinates.splice(-2, 1);
     this.geometryFunction_(coordinates, geometry);
-  } else if (this.mode_ === ol.interaction.Draw.Mode.POLYGON) {
+  } else if (this.mode_ === ol.interaction.Draw.Mode_.POLYGON) {
     coordinates = this.sketchCoords_[0];
     coordinates.splice(-2, 1);
     sketchLineGeom = /** @type {ol.geom.LineString} */ (this.sketchLine_.getGeometry());
@@ -619,11 +619,11 @@ ol.interaction.Draw.prototype.finishDrawing = function() {
   var sketchFeature = this.abortDrawing_();
   var coordinates = this.sketchCoords_;
   var geometry = /** @type {ol.geom.SimpleGeometry} */ (sketchFeature.getGeometry());
-  if (this.mode_ === ol.interaction.Draw.Mode.LINE_STRING) {
+  if (this.mode_ === ol.interaction.Draw.Mode_.LINE_STRING) {
     // remove the redundant last point
     coordinates.pop();
     this.geometryFunction_(coordinates, geometry);
-  } else if (this.mode_ === ol.interaction.Draw.Mode.POLYGON) {
+  } else if (this.mode_ === ol.interaction.Draw.Mode_.POLYGON) {
     // remove the redundant last point in ring
     coordinates[0].pop();
     this.geometryFunction_(coordinates, geometry);
@@ -680,7 +680,7 @@ ol.interaction.Draw.prototype.abortDrawing_ = function() {
  */
 ol.interaction.Draw.prototype.extend = function(feature) {
   var geometry = feature.getGeometry();
-  ol.DEBUG && console.assert(this.mode_ == ol.interaction.Draw.Mode.LINE_STRING,
+  ol.DEBUG && console.assert(this.mode_ == ol.interaction.Draw.Mode_.LINE_STRING,
       'interaction mode must be "line"');
   ol.DEBUG && console.assert(geometry.getType() == ol.geom.GeometryType.LINE_STRING,
       'feature geometry must be a line string');
@@ -806,24 +806,24 @@ ol.interaction.Draw.createBox = function() {
  * Get the drawing mode.  The mode for mult-part geometries is the same as for
  * their single-part cousins.
  * @param {ol.geom.GeometryType} type Geometry type.
- * @return {ol.interaction.Draw.Mode} Drawing mode.
+ * @return {ol.interaction.Draw.Mode_} Drawing mode.
  * @private
  */
 ol.interaction.Draw.getMode_ = function(type) {
   var mode;
   if (type === ol.geom.GeometryType.POINT ||
       type === ol.geom.GeometryType.MULTI_POINT) {
-    mode = ol.interaction.Draw.Mode.POINT;
+    mode = ol.interaction.Draw.Mode_.POINT;
   } else if (type === ol.geom.GeometryType.LINE_STRING ||
       type === ol.geom.GeometryType.MULTI_LINE_STRING) {
-    mode = ol.interaction.Draw.Mode.LINE_STRING;
+    mode = ol.interaction.Draw.Mode_.LINE_STRING;
   } else if (type === ol.geom.GeometryType.POLYGON ||
       type === ol.geom.GeometryType.MULTI_POLYGON) {
-    mode = ol.interaction.Draw.Mode.POLYGON;
+    mode = ol.interaction.Draw.Mode_.POLYGON;
   } else if (type === ol.geom.GeometryType.CIRCLE) {
-    mode = ol.interaction.Draw.Mode.CIRCLE;
+    mode = ol.interaction.Draw.Mode_.CIRCLE;
   }
-  return /** @type {!ol.interaction.Draw.Mode} */ (mode);
+  return /** @type {!ol.interaction.Draw.Mode_} */ (mode);
 };
 
 
@@ -831,8 +831,9 @@ ol.interaction.Draw.getMode_ = function(type) {
  * Draw mode.  This collapses multi-part geometry types with their single-part
  * cousins.
  * @enum {string}
+ * @private
  */
-ol.interaction.Draw.Mode = {
+ol.interaction.Draw.Mode_ = {
   POINT: 'Point',
   LINE_STRING: 'LineString',
   POLYGON: 'Polygon',

--- a/src/ol/interaction/extent.js
+++ b/src/ol/interaction/extent.js
@@ -451,7 +451,7 @@ ol.interaction.Extent.prototype.setExtent = function(extent) {
  * @extends {ol.events.Event}
  */
 ol.interaction.Extent.Event = function(extent) {
-  ol.events.Event.call(this, ol.interaction.Extent.EventType.EXTENTCHANGED);
+  ol.events.Event.call(this, ol.interaction.Extent.EventType_.EXTENTCHANGED);
 
   /**
    * The current extent.
@@ -465,8 +465,9 @@ ol.inherits(ol.interaction.Extent.Event, ol.events.Event);
 
 /**
  * @enum {string}
+ * @private
  */
-ol.interaction.Extent.EventType = {
+ol.interaction.Extent.EventType_ = {
   /**
    * Triggered after the extent is changed
    * @event ol.interaction.Extent.Event

--- a/src/ol/interaction/extent.js
+++ b/src/ol/interaction/extent.js
@@ -2,7 +2,7 @@ goog.provide('ol.interaction.Extent');
 
 goog.require('ol');
 goog.require('ol.Feature');
-goog.require('ol.MapBrowserEvent');
+goog.require('ol.MapBrowserEventType');
 goog.require('ol.MapBrowserPointerEvent');
 goog.require('ol.coordinate');
 goog.require('ol.events.Event');
@@ -132,7 +132,7 @@ ol.interaction.Extent.handleEvent_ = function(mapBrowserEvent) {
     return true;
   }
   //display pointer (if not dragging)
-  if (mapBrowserEvent.type == ol.MapBrowserEvent.EventType.POINTERMOVE && !this.handlingDownUpSequence) {
+  if (mapBrowserEvent.type == ol.MapBrowserEventType.POINTERMOVE && !this.handlingDownUpSequence) {
     this.handlePointerMove_(mapBrowserEvent);
   }
   //call pointer to determine up/down/drag

--- a/src/ol/interaction/modify.js
+++ b/src/ol/interaction/modify.js
@@ -3,7 +3,7 @@ goog.provide('ol.interaction.Modify');
 goog.require('ol');
 goog.require('ol.CollectionEventType');
 goog.require('ol.Feature');
-goog.require('ol.MapBrowserEvent');
+goog.require('ol.MapBrowserEventType');
 goog.require('ol.MapBrowserPointerEvent');
 goog.require('ol.ViewHint');
 goog.require('ol.array');
@@ -656,12 +656,12 @@ ol.interaction.Modify.handleEvent = function(mapBrowserEvent) {
 
   var handled;
   if (!mapBrowserEvent.map.getView().getHints()[ol.ViewHint.INTERACTING] &&
-      mapBrowserEvent.type == ol.MapBrowserEvent.EventType.POINTERMOVE &&
+      mapBrowserEvent.type == ol.MapBrowserEventType.POINTERMOVE &&
       !this.handlingDownUpSequence) {
     this.handlePointerMove_(mapBrowserEvent);
   }
   if (this.vertexFeature_ && this.deleteCondition_(mapBrowserEvent)) {
-    if (mapBrowserEvent.type != ol.MapBrowserEvent.EventType.SINGLECLICK ||
+    if (mapBrowserEvent.type != ol.MapBrowserEventType.SINGLECLICK ||
         !this.ignoreNextSingleClick_) {
       handled = this.removePoint();
     } else {
@@ -669,7 +669,7 @@ ol.interaction.Modify.handleEvent = function(mapBrowserEvent) {
     }
   }
 
-  if (mapBrowserEvent.type == ol.MapBrowserEvent.EventType.SINGLECLICK) {
+  if (mapBrowserEvent.type == ol.MapBrowserEventType.SINGLECLICK) {
     this.ignoreNextSingleClick_ = false;
   }
 
@@ -823,7 +823,7 @@ ol.interaction.Modify.prototype.insertVertex_ = function(segmentData, vertex) {
  * @api
  */
 ol.interaction.Modify.prototype.removePoint = function() {
-  if (this.lastPointerEvent_ && this.lastPointerEvent_.type != ol.MapBrowserEvent.EventType.POINTERDRAG) {
+  if (this.lastPointerEvent_ && this.lastPointerEvent_.type != ol.MapBrowserEventType.POINTERDRAG) {
     var evt = this.lastPointerEvent_;
     this.willModifyFeatures_(evt);
     this.removeVertex_();

--- a/src/ol/interaction/modify.js
+++ b/src/ol/interaction/modify.js
@@ -1,7 +1,7 @@
 goog.provide('ol.interaction.Modify');
 
 goog.require('ol');
-goog.require('ol.Collection');
+goog.require('ol.CollectionEventType');
 goog.require('ol.Feature');
 goog.require('ol.MapBrowserEvent');
 goog.require('ol.MapBrowserPointerEvent');
@@ -173,9 +173,9 @@ ol.interaction.Modify = function(options) {
   this.features_ = options.features;
 
   this.features_.forEach(this.addFeature_, this);
-  ol.events.listen(this.features_, ol.Collection.EventType.ADD,
+  ol.events.listen(this.features_, ol.CollectionEventType.ADD,
       this.handleFeatureAdd_, this);
-  ol.events.listen(this.features_, ol.Collection.EventType.REMOVE,
+  ol.events.listen(this.features_, ol.CollectionEventType.REMOVE,
       this.handleFeatureRemove_, this);
 
   /**

--- a/src/ol/interaction/modify.js
+++ b/src/ol/interaction/modify.js
@@ -214,7 +214,7 @@ ol.interaction.Modify.prototype.willModifyFeatures_ = function(evt) {
   if (!this.modified_) {
     this.modified_ = true;
     this.dispatchEvent(new ol.interaction.Modify.Event(
-        ol.interaction.Modify.EventType.MODIFYSTART, this.features_, evt));
+        ol.interaction.Modify.EventType_.MODIFYSTART, this.features_, evt));
   }
 };
 
@@ -633,7 +633,7 @@ ol.interaction.Modify.handleUpEvent_ = function(evt) {
   }
   if (this.modified_) {
     this.dispatchEvent(new ol.interaction.Modify.Event(
-        ol.interaction.Modify.EventType.MODIFYEND, this.features_, evt));
+        ol.interaction.Modify.EventType_.MODIFYEND, this.features_, evt));
     this.modified_ = false;
   }
   return false;
@@ -828,7 +828,7 @@ ol.interaction.Modify.prototype.removePoint = function() {
     this.willModifyFeatures_(evt);
     this.removeVertex_();
     this.dispatchEvent(new ol.interaction.Modify.Event(
-        ol.interaction.Modify.EventType.MODIFYEND, this.features_, evt));
+        ol.interaction.Modify.EventType_.MODIFYEND, this.features_, evt));
     this.modified_ = false;
     return true;
   }
@@ -1006,7 +1006,7 @@ ol.interaction.Modify.getDefaultStyleFunction = function() {
  * @constructor
  * @extends {ol.events.Event}
  * @implements {oli.ModifyEvent}
- * @param {ol.interaction.Modify.EventType} type Type.
+ * @param {ol.interaction.Modify.EventType_} type Type.
  * @param {ol.Collection.<ol.Feature>} features The features modified.
  * @param {ol.MapBrowserPointerEvent} mapBrowserPointerEvent Associated
  *     {@link ol.MapBrowserPointerEvent}.
@@ -1034,8 +1034,9 @@ ol.inherits(ol.interaction.Modify.Event, ol.events.Event);
 
 /**
  * @enum {string}
+ * @private
  */
-ol.interaction.Modify.EventType = {
+ol.interaction.Modify.EventType_ = {
   /**
    * Triggered upon feature modification start
    * @event ol.interaction.Modify.Event#modifystart

--- a/src/ol/interaction/mousewheelzoom.js
+++ b/src/ol/interaction/mousewheelzoom.js
@@ -70,7 +70,7 @@ ol.interaction.MouseWheelZoom = function(opt_options) {
 
   /**
    * @private
-   * @type {ol.interaction.MouseWheelZoom.Mode|undefined}
+   * @type {ol.interaction.MouseWheelZoom.Mode_|undefined}
    */
   this.mode_ = undefined;
 
@@ -158,11 +158,11 @@ ol.interaction.MouseWheelZoom.handleEvent = function(mapBrowserEvent) {
 
   if (!this.mode_ || now - this.startTime_ > this.trackpadEventGap_) {
     this.mode_ = Math.abs(delta) < 4 ?
-        ol.interaction.MouseWheelZoom.Mode.TRACKPAD :
-        ol.interaction.MouseWheelZoom.Mode.WHEEL;
+        ol.interaction.MouseWheelZoom.Mode_.TRACKPAD :
+        ol.interaction.MouseWheelZoom.Mode_.WHEEL;
   }
 
-  if (this.mode_ === ol.interaction.MouseWheelZoom.Mode.TRACKPAD) {
+  if (this.mode_ === ol.interaction.MouseWheelZoom.Mode_.TRACKPAD) {
     var view = map.getView();
     if (this.trackpadTimeoutId_) {
       clearTimeout(this.trackpadTimeoutId_);
@@ -263,8 +263,9 @@ ol.interaction.MouseWheelZoom.prototype.setMouseAnchor = function(useAnchor) {
 
 /**
  * @enum {string}
+ * @private
  */
-ol.interaction.MouseWheelZoom.Mode = {
+ol.interaction.MouseWheelZoom.Mode_ = {
   TRACKPAD: 'trackpad',
   WHEEL: 'wheel'
 };

--- a/src/ol/interaction/pointer.js
+++ b/src/ol/interaction/pointer.js
@@ -2,7 +2,7 @@ goog.provide('ol.interaction.Pointer');
 
 goog.require('ol');
 goog.require('ol.functions');
-goog.require('ol.MapBrowserEvent');
+goog.require('ol.MapBrowserEventType');
 goog.require('ol.MapBrowserPointerEvent');
 goog.require('ol.interaction.Interaction');
 goog.require('ol.obj');
@@ -109,9 +109,9 @@ ol.interaction.Pointer.centroid = function(pointerEvents) {
 ol.interaction.Pointer.prototype.isPointerDraggingEvent_ = function(mapBrowserEvent) {
   var type = mapBrowserEvent.type;
   return (
-      type === ol.MapBrowserEvent.EventType.POINTERDOWN ||
-      type === ol.MapBrowserEvent.EventType.POINTERDRAG ||
-      type === ol.MapBrowserEvent.EventType.POINTERUP);
+      type === ol.MapBrowserEventType.POINTERDOWN ||
+      type === ol.MapBrowserEventType.POINTERDRAG ||
+      type === ol.MapBrowserEventType.POINTERUP);
 };
 
 
@@ -123,10 +123,10 @@ ol.interaction.Pointer.prototype.updateTrackedPointers_ = function(mapBrowserEve
   if (this.isPointerDraggingEvent_(mapBrowserEvent)) {
     var event = mapBrowserEvent.pointerEvent;
 
-    if (mapBrowserEvent.type == ol.MapBrowserEvent.EventType.POINTERUP) {
+    if (mapBrowserEvent.type == ol.MapBrowserEventType.POINTERUP) {
       delete this.trackedPointers_[event.pointerId];
     } else if (mapBrowserEvent.type ==
-        ol.MapBrowserEvent.EventType.POINTERDOWN) {
+        ol.MapBrowserEventType.POINTERDOWN) {
       this.trackedPointers_[event.pointerId] = event;
     } else if (event.pointerId in this.trackedPointers_) {
       // update only when there was a pointerdown event for this pointer
@@ -184,17 +184,17 @@ ol.interaction.Pointer.handleEvent = function(mapBrowserEvent) {
   var stopEvent = false;
   this.updateTrackedPointers_(mapBrowserEvent);
   if (this.handlingDownUpSequence) {
-    if (mapBrowserEvent.type == ol.MapBrowserEvent.EventType.POINTERDRAG) {
+    if (mapBrowserEvent.type == ol.MapBrowserEventType.POINTERDRAG) {
       this.handleDragEvent_(mapBrowserEvent);
-    } else if (mapBrowserEvent.type == ol.MapBrowserEvent.EventType.POINTERUP) {
+    } else if (mapBrowserEvent.type == ol.MapBrowserEventType.POINTERUP) {
       this.handlingDownUpSequence = this.handleUpEvent_(mapBrowserEvent);
     }
   }
-  if (mapBrowserEvent.type == ol.MapBrowserEvent.EventType.POINTERDOWN) {
+  if (mapBrowserEvent.type == ol.MapBrowserEventType.POINTERDOWN) {
     var handled = this.handleDownEvent_(mapBrowserEvent);
     this.handlingDownUpSequence = handled;
     stopEvent = this.shouldStopEvent(handled);
-  } else if (mapBrowserEvent.type == ol.MapBrowserEvent.EventType.POINTERMOVE) {
+  } else if (mapBrowserEvent.type == ol.MapBrowserEventType.POINTERMOVE) {
     this.handleMoveEvent_(mapBrowserEvent);
   }
   return !stopEvent;

--- a/src/ol/interaction/select.js
+++ b/src/ol/interaction/select.js
@@ -1,12 +1,12 @@
 goog.provide('ol.interaction.Select');
 
 goog.require('ol');
-goog.require('ol.functions');
-goog.require('ol.Collection');
+goog.require('ol.CollectionEventType');
 goog.require('ol.array');
 goog.require('ol.events');
 goog.require('ol.events.Event');
 goog.require('ol.events.condition');
+goog.require('ol.functions');
 goog.require('ol.geom.GeometryType');
 goog.require('ol.interaction.Interaction');
 goog.require('ol.layer.Vector');
@@ -136,9 +136,9 @@ ol.interaction.Select = function(opt_options) {
   this.featureLayerAssociation_ = {};
 
   var features = this.featureOverlay_.getSource().getFeaturesCollection();
-  ol.events.listen(features, ol.Collection.EventType.ADD,
+  ol.events.listen(features, ol.CollectionEventType.ADD,
       this.addFeature_, this);
-  ol.events.listen(features, ol.Collection.EventType.REMOVE,
+  ol.events.listen(features, ol.CollectionEventType.REMOVE,
       this.removeFeature_, this);
 
 };

--- a/src/ol/interaction/select.js
+++ b/src/ol/interaction/select.js
@@ -280,7 +280,7 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
   }
   if (selected.length > 0 || deselected.length > 0) {
     this.dispatchEvent(
-        new ol.interaction.Select.Event(ol.interaction.Select.EventType.SELECT,
+        new ol.interaction.Select.Event(ol.interaction.Select.EventType_.SELECT,
             selected, deselected, mapBrowserEvent));
   }
   return ol.events.condition.pointerMove(mapBrowserEvent);
@@ -378,7 +378,7 @@ ol.interaction.Select.prototype.removeFeatureLayerAssociation_ = function(featur
  * Events emitted by {@link ol.interaction.Select} instances are instances of
  * this type.
  *
- * @param {ol.interaction.Select.EventType} type The event type.
+ * @param {ol.interaction.Select.EventType_} type The event type.
  * @param {Array.<ol.Feature>} selected Selected features.
  * @param {Array.<ol.Feature>} deselected Deselected features.
  * @param {ol.MapBrowserEvent} mapBrowserEvent Associated
@@ -416,8 +416,9 @@ ol.inherits(ol.interaction.Select.Event, ol.events.Event);
 
 /**
  * @enum {string}
+ * @private
  */
-ol.interaction.Select.EventType = {
+ol.interaction.Select.EventType_ = {
   /**
    * Triggered when feature(s) has been (de)selected.
    * @event ol.interaction.Select.Event#select

--- a/src/ol/interaction/snap.js
+++ b/src/ol/interaction/snap.js
@@ -2,6 +2,7 @@ goog.provide('ol.interaction.Snap');
 
 goog.require('ol');
 goog.require('ol.Collection');
+goog.require('ol.CollectionEventType');
 goog.require('ol.Object');
 goog.require('ol.Observable');
 goog.require('ol.coordinate');
@@ -335,9 +336,9 @@ ol.interaction.Snap.prototype.setMap = function(map) {
   if (map) {
     if (this.features_) {
       keys.push(
-        ol.events.listen(this.features_, ol.Collection.EventType.ADD,
+        ol.events.listen(this.features_, ol.CollectionEventType.ADD,
             this.handleFeatureAdd_, this),
-        ol.events.listen(this.features_, ol.Collection.EventType.REMOVE,
+        ol.events.listen(this.features_, ol.CollectionEventType.REMOVE,
             this.handleFeatureRemove_, this)
       );
     } else if (this.source_) {

--- a/src/ol/interaction/snap.js
+++ b/src/ol/interaction/snap.js
@@ -9,10 +9,11 @@ goog.require('ol.coordinate');
 goog.require('ol.events');
 goog.require('ol.events.EventType');
 goog.require('ol.extent');
-goog.require('ol.interaction.Pointer');
 goog.require('ol.functions');
+goog.require('ol.interaction.Pointer');
 goog.require('ol.obj');
 goog.require('ol.source.Vector');
+goog.require('ol.source.VectorEventType');
 goog.require('ol.structs.RBush');
 
 
@@ -343,9 +344,9 @@ ol.interaction.Snap.prototype.setMap = function(map) {
       );
     } else if (this.source_) {
       keys.push(
-        ol.events.listen(this.source_, ol.source.Vector.EventType.ADDFEATURE,
+        ol.events.listen(this.source_, ol.source.VectorEventType.ADDFEATURE,
             this.handleFeatureAdd_, this),
-        ol.events.listen(this.source_, ol.source.Vector.EventType.REMOVEFEATURE,
+        ol.events.listen(this.source_, ol.source.VectorEventType.REMOVEFEATURE,
             this.handleFeatureRemove_, this)
       );
     }

--- a/src/ol/interaction/translate.js
+++ b/src/ol/interaction/translate.js
@@ -101,7 +101,7 @@ ol.interaction.Translate.handleDownEvent_ = function(event) {
 
     this.dispatchEvent(
         new ol.interaction.Translate.Event(
-            ol.interaction.Translate.EventType.TRANSLATESTART, features,
+            ol.interaction.Translate.EventType_.TRANSLATESTART, features,
             event.coordinate));
     return true;
   }
@@ -124,7 +124,7 @@ ol.interaction.Translate.handleUpEvent_ = function(event) {
 
     this.dispatchEvent(
         new ol.interaction.Translate.Event(
-            ol.interaction.Translate.EventType.TRANSLATEEND, features,
+            ol.interaction.Translate.EventType_.TRANSLATEEND, features,
             event.coordinate));
     return true;
   }
@@ -154,7 +154,7 @@ ol.interaction.Translate.handleDragEvent_ = function(event) {
     this.lastCoordinate_ = newCoordinate;
     this.dispatchEvent(
         new ol.interaction.Translate.Event(
-            ol.interaction.Translate.EventType.TRANSLATING, features,
+            ol.interaction.Translate.EventType_.TRANSLATING, features,
             newCoordinate));
   }
 };
@@ -240,7 +240,7 @@ ol.interaction.Translate.prototype.setHitTolerance = function(hitTolerance) {
  * @constructor
  * @extends {ol.events.Event}
  * @implements {oli.interaction.TranslateEvent}
- * @param {ol.interaction.Translate.EventType} type Type.
+ * @param {ol.interaction.Translate.EventType_} type Type.
  * @param {ol.Collection.<ol.Feature>} features The features translated.
  * @param {ol.Coordinate} coordinate The event coordinate.
  */
@@ -268,8 +268,9 @@ ol.inherits(ol.interaction.Translate.Event, ol.events.Event);
 
 /**
  * @enum {string}
+ * @private
  */
-ol.interaction.Translate.EventType = {
+ol.interaction.Translate.EventType_ = {
   /**
    * Triggered upon feature translation start.
    * @event ol.interaction.Translate.Event#translatestart

--- a/src/ol/layer/group.js
+++ b/src/ol/layer/group.js
@@ -3,6 +3,7 @@ goog.provide('ol.layer.Group');
 goog.require('ol');
 goog.require('ol.asserts');
 goog.require('ol.Collection');
+goog.require('ol.CollectionEventType');
 goog.require('ol.Object');
 goog.require('ol.events');
 goog.require('ol.events.EventType');
@@ -88,9 +89,9 @@ ol.layer.Group.prototype.handleLayersChanged_ = function(event) {
 
   var layers = this.getLayers();
   this.layersListenerKeys_.push(
-      ol.events.listen(layers, ol.Collection.EventType.ADD,
+      ol.events.listen(layers, ol.CollectionEventType.ADD,
           this.handleLayersAdd_, this),
-      ol.events.listen(layers, ol.Collection.EventType.REMOVE,
+      ol.events.listen(layers, ol.CollectionEventType.REMOVE,
           this.handleLayersRemove_, this));
 
   for (var id in this.listenerKeys_) {

--- a/src/ol/layer/group.js
+++ b/src/ol/layer/group.js
@@ -1,10 +1,11 @@
 goog.provide('ol.layer.Group');
 
 goog.require('ol');
-goog.require('ol.asserts');
 goog.require('ol.Collection');
 goog.require('ol.CollectionEventType');
 goog.require('ol.Object');
+goog.require('ol.ObjectEventType');
+goog.require('ol.asserts');
 goog.require('ol.events');
 goog.require('ol.events.EventType');
 goog.require('ol.extent');
@@ -104,7 +105,7 @@ ol.layer.Group.prototype.handleLayersChanged_ = function(event) {
   for (i = 0, ii = layersArray.length; i < ii; i++) {
     layer = layersArray[i];
     this.listenerKeys_[ol.getUid(layer).toString()] = [
-      ol.events.listen(layer, ol.Object.EventType.PROPERTYCHANGE,
+      ol.events.listen(layer, ol.ObjectEventType.PROPERTYCHANGE,
           this.handleLayerChange_, this),
       ol.events.listen(layer, ol.events.EventType.CHANGE,
           this.handleLayerChange_, this)
@@ -125,7 +126,7 @@ ol.layer.Group.prototype.handleLayersAdd_ = function(collectionEvent) {
   ol.DEBUG && console.assert(!(key in this.listenerKeys_),
       'listeners already registered');
   this.listenerKeys_[key] = [
-    ol.events.listen(layer, ol.Object.EventType.PROPERTYCHANGE,
+    ol.events.listen(layer, ol.ObjectEventType.PROPERTYCHANGE,
         this.handleLayerChange_, this),
     ol.events.listen(layer, ol.events.EventType.CHANGE,
         this.handleLayerChange_, this)

--- a/src/ol/layer/group.js
+++ b/src/ol/layer/group.js
@@ -48,7 +48,7 @@ ol.layer.Group = function(opt_options) {
   this.listenerKeys_ = {};
 
   ol.events.listen(this,
-      ol.Object.getChangeEventType(ol.layer.Group.Property.LAYERS),
+      ol.Object.getChangeEventType(ol.layer.Group.Property_.LAYERS),
       this.handleLayersChanged_, this);
 
   if (layers) {
@@ -158,7 +158,7 @@ ol.layer.Group.prototype.handleLayersRemove_ = function(collectionEvent) {
  */
 ol.layer.Group.prototype.getLayers = function() {
   return /** @type {!ol.Collection.<ol.layer.Base>} */ (this.get(
-      ol.layer.Group.Property.LAYERS));
+      ol.layer.Group.Property_.LAYERS));
 };
 
 
@@ -171,7 +171,7 @@ ol.layer.Group.prototype.getLayers = function() {
  * @api stable
  */
 ol.layer.Group.prototype.setLayers = function(layers) {
-  this.set(ol.layer.Group.Property.LAYERS, layers);
+  this.set(ol.layer.Group.Property_.LAYERS, layers);
 };
 
 
@@ -232,7 +232,8 @@ ol.layer.Group.prototype.getSourceState = function() {
 
 /**
  * @enum {string}
+ * @private
  */
-ol.layer.Group.Property = {
+ol.layer.Group.Property_ = {
   LAYERS: 'layers'
 };

--- a/src/ol/layer/heatmap.js
+++ b/src/ol/layer/heatmap.js
@@ -62,7 +62,7 @@ ol.layer.Heatmap = function(opt_options) {
   this.styleCache_ = null;
 
   ol.events.listen(this,
-      ol.Object.getChangeEventType(ol.layer.Heatmap.Property.GRADIENT),
+      ol.Object.getChangeEventType(ol.layer.Heatmap.Property_.GRADIENT),
       this.handleGradientChanged_, this);
 
   this.setGradient(options.gradient ?
@@ -73,10 +73,10 @@ ol.layer.Heatmap = function(opt_options) {
   this.setRadius(options.radius !== undefined ? options.radius : 8);
 
   ol.events.listen(this,
-      ol.Object.getChangeEventType(ol.layer.Heatmap.Property.BLUR),
+      ol.Object.getChangeEventType(ol.layer.Heatmap.Property_.BLUR),
       this.handleStyleChanged_, this);
   ol.events.listen(this,
-      ol.Object.getChangeEventType(ol.layer.Heatmap.Property.RADIUS),
+      ol.Object.getChangeEventType(ol.layer.Heatmap.Property_.RADIUS),
       this.handleStyleChanged_, this);
 
   this.handleStyleChanged_();
@@ -186,7 +186,7 @@ ol.layer.Heatmap.prototype.createCircle_ = function() {
  * @observable
  */
 ol.layer.Heatmap.prototype.getBlur = function() {
-  return /** @type {number} */ (this.get(ol.layer.Heatmap.Property.BLUR));
+  return /** @type {number} */ (this.get(ol.layer.Heatmap.Property_.BLUR));
 };
 
 
@@ -198,7 +198,7 @@ ol.layer.Heatmap.prototype.getBlur = function() {
  */
 ol.layer.Heatmap.prototype.getGradient = function() {
   return /** @type {Array.<string>} */ (
-      this.get(ol.layer.Heatmap.Property.GRADIENT));
+      this.get(ol.layer.Heatmap.Property_.GRADIENT));
 };
 
 
@@ -209,7 +209,7 @@ ol.layer.Heatmap.prototype.getGradient = function() {
  * @observable
  */
 ol.layer.Heatmap.prototype.getRadius = function() {
-  return /** @type {number} */ (this.get(ol.layer.Heatmap.Property.RADIUS));
+  return /** @type {number} */ (this.get(ol.layer.Heatmap.Property_.RADIUS));
 };
 
 
@@ -263,7 +263,7 @@ ol.layer.Heatmap.prototype.handleRender_ = function(event) {
  * @observable
  */
 ol.layer.Heatmap.prototype.setBlur = function(blur) {
-  this.set(ol.layer.Heatmap.Property.BLUR, blur);
+  this.set(ol.layer.Heatmap.Property_.BLUR, blur);
 };
 
 
@@ -274,7 +274,7 @@ ol.layer.Heatmap.prototype.setBlur = function(blur) {
  * @observable
  */
 ol.layer.Heatmap.prototype.setGradient = function(colors) {
-  this.set(ol.layer.Heatmap.Property.GRADIENT, colors);
+  this.set(ol.layer.Heatmap.Property_.GRADIENT, colors);
 };
 
 
@@ -285,14 +285,15 @@ ol.layer.Heatmap.prototype.setGradient = function(colors) {
  * @observable
  */
 ol.layer.Heatmap.prototype.setRadius = function(radius) {
-  this.set(ol.layer.Heatmap.Property.RADIUS, radius);
+  this.set(ol.layer.Heatmap.Property_.RADIUS, radius);
 };
 
 
 /**
  * @enum {string}
+ * @private
  */
-ol.layer.Heatmap.Property = {
+ol.layer.Heatmap.Property_ = {
   BLUR: 'blur',
   GRADIENT: 'gradient',
   RADIUS: 'radius'

--- a/src/ol/layer/tile.js
+++ b/src/ol/layer/tile.js
@@ -2,6 +2,7 @@ goog.provide('ol.layer.Tile');
 
 goog.require('ol');
 goog.require('ol.layer.Layer');
+goog.require('ol.layer.TileProperty');
 goog.require('ol.obj');
 
 
@@ -42,7 +43,7 @@ ol.inherits(ol.layer.Tile, ol.layer.Layer);
  * @api
  */
 ol.layer.Tile.prototype.getPreload = function() {
-  return /** @type {number} */ (this.get(ol.layer.Tile.Property.PRELOAD));
+  return /** @type {number} */ (this.get(ol.layer.TileProperty.PRELOAD));
 };
 
 
@@ -62,7 +63,7 @@ ol.layer.Tile.prototype.getSource;
  * @api
  */
 ol.layer.Tile.prototype.setPreload = function(preload) {
-  this.set(ol.layer.Tile.Property.PRELOAD, preload);
+  this.set(ol.layer.TileProperty.PRELOAD, preload);
 };
 
 
@@ -74,7 +75,7 @@ ol.layer.Tile.prototype.setPreload = function(preload) {
  */
 ol.layer.Tile.prototype.getUseInterimTilesOnError = function() {
   return /** @type {boolean} */ (
-      this.get(ol.layer.Tile.Property.USE_INTERIM_TILES_ON_ERROR));
+      this.get(ol.layer.TileProperty.USE_INTERIM_TILES_ON_ERROR));
 };
 
 
@@ -86,14 +87,5 @@ ol.layer.Tile.prototype.getUseInterimTilesOnError = function() {
  */
 ol.layer.Tile.prototype.setUseInterimTilesOnError = function(useInterimTilesOnError) {
   this.set(
-      ol.layer.Tile.Property.USE_INTERIM_TILES_ON_ERROR, useInterimTilesOnError);
-};
-
-
-/**
- * @enum {string}
- */
-ol.layer.Tile.Property = {
-  PRELOAD: 'preload',
-  USE_INTERIM_TILES_ON_ERROR: 'useInterimTilesOnError'
+      ol.layer.TileProperty.USE_INTERIM_TILES_ON_ERROR, useInterimTilesOnError);
 };

--- a/src/ol/layer/tileproperty.js
+++ b/src/ol/layer/tileproperty.js
@@ -1,0 +1,9 @@
+goog.provide('ol.layer.TileProperty');
+
+/**
+ * @enum {string}
+ */
+ol.layer.TileProperty = {
+  PRELOAD: 'preload',
+  USE_INTERIM_TILES_ON_ERROR: 'useInterimTilesOnError'
+};

--- a/src/ol/layer/vector.js
+++ b/src/ol/layer/vector.js
@@ -92,7 +92,7 @@ ol.layer.Vector.prototype.getRenderBuffer = function() {
  */
 ol.layer.Vector.prototype.getRenderOrder = function() {
   return /** @type {function(ol.Feature, ol.Feature):number|null|undefined} */ (
-      this.get(ol.layer.Vector.Property.RENDER_ORDER));
+      this.get(ol.layer.Vector.Property_.RENDER_ORDER));
 };
 
 
@@ -154,7 +154,7 @@ ol.layer.Vector.prototype.setRenderOrder = function(renderOrder) {
       renderOrder === undefined || !renderOrder ||
       typeof renderOrder === 'function',
       'renderOrder must be a comparator function');
-  this.set(ol.layer.Vector.Property.RENDER_ORDER, renderOrder);
+  this.set(ol.layer.Vector.Property_.RENDER_ORDER, renderOrder);
 };
 
 
@@ -179,7 +179,8 @@ ol.layer.Vector.prototype.setStyle = function(style) {
 
 /**
  * @enum {string}
+ * @private
  */
-ol.layer.Vector.Property = {
+ol.layer.Vector.Property_ = {
   RENDER_ORDER: 'renderOrder'
 };

--- a/src/ol/layer/vectortile.js
+++ b/src/ol/layer/vectortile.js
@@ -2,7 +2,7 @@ goog.provide('ol.layer.VectorTile');
 
 goog.require('ol');
 goog.require('ol.asserts');
-goog.require('ol.layer.Tile');
+goog.require('ol.layer.TileProperty');
 goog.require('ol.layer.Vector');
 goog.require('ol.obj');
 
@@ -86,7 +86,7 @@ ol.layer.VectorTile.prototype.getUseInterimTilesOnError = function() {
  * @api
  */
 ol.layer.VectorTile.prototype.setPreload = function(preload) {
-  this.set(ol.layer.Tile.Property.PRELOAD, preload);
+  this.set(ol.layer.TileProperty.PRELOAD, preload);
 };
 
 
@@ -98,7 +98,7 @@ ol.layer.VectorTile.prototype.setPreload = function(preload) {
  */
 ol.layer.VectorTile.prototype.setUseInterimTilesOnError = function(useInterimTilesOnError) {
   this.set(
-      ol.layer.Tile.Property.USE_INTERIM_TILES_ON_ERROR, useInterimTilesOnError);
+      ol.layer.TileProperty.USE_INTERIM_TILES_ON_ERROR, useInterimTilesOnError);
 };
 
 

--- a/src/ol/layer/vectortile.js
+++ b/src/ol/layer/vectortile.js
@@ -55,7 +55,7 @@ ol.inherits(ol.layer.VectorTile, ol.layer.Vector);
  * @api
  */
 ol.layer.VectorTile.prototype.getPreload = function() {
-  return /** @type {number} */ (this.get(ol.layer.VectorTile.Property.PRELOAD));
+  return /** @type {number} */ (this.get(ol.layer.VectorTile.Property_.PRELOAD));
 };
 
 
@@ -75,7 +75,7 @@ ol.layer.VectorTile.prototype.getRenderMode = function() {
  */
 ol.layer.VectorTile.prototype.getUseInterimTilesOnError = function() {
   return /** @type {boolean} */ (
-      this.get(ol.layer.VectorTile.Property.USE_INTERIM_TILES_ON_ERROR));
+      this.get(ol.layer.VectorTile.Property_.USE_INTERIM_TILES_ON_ERROR));
 };
 
 
@@ -104,8 +104,9 @@ ol.layer.VectorTile.prototype.setUseInterimTilesOnError = function(useInterimTil
 
 /**
  * @enum {string}
+ * @private
  */
-ol.layer.VectorTile.Property = {
+ol.layer.VectorTile.Property_ = {
   PRELOAD: 'preload',
   USE_INTERIM_TILES_ON_ERROR: 'useInterimTilesOnError'
 };

--- a/src/ol/layer/vectortile.js
+++ b/src/ol/layer/vectortile.js
@@ -4,6 +4,7 @@ goog.require('ol');
 goog.require('ol.asserts');
 goog.require('ol.layer.TileProperty');
 goog.require('ol.layer.Vector');
+goog.require('ol.layer.VectorTileRenderType');
 goog.require('ol.obj');
 
 
@@ -33,16 +34,16 @@ ol.layer.VectorTile = function(opt_options) {
       options.useInterimTilesOnError : true);
 
   ol.asserts.assert(options.renderMode == undefined ||
-      options.renderMode == ol.layer.VectorTile.RenderType.IMAGE ||
-      options.renderMode == ol.layer.VectorTile.RenderType.HYBRID ||
-      options.renderMode == ol.layer.VectorTile.RenderType.VECTOR,
+      options.renderMode == ol.layer.VectorTileRenderType.IMAGE ||
+      options.renderMode == ol.layer.VectorTileRenderType.HYBRID ||
+      options.renderMode == ol.layer.VectorTileRenderType.VECTOR,
       28); // `renderMode` must be `'image'`, `'hybrid'` or `'vector'`
 
   /**
    * @private
-   * @type {ol.layer.VectorTile.RenderType|string}
+   * @type {ol.layer.VectorTileRenderType|string}
    */
-  this.renderMode_ = options.renderMode || ol.layer.VectorTile.RenderType.HYBRID;
+  this.renderMode_ = options.renderMode || ol.layer.VectorTileRenderType.HYBRID;
 
 };
 ol.inherits(ol.layer.VectorTile, ol.layer.Vector);
@@ -60,7 +61,7 @@ ol.layer.VectorTile.prototype.getPreload = function() {
 
 
 /**
- * @return {ol.layer.VectorTile.RenderType|string} The render mode.
+ * @return {ol.layer.VectorTileRenderType|string} The render mode.
  */
 ol.layer.VectorTile.prototype.getRenderMode = function() {
   return this.renderMode_;
@@ -109,24 +110,4 @@ ol.layer.VectorTile.prototype.setUseInterimTilesOnError = function(useInterimTil
 ol.layer.VectorTile.Property_ = {
   PRELOAD: 'preload',
   USE_INTERIM_TILES_ON_ERROR: 'useInterimTilesOnError'
-};
-
-
-/**
- * @enum {string}
- * Render mode for vector tiles:
- *  * `'image'`: Vector tiles are rendered as images. Great performance, but
- *    point symbols and texts are always rotated with the view and pixels are
- *    scaled during zoom animations.
- *  * `'hybrid'`: Polygon and line elements are rendered as images, so pixels
- *    are scaled during zoom animations. Point symbols and texts are accurately
- *    rendered as vectors and can stay upright on rotated views.
- *  * `'vector'`: Vector tiles are rendered as vectors. Most accurate rendering
- *    even during animations, but slower performance than the other options.
- * @api
- */
-ol.layer.VectorTile.RenderType = {
-  IMAGE: 'image',
-  HYBRID: 'hybrid',
-  VECTOR: 'vector'
 };

--- a/src/ol/layer/vectortilerendertype.js
+++ b/src/ol/layer/vectortilerendertype.js
@@ -1,0 +1,20 @@
+goog.provide('ol.layer.VectorTileRenderType');
+
+/**
+ * @enum {string}
+ * Render mode for vector tiles:
+ *  * `'image'`: Vector tiles are rendered as images. Great performance, but
+ *    point symbols and texts are always rotated with the view and pixels are
+ *    scaled during zoom animations.
+ *  * `'hybrid'`: Polygon and line elements are rendered as images, so pixels
+ *    are scaled during zoom animations. Point symbols and texts are accurately
+ *    rendered as vectors and can stay upright on rotated views.
+ *  * `'vector'`: Vector tiles are rendered as vectors. Most accurate rendering
+ *    even during animations, but slower performance than the other options.
+ * @api
+ */
+ol.layer.VectorTileRenderType = {
+  IMAGE: 'image',
+  HYBRID: 'hybrid',
+  VECTOR: 'vector'
+};

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -8,9 +8,10 @@ goog.require('ol');
 goog.require('ol.Collection');
 goog.require('ol.CollectionEventType');
 goog.require('ol.MapBrowserEvent');
-goog.require('ol.MapBrowserEventType');
 goog.require('ol.MapBrowserEventHandler');
+goog.require('ol.MapBrowserEventType');
 goog.require('ol.MapEvent');
+goog.require('ol.MapEventType');
 goog.require('ol.MapProperty');
 goog.require('ol.Object');
 goog.require('ol.TileQueue');
@@ -1288,13 +1289,13 @@ ol.Map.prototype.renderFrame_ = function(time) {
 
     if (idle) {
       this.dispatchEvent(
-          new ol.MapEvent(ol.MapEvent.Type.MOVEEND, this, frameState));
+          new ol.MapEvent(ol.MapEventType.MOVEEND, this, frameState));
       ol.extent.clone(frameState.extent, this.previousExtent_);
     }
   }
 
   this.dispatchEvent(
-      new ol.MapEvent(ol.MapEvent.Type.POSTRENDER, this, frameState));
+      new ol.MapEvent(ol.MapEventType.POSTRENDER, this, frameState));
 
   setTimeout(this.handlePostRender.bind(this), 0);
 

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -14,6 +14,7 @@ goog.require('ol.MapEvent');
 goog.require('ol.MapEventType');
 goog.require('ol.MapProperty');
 goog.require('ol.Object');
+goog.require('ol.ObjectEventType');
 goog.require('ol.TileQueue');
 goog.require('ol.View');
 goog.require('ol.ViewHint');
@@ -1099,7 +1100,7 @@ ol.Map.prototype.handleViewChanged_ = function() {
   if (view) {
     this.viewport_.setAttribute('data-view', ol.getUid(view));
     this.viewPropertyListenerKey_ = ol.events.listen(
-        view, ol.Object.EventType.PROPERTYCHANGE,
+        view, ol.ObjectEventType.PROPERTYCHANGE,
         this.handleViewPropertyChanged_, this);
     this.viewChangeListenerKey_ = ol.events.listen(
         view, ol.events.EventType.CHANGE,
@@ -1121,7 +1122,7 @@ ol.Map.prototype.handleLayerGroupChanged_ = function() {
   if (layerGroup) {
     this.layerGroupPropertyListenerKeys_ = [
       ol.events.listen(
-          layerGroup, ol.Object.EventType.PROPERTYCHANGE,
+          layerGroup, ol.ObjectEventType.PROPERTYCHANGE,
           this.render, this),
       ol.events.listen(
           layerGroup, ol.events.EventType.CHANGE,

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -6,6 +6,7 @@ goog.provide('ol.Map');
 
 goog.require('ol');
 goog.require('ol.Collection');
+goog.require('ol.CollectionEventType');
 goog.require('ol.MapBrowserEvent');
 goog.require('ol.MapBrowserEventHandler');
 goog.require('ol.MapEvent');
@@ -391,7 +392,7 @@ ol.Map = function(options) {
         control.setMap(this);
       }, this);
 
-  ol.events.listen(this.controls_, ol.Collection.EventType.ADD,
+  ol.events.listen(this.controls_, ol.CollectionEventType.ADD,
       /**
        * @param {ol.Collection.Event} event Collection event.
        */
@@ -399,7 +400,7 @@ ol.Map = function(options) {
         event.element.setMap(this);
       }, this);
 
-  ol.events.listen(this.controls_, ol.Collection.EventType.REMOVE,
+  ol.events.listen(this.controls_, ol.CollectionEventType.REMOVE,
       /**
        * @param {ol.Collection.Event} event Collection event.
        */
@@ -416,7 +417,7 @@ ol.Map = function(options) {
         interaction.setMap(this);
       }, this);
 
-  ol.events.listen(this.interactions_, ol.Collection.EventType.ADD,
+  ol.events.listen(this.interactions_, ol.CollectionEventType.ADD,
       /**
        * @param {ol.Collection.Event} event Collection event.
        */
@@ -424,7 +425,7 @@ ol.Map = function(options) {
         event.element.setMap(this);
       }, this);
 
-  ol.events.listen(this.interactions_, ol.Collection.EventType.REMOVE,
+  ol.events.listen(this.interactions_, ol.CollectionEventType.REMOVE,
       /**
        * @param {ol.Collection.Event} event Collection event.
        */
@@ -434,7 +435,7 @@ ol.Map = function(options) {
 
   this.overlays_.forEach(this.addOverlayInternal_, this);
 
-  ol.events.listen(this.overlays_, ol.Collection.EventType.ADD,
+  ol.events.listen(this.overlays_, ol.CollectionEventType.ADD,
       /**
        * @param {ol.Collection.Event} event Collection event.
        */
@@ -442,7 +443,7 @@ ol.Map = function(options) {
         this.addOverlayInternal_(/** @type {ol.Overlay} */ (event.element));
       }, this);
 
-  ol.events.listen(this.overlays_, ol.Collection.EventType.REMOVE,
+  ol.events.listen(this.overlays_, ol.CollectionEventType.REMOVE,
       /**
        * @param {ol.Collection.Event} event Collection event.
        */

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -8,6 +8,7 @@ goog.require('ol');
 goog.require('ol.Collection');
 goog.require('ol.CollectionEventType');
 goog.require('ol.MapBrowserEvent');
+goog.require('ol.MapBrowserEventType');
 goog.require('ol.MapBrowserEventHandler');
 goog.require('ol.MapEvent');
 goog.require('ol.MapProperty');
@@ -262,7 +263,7 @@ ol.Map = function(options) {
     ol.events.EventType.MOUSEDOWN,
     ol.events.EventType.TOUCHSTART,
     ol.events.EventType.MSPOINTERDOWN,
-    ol.MapBrowserEvent.EventType.POINTERDOWN,
+    ol.MapBrowserEventType.POINTERDOWN,
     ol.events.EventType.MOUSEWHEEL,
     ol.events.EventType.WHEEL
   ];
@@ -277,8 +278,8 @@ ol.Map = function(options) {
    * @type {ol.MapBrowserEventHandler}
    */
   this.mapBrowserEventHandler_ = new ol.MapBrowserEventHandler(this);
-  for (var key in ol.MapBrowserEvent.EventType) {
-    ol.events.listen(this.mapBrowserEventHandler_, ol.MapBrowserEvent.EventType[key],
+  for (var key in ol.MapBrowserEventType) {
+    ol.events.listen(this.mapBrowserEventHandler_, ol.MapBrowserEventType[key],
         this.handleMapBrowserEvent, this);
   }
 

--- a/src/ol/mapbrowserevent.js
+++ b/src/ol/mapbrowserevent.js
@@ -2,7 +2,6 @@ goog.provide('ol.MapBrowserEvent');
 
 goog.require('ol');
 goog.require('ol.MapEvent');
-goog.require('ol.events.EventType');
 
 
 /**
@@ -80,57 +79,4 @@ ol.MapBrowserEvent.prototype.preventDefault = function() {
 ol.MapBrowserEvent.prototype.stopPropagation = function() {
   ol.MapEvent.prototype.stopPropagation.call(this);
   this.originalEvent.stopPropagation();
-};
-
-
-/**
- * Constants for event names.
- * @enum {string}
- */
-ol.MapBrowserEvent.EventType = {
-
-  /**
-   * A true single click with no dragging and no double click. Note that this
-   * event is delayed by 250 ms to ensure that it is not a double click.
-   * @event ol.MapBrowserEvent#singleclick
-   * @api stable
-   */
-  SINGLECLICK: 'singleclick',
-
-  /**
-   * A click with no dragging. A double click will fire two of this.
-   * @event ol.MapBrowserEvent#click
-   * @api stable
-   */
-  CLICK: ol.events.EventType.CLICK,
-
-  /**
-   * A true double click, with no dragging.
-   * @event ol.MapBrowserEvent#dblclick
-   * @api stable
-   */
-  DBLCLICK: ol.events.EventType.DBLCLICK,
-
-  /**
-   * Triggered when a pointer is dragged.
-   * @event ol.MapBrowserEvent#pointerdrag
-   * @api
-   */
-  POINTERDRAG: 'pointerdrag',
-
-  /**
-   * Triggered when a pointer is moved. Note that on touch devices this is
-   * triggered when the map is panned, so is not the same as mousemove.
-   * @event ol.MapBrowserEvent#pointermove
-   * @api stable
-   */
-  POINTERMOVE: 'pointermove',
-
-  POINTERDOWN: 'pointerdown',
-  POINTERUP: 'pointerup',
-  POINTEROVER: 'pointerover',
-  POINTEROUT: 'pointerout',
-  POINTERENTER: 'pointerenter',
-  POINTERLEAVE: 'pointerleave',
-  POINTERCANCEL: 'pointercancel'
 };

--- a/src/ol/mapbrowsereventhandler.js
+++ b/src/ol/mapbrowsereventhandler.js
@@ -1,7 +1,7 @@
 goog.provide('ol.MapBrowserEventHandler');
 
 goog.require('ol');
-goog.require('ol.MapBrowserEvent');
+goog.require('ol.MapBrowserEventType');
 goog.require('ol.MapBrowserPointerEvent');
 goog.require('ol.events');
 goog.require('ol.events.EventTarget');
@@ -109,21 +109,21 @@ ol.inherits(ol.MapBrowserEventHandler, ol.events.EventTarget);
  */
 ol.MapBrowserEventHandler.prototype.emulateClick_ = function(pointerEvent) {
   var newEvent = new ol.MapBrowserPointerEvent(
-      ol.MapBrowserEvent.EventType.CLICK, this.map_, pointerEvent);
+      ol.MapBrowserEventType.CLICK, this.map_, pointerEvent);
   this.dispatchEvent(newEvent);
   if (this.clickTimeoutId_ !== 0) {
     // double-click
     clearTimeout(this.clickTimeoutId_);
     this.clickTimeoutId_ = 0;
     newEvent = new ol.MapBrowserPointerEvent(
-        ol.MapBrowserEvent.EventType.DBLCLICK, this.map_, pointerEvent);
+        ol.MapBrowserEventType.DBLCLICK, this.map_, pointerEvent);
     this.dispatchEvent(newEvent);
   } else {
     // click
     this.clickTimeoutId_ = setTimeout(function() {
       this.clickTimeoutId_ = 0;
       var newEvent = new ol.MapBrowserPointerEvent(
-          ol.MapBrowserEvent.EventType.SINGLECLICK, this.map_, pointerEvent);
+          ol.MapBrowserEventType.SINGLECLICK, this.map_, pointerEvent);
       this.dispatchEvent(newEvent);
     }.bind(this), 250);
   }
@@ -139,10 +139,10 @@ ol.MapBrowserEventHandler.prototype.emulateClick_ = function(pointerEvent) {
 ol.MapBrowserEventHandler.prototype.updateActivePointers_ = function(pointerEvent) {
   var event = pointerEvent;
 
-  if (event.type == ol.MapBrowserEvent.EventType.POINTERUP ||
-      event.type == ol.MapBrowserEvent.EventType.POINTERCANCEL) {
+  if (event.type == ol.MapBrowserEventType.POINTERUP ||
+      event.type == ol.MapBrowserEventType.POINTERCANCEL) {
     delete this.trackedTouches_[event.pointerId];
-  } else if (event.type == ol.MapBrowserEvent.EventType.POINTERDOWN) {
+  } else if (event.type == ol.MapBrowserEventType.POINTERDOWN) {
     this.trackedTouches_[event.pointerId] = true;
   }
   this.activePointers_ = Object.keys(this.trackedTouches_).length;
@@ -156,7 +156,7 @@ ol.MapBrowserEventHandler.prototype.updateActivePointers_ = function(pointerEven
 ol.MapBrowserEventHandler.prototype.handlePointerUp_ = function(pointerEvent) {
   this.updateActivePointers_(pointerEvent);
   var newEvent = new ol.MapBrowserPointerEvent(
-      ol.MapBrowserEvent.EventType.POINTERUP, this.map_, pointerEvent);
+      ol.MapBrowserEventType.POINTERUP, this.map_, pointerEvent);
   this.dispatchEvent(newEvent);
 
   // We emulate click events on left mouse button click, touch contact, and pen
@@ -198,7 +198,7 @@ ol.MapBrowserEventHandler.prototype.isMouseActionButton_ = function(pointerEvent
 ol.MapBrowserEventHandler.prototype.handlePointerDown_ = function(pointerEvent) {
   this.updateActivePointers_(pointerEvent);
   var newEvent = new ol.MapBrowserPointerEvent(
-      ol.MapBrowserEvent.EventType.POINTERDOWN, this.map_, pointerEvent);
+      ol.MapBrowserEventType.POINTERDOWN, this.map_, pointerEvent);
   this.dispatchEvent(newEvent);
 
   this.down_ = pointerEvent;
@@ -213,10 +213,10 @@ ol.MapBrowserEventHandler.prototype.handlePointerDown_ = function(pointerEvent) 
 
     this.dragListenerKeys_.push(
       ol.events.listen(this.documentPointerEventHandler_,
-          ol.MapBrowserEvent.EventType.POINTERMOVE,
+          ol.MapBrowserEventType.POINTERMOVE,
           this.handlePointerMove_, this),
       ol.events.listen(this.documentPointerEventHandler_,
-          ol.MapBrowserEvent.EventType.POINTERUP,
+          ol.MapBrowserEventType.POINTERUP,
           this.handlePointerUp_, this),
       /* Note that the listener for `pointercancel is set up on
        * `pointerEventHandler_` and not `documentPointerEventHandler_` like
@@ -232,7 +232,7 @@ ol.MapBrowserEventHandler.prototype.handlePointerDown_ = function(pointerEvent) 
        * only registered there.
        */
       ol.events.listen(this.pointerEventHandler_,
-          ol.MapBrowserEvent.EventType.POINTERCANCEL,
+          ol.MapBrowserEventType.POINTERCANCEL,
           this.handlePointerUp_, this)
     );
   }
@@ -252,7 +252,7 @@ ol.MapBrowserEventHandler.prototype.handlePointerMove_ = function(pointerEvent) 
   if (this.isMoving_(pointerEvent)) {
     this.dragging_ = true;
     var newEvent = new ol.MapBrowserPointerEvent(
-        ol.MapBrowserEvent.EventType.POINTERDRAG, this.map_, pointerEvent,
+        ol.MapBrowserEventType.POINTERDRAG, this.map_, pointerEvent,
         this.dragging_);
     this.dispatchEvent(newEvent);
   }

--- a/src/ol/mapbrowsereventtype.js
+++ b/src/ol/mapbrowsereventtype.js
@@ -1,0 +1,56 @@
+goog.provide('ol.MapBrowserEventType');
+
+goog.require('ol.events.EventType');
+
+
+/**
+ * Constants for event names.
+ * @enum {string}
+ */
+ol.MapBrowserEventType = {
+
+  /**
+   * A true single click with no dragging and no double click. Note that this
+   * event is delayed by 250 ms to ensure that it is not a double click.
+   * @event ol.MapBrowserEvent#singleclick
+   * @api stable
+   */
+  SINGLECLICK: 'singleclick',
+
+  /**
+   * A click with no dragging. A double click will fire two of this.
+   * @event ol.MapBrowserEvent#click
+   * @api stable
+   */
+  CLICK: ol.events.EventType.CLICK,
+
+  /**
+   * A true double click, with no dragging.
+   * @event ol.MapBrowserEvent#dblclick
+   * @api stable
+   */
+  DBLCLICK: ol.events.EventType.DBLCLICK,
+
+  /**
+   * Triggered when a pointer is dragged.
+   * @event ol.MapBrowserEvent#pointerdrag
+   * @api
+   */
+  POINTERDRAG: 'pointerdrag',
+
+  /**
+   * Triggered when a pointer is moved. Note that on touch devices this is
+   * triggered when the map is panned, so is not the same as mousemove.
+   * @event ol.MapBrowserEvent#pointermove
+   * @api stable
+   */
+  POINTERMOVE: 'pointermove',
+
+  POINTERDOWN: 'pointerdown',
+  POINTERUP: 'pointerup',
+  POINTEROVER: 'pointerover',
+  POINTEROUT: 'pointerout',
+  POINTERENTER: 'pointerenter',
+  POINTERLEAVE: 'pointerleave',
+  POINTERCANCEL: 'pointercancel'
+};

--- a/src/ol/mapevent.js
+++ b/src/ol/mapevent.js
@@ -36,25 +36,3 @@ ol.MapEvent = function(type, map, opt_frameState) {
 
 };
 ol.inherits(ol.MapEvent, ol.events.Event);
-
-
-/**
- * @enum {string}
- */
-ol.MapEvent.Type = {
-
-  /**
-   * Triggered after a map frame is rendered.
-   * @event ol.MapEvent#postrender
-   * @api
-   */
-  POSTRENDER: 'postrender',
-
-  /**
-   * Triggered after the map is moved.
-   * @event ol.MapEvent#moveend
-   * @api stable
-   */
-  MOVEEND: 'moveend'
-
-};

--- a/src/ol/mapeventtype.js
+++ b/src/ol/mapeventtype.js
@@ -1,0 +1,22 @@
+goog.provide('ol.MapEventType');
+
+/**
+ * @enum {string}
+ */
+ol.MapEventType = {
+
+  /**
+   * Triggered after a map frame is rendered.
+   * @event ol.MapEvent#postrender
+   * @api
+   */
+  POSTRENDER: 'postrender',
+
+  /**
+   * Triggered after the map is moved.
+   * @event ol.MapEvent#moveend
+   * @api stable
+   */
+  MOVEEND: 'moveend'
+
+};

--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -1,6 +1,7 @@
 goog.provide('ol.Object');
 
 goog.require('ol');
+goog.require('ol.ObjectEventType');
 goog.require('ol.Observable');
 goog.require('ol.events.Event');
 goog.require('ol.obj');
@@ -134,7 +135,7 @@ ol.Object.prototype.notify = function(key, oldValue) {
   var eventType;
   eventType = ol.Object.getChangeEventType(key);
   this.dispatchEvent(new ol.Object.Event(eventType, key, oldValue));
-  eventType = ol.Object.EventType.PROPERTYCHANGE;
+  eventType = ol.ObjectEventType.PROPERTYCHANGE;
   this.dispatchEvent(new ol.Object.Event(eventType, key, oldValue));
 };
 
@@ -188,19 +189,6 @@ ol.Object.prototype.unset = function(key, opt_silent) {
       this.notify(key, oldValue);
     }
   }
-};
-
-
-/**
- * @enum {string}
- */
-ol.Object.EventType = {
-  /**
-   * Triggered when a property is changed.
-   * @event ol.Object.Event#propertychange
-   * @api stable
-   */
-  PROPERTYCHANGE: 'propertychange'
 };
 
 

--- a/src/ol/objecteventtype.js
+++ b/src/ol/objecteventtype.js
@@ -1,0 +1,13 @@
+goog.provide('ol.ObjectEventType');
+
+/**
+ * @enum {string}
+ */
+ol.ObjectEventType = {
+  /**
+   * Triggered when a property is changed.
+   * @event ol.Object.Event#propertychange
+   * @api stable
+   */
+  PROPERTYCHANGE: 'propertychange'
+};

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -104,23 +104,23 @@ ol.Overlay = function(options) {
   this.mapPostrenderListenerKey_ = null;
 
   ol.events.listen(
-      this, ol.Object.getChangeEventType(ol.Overlay.Property.ELEMENT),
+      this, ol.Object.getChangeEventType(ol.Overlay.Property_.ELEMENT),
       this.handleElementChanged, this);
 
   ol.events.listen(
-      this, ol.Object.getChangeEventType(ol.Overlay.Property.MAP),
+      this, ol.Object.getChangeEventType(ol.Overlay.Property_.MAP),
       this.handleMapChanged, this);
 
   ol.events.listen(
-      this, ol.Object.getChangeEventType(ol.Overlay.Property.OFFSET),
+      this, ol.Object.getChangeEventType(ol.Overlay.Property_.OFFSET),
       this.handleOffsetChanged, this);
 
   ol.events.listen(
-      this, ol.Object.getChangeEventType(ol.Overlay.Property.POSITION),
+      this, ol.Object.getChangeEventType(ol.Overlay.Property_.POSITION),
       this.handlePositionChanged, this);
 
   ol.events.listen(
-      this, ol.Object.getChangeEventType(ol.Overlay.Property.POSITIONING),
+      this, ol.Object.getChangeEventType(ol.Overlay.Property_.POSITIONING),
       this.handlePositioningChanged, this);
 
   if (options.element !== undefined) {
@@ -149,7 +149,7 @@ ol.inherits(ol.Overlay, ol.Object);
  */
 ol.Overlay.prototype.getElement = function() {
   return /** @type {Element|undefined} */ (
-      this.get(ol.Overlay.Property.ELEMENT));
+      this.get(ol.Overlay.Property_.ELEMENT));
 };
 
 
@@ -171,7 +171,7 @@ ol.Overlay.prototype.getId = function() {
  */
 ol.Overlay.prototype.getMap = function() {
   return /** @type {ol.Map|undefined} */ (
-      this.get(ol.Overlay.Property.MAP));
+      this.get(ol.Overlay.Property_.MAP));
 };
 
 
@@ -183,7 +183,7 @@ ol.Overlay.prototype.getMap = function() {
  */
 ol.Overlay.prototype.getOffset = function() {
   return /** @type {Array.<number>} */ (
-      this.get(ol.Overlay.Property.OFFSET));
+      this.get(ol.Overlay.Property_.OFFSET));
 };
 
 
@@ -196,7 +196,7 @@ ol.Overlay.prototype.getOffset = function() {
  */
 ol.Overlay.prototype.getPosition = function() {
   return /** @type {ol.Coordinate|undefined} */ (
-      this.get(ol.Overlay.Property.POSITION));
+      this.get(ol.Overlay.Property_.POSITION));
 };
 
 
@@ -209,7 +209,7 @@ ol.Overlay.prototype.getPosition = function() {
  */
 ol.Overlay.prototype.getPositioning = function() {
   return /** @type {ol.OverlayPositioning} */ (
-      this.get(ol.Overlay.Property.POSITIONING));
+      this.get(ol.Overlay.Property_.POSITIONING));
 };
 
 
@@ -271,7 +271,7 @@ ol.Overlay.prototype.handleOffsetChanged = function() {
  */
 ol.Overlay.prototype.handlePositionChanged = function() {
   this.updatePixelPosition();
-  if (this.get(ol.Overlay.Property.POSITION) !== undefined && this.autoPan) {
+  if (this.get(ol.Overlay.Property_.POSITION) !== undefined && this.autoPan) {
     this.panIntoView_();
   }
 };
@@ -292,7 +292,7 @@ ol.Overlay.prototype.handlePositioningChanged = function() {
  * @api stable
  */
 ol.Overlay.prototype.setElement = function(element) {
-  this.set(ol.Overlay.Property.ELEMENT, element);
+  this.set(ol.Overlay.Property_.ELEMENT, element);
 };
 
 
@@ -303,7 +303,7 @@ ol.Overlay.prototype.setElement = function(element) {
  * @api stable
  */
 ol.Overlay.prototype.setMap = function(map) {
-  this.set(ol.Overlay.Property.MAP, map);
+  this.set(ol.Overlay.Property_.MAP, map);
 };
 
 
@@ -314,7 +314,7 @@ ol.Overlay.prototype.setMap = function(map) {
  * @api stable
  */
 ol.Overlay.prototype.setOffset = function(offset) {
-  this.set(ol.Overlay.Property.OFFSET, offset);
+  this.set(ol.Overlay.Property_.OFFSET, offset);
 };
 
 
@@ -327,7 +327,7 @@ ol.Overlay.prototype.setOffset = function(offset) {
  * @api stable
  */
 ol.Overlay.prototype.setPosition = function(position) {
-  this.set(ol.Overlay.Property.POSITION, position);
+  this.set(ol.Overlay.Property_.POSITION, position);
 };
 
 
@@ -418,7 +418,7 @@ ol.Overlay.prototype.getRect_ = function(element, size) {
  * @api stable
  */
 ol.Overlay.prototype.setPositioning = function(positioning) {
-  this.set(ol.Overlay.Property.POSITIONING, positioning);
+  this.set(ol.Overlay.Property_.POSITIONING, positioning);
 };
 
 
@@ -523,8 +523,9 @@ ol.Overlay.prototype.updateRenderedPosition = function(pixel, mapSize) {
 
 /**
  * @enum {string}
+ * @private
  */
-ol.Overlay.Property = {
+ol.Overlay.Property_ = {
   ELEMENT: 'element',
   MAP: 'map',
   OFFSET: 'offset',

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -1,7 +1,7 @@
 goog.provide('ol.Overlay');
 
 goog.require('ol');
-goog.require('ol.MapEvent');
+goog.require('ol.MapEventType');
 goog.require('ol.Object');
 goog.require('ol.dom');
 goog.require('ol.events');
@@ -236,7 +236,7 @@ ol.Overlay.prototype.handleMapChanged = function() {
   var map = this.getMap();
   if (map) {
     this.mapPostrenderListenerKey_ = ol.events.listen(map,
-        ol.MapEvent.Type.POSTRENDER, this.render, this);
+        ol.MapEventType.POSTRENDER, this.render, this);
     this.updatePixelPosition();
     var container = this.stopEvent_ ?
         map.getOverlayContainerStopEvent() : map.getOverlayContainer();

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -3,6 +3,7 @@ goog.provide('ol.Overlay');
 goog.require('ol');
 goog.require('ol.MapEventType');
 goog.require('ol.Object');
+goog.require('ol.OverlayPositioning');
 goog.require('ol.dom');
 goog.require('ol.events');
 goog.require('ol.extent');
@@ -129,8 +130,8 @@ ol.Overlay = function(options) {
   this.setOffset(options.offset !== undefined ? options.offset : [0, 0]);
 
   this.setPositioning(options.positioning !== undefined ?
-      /** @type {ol.Overlay.Positioning} */ (options.positioning) :
-      ol.Overlay.Positioning.TOP_LEFT);
+      /** @type {ol.OverlayPositioning} */ (options.positioning) :
+      ol.OverlayPositioning.TOP_LEFT);
 
   if (options.position !== undefined) {
     this.setPosition(options.position);
@@ -201,13 +202,13 @@ ol.Overlay.prototype.getPosition = function() {
 
 /**
  * Get the current positioning of this overlay.
- * @return {ol.Overlay.Positioning} How the overlay is positioned
+ * @return {ol.OverlayPositioning} How the overlay is positioned
  *     relative to its point on the map.
  * @observable
  * @api stable
  */
 ol.Overlay.prototype.getPositioning = function() {
-  return /** @type {ol.Overlay.Positioning} */ (
+  return /** @type {ol.OverlayPositioning} */ (
       this.get(ol.Overlay.Property.POSITIONING));
 };
 
@@ -411,7 +412,7 @@ ol.Overlay.prototype.getRect_ = function(element, size) {
 
 /**
  * Set the positioning for this overlay.
- * @param {ol.Overlay.Positioning} positioning how the overlay is
+ * @param {ol.OverlayPositioning} positioning how the overlay is
  *     positioned relative to its point on the map.
  * @observable
  * @api stable
@@ -467,9 +468,9 @@ ol.Overlay.prototype.updateRenderedPosition = function(pixel, mapSize) {
 
   var offsetX = offset[0];
   var offsetY = offset[1];
-  if (positioning == ol.Overlay.Positioning.BOTTOM_RIGHT ||
-      positioning == ol.Overlay.Positioning.CENTER_RIGHT ||
-      positioning == ol.Overlay.Positioning.TOP_RIGHT) {
+  if (positioning == ol.OverlayPositioning.BOTTOM_RIGHT ||
+      positioning == ol.OverlayPositioning.CENTER_RIGHT ||
+      positioning == ol.OverlayPositioning.TOP_RIGHT) {
     if (this.rendered_.left_ !== '') {
       this.rendered_.left_ = style.left = '';
     }
@@ -481,9 +482,9 @@ ol.Overlay.prototype.updateRenderedPosition = function(pixel, mapSize) {
     if (this.rendered_.right_ !== '') {
       this.rendered_.right_ = style.right = '';
     }
-    if (positioning == ol.Overlay.Positioning.BOTTOM_CENTER ||
-        positioning == ol.Overlay.Positioning.CENTER_CENTER ||
-        positioning == ol.Overlay.Positioning.TOP_CENTER) {
+    if (positioning == ol.OverlayPositioning.BOTTOM_CENTER ||
+        positioning == ol.OverlayPositioning.CENTER_CENTER ||
+        positioning == ol.OverlayPositioning.TOP_CENTER) {
       offsetX -= this.element_.offsetWidth / 2;
     }
     var left = Math.round(pixel[0] + offsetX) + 'px';
@@ -491,9 +492,9 @@ ol.Overlay.prototype.updateRenderedPosition = function(pixel, mapSize) {
       this.rendered_.left_ = style.left = left;
     }
   }
-  if (positioning == ol.Overlay.Positioning.BOTTOM_LEFT ||
-      positioning == ol.Overlay.Positioning.BOTTOM_CENTER ||
-      positioning == ol.Overlay.Positioning.BOTTOM_RIGHT) {
+  if (positioning == ol.OverlayPositioning.BOTTOM_LEFT ||
+      positioning == ol.OverlayPositioning.BOTTOM_CENTER ||
+      positioning == ol.OverlayPositioning.BOTTOM_RIGHT) {
     if (this.rendered_.top_ !== '') {
       this.rendered_.top_ = style.top = '';
     }
@@ -505,9 +506,9 @@ ol.Overlay.prototype.updateRenderedPosition = function(pixel, mapSize) {
     if (this.rendered_.bottom_ !== '') {
       this.rendered_.bottom_ = style.bottom = '';
     }
-    if (positioning == ol.Overlay.Positioning.CENTER_LEFT ||
-        positioning == ol.Overlay.Positioning.CENTER_CENTER ||
-        positioning == ol.Overlay.Positioning.CENTER_RIGHT) {
+    if (positioning == ol.OverlayPositioning.CENTER_LEFT ||
+        positioning == ol.OverlayPositioning.CENTER_CENTER ||
+        positioning == ol.OverlayPositioning.CENTER_RIGHT) {
       offsetY -= this.element_.offsetHeight / 2;
     }
     var top = Math.round(pixel[1] + offsetY) + 'px';
@@ -517,25 +518,6 @@ ol.Overlay.prototype.updateRenderedPosition = function(pixel, mapSize) {
   }
 
   this.setVisible(true);
-};
-
-
-/**
- * Overlay position: `'bottom-left'`, `'bottom-center'`,  `'bottom-right'`,
- * `'center-left'`, `'center-center'`, `'center-right'`, `'top-left'`,
- * `'top-center'`, `'top-right'`
- * @enum {string}
- */
-ol.Overlay.Positioning = {
-  BOTTOM_LEFT: 'bottom-left',
-  BOTTOM_CENTER: 'bottom-center',
-  BOTTOM_RIGHT: 'bottom-right',
-  CENTER_LEFT: 'center-left',
-  CENTER_CENTER: 'center-center',
-  CENTER_RIGHT: 'center-right',
-  TOP_LEFT: 'top-left',
-  TOP_CENTER: 'top-center',
-  TOP_RIGHT: 'top-right'
 };
 
 

--- a/src/ol/overlaypositioning.js
+++ b/src/ol/overlaypositioning.js
@@ -1,0 +1,19 @@
+goog.provide('ol.OverlayPositioning');
+
+/**
+ * Overlay position: `'bottom-left'`, `'bottom-center'`,  `'bottom-right'`,
+ * `'center-left'`, `'center-center'`, `'center-right'`, `'top-left'`,
+ * `'top-center'`, `'top-right'`
+ * @enum {string}
+ */
+ol.OverlayPositioning = {
+  BOTTOM_LEFT: 'bottom-left',
+  BOTTOM_CENTER: 'bottom-center',
+  BOTTOM_RIGHT: 'bottom-right',
+  CENTER_LEFT: 'center-left',
+  CENTER_CENTER: 'center-center',
+  CENTER_RIGHT: 'center-right',
+  TOP_LEFT: 'top-left',
+  TOP_CENTER: 'top-center',
+  TOP_RIGHT: 'top-right'
+};

--- a/src/ol/render/webgl.js
+++ b/src/ol/render/webgl.js
@@ -46,21 +46,6 @@ ol.render.webgl.defaultStrokeStyle = [0.0, 0.0, 0.0, 1.0];
 ol.render.webgl.defaultLineWidth = 1;
 
 /**
- * @enum {number}
- */
-ol.render.webgl.lineStringInstruction = {
-  ROUND: 2,
-  BEGIN_LINE: 3,
-  END_LINE: 5,
-  BEGIN_LINE_CAP: 7,
-  END_LINE_CAP: 11,
-  BEVEL_FIRST: 13,
-  BEVEL_SECOND: 17,
-  MITER_BOTTOM: 19,
-  MITER_TOP: 23
-};
-
-/**
  * Calculates the orientation of a triangle based on the determinant method.
  * @param {number} x1 First X coordinate.
  * @param {number} y1 First Y coordinate.

--- a/src/ol/render/webgl/linestringreplay.js
+++ b/src/ol/render/webgl/linestringreplay.js
@@ -81,7 +81,7 @@ ol.render.webgl.LineStringReplay.prototype.drawCoordinates_ = function(flatCoord
   var numVertices = this.vertices.length;
   var numIndices = this.indices.length;
   //To save a vertex, the direction of a point is a product of the sign (1 or -1), a prime from
-  //ol.render.webgl.lineStringInstruction, and a rounding factor (1 or 2). If the product is even,
+  //ol.render.webgl.LineStringReplay.Instruction_, and a rounding factor (1 or 2). If the product is even,
   //we round it. If it is odd, we don't.
   var lineJoin = this.state_.lineJoin === 'bevel' ? 0 :
       this.state_.lineJoin === 'miter' ? 1 : 2;
@@ -117,10 +117,10 @@ ol.render.webgl.LineStringReplay.prototype.drawCoordinates_ = function(flatCoord
 
         if (lineCap) {
           numVertices = this.addVertices_([0, 0], p1, p2,
-              lastSign * ol.render.webgl.lineStringInstruction.BEGIN_LINE_CAP * lineCap, numVertices);
+              lastSign * ol.render.webgl.LineStringReplay.Instruction_.BEGIN_LINE_CAP * lineCap, numVertices);
 
           numVertices = this.addVertices_([0, 0], p1, p2,
-              -lastSign * ol.render.webgl.lineStringInstruction.BEGIN_LINE_CAP * lineCap, numVertices);
+              -lastSign * ol.render.webgl.LineStringReplay.Instruction_.BEGIN_LINE_CAP * lineCap, numVertices);
 
           this.indices[numIndices++] = n + 2;
           this.indices[numIndices++] = n;
@@ -133,10 +133,10 @@ ol.render.webgl.LineStringReplay.prototype.drawCoordinates_ = function(flatCoord
         }
 
         numVertices = this.addVertices_([0, 0], p1, p2,
-            lastSign * ol.render.webgl.lineStringInstruction.BEGIN_LINE * (lineCap || 1), numVertices);
+            lastSign * ol.render.webgl.LineStringReplay.Instruction_.BEGIN_LINE * (lineCap || 1), numVertices);
 
         numVertices = this.addVertices_([0, 0], p1, p2,
-            -lastSign * ol.render.webgl.lineStringInstruction.BEGIN_LINE * (lineCap || 1), numVertices);
+            -lastSign * ol.render.webgl.LineStringReplay.Instruction_.BEGIN_LINE * (lineCap || 1), numVertices);
 
         lastIndex = numVertices / 7 - 1;
 
@@ -154,10 +154,10 @@ ol.render.webgl.LineStringReplay.prototype.drawCoordinates_ = function(flatCoord
         p0 = p0 || [0, 0];
 
         numVertices = this.addVertices_(p0, p1, [0, 0],
-            lastSign * ol.render.webgl.lineStringInstruction.END_LINE * (lineCap || 1), numVertices);
+            lastSign * ol.render.webgl.LineStringReplay.Instruction_.END_LINE * (lineCap || 1), numVertices);
 
         numVertices = this.addVertices_(p0, p1, [0, 0],
-            -lastSign * ol.render.webgl.lineStringInstruction.END_LINE * (lineCap || 1), numVertices);
+            -lastSign * ol.render.webgl.LineStringReplay.Instruction_.END_LINE * (lineCap || 1), numVertices);
 
         this.indices[numIndices++] = n;
         this.indices[numIndices++] = lastIndex - 1;
@@ -169,10 +169,10 @@ ol.render.webgl.LineStringReplay.prototype.drawCoordinates_ = function(flatCoord
 
         if (lineCap) {
           numVertices = this.addVertices_(p0, p1, [0, 0],
-              lastSign * ol.render.webgl.lineStringInstruction.END_LINE_CAP * lineCap, numVertices);
+              lastSign * ol.render.webgl.LineStringReplay.Instruction_.END_LINE_CAP * lineCap, numVertices);
 
           numVertices = this.addVertices_(p0, p1, [0, 0],
-              -lastSign * ol.render.webgl.lineStringInstruction.END_LINE_CAP * lineCap, numVertices);
+              -lastSign * ol.render.webgl.LineStringReplay.Instruction_.END_LINE_CAP * lineCap, numVertices);
 
           this.indices[numIndices++] = n + 2;
           this.indices[numIndices++] = n;
@@ -195,13 +195,13 @@ ol.render.webgl.LineStringReplay.prototype.drawCoordinates_ = function(flatCoord
         ? -1 : 1;
 
     numVertices = this.addVertices_(p0, p1, p2,
-        sign * ol.render.webgl.lineStringInstruction.BEVEL_FIRST * (lineJoin || 1), numVertices);
+        sign * ol.render.webgl.LineStringReplay.Instruction_.BEVEL_FIRST * (lineJoin || 1), numVertices);
 
     numVertices = this.addVertices_(p0, p1, p2,
-        sign * ol.render.webgl.lineStringInstruction.BEVEL_SECOND * (lineJoin || 1), numVertices);
+        sign * ol.render.webgl.LineStringReplay.Instruction_.BEVEL_SECOND * (lineJoin || 1), numVertices);
 
     numVertices = this.addVertices_(p0, p1, p2,
-        -sign * ol.render.webgl.lineStringInstruction.MITER_BOTTOM * (lineJoin || 1), numVertices);
+        -sign * ol.render.webgl.LineStringReplay.Instruction_.MITER_BOTTOM * (lineJoin || 1), numVertices);
 
     if (i > offset) {
       this.indices[numIndices++] = n;
@@ -223,7 +223,7 @@ ol.render.webgl.LineStringReplay.prototype.drawCoordinates_ = function(flatCoord
     //Add miter
     if (lineJoin) {
       numVertices = this.addVertices_(p0, p1, p2,
-          sign * ol.render.webgl.lineStringInstruction.MITER_TOP * lineJoin, numVertices);
+          sign * ol.render.webgl.LineStringReplay.Instruction_.MITER_TOP * lineJoin, numVertices);
 
       this.indices[numIndices++] = n + 1;
       this.indices[numIndices++] = n + 3;
@@ -240,10 +240,10 @@ ol.render.webgl.LineStringReplay.prototype.drawCoordinates_ = function(flatCoord
         ? 1 : -1;
 
     numVertices = this.addVertices_(p0, p1, p2,
-        sign * ol.render.webgl.lineStringInstruction.BEVEL_FIRST * (lineJoin || 1), numVertices);
+        sign * ol.render.webgl.LineStringReplay.Instruction_.BEVEL_FIRST * (lineJoin || 1), numVertices);
 
     numVertices = this.addVertices_(p0, p1, p2,
-        -sign * ol.render.webgl.lineStringInstruction.MITER_BOTTOM * (lineJoin || 1), numVertices);
+        -sign * ol.render.webgl.LineStringReplay.Instruction_.MITER_BOTTOM * (lineJoin || 1), numVertices);
 
     this.indices[numIndices++] = n;
     this.indices[numIndices++] = lastIndex - 1;
@@ -680,4 +680,20 @@ ol.render.webgl.LineStringReplay.prototype.setFillStrokeStyle = function(fillSty
     this.state_.miterLimit = strokeStyleMiterLimit;
     this.styles_.push([strokeStyleColor, strokeStyleWidth, strokeStyleMiterLimit]);
   }
+};
+
+/**
+ * @enum {number}
+ * @private
+ */
+ol.render.webgl.LineStringReplay.Instruction_ = {
+  ROUND: 2,
+  BEGIN_LINE: 3,
+  END_LINE: 5,
+  BEGIN_LINE_CAP: 7,
+  END_LINE_CAP: 11,
+  BEVEL_FIRST: 13,
+  BEVEL_SECOND: 17,
+  MITER_BOTTOM: 19,
+  MITER_TOP: 23
 };

--- a/src/ol/renderer/canvas/vectortilelayer.js
+++ b/src/ol/renderer/canvas/vectortilelayer.js
@@ -4,7 +4,7 @@ goog.require('ol');
 goog.require('ol.extent');
 goog.require('ol.proj');
 goog.require('ol.proj.Units');
-goog.require('ol.layer.VectorTile');
+goog.require('ol.layer.VectorTileRenderType');
 goog.require('ol.render.ReplayType');
 goog.require('ol.render.canvas');
 goog.require('ol.render.canvas.ReplayGroup');
@@ -44,7 +44,7 @@ ol.renderer.canvas.VectorTileLayer = function(layer) {
 
   // Use lower resolution for pure vector rendering. Closest resolution otherwise.
   this.zDirection =
-      layer.getRenderMode() == ol.layer.VectorTile.RenderType.VECTOR ? 1 : 0;
+      layer.getRenderMode() == ol.layer.VectorTileRenderType.VECTOR ? 1 : 0;
 
 };
 ol.inherits(ol.renderer.canvas.VectorTileLayer, ol.renderer.canvas.TileLayer);
@@ -185,7 +185,7 @@ ol.renderer.canvas.VectorTileLayer.prototype.drawTileImage = function(
   var vectorTile = /** @type {ol.VectorTile} */ (tile);
   this.createReplayGroup_(vectorTile, frameState);
   var layer = this.getLayer();
-  if (layer.getRenderMode() != ol.layer.VectorTile.RenderType.VECTOR) {
+  if (layer.getRenderMode() != ol.layer.VectorTileRenderType.VECTOR) {
     this.renderTileImage_(vectorTile, frameState, layerState);
   }
   ol.renderer.canvas.TileLayer.prototype.drawTileImage.apply(this, arguments);

--- a/src/ol/source/image.js
+++ b/src/ol/source/image.js
@@ -149,17 +149,17 @@ ol.source.Image.prototype.handleImageChange = function(event) {
   switch (image.getState()) {
     case ol.ImageState.LOADING:
       this.dispatchEvent(
-          new ol.source.Image.Event(ol.source.Image.EventType.IMAGELOADSTART,
+          new ol.source.Image.Event(ol.source.Image.EventType_.IMAGELOADSTART,
               image));
       break;
     case ol.ImageState.LOADED:
       this.dispatchEvent(
-          new ol.source.Image.Event(ol.source.Image.EventType.IMAGELOADEND,
+          new ol.source.Image.Event(ol.source.Image.EventType_.IMAGELOADEND,
               image));
       break;
     case ol.ImageState.ERROR:
       this.dispatchEvent(
-          new ol.source.Image.Event(ol.source.Image.EventType.IMAGELOADERROR,
+          new ol.source.Image.Event(ol.source.Image.EventType_.IMAGELOADERROR,
               image));
       break;
     default:
@@ -207,8 +207,9 @@ ol.inherits(ol.source.Image.Event, ol.events.Event);
 
 /**
  * @enum {string}
+ * @private
  */
-ol.source.Image.EventType = {
+ol.source.Image.EventType_ = {
 
   /**
    * Triggered when an image starts loading.

--- a/src/ol/source/raster.js
+++ b/src/ol/source/raster.js
@@ -295,7 +295,7 @@ ol.source.Raster.prototype.composeFrame_ = function(frameState, callback) {
   if (imageDatas) {
     var data = {};
     this.dispatchEvent(new ol.source.Raster.Event(
-        ol.source.Raster.EventType.BEFOREOPERATIONS, frameState, data));
+        ol.source.Raster.EventType_.BEFOREOPERATIONS, frameState, data));
 
     this.worker_.process(imageDatas, data,
         this.onWorkerComplete_.bind(this, frameState, callback));
@@ -325,7 +325,7 @@ ol.source.Raster.prototype.onWorkerComplete_ = function(frameState, callback, er
   }
 
   this.dispatchEvent(new ol.source.Raster.Event(
-      ol.source.Raster.EventType.AFTEROPERATIONS, frameState, data));
+      ol.source.Raster.EventType_.AFTEROPERATIONS, frameState, data));
 
   var resolution = frameState.viewState.resolution / frameState.pixelRatio;
   if (!this.isDirty_(frameState.extent, resolution)) {
@@ -488,8 +488,9 @@ ol.inherits(ol.source.Raster.Event, ol.events.Event);
 
 /**
  * @enum {string}
+ * @private
  */
-ol.source.Raster.EventType = {
+ol.source.Raster.EventType_ = {
   /**
    * Triggered before operations are run.
    * @event ol.source.Raster.Event#beforeoperations

--- a/src/ol/source/raster.js
+++ b/src/ol/source/raster.js
@@ -1,7 +1,6 @@
 goog.provide('ol.source.Raster');
 
 goog.require('ol');
-goog.require('ol.transform');
 goog.require('ol.ImageCanvas');
 goog.require('ol.TileQueue');
 goog.require('ol.dom');
@@ -16,8 +15,10 @@ goog.require('ol.obj');
 goog.require('ol.renderer.canvas.ImageLayer');
 goog.require('ol.renderer.canvas.TileLayer');
 goog.require('ol.source.Image');
+goog.require('ol.source.RasterOperationType');
 goog.require('ol.source.State');
 goog.require('ol.source.Tile');
+goog.require('ol.transform');
 
 
 /**
@@ -42,10 +43,10 @@ ol.source.Raster = function(options) {
 
   /**
    * @private
-   * @type {ol.source.Raster.OperationType}
+   * @type {ol.source.RasterOperationType}
    */
   this.operationType_ = options.operationType !== undefined ?
-      options.operationType : ol.source.Raster.OperationType.PIXEL;
+      options.operationType : ol.source.RasterOperationType.PIXEL;
 
   /**
    * @private
@@ -149,7 +150,7 @@ ol.inherits(ol.source.Raster, ol.source.Image);
 ol.source.Raster.prototype.setOperation = function(operation, opt_lib) {
   this.worker_ = new ol.ext.pixelworks.Processor({
     operation: operation,
-    imageOps: this.operationType_ === ol.source.Raster.OperationType.IMAGE,
+    imageOps: this.operationType_ === ol.source.RasterOperationType.IMAGE,
     queue: 1,
     lib: opt_lib,
     threads: this.threads_
@@ -504,14 +505,4 @@ ol.source.Raster.EventType_ = {
    * @api
    */
   AFTEROPERATIONS: 'afteroperations'
-};
-
-
-/**
- * Raster operation type. Supported values are `'pixel'` and `'image'`.
- * @enum {string}
- */
-ol.source.Raster.OperationType = {
-  PIXEL: 'pixel',
-  IMAGE: 'image'
 };

--- a/src/ol/source/rasteroperationtype.js
+++ b/src/ol/source/rasteroperationtype.js
@@ -1,0 +1,10 @@
+goog.provide('ol.source.RasterOperationType');
+
+/**
+ * Raster operation type. Supported values are `'pixel'` and `'image'`.
+ * @enum {string}
+ */
+ol.source.RasterOperationType = {
+  PIXEL: 'pixel',
+  IMAGE: 'image'
+};

--- a/src/ol/source/tile.js
+++ b/src/ol/source/tile.js
@@ -334,32 +334,3 @@ ol.source.Tile.Event = function(type, tile) {
 
 };
 ol.inherits(ol.source.Tile.Event, ol.events.Event);
-
-
-/**
- * @enum {string}
- */
-ol.source.Tile.EventType = {
-
-  /**
-   * Triggered when a tile starts loading.
-   * @event ol.source.Tile.Event#tileloadstart
-   * @api stable
-   */
-  TILELOADSTART: 'tileloadstart',
-
-  /**
-   * Triggered when a tile finishes loading.
-   * @event ol.source.Tile.Event#tileloadend
-   * @api stable
-   */
-  TILELOADEND: 'tileloadend',
-
-  /**
-   * Triggered if tile loading results in an error.
-   * @event ol.source.Tile.Event#tileloaderror
-   * @api stable
-   */
-  TILELOADERROR: 'tileloaderror'
-
-};

--- a/src/ol/source/tileeventtype.js
+++ b/src/ol/source/tileeventtype.js
@@ -1,0 +1,29 @@
+goog.provide('ol.source.TileEventType');
+
+/**
+ * @enum {string}
+ */
+ol.source.TileEventType = {
+
+  /**
+   * Triggered when a tile starts loading.
+   * @event ol.source.Tile.Event#tileloadstart
+   * @api stable
+   */
+  TILELOADSTART: 'tileloadstart',
+
+  /**
+   * Triggered when a tile finishes loading.
+   * @event ol.source.Tile.Event#tileloadend
+   * @api stable
+   */
+  TILELOADEND: 'tileloadend',
+
+  /**
+   * Triggered if tile loading results in an error.
+   * @event ol.source.Tile.Event#tileloaderror
+   * @api stable
+   */
+  TILELOADERROR: 'tileloaderror'
+
+};

--- a/src/ol/source/urltile.js
+++ b/src/ol/source/urltile.js
@@ -4,6 +4,7 @@ goog.require('ol');
 goog.require('ol.TileState');
 goog.require('ol.TileUrlFunction');
 goog.require('ol.source.Tile');
+goog.require('ol.source.TileEventType');
 
 
 /**
@@ -111,15 +112,15 @@ ol.source.UrlTile.prototype.handleTileChange = function(event) {
   switch (tile.getState()) {
     case ol.TileState.LOADING:
       this.dispatchEvent(
-          new ol.source.Tile.Event(ol.source.Tile.EventType.TILELOADSTART, tile));
+          new ol.source.Tile.Event(ol.source.TileEventType.TILELOADSTART, tile));
       break;
     case ol.TileState.LOADED:
       this.dispatchEvent(
-          new ol.source.Tile.Event(ol.source.Tile.EventType.TILELOADEND, tile));
+          new ol.source.Tile.Event(ol.source.TileEventType.TILELOADEND, tile));
       break;
     case ol.TileState.ERROR:
       this.dispatchEvent(
-          new ol.source.Tile.Event(ol.source.Tile.EventType.TILELOADERROR, tile));
+          new ol.source.Tile.Event(ol.source.TileEventType.TILELOADERROR, tile));
       break;
     default:
       // pass

--- a/src/ol/source/vector.js
+++ b/src/ol/source/vector.js
@@ -5,6 +5,7 @@ goog.provide('ol.source.Vector');
 
 goog.require('ol');
 goog.require('ol.Collection');
+goog.require('ol.CollectionEventType');
 goog.require('ol.Object');
 goog.require('ol.array');
 goog.require('ol.asserts');
@@ -316,7 +317,7 @@ ol.source.Vector.prototype.bindFeaturesCollection_ = function(collection) {
           modifyingCollection = false;
         }
       });
-  ol.events.listen(collection, ol.Collection.EventType.ADD,
+  ol.events.listen(collection, ol.CollectionEventType.ADD,
       function(evt) {
         if (!modifyingCollection) {
           modifyingCollection = true;
@@ -324,7 +325,7 @@ ol.source.Vector.prototype.bindFeaturesCollection_ = function(collection) {
           modifyingCollection = false;
         }
       }, this);
-  ol.events.listen(collection, ol.Collection.EventType.REMOVE,
+  ol.events.listen(collection, ol.CollectionEventType.REMOVE,
       function(evt) {
         if (!modifyingCollection) {
           modifyingCollection = true;

--- a/src/ol/source/vector.js
+++ b/src/ol/source/vector.js
@@ -6,7 +6,7 @@ goog.provide('ol.source.Vector');
 goog.require('ol');
 goog.require('ol.Collection');
 goog.require('ol.CollectionEventType');
-goog.require('ol.Object');
+goog.require('ol.ObjectEventType');
 goog.require('ol.array');
 goog.require('ol.asserts');
 goog.require('ol.events');
@@ -206,7 +206,7 @@ ol.source.Vector.prototype.setupChangeEvents_ = function(featureKey, feature) {
   this.featureChangeKeys_[featureKey] = [
     ol.events.listen(feature, ol.events.EventType.CHANGE,
         this.handleFeatureChange_, this),
-    ol.events.listen(feature, ol.Object.EventType.PROPERTYCHANGE,
+    ol.events.listen(feature, ol.ObjectEventType.PROPERTYCHANGE,
         this.handleFeatureChange_, this)
   ];
 };

--- a/src/ol/source/vector.js
+++ b/src/ol/source/vector.js
@@ -19,6 +19,7 @@ goog.require('ol.loadingstrategy');
 goog.require('ol.obj');
 goog.require('ol.source.Source');
 goog.require('ol.source.State');
+goog.require('ol.source.VectorEventType');
 goog.require('ol.structs.RBush');
 
 
@@ -191,7 +192,7 @@ ol.source.Vector.prototype.addFeatureInternal = function(feature) {
   }
 
   this.dispatchEvent(
-      new ol.source.Vector.Event(ol.source.Vector.EventType.ADDFEATURE, feature));
+      new ol.source.Vector.Event(ol.source.VectorEventType.ADDFEATURE, feature));
 };
 
 
@@ -288,7 +289,7 @@ ol.source.Vector.prototype.addFeaturesInternal = function(features) {
 
   for (i = 0, length = newFeatures.length; i < length; i++) {
     this.dispatchEvent(new ol.source.Vector.Event(
-        ol.source.Vector.EventType.ADDFEATURE, newFeatures[i]));
+        ol.source.VectorEventType.ADDFEATURE, newFeatures[i]));
   }
 };
 
@@ -301,7 +302,7 @@ ol.source.Vector.prototype.bindFeaturesCollection_ = function(collection) {
   ol.DEBUG && console.assert(!this.featuresCollection_,
       'bindFeaturesCollection can only be called once');
   var modifyingCollection = false;
-  ol.events.listen(this, ol.source.Vector.EventType.ADDFEATURE,
+  ol.events.listen(this, ol.source.VectorEventType.ADDFEATURE,
       function(evt) {
         if (!modifyingCollection) {
           modifyingCollection = true;
@@ -309,7 +310,7 @@ ol.source.Vector.prototype.bindFeaturesCollection_ = function(collection) {
           modifyingCollection = false;
         }
       });
-  ol.events.listen(this, ol.source.Vector.EventType.REMOVEFEATURE,
+  ol.events.listen(this, ol.source.VectorEventType.REMOVEFEATURE,
       function(evt) {
         if (!modifyingCollection) {
           modifyingCollection = true;
@@ -377,7 +378,7 @@ ol.source.Vector.prototype.clear = function(opt_fast) {
   this.loadedExtentsRtree_.clear();
   this.nullGeometryFeatures_ = {};
 
-  var clearEvent = new ol.source.Vector.Event(ol.source.Vector.EventType.CLEAR);
+  var clearEvent = new ol.source.Vector.Event(ol.source.VectorEventType.CLEAR);
   this.dispatchEvent(clearEvent);
   this.changed();
 };
@@ -740,7 +741,7 @@ ol.source.Vector.prototype.handleFeatureChange_ = function(event) {
   }
   this.changed();
   this.dispatchEvent(new ol.source.Vector.Event(
-      ol.source.Vector.EventType.CHANGEFEATURE, feature));
+      ol.source.VectorEventType.CHANGEFEATURE, feature));
 };
 
 
@@ -820,7 +821,7 @@ ol.source.Vector.prototype.removeFeatureInternal = function(feature) {
     delete this.undefIdIndex_[featureKey];
   }
   this.dispatchEvent(new ol.source.Vector.Event(
-      ol.source.Vector.EventType.REMOVEFEATURE, feature));
+      ol.source.VectorEventType.REMOVEFEATURE, feature));
 };
 
 
@@ -868,38 +869,3 @@ ol.source.Vector.Event = function(type, opt_feature) {
 
 };
 ol.inherits(ol.source.Vector.Event, ol.events.Event);
-
-
-/**
- * @enum {string}
- */
-ol.source.Vector.EventType = {
-  /**
-   * Triggered when a feature is added to the source.
-   * @event ol.source.Vector.Event#addfeature
-   * @api stable
-   */
-  ADDFEATURE: 'addfeature',
-
-  /**
-   * Triggered when a feature is updated.
-   * @event ol.source.Vector.Event#changefeature
-   * @api
-   */
-  CHANGEFEATURE: 'changefeature',
-
-  /**
-   * Triggered when the clear method is called on the source.
-   * @event ol.source.Vector.Event#clear
-   * @api
-   */
-  CLEAR: 'clear',
-
-  /**
-   * Triggered when a feature is removed from the source.
-   * See {@link ol.source.Vector#clear source.clear()} for exceptions.
-   * @event ol.source.Vector.Event#removefeature
-   * @api stable
-   */
-  REMOVEFEATURE: 'removefeature'
-};

--- a/src/ol/source/vectoreventtype.js
+++ b/src/ol/source/vectoreventtype.js
@@ -1,0 +1,35 @@
+goog.provide('ol.source.VectorEventType');
+
+/**
+ * @enum {string}
+ */
+ol.source.VectorEventType = {
+  /**
+   * Triggered when a feature is added to the source.
+   * @event ol.source.Vector.Event#addfeature
+   * @api stable
+   */
+  ADDFEATURE: 'addfeature',
+
+  /**
+   * Triggered when a feature is updated.
+   * @event ol.source.Vector.Event#changefeature
+   * @api
+   */
+  CHANGEFEATURE: 'changefeature',
+
+  /**
+   * Triggered when the clear method is called on the source.
+   * @event ol.source.Vector.Event#clear
+   * @api
+   */
+  CLEAR: 'clear',
+
+  /**
+   * Triggered when a feature is removed from the source.
+   * See {@link ol.source.Vector#clear source.clear()} for exceptions.
+   * @event ol.source.Vector.Event#removefeature
+   * @api stable
+   */
+  REMOVEFEATURE: 'removefeature'
+};

--- a/src/ol/source/wmts.js
+++ b/src/ol/source/wmts.js
@@ -7,6 +7,7 @@ goog.require('ol.extent');
 goog.require('ol.obj');
 goog.require('ol.proj');
 goog.require('ol.source.TileImage');
+goog.require('ol.source.WMTSRequestEncoding');
 goog.require('ol.tilegrid.WMTS');
 goog.require('ol.uri');
 
@@ -70,11 +71,11 @@ ol.source.WMTS = function(options) {
 
   /**
    * @private
-   * @type {ol.source.WMTS.RequestEncoding}
+   * @type {ol.source.WMTSRequestEncoding}
    */
   this.requestEncoding_ = options.requestEncoding !== undefined ?
-      /** @type {ol.source.WMTS.RequestEncoding} */ (options.requestEncoding) :
-      ol.source.WMTS.RequestEncoding.KVP;
+      /** @type {ol.source.WMTSRequestEncoding} */ (options.requestEncoding) :
+      ol.source.WMTSRequestEncoding.KVP;
 
   var requestEncoding = this.requestEncoding_;
 
@@ -90,7 +91,7 @@ ol.source.WMTS = function(options) {
     'tilematrixset': this.matrixSet_
   };
 
-  if (requestEncoding == ol.source.WMTS.RequestEncoding.KVP) {
+  if (requestEncoding == ol.source.WMTSRequestEncoding.KVP) {
     ol.obj.assign(context, {
       'Service': 'WMTS',
       'Request': 'GetTile',
@@ -111,7 +112,7 @@ ol.source.WMTS = function(options) {
     // order conforms to wmts spec guidance, and so that we can avoid to escape
     // special template params
 
-    template = (requestEncoding == ol.source.WMTS.RequestEncoding.KVP) ?
+    template = (requestEncoding == ol.source.WMTSRequestEncoding.KVP) ?
         ol.uri.appendParams(template, context) :
         template.replace(/\{(\w+?)\}/g, function(m, p) {
           return (p.toLowerCase() in context) ? context[p.toLowerCase()] : m;
@@ -135,7 +136,7 @@ ol.source.WMTS = function(options) {
             };
             ol.obj.assign(localContext, dimensions);
             var url = template;
-            if (requestEncoding == ol.source.WMTS.RequestEncoding.KVP) {
+            if (requestEncoding == ol.source.WMTSRequestEncoding.KVP) {
               url = ol.uri.appendParams(url, localContext);
             } else {
               url = url.replace(/\{(\w+?)\}/g, function(m, p) {
@@ -218,7 +219,7 @@ ol.source.WMTS.prototype.getMatrixSet = function() {
 
 /**
  * Return the request encoding, either "KVP" or "REST".
- * @return {ol.source.WMTS.RequestEncoding} Request encoding.
+ * @return {ol.source.WMTSRequestEncoding} Request encoding.
  * @api
  */
 ol.source.WMTS.prototype.getRequestEncoding = function() {
@@ -438,8 +439,8 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
         // requestEncoding not provided, use the first encoding from the list
         requestEncoding = encodings[0];
       }
-      if (requestEncoding === ol.source.WMTS.RequestEncoding.KVP) {
-        if (ol.array.includes(encodings, ol.source.WMTS.RequestEncoding.KVP)) {
+      if (requestEncoding === ol.source.WMTSRequestEncoding.KVP) {
+        if (ol.array.includes(encodings, ol.source.WMTSRequestEncoding.KVP)) {
           urls.push(/** @type {string} */ (gets[i]['href']));
         }
       } else {
@@ -448,7 +449,7 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
     }
   }
   if (urls.length === 0) {
-    requestEncoding = ol.source.WMTS.RequestEncoding.REST;
+    requestEncoding = ol.source.WMTSRequestEncoding.REST;
     l['ResourceURL'].forEach(function(element) {
       if (element['resourceType'] === 'tile') {
         format = element['format'];
@@ -471,14 +472,4 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
     wrapX: wrapX
   };
 
-};
-
-
-/**
- * Request encoding. One of 'KVP', 'REST'.
- * @enum {string}
- */
-ol.source.WMTS.RequestEncoding = {
-  KVP: 'KVP',  // see spec §8
-  REST: 'REST' // see spec §10
 };

--- a/src/ol/source/wmtsrequestencoding.js
+++ b/src/ol/source/wmtsrequestencoding.js
@@ -1,0 +1,10 @@
+goog.provide('ol.source.WMTSRequestEncoding');
+
+/**
+ * Request encoding. One of 'KVP', 'REST'.
+ * @enum {string}
+ */
+ol.source.WMTSRequestEncoding = {
+  KVP: 'KVP',  // see spec §8
+  REST: 'REST' // see spec §10
+};

--- a/src/ol/source/zoomify.js
+++ b/src/ol/source/zoomify.js
@@ -26,7 +26,7 @@ ol.source.Zoomify = function(opt_options) {
   var size = options.size;
   var tierSizeCalculation = options.tierSizeCalculation !== undefined ?
       options.tierSizeCalculation :
-      ol.source.Zoomify.TierSizeCalculation.DEFAULT;
+      ol.source.Zoomify.TierSizeCalculation_.DEFAULT;
 
   var imageWidth = size[0];
   var imageHeight = size[1];
@@ -34,7 +34,7 @@ ol.source.Zoomify = function(opt_options) {
   var tileSize = ol.DEFAULT_TILE_SIZE;
 
   switch (tierSizeCalculation) {
-    case ol.source.Zoomify.TierSizeCalculation.DEFAULT:
+    case ol.source.Zoomify.TierSizeCalculation_.DEFAULT:
       while (imageWidth > tileSize || imageHeight > tileSize) {
         tierSizeInTiles.push([
           Math.ceil(imageWidth / tileSize),
@@ -43,7 +43,7 @@ ol.source.Zoomify = function(opt_options) {
         tileSize += tileSize;
       }
       break;
-    case ol.source.Zoomify.TierSizeCalculation.TRUNCATED:
+    case ol.source.Zoomify.TierSizeCalculation_.TRUNCATED:
       var width = imageWidth;
       var height = imageHeight;
       while (width > tileSize || height > tileSize) {
@@ -175,8 +175,9 @@ ol.source.Zoomify.Tile_.prototype.getImage = function() {
 
 /**
  * @enum {string}
+ * @private
  */
-ol.source.Zoomify.TierSizeCalculation = {
+ol.source.Zoomify.TierSizeCalculation_ = {
   DEFAULT: 'default',
   TRUNCATED: 'truncated'
 };

--- a/src/ol/webgl/buffer.js
+++ b/src/ol/webgl/buffer.js
@@ -23,7 +23,7 @@ ol.webgl.Buffer = function(opt_arr, opt_usage) {
    * @type {number}
    */
   this.usage_ = opt_usage !== undefined ?
-      opt_usage : ol.webgl.Buffer.Usage.STATIC_DRAW;
+      opt_usage : ol.webgl.Buffer.Usage_.STATIC_DRAW;
 
 };
 
@@ -46,8 +46,9 @@ ol.webgl.Buffer.prototype.getUsage = function() {
 
 /**
  * @enum {number}
+ * @private
  */
-ol.webgl.Buffer.Usage = {
+ol.webgl.Buffer.Usage_ = {
   STATIC_DRAW: ol.webgl.STATIC_DRAW,
   STREAM_DRAW: ol.webgl.STREAM_DRAW,
   DYNAMIC_DRAW: ol.webgl.DYNAMIC_DRAW

--- a/test/spec/ol/collection.test.js
+++ b/test/spec/ol/collection.test.js
@@ -2,6 +2,7 @@ goog.provide('ol.test.Collection');
 
 goog.require('ol.events');
 goog.require('ol.Collection');
+goog.require('ol.CollectionEventType');
 
 
 describe('ol.collection', function() {
@@ -130,7 +131,7 @@ describe('ol.collection', function() {
     it('fires a remove event', function() {
       var collection = new ol.Collection([0, 1, 2]);
       var cb = sinon.spy();
-      ol.events.listen(collection, ol.Collection.EventType.REMOVE, cb);
+      ol.events.listen(collection, ol.CollectionEventType.REMOVE, cb);
       expect(collection.remove(1)).to.eql(1);
       expect(cb).to.be.called();
       expect(cb.lastCall.args[0].element).to.eql(1);
@@ -153,11 +154,11 @@ describe('ol.collection', function() {
     it('does dispatch events', function() {
       var collection = new ol.Collection(['a', 'b']);
       var added, removed;
-      ol.events.listen(collection, ol.Collection.EventType.ADD, function(e) {
+      ol.events.listen(collection, ol.CollectionEventType.ADD, function(e) {
         added = e.element;
       });
       ol.events.listen(
-          collection, ol.Collection.EventType.REMOVE, function(e) {
+          collection, ol.CollectionEventType.REMOVE, function(e) {
             removed = e.element;
           });
       collection.setAt(1, 1);
@@ -171,7 +172,7 @@ describe('ol.collection', function() {
       var collection = new ol.Collection(['a']);
       var removed;
       ol.events.listen(
-          collection, ol.Collection.EventType.REMOVE, function(e) {
+          collection, ol.CollectionEventType.REMOVE, function(e) {
             removed = e.element;
           });
       collection.pop();
@@ -184,7 +185,7 @@ describe('ol.collection', function() {
       var collection = new ol.Collection([0, 2]);
       var added;
       ol.events.listen(
-          collection, ol.Collection.EventType.ADD, function(e) {
+          collection, ol.CollectionEventType.ADD, function(e) {
             added = e.element;
           });
       collection.insertAt(1, 1);
@@ -196,7 +197,7 @@ describe('ol.collection', function() {
     it('triggers events properly', function() {
       var added = [];
       ol.events.listen(
-          collection, ol.Collection.EventType.ADD, function(e) {
+          collection, ol.CollectionEventType.ADD, function(e) {
             added.push(e.element);
           });
       collection.setAt(2, 0);
@@ -245,7 +246,7 @@ describe('ol.collection', function() {
     it('triggers add when pushing', function() {
       var collection = new ol.Collection();
       var elem;
-      ol.events.listen(collection, ol.Collection.EventType.ADD, function(e) {
+      ol.events.listen(collection, ol.CollectionEventType.ADD, function(e) {
         elem = e.element;
       });
       var length = collection.push(1);
@@ -262,8 +263,8 @@ describe('ol.collection', function() {
     });
     describe('setAt', function() {
       it('triggers remove', function() {
-        ol.events.listen(collection, ol.Collection.EventType.ADD, cb1);
-        ol.events.listen(collection, ol.Collection.EventType.REMOVE, cb2);
+        ol.events.listen(collection, ol.CollectionEventType.ADD, cb1);
+        ol.events.listen(collection, ol.CollectionEventType.REMOVE, cb2);
         collection.setAt(0, 2);
         expect(cb2.lastCall.args[0].element).to.eql(1);
         expect(cb1.lastCall.args[0].element).to.eql(2);
@@ -271,7 +272,7 @@ describe('ol.collection', function() {
     });
     describe('pop', function() {
       it('triggers remove', function() {
-        ol.events.listen(collection, ol.Collection.EventType.REMOVE, cb1);
+        ol.events.listen(collection, ol.CollectionEventType.REMOVE, cb1);
         collection.pop();
         expect(cb1.lastCall.args[0].element).to.eql(1);
       });
@@ -289,7 +290,7 @@ describe('ol.collection', function() {
     it('fires events', function() {
       var collection = new ol.Collection();
       var elems = [];
-      ol.events.listen(collection, ol.Collection.EventType.ADD, function(e) {
+      ol.events.listen(collection, ol.CollectionEventType.ADD, function(e) {
         elems.push(e.element);
       });
       collection.extend([1, 2]);

--- a/test/spec/ol/interaction/mousewheelzoom.test.js
+++ b/test/spec/ol/interaction/mousewheelzoom.test.js
@@ -69,7 +69,7 @@ describe('ol.interaction.MouseWheelZoom', function() {
       var origHasFirefox = ol.has.FIREFOX;
       ol.has.FIREFOX = true;
       map.once('postrender', function() {
-        expect(interaction.mode_).to.be(ol.interaction.MouseWheelZoom.Mode.TRACKPAD);
+        expect(interaction.mode_).to.be(ol.interaction.MouseWheelZoom.Mode_.TRACKPAD);
         ol.has.FIREFOX = origHasFirefox;
         done();
       });
@@ -88,7 +88,7 @@ describe('ol.interaction.MouseWheelZoom', function() {
       var origHasFirefox = ol.has.FIREFOX;
       ol.has.FIREFOX = false;
       map.once('postrender', function() {
-        expect(interaction.mode_).to.be(ol.interaction.MouseWheelZoom.Mode.TRACKPAD);
+        expect(interaction.mode_).to.be(ol.interaction.MouseWheelZoom.Mode_.TRACKPAD);
         ol.has.FIREFOX = origHasFirefox;
         done();
       });

--- a/test/spec/ol/interaction/select.test.js
+++ b/test/spec/ol/interaction/select.test.js
@@ -3,7 +3,7 @@ goog.provide('ol.test.interaction.Select');
 goog.require('ol.Collection');
 goog.require('ol.Feature');
 goog.require('ol.Map');
-goog.require('ol.MapBrowserEvent');
+goog.require('ol.MapBrowserEventType');
 goog.require('ol.MapBrowserPointerEvent');
 goog.require('ol.View');
 goog.require('ol.geom.Polygon');
@@ -150,7 +150,7 @@ describe('ol.interaction.Select', function() {
       });
       select.on('select', listenerSpy);
 
-      simulateEvent(ol.MapBrowserEvent.EventType.SINGLECLICK, -10, -10);
+      simulateEvent(ol.MapBrowserEventType.SINGLECLICK, -10, -10);
 
       expect(listenerSpy.callCount).to.be(0);
 
@@ -164,8 +164,8 @@ describe('ol.interaction.Select', function() {
       });
       select.on('select', listenerSpy);
 
-      simulateEvent(ol.MapBrowserEvent.EventType.SINGLECLICK, 10, -20);
-      simulateEvent(ol.MapBrowserEvent.EventType.SINGLECLICK, 9, -21);
+      simulateEvent(ol.MapBrowserEventType.SINGLECLICK, 10, -20);
+      simulateEvent(ol.MapBrowserEventType.SINGLECLICK, 9, -21);
 
       expect(listenerSpy.callCount).to.be(1);
 


### PR DESCRIPTION
This brings consistency to our enums:

 - if an enum is shared between two or more files, it needs to be in a dedicated file
 - otherwise, the enum must be private

A linter rule now enforces this convention.
