### PR TITLE
(WIP) Make layers responsible for creating layer renderers

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,6 +2,10 @@
 
 ### Next release
 
+#### Removed build flags (`@define`)
+
+The `ol.ENABLE_TILE`, `ol.ENABLE_IMAGE`, `ol.ENABLE_VECTOR`, and `ol.ENABLE_VECTOR_TILE` build flags are no longer necessary and have been removed.  If you were using these in a `define` array for a custom build, you can remove them.
+
 #### Simplified `ol.View#fit()` API
 
 In most cases, it is no longer necessary to provide an `ol.Size` (previously the 2nd argument) to `ol.View#fit()`. By default, the size of the first map that uses the view will be used. If you want to specify a different size, it goes in the options now (previously the 3rd argument, now the 2nd).

--- a/doc/tutorials/custom-builds.md
+++ b/doc/tutorials/custom-builds.md
@@ -158,8 +158,6 @@ You might have noticed that the build file you've just created is considerably s
 ```
       "ol.ENABLE_WEBGL=false",
       "ol.ENABLE_PROJ4JS=false",
-      "ol.ENABLE_IMAGE=false",
-      "ol.ENABLE_VECTOR=false",
 ```
 
 and re-run the build script. The build size should now be smaller.
@@ -208,7 +206,6 @@ Now let's try a more complicated example: [`heatmaps-earthquakes`](https://openl
     "define": [
       "ol.ENABLE_WEBGL=false",
       "ol.ENABLE_PROJ4JS=false",
-      "ol.ENABLE_IMAGE=false",
       "ol.DEBUG=false"
     ],
     "compilation_level": "ADVANCED",

--- a/src/ol/index.js
+++ b/src/ol/index.js
@@ -68,14 +68,6 @@ ol.ENABLE_CANVAS = true;
 
 
 /**
- * @define {boolean} Enable rendering of ol.layer.Image based layers.  Default
- *     is `true`. Setting this to false at compile time in advanced mode removes
- *     all code supporting Image layers from the build.
- */
-ol.ENABLE_IMAGE = true;
-
-
-/**
  * @define {boolean} Enable integration with the Proj4js library.  Default is
  *     `true`.
  */
@@ -87,30 +79,6 @@ ol.ENABLE_PROJ4JS = true;
  *     `true`.
  */
 ol.ENABLE_RASTER_REPROJECTION = true;
-
-
-/**
- * @define {boolean} Enable rendering of ol.layer.Tile based layers.  Default is
- *     `true`. Setting this to false at compile time in advanced mode removes
- *     all code supporting Tile layers from the build.
- */
-ol.ENABLE_TILE = true;
-
-
-/**
- * @define {boolean} Enable rendering of ol.layer.Vector based layers.  Default
- *     is `true`. Setting this to false at compile time in advanced mode removes
- *     all code supporting Vector layers from the build.
- */
-ol.ENABLE_VECTOR = true;
-
-
-/**
- * @define {boolean} Enable rendering of ol.layer.VectorTile based layers.
- *     Default is `true`. Setting this to false at compile time in advanced mode
- *     removes all code supporting VectorTile layers from the build.
- */
-ol.ENABLE_VECTOR_TILE = true;
 
 
 /**

--- a/src/ol/layer/base.js
+++ b/src/ol/layer/base.js
@@ -55,6 +55,15 @@ ol.inherits(ol.layer.Base, ol.Object);
 
 
 /**
+ * Create a renderer for this layer.
+ * @abstract
+ * @param {ol.renderer.Map} mapRenderer The map renderer.
+ * @return {ol.renderer.Layer} A layer renderer.
+ */
+ol.layer.Base.prototype.createRenderer = function(mapRenderer) {};
+
+
+/**
  * @return {ol.LayerState} Layer state.
  */
 ol.layer.Base.prototype.getLayerState = function() {

--- a/src/ol/layer/image.js
+++ b/src/ol/layer/image.js
@@ -2,6 +2,9 @@ goog.provide('ol.layer.Image');
 
 goog.require('ol');
 goog.require('ol.layer.Layer');
+goog.require('ol.renderer.Type');
+goog.require('ol.renderer.canvas.ImageLayer');
+goog.require('ol.renderer.webgl.ImageLayer');
 
 
 /**
@@ -23,6 +26,21 @@ ol.layer.Image = function(opt_options) {
   ol.layer.Layer.call(this,  /** @type {olx.layer.LayerOptions} */ (options));
 };
 ol.inherits(ol.layer.Image, ol.layer.Layer);
+
+
+/**
+ * @inheritDoc
+ */
+ol.layer.Image.prototype.createRenderer = function(mapRenderer) {
+  var renderer = null;
+  var type = mapRenderer.getType();
+  if (ol.ENABLE_CANVAS && type === ol.renderer.Type.CANVAS) {
+    renderer = new ol.renderer.canvas.ImageLayer(this);
+  } else if (ol.ENABLE_WEBGL && type === ol.renderer.Type.WEBGL) {
+    renderer = new ol.renderer.webgl.ImageLayer(/** @type {ol.renderer.webgl.Map} */ (mapRenderer), this);
+  }
+  return renderer;
+};
 
 
 /**

--- a/src/ol/layer/tile.js
+++ b/src/ol/layer/tile.js
@@ -4,6 +4,9 @@ goog.require('ol');
 goog.require('ol.layer.Layer');
 goog.require('ol.layer.TileProperty');
 goog.require('ol.obj');
+goog.require('ol.renderer.Type');
+goog.require('ol.renderer.canvas.TileLayer');
+goog.require('ol.renderer.webgl.TileLayer');
 
 
 /**
@@ -34,6 +37,21 @@ ol.layer.Tile = function(opt_options) {
       options.useInterimTilesOnError : true);
 };
 ol.inherits(ol.layer.Tile, ol.layer.Layer);
+
+
+/**
+ * @inheritDoc
+ */
+ol.layer.Tile.prototype.createRenderer = function(mapRenderer) {
+  var renderer = null;
+  var type = mapRenderer.getType();
+  if (ol.ENABLE_CANVAS && type === ol.renderer.Type.CANVAS) {
+    renderer = new ol.renderer.canvas.TileLayer(this);
+  } else if (ol.ENABLE_WEBGL && type === ol.renderer.Type.WEBGL) {
+    renderer = new ol.renderer.webgl.TileLayer(/** @type {ol.renderer.webgl.Map} */ (mapRenderer), this);
+  }
+  return renderer;
+};
 
 
 /**

--- a/src/ol/layer/vector.js
+++ b/src/ol/layer/vector.js
@@ -3,6 +3,9 @@ goog.provide('ol.layer.Vector');
 goog.require('ol');
 goog.require('ol.layer.Layer');
 goog.require('ol.obj');
+goog.require('ol.renderer.Type');
+goog.require('ol.renderer.canvas.VectorLayer');
+goog.require('ol.renderer.webgl.VectorLayer');
 goog.require('ol.style.Style');
 
 
@@ -76,6 +79,21 @@ ol.layer.Vector = function(opt_options) {
 
 };
 ol.inherits(ol.layer.Vector, ol.layer.Layer);
+
+
+/**
+ * @inheritDoc
+ */
+ol.layer.Vector.prototype.createRenderer = function(mapRenderer) {
+  var renderer = null;
+  var type = mapRenderer.getType();
+  if (ol.ENABLE_CANVAS && type === ol.renderer.Type.CANVAS) {
+    renderer = new ol.renderer.canvas.VectorLayer(this);
+  } else if (ol.ENABLE_WEBGL && type === ol.renderer.Type.WEBGL) {
+    renderer = new ol.renderer.webgl.VectorLayer(/** @type {ol.renderer.webgl.Map} */ (mapRenderer), this);
+  }
+  return renderer;
+};
 
 
 /**

--- a/src/ol/layer/vectortile.js
+++ b/src/ol/layer/vectortile.js
@@ -6,6 +6,8 @@ goog.require('ol.layer.TileProperty');
 goog.require('ol.layer.Vector');
 goog.require('ol.layer.VectorTileRenderType');
 goog.require('ol.obj');
+goog.require('ol.renderer.Type');
+goog.require('ol.renderer.canvas.VectorTileLayer');
 
 
 /**
@@ -47,6 +49,19 @@ ol.layer.VectorTile = function(opt_options) {
 
 };
 ol.inherits(ol.layer.VectorTile, ol.layer.Vector);
+
+
+/**
+ * @inheritDoc
+ */
+ol.layer.VectorTile.prototype.createRenderer = function(mapRenderer) {
+  var renderer = null;
+  var type = mapRenderer.getType();
+  if (ol.ENABLE_CANVAS && type === ol.renderer.Type.CANVAS) {
+    renderer = new ol.renderer.canvas.VectorTileLayer(this);
+  }
+  return renderer;
+};
 
 
 /**

--- a/src/ol/renderer/canvas/map.js
+++ b/src/ol/renderer/canvas/map.js
@@ -7,21 +7,13 @@ goog.require('ol');
 goog.require('ol.array');
 goog.require('ol.css');
 goog.require('ol.dom');
-goog.require('ol.layer.Image');
 goog.require('ol.layer.Layer');
-goog.require('ol.layer.Tile');
-goog.require('ol.layer.Vector');
-goog.require('ol.layer.VectorTile');
 goog.require('ol.render.Event');
 goog.require('ol.render.EventType');
 goog.require('ol.render.canvas');
 goog.require('ol.render.canvas.Immediate');
 goog.require('ol.renderer.Map');
 goog.require('ol.renderer.Type');
-goog.require('ol.renderer.canvas.ImageLayer');
-goog.require('ol.renderer.canvas.TileLayer');
-goog.require('ol.renderer.canvas.VectorLayer');
-goog.require('ol.renderer.canvas.VectorTileLayer');
 goog.require('ol.source.State');
 
 
@@ -66,25 +58,6 @@ ol.renderer.canvas.Map = function(container, map) {
 
 };
 ol.inherits(ol.renderer.canvas.Map, ol.renderer.Map);
-
-
-/**
- * @inheritDoc
- */
-ol.renderer.canvas.Map.prototype.createLayerRenderer = function(layer) {
-  if (ol.ENABLE_IMAGE && layer instanceof ol.layer.Image) {
-    return new ol.renderer.canvas.ImageLayer(layer);
-  } else if (ol.ENABLE_TILE && layer instanceof ol.layer.Tile) {
-    return new ol.renderer.canvas.TileLayer(layer);
-  } else if (ol.ENABLE_VECTOR_TILE && layer instanceof ol.layer.VectorTile) {
-    return new ol.renderer.canvas.VectorTileLayer(layer);
-  } else if (ol.ENABLE_VECTOR && layer instanceof ol.layer.Vector) {
-    return new ol.renderer.canvas.VectorLayer(layer);
-  } else {
-    ol.DEBUG && console.assert(false, 'unexpected layer configuration');
-    return null;
-  }
-};
 
 
 /**

--- a/src/ol/renderer/map.js
+++ b/src/ol/renderer/map.js
@@ -68,15 +68,6 @@ ol.renderer.Map.prototype.calculateMatrices2D = function(frameState) {
 
 
 /**
- * @abstract
- * @param {ol.layer.Layer} layer Layer.
- * @protected
- * @return {ol.renderer.Layer} layerRenderer Layer renderer.
- */
-ol.renderer.Map.prototype.createLayerRenderer = function(layer) {};
-
-
-/**
  * @inheritDoc
  */
 ol.renderer.Map.prototype.disposeInternal = function() {
@@ -216,7 +207,7 @@ ol.renderer.Map.prototype.getLayerRenderer = function(layer) {
   if (layerKey in this.layerRenderers_) {
     return this.layerRenderers_[layerKey];
   } else {
-    var layerRenderer = this.createLayerRenderer(layer);
+    var layerRenderer = layer.createRenderer(this);
     this.layerRenderers_[layerKey] = layerRenderer;
     this.layerRendererListeners_[layerKey] = ol.events.listen(layerRenderer,
         ol.events.EventType.CHANGE, this.handleLayerRendererChange_, this);

--- a/src/ol/renderer/webgl/map.js
+++ b/src/ol/renderer/webgl/map.js
@@ -7,18 +7,12 @@ goog.require('ol.array');
 goog.require('ol.css');
 goog.require('ol.dom');
 goog.require('ol.events');
-goog.require('ol.layer.Image');
 goog.require('ol.layer.Layer');
-goog.require('ol.layer.Tile');
-goog.require('ol.layer.Vector');
 goog.require('ol.render.Event');
 goog.require('ol.render.EventType');
 goog.require('ol.render.webgl.Immediate');
 goog.require('ol.renderer.Map');
 goog.require('ol.renderer.Type');
-goog.require('ol.renderer.webgl.ImageLayer');
-goog.require('ol.renderer.webgl.TileLayer');
-goog.require('ol.renderer.webgl.VectorLayer');
 goog.require('ol.source.State');
 goog.require('ol.structs.LRUCache');
 goog.require('ol.structs.PriorityQueue');
@@ -229,23 +223,6 @@ ol.renderer.webgl.Map.prototype.bindTileTexture = function(tile, tileSize, tileG
       magFilter: magFilter,
       minFilter: minFilter
     });
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-ol.renderer.webgl.Map.prototype.createLayerRenderer = function(layer) {
-  if (ol.ENABLE_IMAGE && layer instanceof ol.layer.Image) {
-    return new ol.renderer.webgl.ImageLayer(this, layer);
-  } else if (ol.ENABLE_TILE && layer instanceof ol.layer.Tile) {
-    return new ol.renderer.webgl.TileLayer(this, layer);
-  } else if (ol.ENABLE_VECTOR && layer instanceof ol.layer.Vector) {
-    return new ol.renderer.webgl.VectorLayer(this, layer);
-  } else {
-    ol.DEBUG && console.assert(false, 'unexpected layer configuration');
-    return null;
   }
 };
 


### PR DESCRIPTION
Instead of having the map renderers depend on all layer types and all layer renderer types, the layers can take responsibility for creating layer renderers.

This will make it easier to create small builds without having to rely on `@define`s to indicate dependencies.