### PR TITLE
Remove ol.DEBUG

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -4,7 +4,7 @@
 
 #### Removed build flags (`@define`)
 
-The `ol.ENABLE_TILE`, `ol.ENABLE_IMAGE`, `ol.ENABLE_VECTOR`, and `ol.ENABLE_VECTOR_TILE` build flags are no longer necessary and have been removed.  If you were using these in a `define` array for a custom build, you can remove them.
+The `ol.DEBUG`, `ol.ENABLE_TILE`, `ol.ENABLE_IMAGE`, `ol.ENABLE_VECTOR`, and `ol.ENABLE_VECTOR_TILE` build flags are no longer necessary and have been removed.  If you were using these in a `define` array for a custom build, you can remove them.
 
 #### Simplified `ol.View#fit()` API
 

--- a/config/example.json
+++ b/config/example.json
@@ -23,9 +23,6 @@
       "externs/tilejson.js",
       "externs/topojson.js"
     ],
-    "define": [
-      "ol.DEBUG=false"
-    ],
     "jscomp_error": [
       "*"
     ],

--- a/config/examples-all.json
+++ b/config/examples-all.json
@@ -23,9 +23,6 @@
       "externs/tilejson.js",
       "externs/topojson.js"
     ],
-    "define": [
-      "ol.DEBUG=false"
-    ],
     "jscomp_error": [
       "*"
     ],

--- a/config/ol.json
+++ b/config/ol.json
@@ -14,9 +14,6 @@
       "externs/tilejson.js",
       "externs/topojson.js"
     ],
-    "define": [
-      "ol.DEBUG=false"
-    ],
     "jscomp_error": [
       "*"
     ],

--- a/doc/tutorials/closure.md
+++ b/doc/tutorials/closure.md
@@ -169,7 +169,6 @@ The minimum config file looks like this:
       "node_modules/openlayers/externs/topojson.js"
     ],
     "define": [
-      "ol.DEBUG=false",
       "ol.ENABLE_WEBGL=false"
     ],
     "js": [
@@ -220,7 +219,6 @@ Here is a version of `config.json` with more compilation checks enabled:
       "node_modules/openlayers/externs/topojson.js"
     ],
     "define": [
-      "ol.DEBUG=false",
       "ol.ENABLE_WEBGL=false"
     ],
     "js": [

--- a/doc/tutorials/custom-builds.md
+++ b/doc/tutorials/custom-builds.md
@@ -59,9 +59,6 @@ Creating a custom build requires writing a build configuration file. The format 
       "externs/tilejson.js",
       "externs/topojson.js"
     ],
-    "define": [
-      "ol.DEBUG=false"
-    ],
     "extra_annotation_name": [
       "api", "observable"
     ],
@@ -205,8 +202,7 @@ Now let's try a more complicated example: [`heatmaps-earthquakes`](https://openl
     ],
     "define": [
       "ol.ENABLE_WEBGL=false",
-      "ol.ENABLE_PROJ4JS=false",
-      "ol.DEBUG=false"
+      "ol.ENABLE_PROJ4JS=false"
     ],
     "compilation_level": "ADVANCED",
     "manage_closure_dependencies": true

--- a/src/ol/animation.js
+++ b/src/ol/animation.js
@@ -15,7 +15,6 @@ goog.require('ol.easing');
  * @api
  */
 ol.animation.bounce = function(options) {
-  ol.DEBUG && console.warn('ol.animation.bounce() is deprecated.  Use view.animate() instead.');
   var resolution = options.resolution;
   var start = options.start ? options.start : Date.now();
   var duration = options.duration !== undefined ? options.duration : 1000;
@@ -54,7 +53,6 @@ ol.animation.bounce = function(options) {
  * @api
  */
 ol.animation.pan = function(options) {
-  ol.DEBUG && console.warn('ol.animation.pan() is deprecated.  Use view.animate() instead.');
   var source = options.source;
   var start = options.start ? options.start : Date.now();
   var sourceX = source[0];
@@ -97,7 +95,6 @@ ol.animation.pan = function(options) {
  * @api
  */
 ol.animation.rotate = function(options) {
-  ol.DEBUG && console.warn('ol.animation.rotate() is deprecated.  Use view.animate() instead.');
   var sourceRotation = options.rotation ? options.rotation : 0;
   var start = options.start ? options.start : Date.now();
   var duration = options.duration !== undefined ? options.duration : 1000;
@@ -146,7 +143,6 @@ ol.animation.rotate = function(options) {
  * @api
  */
 ol.animation.zoom = function(options) {
-  ol.DEBUG && console.warn('ol.animation.zoom() is deprecated.  Use view.animate() instead.');
   var sourceResolution = options.resolution;
   var start = options.start ? options.start : Date.now();
   var duration = options.duration !== undefined ? options.duration : 1000;

--- a/src/ol/array.js
+++ b/src/ol/array.js
@@ -114,10 +114,6 @@ ol.array.linearFindNearest = function(arr, target, direction) {
  * @param {number} end End index.
  */
 ol.array.reverseSubArray = function(arr, begin, end) {
-  ol.DEBUG && console.assert(begin >= 0,
-      'Array begin index should be equal to or greater than 0');
-  ol.DEBUG && console.assert(end < arr.length,
-      'Array end index should be less than the array length');
   while (begin < end) {
     var tmp = arr[begin];
     arr[begin] = arr[end];

--- a/src/ol/events/eventtarget.js
+++ b/src/ol/events/eventtarget.js
@@ -144,7 +144,6 @@ ol.events.EventTarget.prototype.removeEventListener = function(type, listener) {
   var listeners = this.listeners_[type];
   if (listeners) {
     var index = listeners.indexOf(listener);
-    ol.DEBUG && console.assert(index != -1, 'listener not found');
     if (type in this.pendingRemovals_) {
       // make listener a no-op, and remove later in #dispatchEvent()
       listeners[index] = ol.nullFunction;

--- a/src/ol/extent.js
+++ b/src/ol/extent.js
@@ -30,8 +30,6 @@ ol.extent.boundingExtent = function(coordinates) {
  * @return {ol.Extent} Extent.
  */
 ol.extent.boundingExtentXYs_ = function(xs, ys, opt_extent) {
-  ol.DEBUG && console.assert(xs.length > 0, 'xs length should be larger than 0');
-  ol.DEBUG && console.assert(ys.length > 0, 'ys length should be larger than 0');
   var minX = Math.min.apply(null, xs);
   var minY = Math.min.apply(null, ys);
   var maxX = Math.max.apply(null, xs);

--- a/src/ol/format/esrijson.js
+++ b/src/ol/format/esrijson.js
@@ -144,8 +144,6 @@ ol.format.EsriJSON.convertRings_ = function(rings, layout) {
  * @return {ol.geom.Geometry} Point.
  */
 ol.format.EsriJSON.readPointGeometry_ = function(object) {
-  ol.DEBUG && console.assert(typeof object.x === 'number', 'object.x should be number');
-  ol.DEBUG && console.assert(typeof object.y === 'number', 'object.y should be number');
   var point;
   if (object.m !== undefined && object.z !== undefined) {
     point = new ol.geom.Point([object.x, object.y, object.z, object.m],
@@ -169,10 +167,6 @@ ol.format.EsriJSON.readPointGeometry_ = function(object) {
  * @return {ol.geom.Geometry} LineString.
  */
 ol.format.EsriJSON.readLineStringGeometry_ = function(object) {
-  ol.DEBUG && console.assert(Array.isArray(object.paths),
-      'object.paths should be an array');
-  ol.DEBUG && console.assert(object.paths.length === 1,
-      'object.paths array length should be 1');
   var layout = ol.format.EsriJSON.getGeometryLayout_(object);
   return new ol.geom.LineString(object.paths[0], layout);
 };
@@ -184,10 +178,6 @@ ol.format.EsriJSON.readLineStringGeometry_ = function(object) {
  * @return {ol.geom.Geometry} MultiLineString.
  */
 ol.format.EsriJSON.readMultiLineStringGeometry_ = function(object) {
-  ol.DEBUG && console.assert(Array.isArray(object.paths),
-      'object.paths should be an array');
-  ol.DEBUG && console.assert(object.paths.length > 1,
-      'object.paths array length should be more than 1');
   var layout = ol.format.EsriJSON.getGeometryLayout_(object);
   return new ol.geom.MultiLineString(object.paths, layout);
 };
@@ -228,8 +218,6 @@ ol.format.EsriJSON.readMultiPointGeometry_ = function(object) {
  * @return {ol.geom.Geometry} MultiPolygon.
  */
 ol.format.EsriJSON.readMultiPolygonGeometry_ = function(object) {
-  ol.DEBUG && console.assert(object.rings.length > 1,
-      'object.rings should have length larger than 1');
   var layout = ol.format.EsriJSON.getGeometryLayout_(object);
   return new ol.geom.MultiPolygon(
       /** @type {Array.<Array.<Array.<Array.<number>>>>} */(object.rings),
@@ -243,7 +231,6 @@ ol.format.EsriJSON.readMultiPolygonGeometry_ = function(object) {
  * @return {ol.geom.Geometry} Polygon.
  */
 ol.format.EsriJSON.readPolygonGeometry_ = function(object) {
-  ol.DEBUG && console.assert(object.rings);
   var layout = ol.format.EsriJSON.getGeometryLayout_(object);
   return new ol.geom.Polygon(object.rings, layout);
 };
@@ -469,9 +456,6 @@ ol.format.EsriJSON.prototype.readFeatures;
 ol.format.EsriJSON.prototype.readFeatureFromObject = function(
     object, opt_options) {
   var esriJSONFeature = /** @type {EsriJSONFeature} */ (object);
-  ol.DEBUG && console.assert(esriJSONFeature.geometry ||
-      esriJSONFeature.attributes,
-      'geometry or attributes should be defined');
   var geometry = ol.format.EsriJSON.readGeometry_(esriJSONFeature.geometry,
       opt_options);
   var feature = new ol.Feature();
@@ -481,9 +465,6 @@ ol.format.EsriJSON.prototype.readFeatureFromObject = function(
   feature.setGeometry(geometry);
   if (opt_options && opt_options.idField &&
       esriJSONFeature.attributes[opt_options.idField]) {
-    ol.DEBUG && console.assert(
-        typeof esriJSONFeature.attributes[opt_options.idField] === 'number',
-        'objectIdFieldName value should be a number');
     feature.setId(/** @type {number} */(
         esriJSONFeature.attributes[opt_options.idField]));
   }

--- a/src/ol/format/geojson.js
+++ b/src/ol/format/geojson.js
@@ -90,8 +90,6 @@ ol.format.GeoJSON.readGeometry_ = function(object, opt_options) {
  */
 ol.format.GeoJSON.readGeometryCollectionGeometry_ = function(
     object, opt_options) {
-  ol.DEBUG && console.assert(object.type == 'GeometryCollection',
-      'object.type should be GeometryCollection');
   var geometries = object.geometries.map(
       /**
        * @param {GeoJSONGeometry} geometry Geometry.
@@ -110,8 +108,6 @@ ol.format.GeoJSON.readGeometryCollectionGeometry_ = function(
  * @return {ol.geom.Point} Point.
  */
 ol.format.GeoJSON.readPointGeometry_ = function(object) {
-  ol.DEBUG && console.assert(object.type == 'Point',
-      'object.type should be Point');
   return new ol.geom.Point(object.coordinates);
 };
 
@@ -122,8 +118,6 @@ ol.format.GeoJSON.readPointGeometry_ = function(object) {
  * @return {ol.geom.LineString} LineString.
  */
 ol.format.GeoJSON.readLineStringGeometry_ = function(object) {
-  ol.DEBUG && console.assert(object.type == 'LineString',
-      'object.type should be LineString');
   return new ol.geom.LineString(object.coordinates);
 };
 
@@ -134,8 +128,6 @@ ol.format.GeoJSON.readLineStringGeometry_ = function(object) {
  * @return {ol.geom.MultiLineString} MultiLineString.
  */
 ol.format.GeoJSON.readMultiLineStringGeometry_ = function(object) {
-  ol.DEBUG && console.assert(object.type == 'MultiLineString',
-      'object.type should be MultiLineString');
   return new ol.geom.MultiLineString(object.coordinates);
 };
 
@@ -146,8 +138,6 @@ ol.format.GeoJSON.readMultiLineStringGeometry_ = function(object) {
  * @return {ol.geom.MultiPoint} MultiPoint.
  */
 ol.format.GeoJSON.readMultiPointGeometry_ = function(object) {
-  ol.DEBUG && console.assert(object.type == 'MultiPoint',
-      'object.type should be MultiPoint');
   return new ol.geom.MultiPoint(object.coordinates);
 };
 
@@ -158,8 +148,6 @@ ol.format.GeoJSON.readMultiPointGeometry_ = function(object) {
  * @return {ol.geom.MultiPolygon} MultiPolygon.
  */
 ol.format.GeoJSON.readMultiPolygonGeometry_ = function(object) {
-  ol.DEBUG && console.assert(object.type == 'MultiPolygon',
-      'object.type should be MultiPolygon');
   return new ol.geom.MultiPolygon(object.coordinates);
 };
 
@@ -170,8 +158,6 @@ ol.format.GeoJSON.readMultiPolygonGeometry_ = function(object) {
  * @return {ol.geom.Polygon} Polygon.
  */
 ol.format.GeoJSON.readPolygonGeometry_ = function(object) {
-  ol.DEBUG && console.assert(object.type == 'Polygon',
-      'object.type should be Polygon');
   return new ol.geom.Polygon(object.coordinates);
 };
 
@@ -389,9 +375,6 @@ ol.format.GeoJSON.prototype.readFeatures;
  */
 ol.format.GeoJSON.prototype.readFeatureFromObject = function(
     object, opt_options) {
-
-  ol.DEBUG && console.assert(object.type !== 'FeatureCollection', 'Expected a Feature or geometry');
-
   /**
    * @type {GeoJSONFeature}
    */

--- a/src/ol/format/gml2.js
+++ b/src/ol/format/gml2.js
@@ -100,9 +100,6 @@ ol.format.GML2.prototype.readFlatCoordinates_ = function(node, objectStack) {
  * @return {ol.Extent|undefined} Envelope.
  */
 ol.format.GML2.prototype.readBox_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Box', 'localName should be Box');
   /** @type {Array.<number>} */
   var flatCoordinates = ol.xml.pushParseAndPop([null],
       this.BOX_PARSERS_, node, objectStack, this);
@@ -118,20 +115,12 @@ ol.format.GML2.prototype.readBox_ = function(node, objectStack) {
  * @private
  */
 ol.format.GML2.prototype.innerBoundaryIsParser_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'innerBoundaryIs',
-      'localName should be innerBoundaryIs');
   /** @type {Array.<number>|undefined} */
   var flatLinearRing = ol.xml.pushParseAndPop(undefined,
       this.RING_PARSERS, node, objectStack, this);
   if (flatLinearRing) {
     var flatLinearRings = /** @type {Array.<Array.<number>>} */
         (objectStack[objectStack.length - 1]);
-    ol.DEBUG && console.assert(Array.isArray(flatLinearRings),
-        'flatLinearRings should be an array');
-    ol.DEBUG && console.assert(flatLinearRings.length > 0,
-        'flatLinearRings should have an array length larger than 0');
     flatLinearRings.push(flatLinearRing);
   }
 };
@@ -143,20 +132,12 @@ ol.format.GML2.prototype.innerBoundaryIsParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.GML2.prototype.outerBoundaryIsParser_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'outerBoundaryIs',
-      'localName should be outerBoundaryIs');
   /** @type {Array.<number>|undefined} */
   var flatLinearRing = ol.xml.pushParseAndPop(undefined,
       this.RING_PARSERS, node, objectStack, this);
   if (flatLinearRing) {
     var flatLinearRings = /** @type {Array.<Array.<number>>} */
         (objectStack[objectStack.length - 1]);
-    ol.DEBUG && console.assert(Array.isArray(flatLinearRings),
-        'flatLinearRings should be an array');
-    ol.DEBUG && console.assert(flatLinearRings.length > 0,
-        'flatLinearRings should have an array length larger than 0');
     flatLinearRings[0] = flatLinearRing;
   }
 };

--- a/src/ol/format/gml3.js
+++ b/src/ol/format/gml3.js
@@ -88,10 +88,6 @@ ol.format.GML3.schemaLocation_ = ol.format.GMLBase.GMLNS +
  * @return {ol.geom.MultiLineString|undefined} MultiLineString.
  */
 ol.format.GML3.prototype.readMultiCurve_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'MultiCurve',
-      'localName should be MultiCurve');
   /** @type {Array.<ol.geom.LineString>} */
   var lineStrings = ol.xml.pushParseAndPop([],
       this.MULTICURVE_PARSERS_, node, objectStack, this);
@@ -112,10 +108,6 @@ ol.format.GML3.prototype.readMultiCurve_ = function(node, objectStack) {
  * @return {ol.geom.MultiPolygon|undefined} MultiPolygon.
  */
 ol.format.GML3.prototype.readMultiSurface_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'MultiSurface',
-      'localName should be MultiSurface');
   /** @type {Array.<ol.geom.Polygon>} */
   var polygons = ol.xml.pushParseAndPop([],
       this.MULTISURFACE_PARSERS_, node, objectStack, this);
@@ -135,11 +127,6 @@ ol.format.GML3.prototype.readMultiSurface_ = function(node, objectStack) {
  * @private
  */
 ol.format.GML3.prototype.curveMemberParser_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'curveMember' ||
-      node.localName == 'curveMembers',
-      'localName should be curveMember or curveMembers');
   ol.xml.parseNode(this.CURVEMEMBER_PARSERS_, node, objectStack, this);
 };
 
@@ -150,11 +137,6 @@ ol.format.GML3.prototype.curveMemberParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.GML3.prototype.surfaceMemberParser_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'surfaceMember' ||
-      node.localName == 'surfaceMembers',
-      'localName should be surfaceMember or surfaceMembers');
   ol.xml.parseNode(this.SURFACEMEMBER_PARSERS_,
       node, objectStack, this);
 };
@@ -167,10 +149,6 @@ ol.format.GML3.prototype.surfaceMemberParser_ = function(node, objectStack) {
  * @return {Array.<(Array.<number>)>|undefined} flat coordinates.
  */
 ol.format.GML3.prototype.readPatch_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'patches',
-      'localName should be patches');
   return ol.xml.pushParseAndPop([null],
       this.PATCHES_PARSERS_, node, objectStack, this);
 };
@@ -183,10 +161,6 @@ ol.format.GML3.prototype.readPatch_ = function(node, objectStack) {
  * @return {Array.<number>|undefined} flat coordinates.
  */
 ol.format.GML3.prototype.readSegment_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'segments',
-      'localName should be segments');
   return ol.xml.pushParseAndPop([null],
       this.SEGMENTS_PARSERS_, node, objectStack, this);
 };
@@ -199,10 +173,6 @@ ol.format.GML3.prototype.readSegment_ = function(node, objectStack) {
  * @return {Array.<(Array.<number>)>|undefined} flat coordinates.
  */
 ol.format.GML3.prototype.readPolygonPatch_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'npde.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'PolygonPatch',
-      'localName should be PolygonPatch');
   return ol.xml.pushParseAndPop([null],
       this.FLAT_LINEAR_RINGS_PARSERS_, node, objectStack, this);
 };
@@ -215,10 +185,6 @@ ol.format.GML3.prototype.readPolygonPatch_ = function(node, objectStack) {
  * @return {Array.<number>|undefined} flat coordinates.
  */
 ol.format.GML3.prototype.readLineStringSegment_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'LineStringSegment',
-      'localName should be LineStringSegment');
   return ol.xml.pushParseAndPop([null],
       this.GEOMETRY_FLAT_COORDINATES_PARSERS_,
       node, objectStack, this);
@@ -231,20 +197,12 @@ ol.format.GML3.prototype.readLineStringSegment_ = function(node, objectStack) {
  * @private
  */
 ol.format.GML3.prototype.interiorParser_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'interior',
-      'localName should be interior');
   /** @type {Array.<number>|undefined} */
   var flatLinearRing = ol.xml.pushParseAndPop(undefined,
       this.RING_PARSERS, node, objectStack, this);
   if (flatLinearRing) {
     var flatLinearRings = /** @type {Array.<Array.<number>>} */
         (objectStack[objectStack.length - 1]);
-    ol.DEBUG && console.assert(Array.isArray(flatLinearRings),
-        'flatLinearRings should be an array');
-    ol.DEBUG && console.assert(flatLinearRings.length > 0,
-        'flatLinearRings should have an array length of 1 or more');
     flatLinearRings.push(flatLinearRing);
   }
 };
@@ -256,20 +214,12 @@ ol.format.GML3.prototype.interiorParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.GML3.prototype.exteriorParser_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'exterior',
-      'localName should be exterior');
-   /** @type {Array.<number>|undefined} */
+  /** @type {Array.<number>|undefined} */
   var flatLinearRing = ol.xml.pushParseAndPop(undefined,
       this.RING_PARSERS, node, objectStack, this);
   if (flatLinearRing) {
     var flatLinearRings = /** @type {Array.<Array.<number>>} */
         (objectStack[objectStack.length - 1]);
-    ol.DEBUG && console.assert(Array.isArray(flatLinearRings),
-        'flatLinearRings should be an array');
-    ol.DEBUG && console.assert(flatLinearRings.length > 0,
-        'flatLinearRings should have an array length of 1 or more');
     flatLinearRings[0] = flatLinearRing;
   }
 };
@@ -282,10 +232,6 @@ ol.format.GML3.prototype.exteriorParser_ = function(node, objectStack) {
  * @return {ol.geom.Polygon|undefined} Polygon.
  */
 ol.format.GML3.prototype.readSurface_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Surface',
-      'localName should be Surface');
   /** @type {Array.<Array.<number>>} */
   var flatLinearRings = ol.xml.pushParseAndPop([null],
       this.SURFACE_PARSERS_, node, objectStack, this);
@@ -314,9 +260,6 @@ ol.format.GML3.prototype.readSurface_ = function(node, objectStack) {
  * @return {ol.geom.LineString|undefined} LineString.
  */
 ol.format.GML3.prototype.readCurve_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Curve', 'localName should be Curve');
   /** @type {Array.<number>} */
   var flatCoordinates = ol.xml.pushParseAndPop([null],
       this.CURVE_PARSERS_, node, objectStack, this);
@@ -337,10 +280,6 @@ ol.format.GML3.prototype.readCurve_ = function(node, objectStack) {
  * @return {ol.Extent|undefined} Envelope.
  */
 ol.format.GML3.prototype.readEnvelope_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Envelope',
-      'localName should be Envelope');
   /** @type {Array.<number>} */
   var flatCoordinates = ol.xml.pushParseAndPop([null],
       this.ENVELOPE_PARSERS_, node, objectStack, this);
@@ -718,7 +657,6 @@ ol.format.GML3.ENVELOPE_SERIALIZERS_ = {
  * @param {Array.<*>} objectStack Node stack.
  */
 ol.format.GML3.prototype.writeEnvelope = function(node, extent, objectStack) {
-  ol.DEBUG && console.assert(extent.length == 4, 'extent should have 4 items');
   var context = objectStack[objectStack.length - 1];
   var srsName = context['srsName'];
   if (srsName) {
@@ -1179,8 +1117,6 @@ ol.format.GML3.MULTIGEOMETRY_TO_MEMBER_NODENAME_ = {
  */
 ol.format.GML3.prototype.MULTIGEOMETRY_MEMBER_NODE_FACTORY_ = function(value, objectStack, opt_nodeName) {
   var parentNode = objectStack[objectStack.length - 1].node;
-  ol.DEBUG && console.assert(ol.xml.isNode(parentNode),
-      'parentNode should be a node');
   return ol.xml.createElementNS('http://www.opengis.net/gml',
       ol.format.GML3.MULTIGEOMETRY_TO_MEMBER_NODENAME_[parentNode.nodeName]);
 };
@@ -1200,9 +1136,6 @@ ol.format.GML3.prototype.GEOMETRY_NODE_FACTORY_ = function(value, objectStack, o
   var surface = context['surface'];
   var curve = context['curve'];
   var multiCurve = context['multiCurve'];
-  var parentNode = objectStack[objectStack.length - 1].node;
-  ol.DEBUG && console.assert(ol.xml.isNode(parentNode),
-      'parentNode should be a node');
   var nodeName;
   if (!Array.isArray(value)) {
     nodeName = /** @type {ol.geom.Geometry} */ (value).getType();

--- a/src/ol/format/gmlbase.js
+++ b/src/ol/format/gmlbase.js
@@ -107,8 +107,6 @@ ol.format.GMLBase.ONLY_WHITESPACE_RE_ = /^[\s\xa0]*$/;
  * @return {Array.<ol.Feature> | undefined} Features.
  */
 ol.format.GMLBase.prototype.readFeaturesInternal = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
   var localName = node.localName;
   var features = null;
   if (localName == 'FeatureCollection') {
@@ -259,15 +257,10 @@ ol.format.GMLBase.prototype.readFeatureElement = function(node, objectStack) {
  * @return {ol.geom.Point|undefined} Point.
  */
 ol.format.GMLBase.prototype.readPoint = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Point', 'localName should be Point');
   var flatCoordinates =
       this.readFlatCoordinatesFromNode_(node, objectStack);
   if (flatCoordinates) {
     var point = new ol.geom.Point(null);
-    ol.DEBUG && console.assert(flatCoordinates.length == 3,
-        'flatCoordinates should have a length of 3');
     point.setFlatCoordinates(ol.geom.GeometryLayout.XYZ, flatCoordinates);
     return point;
   }
@@ -280,10 +273,6 @@ ol.format.GMLBase.prototype.readPoint = function(node, objectStack) {
  * @return {ol.geom.MultiPoint|undefined} MultiPoint.
  */
 ol.format.GMLBase.prototype.readMultiPoint = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'MultiPoint',
-      'localName should be MultiPoint');
   /** @type {Array.<Array.<number>>} */
   var coordinates = ol.xml.pushParseAndPop([],
       this.MULTIPOINT_PARSERS_, node, objectStack, this);
@@ -301,10 +290,6 @@ ol.format.GMLBase.prototype.readMultiPoint = function(node, objectStack) {
  * @return {ol.geom.MultiLineString|undefined} MultiLineString.
  */
 ol.format.GMLBase.prototype.readMultiLineString = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'MultiLineString',
-      'localName should be MultiLineString');
   /** @type {Array.<ol.geom.LineString>} */
   var lineStrings = ol.xml.pushParseAndPop([],
       this.MULTILINESTRING_PARSERS_, node, objectStack, this);
@@ -324,10 +309,6 @@ ol.format.GMLBase.prototype.readMultiLineString = function(node, objectStack) {
  * @return {ol.geom.MultiPolygon|undefined} MultiPolygon.
  */
 ol.format.GMLBase.prototype.readMultiPolygon = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'MultiPolygon',
-      'localName should be MultiPolygon');
   /** @type {Array.<ol.geom.Polygon>} */
   var polygons = ol.xml.pushParseAndPop([],
       this.MULTIPOLYGON_PARSERS_, node, objectStack, this);
@@ -347,11 +328,6 @@ ol.format.GMLBase.prototype.readMultiPolygon = function(node, objectStack) {
  * @private
  */
 ol.format.GMLBase.prototype.pointMemberParser_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'pointMember' ||
-      node.localName == 'pointMembers',
-      'localName should be pointMember or pointMembers');
   ol.xml.parseNode(this.POINTMEMBER_PARSERS_,
       node, objectStack, this);
 };
@@ -363,11 +339,6 @@ ol.format.GMLBase.prototype.pointMemberParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.GMLBase.prototype.lineStringMemberParser_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'lineStringMember' ||
-      node.localName == 'lineStringMembers',
-      'localName should be LineStringMember or LineStringMembers');
   ol.xml.parseNode(this.LINESTRINGMEMBER_PARSERS_,
       node, objectStack, this);
 };
@@ -379,11 +350,6 @@ ol.format.GMLBase.prototype.lineStringMemberParser_ = function(node, objectStack
  * @private
  */
 ol.format.GMLBase.prototype.polygonMemberParser_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'polygonMember' ||
-      node.localName == 'polygonMembers',
-      'localName should be polygonMember or polygonMembers');
   ol.xml.parseNode(this.POLYGONMEMBER_PARSERS_, node,
       objectStack, this);
 };
@@ -395,10 +361,6 @@ ol.format.GMLBase.prototype.polygonMemberParser_ = function(node, objectStack) {
  * @return {ol.geom.LineString|undefined} LineString.
  */
 ol.format.GMLBase.prototype.readLineString = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'LineString',
-      'localName should be LineString');
   var flatCoordinates =
       this.readFlatCoordinatesFromNode_(node, objectStack);
   if (flatCoordinates) {
@@ -418,10 +380,6 @@ ol.format.GMLBase.prototype.readLineString = function(node, objectStack) {
  * @return {Array.<number>|undefined} LinearRing flat coordinates.
  */
 ol.format.GMLBase.prototype.readFlatLinearRing_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'LinearRing',
-      'localName should be LinearRing');
   var ring = ol.xml.pushParseAndPop(null,
       this.GEOMETRY_FLAT_COORDINATES_PARSERS_, node,
       objectStack, this);
@@ -439,10 +397,6 @@ ol.format.GMLBase.prototype.readFlatLinearRing_ = function(node, objectStack) {
  * @return {ol.geom.LinearRing|undefined} LinearRing.
  */
 ol.format.GMLBase.prototype.readLinearRing = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'LinearRing',
-      'localName should be LinearRing');
   var flatCoordinates =
       this.readFlatCoordinatesFromNode_(node, objectStack);
   if (flatCoordinates) {
@@ -461,10 +415,6 @@ ol.format.GMLBase.prototype.readLinearRing = function(node, objectStack) {
  * @return {ol.geom.Polygon|undefined} Polygon.
  */
 ol.format.GMLBase.prototype.readPolygon = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Polygon',
-      'localName should be Polygon');
   /** @type {Array.<Array.<number>>} */
   var flatLinearRings = ol.xml.pushParseAndPop([null],
       this.FLAT_LINEAR_RINGS_PARSERS_, node, objectStack, this);
@@ -493,8 +443,6 @@ ol.format.GMLBase.prototype.readPolygon = function(node, objectStack) {
  * @return {Array.<number>} Flat coordinates.
  */
 ol.format.GMLBase.prototype.readFlatCoordinatesFromNode_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
   return ol.xml.pushParseAndPop(null,
       this.GEOMETRY_FLAT_COORDINATES_PARSERS_, node,
       objectStack, this);

--- a/src/ol/format/gpx.js
+++ b/src/ol/format/gpx.js
@@ -73,8 +73,6 @@ ol.format.GPX.SCHEMA_LOCATION_ = 'http://www.topografix.com/GPX/1/1 ' +
  * @return {Array.<number>} Flat coordinates.
  */
 ol.format.GPX.appendCoordinate_ = function(flatCoordinates, layoutOptions, node, values) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
   flatCoordinates.push(
       parseFloat(node.getAttribute('lon')),
       parseFloat(node.getAttribute('lat')));
@@ -147,9 +145,6 @@ ol.format.GPX.applyLayoutOptions_ = function(layoutOptions, flatCoordinates, end
  * @private
  */
 ol.format.GPX.parseLink_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'link', 'localName should be link');
   var values = /** @type {Object} */ (objectStack[objectStack.length - 1]);
   var href = node.getAttribute('href');
   if (href !== null) {
@@ -165,10 +160,6 @@ ol.format.GPX.parseLink_ = function(node, objectStack) {
  * @private
  */
 ol.format.GPX.parseExtensions_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'extensions',
-      'localName should be extensions');
   var values = /** @type {Object} */ (objectStack[objectStack.length - 1]);
   values['extensionsNode_'] = node;
 };
@@ -180,9 +171,6 @@ ol.format.GPX.parseExtensions_ = function(node, objectStack) {
  * @private
  */
 ol.format.GPX.parseRtePt_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'rtept', 'localName should be rtept');
   var values = ol.xml.pushParseAndPop(
       {}, ol.format.GPX.RTEPT_PARSERS_, node, objectStack);
   if (values) {
@@ -202,9 +190,6 @@ ol.format.GPX.parseRtePt_ = function(node, objectStack) {
  * @private
  */
 ol.format.GPX.parseTrkPt_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'trkpt', 'localName should be trkpt');
   var values = ol.xml.pushParseAndPop(
       {}, ol.format.GPX.TRKPT_PARSERS_, node, objectStack);
   if (values) {
@@ -224,10 +209,6 @@ ol.format.GPX.parseTrkPt_ = function(node, objectStack) {
  * @private
  */
 ol.format.GPX.parseTrkSeg_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'trkseg',
-      'localName should be trkseg');
   var values = /** @type {Object} */ (objectStack[objectStack.length - 1]);
   ol.xml.parseNode(ol.format.GPX.TRKSEG_PARSERS_, node, objectStack);
   var flatCoordinates = /** @type {Array.<number>} */
@@ -244,9 +225,6 @@ ol.format.GPX.parseTrkSeg_ = function(node, objectStack) {
  * @return {ol.Feature|undefined} Track.
  */
 ol.format.GPX.readRte_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'rte', 'localName should be rte');
   var options = /** @type {olx.format.ReadOptions} */ (objectStack[0]);
   var values = ol.xml.pushParseAndPop({
     'flatCoordinates': [],
@@ -277,9 +255,6 @@ ol.format.GPX.readRte_ = function(node, objectStack) {
  * @return {ol.Feature|undefined} Track.
  */
 ol.format.GPX.readTrk_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'trk', 'localName should be trk');
   var options = /** @type {olx.format.ReadOptions} */ (objectStack[0]);
   var values = ol.xml.pushParseAndPop({
     'flatCoordinates': [],
@@ -313,9 +288,6 @@ ol.format.GPX.readTrk_ = function(node, objectStack) {
  * @return {ol.Feature|undefined} Waypoint.
  */
 ol.format.GPX.readWpt_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'wpt', 'localName should be wpt');
   var options = /** @type {olx.format.ReadOptions} */ (objectStack[0]);
   var values = ol.xml.pushParseAndPop(
       {}, ol.format.GPX.WPT_PARSERS_, node, objectStack);
@@ -516,8 +488,6 @@ ol.format.GPX.prototype.readFeature;
  * @inheritDoc
  */
 ol.format.GPX.prototype.readFeatureFromNode = function(node, opt_options) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
   if (!ol.array.includes(ol.format.GPX.NAMESPACE_URIS_, node.namespaceURI)) {
     return null;
   }
@@ -552,8 +522,6 @@ ol.format.GPX.prototype.readFeatures;
  * @inheritDoc
  */
 ol.format.GPX.prototype.readFeaturesFromNode = function(node, opt_options) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
   if (!ol.array.includes(ol.format.GPX.NAMESPACE_URIS_, node.namespaceURI)) {
     return [];
   }
@@ -612,8 +580,6 @@ ol.format.GPX.writeLink_ = function(node, value, objectStack) {
 ol.format.GPX.writeWptType_ = function(node, coordinate, objectStack) {
   var context = objectStack[objectStack.length - 1];
   var parentNode = context.node;
-  ol.DEBUG && console.assert(ol.xml.isNode(parentNode),
-      'parentNode should be an XML node');
   var namespaceURI = parentNode.namespaceURI;
   var properties = context['properties'];
   //FIXME Projection handling
@@ -919,8 +885,6 @@ ol.format.GPX.GPX_NODE_FACTORY_ = function(value, objectStack, opt_nodeName) {
     var nodeName = ol.format.GPX.GEOMETRY_TYPE_TO_NODENAME_[geometry.getType()];
     if (nodeName) {
       var parentNode = objectStack[objectStack.length - 1].node;
-      ol.DEBUG && console.assert(ol.xml.isNode(parentNode),
-          'parentNode should be an XML node');
       return ol.xml.createElementNS(parentNode.namespaceURI, nodeName);
     }
   }

--- a/src/ol/format/igc.js
+++ b/src/ol/format/igc.js
@@ -143,7 +143,6 @@ ol.format.IGC.prototype.readFeatureFromText = function(text, opt_options) {
           } else if (altitudeMode == ol.format.IGCZ.BAROMETRIC) {
             z = parseInt(m[12], 10);
           } else {
-            ol.DEBUG && console.assert(false, 'Unknown altitude mode.');
             z = 0;
           }
           flatCoordinates.push(z);

--- a/src/ol/format/kml.js
+++ b/src/ol/format/kml.js
@@ -17,7 +17,6 @@ goog.require('ol.geom.GeometryCollection');
 goog.require('ol.geom.GeometryLayout');
 goog.require('ol.geom.GeometryType');
 goog.require('ol.geom.LineString');
-goog.require('ol.geom.LinearRing');
 goog.require('ol.geom.MultiLineString');
 goog.require('ol.geom.MultiPoint');
 goog.require('ol.geom.MultiPolygon');
@@ -548,10 +547,6 @@ ol.format.KML.readStyleMapValue_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.IconStyleParser_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be an ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'IconStyle',
-      'localName should be IconStyle');
   // FIXME refreshMode
   // FIXME refreshInterval
   // FIXME viewRefreshTime
@@ -654,10 +649,6 @@ ol.format.KML.IconStyleParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.LabelStyleParser_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'LabelStyle',
-      'localName should be LabelStyle');
   // FIXME colorMode
   var object = ol.xml.pushParseAndPop(
       {}, ol.format.KML.LABEL_STYLE_PARSERS_, node, objectStack);
@@ -683,10 +674,6 @@ ol.format.KML.LabelStyleParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.LineStyleParser_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'LineStyle',
-      'localName should be LineStyle');
   // FIXME colorMode
   // FIXME gx:outerColor
   // FIXME gx:outerWidth
@@ -713,10 +700,6 @@ ol.format.KML.LineStyleParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.PolyStyleParser_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'PolyStyle',
-      'localName should be PolyStyle');
   // FIXME colorMode
   var object = ol.xml.pushParseAndPop(
       {}, ol.format.KML.POLY_STYLE_PARSERS_, node, objectStack);
@@ -748,10 +731,6 @@ ol.format.KML.PolyStyleParser_ = function(node, objectStack) {
  * @return {Array.<number>} LinearRing flat coordinates.
  */
 ol.format.KML.readFlatLinearRing_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'LinearRing',
-      'localName should be LinearRing');
   return ol.xml.pushParseAndPop(null,
       ol.format.KML.FLAT_LINEAR_RING_PARSERS_, node, objectStack);
 };
@@ -763,12 +742,6 @@ ol.format.KML.readFlatLinearRing_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.gxCoordParser_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(ol.array.includes(
-      ol.format.KML.GX_NAMESPACE_URIS_, node.namespaceURI),
-      'namespaceURI of the node should be known to the KML parser');
-  ol.DEBUG && console.assert(node.localName == 'coord', 'localName should be coord');
   var gxTrackObject = /** @type {ol.KMLGxTrackObject_} */
       (objectStack[objectStack.length - 1]);
   var flatCoordinates = gxTrackObject.flatCoordinates;
@@ -794,13 +767,6 @@ ol.format.KML.gxCoordParser_ = function(node, objectStack) {
  * @return {ol.geom.MultiLineString|undefined} MultiLineString.
  */
 ol.format.KML.readGxMultiTrack_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(ol.array.includes(
-      ol.format.KML.GX_NAMESPACE_URIS_, node.namespaceURI),
-      'namespaceURI of the node should be known to the KML parser');
-  ol.DEBUG && console.assert(node.localName == 'MultiTrack',
-      'localName should be MultiTrack');
   var lineStrings = ol.xml.pushParseAndPop([],
       ol.format.KML.GX_MULTITRACK_GEOMETRY_PARSERS_, node, objectStack);
   if (!lineStrings) {
@@ -819,12 +785,6 @@ ol.format.KML.readGxMultiTrack_ = function(node, objectStack) {
  * @return {ol.geom.LineString|undefined} LineString.
  */
 ol.format.KML.readGxTrack_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(ol.array.includes(
-      ol.format.KML.GX_NAMESPACE_URIS_, node.namespaceURI),
-      'namespaceURI of the node should be known to the KML parser');
-  ol.DEBUG && console.assert(node.localName == 'Track', 'localName should be Track');
   var gxTrackObject = ol.xml.pushParseAndPop(
       /** @type {ol.KMLGxTrackObject_} */ ({
         flatCoordinates: [],
@@ -835,9 +795,6 @@ ol.format.KML.readGxTrack_ = function(node, objectStack) {
   }
   var flatCoordinates = gxTrackObject.flatCoordinates;
   var whens = gxTrackObject.whens;
-  ol.DEBUG && console.assert(flatCoordinates.length / 4 == whens.length,
-      'the length of the flatCoordinates array divided by 4 should be the ' +
-      'length of the whens array');
   var i, ii;
   for (i = 0, ii = Math.min(flatCoordinates.length, whens.length); i < ii;
        ++i) {
@@ -856,9 +813,6 @@ ol.format.KML.readGxTrack_ = function(node, objectStack) {
  * @return {Object} Icon object.
  */
 ol.format.KML.readIcon_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Icon', 'localName should be Icon');
   var iconObject = ol.xml.pushParseAndPop(
       {}, ol.format.KML.ICON_PARSERS_, node, objectStack);
   if (iconObject) {
@@ -876,8 +830,6 @@ ol.format.KML.readIcon_ = function(node, objectStack) {
  * @return {Array.<number>} Flat coordinates.
  */
 ol.format.KML.readFlatCoordinatesFromNode_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
   return ol.xml.pushParseAndPop(null,
       ol.format.KML.GEOMETRY_FLAT_COORDINATES_PARSERS_, node, objectStack);
 };
@@ -890,10 +842,6 @@ ol.format.KML.readFlatCoordinatesFromNode_ = function(node, objectStack) {
  * @return {ol.geom.LineString|undefined} LineString.
  */
 ol.format.KML.readLineString_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'LineString',
-      'localName should be LineString');
   var properties = ol.xml.pushParseAndPop({},
       ol.format.KML.EXTRUDE_AND_ALTITUDE_MODE_PARSERS_, node,
       objectStack);
@@ -917,10 +865,6 @@ ol.format.KML.readLineString_ = function(node, objectStack) {
  * @return {ol.geom.Polygon|undefined} Polygon.
  */
 ol.format.KML.readLinearRing_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'LinearRing',
-      'localName should be LinearRing');
   var properties = ol.xml.pushParseAndPop({},
       ol.format.KML.EXTRUDE_AND_ALTITUDE_MODE_PARSERS_, node,
       objectStack);
@@ -945,10 +889,6 @@ ol.format.KML.readLinearRing_ = function(node, objectStack) {
  * @return {ol.geom.Geometry} Geometry.
  */
 ol.format.KML.readMultiGeometry_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'MultiGeometry',
-      'localName should be MultiGeometry');
   var geometries = ol.xml.pushParseAndPop([],
       ol.format.KML.MULTI_GEOMETRY_PARSERS_, node, objectStack);
   if (!geometries) {
@@ -978,8 +918,6 @@ ol.format.KML.readMultiGeometry_ = function(node, objectStack) {
       flatCoordinates = point.getFlatCoordinates();
       for (i = 1, ii = geometries.length; i < ii; ++i) {
         geometry = geometries[i];
-        ol.DEBUG && console.assert(geometry.getLayout() == layout,
-            'geometry layout should be consistent');
         ol.array.extend(flatCoordinates, geometry.getFlatCoordinates());
       }
       multiGeometry = new ol.geom.MultiPoint(null);
@@ -1012,9 +950,6 @@ ol.format.KML.readMultiGeometry_ = function(node, objectStack) {
  * @return {ol.geom.Point|undefined} Point.
  */
 ol.format.KML.readPoint_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Point', 'localName should be Point');
   var properties = ol.xml.pushParseAndPop({},
       ol.format.KML.EXTRUDE_AND_ALTITUDE_MODE_PARSERS_, node,
       objectStack);
@@ -1022,8 +957,6 @@ ol.format.KML.readPoint_ = function(node, objectStack) {
       ol.format.KML.readFlatCoordinatesFromNode_(node, objectStack);
   if (flatCoordinates) {
     var point = new ol.geom.Point(null);
-    ol.DEBUG && console.assert(flatCoordinates.length == 3,
-        'flatCoordinates should have a length of 3');
     point.setFlatCoordinates(ol.geom.GeometryLayout.XYZ, flatCoordinates);
     point.setProperties(properties);
     return point;
@@ -1040,10 +973,6 @@ ol.format.KML.readPoint_ = function(node, objectStack) {
  * @return {ol.geom.Polygon|undefined} Polygon.
  */
 ol.format.KML.readPolygon_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Polygon',
-      'localName should be Polygon');
   var properties = ol.xml.pushParseAndPop(/** @type {Object<string,*>} */ ({}),
       ol.format.KML.EXTRUDE_AND_ALTITUDE_MODE_PARSERS_, node,
       objectStack);
@@ -1075,9 +1004,6 @@ ol.format.KML.readPolygon_ = function(node, objectStack) {
  * @return {Array.<ol.style.Style>} Style.
  */
 ol.format.KML.readStyle_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Style', 'localName should be Style');
   var styleObject = ol.xml.pushParseAndPop(
       {}, ol.format.KML.STYLE_PARSERS_, node, objectStack);
   if (!styleObject) {
@@ -1154,9 +1080,6 @@ ol.format.KML.setCommonGeometryProperties_ = function(multiGeometry,
  * @private
  */
 ol.format.KML.DataParser_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Data', 'localName should be Data');
   var name = node.getAttribute('name');
   ol.xml.parseNode(ol.format.KML.DATA_PARSERS_, node, objectStack);
   var featureObject =
@@ -1175,10 +1098,6 @@ ol.format.KML.DataParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.ExtendedDataParser_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'ExtendedData',
-      'localName should be ExtendedData');
   ol.xml.parseNode(ol.format.KML.EXTENDED_DATA_PARSERS_, node, objectStack);
 };
 
@@ -1188,10 +1107,6 @@ ol.format.KML.ExtendedDataParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.RegionParser_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Region',
-      'localName should be Region');
   ol.xml.parseNode(ol.format.KML.REGION_PARSERS_, node, objectStack);
 };
 
@@ -1201,9 +1116,6 @@ ol.format.KML.RegionParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.PairDataParser_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Pair', 'localName should be Pair');
   var pairObject = ol.xml.pushParseAndPop(
       {}, ol.format.KML.PAIR_PARSERS_, node, objectStack);
   if (!pairObject) {
@@ -1232,10 +1144,6 @@ ol.format.KML.PairDataParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.PlacemarkStyleMapParser_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'StyleMap',
-      'localName should be StyleMap');
   var styleMapValue = ol.format.KML.readStyleMapValue_(node, objectStack);
   if (!styleMapValue) {
     return;
@@ -1257,10 +1165,6 @@ ol.format.KML.PlacemarkStyleMapParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.SchemaDataParser_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'SchemaData',
-      'localName should be SchemaData');
   ol.xml.parseNode(ol.format.KML.SCHEMA_DATA_PARSERS_, node, objectStack);
 };
 
@@ -1271,10 +1175,6 @@ ol.format.KML.SchemaDataParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.SimpleDataParser_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'SimpleData',
-      'localName should be SimpleData');
   var name = node.getAttribute('name');
   if (name !== null) {
     var data = ol.format.XSD.readString(node);
@@ -1291,10 +1191,6 @@ ol.format.KML.SimpleDataParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.LatLonAltBoxParser_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'LatLonAltBox',
-      'localName should be LatLonAltBox');
   var object = ol.xml.pushParseAndPop({}, ol.format.KML.LAT_LON_ALT_BOX_PARSERS_, node, objectStack);
   if (!object) {
     return;
@@ -1319,10 +1215,6 @@ ol.format.KML.LatLonAltBoxParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.LodParser_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Lod',
-      'localName should be Lod');
   var object = ol.xml.pushParseAndPop({}, ol.format.KML.LOD_PARSERS_, node, objectStack);
   if (!object) {
     return;
@@ -1341,20 +1233,12 @@ ol.format.KML.LodParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.innerBoundaryIsParser_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'innerBoundaryIs',
-      'localName should be innerBoundaryIs');
   /** @type {Array.<number>|undefined} */
   var flatLinearRing = ol.xml.pushParseAndPop(undefined,
       ol.format.KML.INNER_BOUNDARY_IS_PARSERS_, node, objectStack);
   if (flatLinearRing) {
     var flatLinearRings = /** @type {Array.<Array.<number>>} */
         (objectStack[objectStack.length - 1]);
-    ol.DEBUG && console.assert(Array.isArray(flatLinearRings),
-        'flatLinearRings should be an array');
-    ol.DEBUG && console.assert(flatLinearRings.length > 0,
-        'flatLinearRings array should not be empty');
     flatLinearRings.push(flatLinearRing);
   }
 };
@@ -1366,20 +1250,12 @@ ol.format.KML.innerBoundaryIsParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.outerBoundaryIsParser_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'outerBoundaryIs',
-      'localName should be outerBoundaryIs');
   /** @type {Array.<number>|undefined} */
   var flatLinearRing = ol.xml.pushParseAndPop(undefined,
       ol.format.KML.OUTER_BOUNDARY_IS_PARSERS_, node, objectStack);
   if (flatLinearRing) {
     var flatLinearRings = /** @type {Array.<Array.<number>>} */
         (objectStack[objectStack.length - 1]);
-    ol.DEBUG && console.assert(Array.isArray(flatLinearRings),
-        'flatLinearRings should be an array');
-    ol.DEBUG && console.assert(flatLinearRings.length > 0,
-        'flatLinearRings array should not be empty');
     flatLinearRings[0] = flatLinearRing;
   }
 };
@@ -1391,9 +1267,6 @@ ol.format.KML.outerBoundaryIsParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.LinkParser_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Link', 'localName should be Link');
   ol.xml.parseNode(ol.format.KML.LINK_PARSERS_, node, objectStack);
 };
 
@@ -1404,9 +1277,6 @@ ol.format.KML.LinkParser_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.whenParser_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'when', 'localName should be when');
   var gxTrackObject = /** @type {ol.KMLGxTrackObject_} */
       (objectStack[objectStack.length - 1]);
   var whens = gxTrackObject.whens;
@@ -1791,11 +1661,6 @@ ol.format.KML.prototype.getExtensions = function() {
  * @return {Array.<ol.Feature>|undefined} Features.
  */
 ol.format.KML.prototype.readDocumentOrFolder_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  var localName = node.localName;
-  ol.DEBUG && console.assert(localName == 'Document' || localName == 'Folder',
-      'localName should be Document or Folder');
   // FIXME use scope somehow
   var parsersNS = ol.xml.makeStructureNS(
       ol.format.KML.NAMESPACE_URIS_, {
@@ -1822,10 +1687,6 @@ ol.format.KML.prototype.readDocumentOrFolder_ = function(node, objectStack) {
  * @return {ol.Feature|undefined} Feature.
  */
 ol.format.KML.prototype.readPlacemark_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Placemark',
-      'localName should be Placemark');
   var object = ol.xml.pushParseAndPop({'geometry': null},
       ol.format.KML.PLACEMARK_PARSERS_, node, objectStack);
   if (!object) {
@@ -1869,9 +1730,6 @@ ol.format.KML.prototype.readPlacemark_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.prototype.readSharedStyle_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Style', 'localName should be Style');
   var id = node.getAttribute('id');
   if (id !== null) {
     var style = ol.format.KML.readStyle_(node, objectStack);
@@ -1895,10 +1753,6 @@ ol.format.KML.prototype.readSharedStyle_ = function(node, objectStack) {
  * @private
  */
 ol.format.KML.prototype.readSharedStyleMap_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'StyleMap',
-      'localName should be StyleMap');
   var id = node.getAttribute('id');
   if (id === null) {
     return;
@@ -1936,13 +1790,9 @@ ol.format.KML.prototype.readFeature;
  * @inheritDoc
  */
 ol.format.KML.prototype.readFeatureFromNode = function(node, opt_options) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
   if (!ol.array.includes(ol.format.KML.NAMESPACE_URIS_, node.namespaceURI)) {
     return null;
   }
-  ol.DEBUG && console.assert(node.localName == 'Placemark',
-      'localName should be Placemark');
   var feature = this.readPlacemark_(
       node, [this.getReadOptions(node, opt_options)]);
   if (feature) {
@@ -1971,8 +1821,6 @@ ol.format.KML.prototype.readFeatures;
  * @inheritDoc
  */
 ol.format.KML.prototype.readFeaturesFromNode = function(node, opt_options) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
   if (!ol.array.includes(ol.format.KML.NAMESPACE_URIS_, node.namespaceURI)) {
     return [];
   }
@@ -2614,12 +2462,6 @@ ol.format.KML.writePlacemark_ = function(node, feature, objectStack) {
  * @private
  */
 ol.format.KML.writePrimitiveGeometry_ = function(node, geometry, objectStack) {
-  ol.DEBUG && console.assert(
-      (geometry instanceof ol.geom.Point) ||
-      (geometry instanceof ol.geom.LineString) ||
-      (geometry instanceof ol.geom.LinearRing),
-      'geometry should be one of ol.geom.Point, ol.geom.LineString ' +
-      'or ol.geom.LinearRing');
   var flatCoordinates = geometry.getFlatCoordinates();
   var /** @type {ol.XmlNodeStackItem} */ context = {node: node};
   context['layout'] = geometry.getLayout();
@@ -2639,8 +2481,6 @@ ol.format.KML.writePrimitiveGeometry_ = function(node, geometry, objectStack) {
  */
 ol.format.KML.writePolygon_ = function(node, polygon, objectStack) {
   var linearRings = polygon.getLinearRings();
-  ol.DEBUG && console.assert(linearRings.length > 0,
-      'linearRings should not be empty');
   var outerRing = linearRings.shift();
   var /** @type {ol.XmlNodeStackItem} */ context = {node: node};
   // inner rings
@@ -3053,8 +2893,6 @@ ol.format.KML.GX_NODE_FACTORY_ = function(value, objectStack, opt_nodeName) {
 ol.format.KML.DOCUMENT_NODE_FACTORY_ = function(value, objectStack,
     opt_nodeName) {
   var parentNode = objectStack[objectStack.length - 1].node;
-  ol.DEBUG && console.assert(ol.xml.isNode(parentNode),
-      'parentNode should be an XML node');
   return ol.xml.createElementNS(parentNode.namespaceURI, 'Placemark');
 };
 
@@ -3071,8 +2909,6 @@ ol.format.KML.GEOMETRY_NODE_FACTORY_ = function(value, objectStack,
     opt_nodeName) {
   if (value) {
     var parentNode = objectStack[objectStack.length - 1].node;
-    ol.DEBUG && console.assert(ol.xml.isNode(parentNode),
-        'parentNode should be an XML node');
     return ol.xml.createElementNS(parentNode.namespaceURI,
         ol.format.KML.GEOMETRY_TYPE_TO_NODENAME_[/** @type {ol.geom.Geometry} */ (value).getType()]);
   }

--- a/src/ol/format/osmxml.js
+++ b/src/ol/format/osmxml.js
@@ -57,9 +57,6 @@ ol.format.OSMXML.prototype.getExtensions = function() {
  * @private
  */
 ol.format.OSMXML.readNode_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'node', 'localName should be node');
   var options = /** @type {olx.format.ReadOptions} */ (objectStack[0]);
   var state = /** @type {Object} */ (objectStack[objectStack.length - 1]);
   var id = node.getAttribute('id');
@@ -90,9 +87,6 @@ ol.format.OSMXML.readNode_ = function(node, objectStack) {
  * @private
  */
 ol.format.OSMXML.readWay_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'way', 'localName should be way');
   var options = /** @type {olx.format.ReadOptions} */ (objectStack[0]);
   var id = node.getAttribute('id');
   var values = ol.xml.pushParseAndPop({
@@ -130,9 +124,6 @@ ol.format.OSMXML.readWay_ = function(node, objectStack) {
  * @private
  */
 ol.format.OSMXML.readNd_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'nd', 'localName should be nd');
   var values = /** @type {Object} */ (objectStack[objectStack.length - 1]);
   values.ndrefs.push(node.getAttribute('ref'));
 };
@@ -144,9 +135,6 @@ ol.format.OSMXML.readNd_ = function(node, objectStack) {
  * @private
  */
 ol.format.OSMXML.readTag_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'tag', 'localName should be tag');
   var values = /** @type {Object} */ (objectStack[objectStack.length - 1]);
   values.tags[node.getAttribute('k')] = node.getAttribute('v');
 };
@@ -213,8 +201,6 @@ ol.format.OSMXML.prototype.readFeatures;
  * @inheritDoc
  */
 ol.format.OSMXML.prototype.readFeaturesFromNode = function(node, opt_options) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
   var options = this.getReadOptions(node, opt_options);
   if (node.localName == 'osm') {
     var state = ol.xml.pushParseAndPop({

--- a/src/ol/format/ows.js
+++ b/src/ol/format/ows.js
@@ -22,8 +22,6 @@ ol.inherits(ol.format.OWS, ol.format.XML);
  * @return {Object} OWS object.
  */
 ol.format.OWS.prototype.readFromDocument = function(doc) {
-  ol.DEBUG && console.assert(doc.nodeType == Node.DOCUMENT_NODE,
-      'doc.nodeType should be DOCUMENT');
   for (var n = doc.firstChild; n; n = n.nextSibling) {
     if (n.nodeType == Node.ELEMENT_NODE) {
       return this.readFromNode(n);
@@ -38,8 +36,6 @@ ol.format.OWS.prototype.readFromDocument = function(doc) {
  * @return {Object} OWS object.
  */
 ol.format.OWS.prototype.readFromNode = function(node) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
   var owsObject = ol.xml.pushParseAndPop({},
       ol.format.OWS.PARSERS_, node, []);
   return owsObject ? owsObject : null;
@@ -53,10 +49,6 @@ ol.format.OWS.prototype.readFromNode = function(node) {
  * @return {Object|undefined} The address.
  */
 ol.format.OWS.readAddress_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Address',
-      'localName should be Address');
   return ol.xml.pushParseAndPop({},
       ol.format.OWS.ADDRESS_PARSERS_, node, objectStack);
 };
@@ -69,10 +61,6 @@ ol.format.OWS.readAddress_ = function(node, objectStack) {
  * @return {Object|undefined} The values.
  */
 ol.format.OWS.readAllowedValues_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'AllowedValues',
-      'localName should be AllowedValues');
   return ol.xml.pushParseAndPop({},
       ol.format.OWS.ALLOWED_VALUES_PARSERS_, node, objectStack);
 };
@@ -85,10 +73,6 @@ ol.format.OWS.readAllowedValues_ = function(node, objectStack) {
  * @return {Object|undefined} The constraint.
  */
 ol.format.OWS.readConstraint_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Constraint',
-      'localName should be Constraint');
   var name = node.getAttribute('name');
   if (!name) {
     return undefined;
@@ -106,10 +90,6 @@ ol.format.OWS.readConstraint_ = function(node, objectStack) {
  * @return {Object|undefined} The contact info.
  */
 ol.format.OWS.readContactInfo_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'ContactInfo',
-      'localName should be ContactInfo');
   return ol.xml.pushParseAndPop({},
       ol.format.OWS.CONTACT_INFO_PARSERS_, node, objectStack);
 };
@@ -122,9 +102,6 @@ ol.format.OWS.readContactInfo_ = function(node, objectStack) {
  * @return {Object|undefined} The DCP.
  */
 ol.format.OWS.readDcp_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'DCP', 'localName should be DCP');
   return ol.xml.pushParseAndPop({},
       ol.format.OWS.DCP_PARSERS_, node, objectStack);
 };
@@ -137,9 +114,6 @@ ol.format.OWS.readDcp_ = function(node, objectStack) {
  * @return {Object|undefined} The GET object.
  */
 ol.format.OWS.readGet_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Get', 'localName should be Get');
   var href = ol.format.XLink.readHref(node);
   if (!href) {
     return undefined;
@@ -156,9 +130,6 @@ ol.format.OWS.readGet_ = function(node, objectStack) {
  * @return {Object|undefined} The HTTP object.
  */
 ol.format.OWS.readHttp_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'HTTP', 'localName should be HTTP');
   return ol.xml.pushParseAndPop({}, ol.format.OWS.HTTP_PARSERS_,
       node, objectStack);
 };
@@ -171,10 +142,6 @@ ol.format.OWS.readHttp_ = function(node, objectStack) {
  * @return {Object|undefined} The operation.
  */
 ol.format.OWS.readOperation_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Operation',
-      'localName should be Operation');
   var name = node.getAttribute('name');
   var value = ol.xml.pushParseAndPop({},
       ol.format.OWS.OPERATION_PARSERS_, node, objectStack);
@@ -184,7 +151,6 @@ ol.format.OWS.readOperation_ = function(node, objectStack) {
   var object = /** @type {Object} */
       (objectStack[objectStack.length - 1]);
   object[name] = value;
-
 };
 
 
@@ -196,10 +162,6 @@ ol.format.OWS.readOperation_ = function(node, objectStack) {
  */
 ol.format.OWS.readOperationsMetadata_ = function(node,
     objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'OperationsMetadata',
-      'localName should be OperationsMetadata');
   return ol.xml.pushParseAndPop({},
       ol.format.OWS.OPERATIONS_METADATA_PARSERS_, node,
       objectStack);
@@ -213,9 +175,6 @@ ol.format.OWS.readOperationsMetadata_ = function(node,
  * @return {Object|undefined} The phone.
  */
 ol.format.OWS.readPhone_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Phone', 'localName should be Phone');
   return ol.xml.pushParseAndPop({},
       ol.format.OWS.PHONE_PARSERS_, node, objectStack);
 };
@@ -229,10 +188,6 @@ ol.format.OWS.readPhone_ = function(node, objectStack) {
  */
 ol.format.OWS.readServiceIdentification_ = function(node,
     objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'ServiceIdentification',
-      'localName should be ServiceIdentification');
   return ol.xml.pushParseAndPop(
       {}, ol.format.OWS.SERVICE_IDENTIFICATION_PARSERS_, node,
       objectStack);
@@ -246,10 +201,6 @@ ol.format.OWS.readServiceIdentification_ = function(node,
  * @return {Object|undefined} The service contact.
  */
 ol.format.OWS.readServiceContact_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'ServiceContact',
-      'localName should be ServiceContact');
   return ol.xml.pushParseAndPop(
       {}, ol.format.OWS.SERVICE_CONTACT_PARSERS_, node,
       objectStack);
@@ -263,10 +214,6 @@ ol.format.OWS.readServiceContact_ = function(node, objectStack) {
  * @return {Object|undefined} The service provider.
  */
 ol.format.OWS.readServiceProvider_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'ServiceProvider',
-      'localName should be ServiceProvider');
   return ol.xml.pushParseAndPop(
       {}, ol.format.OWS.SERVICE_PROVIDER_PARSERS_, node,
       objectStack);
@@ -280,9 +227,6 @@ ol.format.OWS.readServiceProvider_ = function(node, objectStack) {
  * @return {string|undefined} The value.
  */
 ol.format.OWS.readValue_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Value', 'localName should be Value');
   return ol.format.XSD.readString(node);
 };
 

--- a/src/ol/format/polyline.js
+++ b/src/ol/format/polyline.js
@@ -367,8 +367,6 @@ ol.format.Polyline.prototype.writeFeatureText = function(feature, opt_options) {
  * @inheritDoc
  */
 ol.format.Polyline.prototype.writeFeaturesText = function(features, opt_options) {
-  ol.DEBUG && console.assert(features.length == 1,
-      'features array should have 1 item');
   return this.writeFeatureText(features[0], opt_options);
 };
 

--- a/src/ol/format/wfs.js
+++ b/src/ol/format/wfs.js
@@ -184,8 +184,6 @@ ol.format.WFS.prototype.readFeatureCollectionMetadata = function(source) {
  *     FeatureCollection metadata.
  */
 ol.format.WFS.prototype.readFeatureCollectionMetadataFromDocument = function(doc) {
-  ol.DEBUG && console.assert(doc.nodeType == Node.DOCUMENT_NODE,
-      'doc.nodeType should be DOCUMENT');
   for (var n = doc.firstChild; n; n = n.nextSibling) {
     if (n.nodeType == Node.ELEMENT_NODE) {
       return this.readFeatureCollectionMetadataFromNode(n);
@@ -214,10 +212,6 @@ ol.format.WFS.FEATURE_COLLECTION_PARSERS_ = {
  *     FeatureCollection metadata.
  */
 ol.format.WFS.prototype.readFeatureCollectionMetadataFromNode = function(node) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'FeatureCollection',
-      'localName should be FeatureCollection');
   var result = {};
   var value = ol.format.XSD.readNonNegativeIntegerString(
       node.getAttribute('numberOfFeatures'));
@@ -325,8 +319,6 @@ ol.format.WFS.TRANSACTION_RESPONSE_PARSERS_ = {
  * @return {ol.WFSTransactionResponse|undefined} Transaction response.
  */
 ol.format.WFS.prototype.readTransactionResponseFromDocument = function(doc) {
-  ol.DEBUG && console.assert(doc.nodeType == Node.DOCUMENT_NODE,
-      'doc.nodeType should be DOCUMENT');
   for (var n = doc.firstChild; n; n = n.nextSibling) {
     if (n.nodeType == Node.ELEMENT_NODE) {
       return this.readTransactionResponseFromNode(n);
@@ -341,10 +333,6 @@ ol.format.WFS.prototype.readTransactionResponseFromDocument = function(doc) {
  * @return {ol.WFSTransactionResponse|undefined} Transaction response.
  */
 ol.format.WFS.prototype.readTransactionResponseFromNode = function(node) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should  be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'TransactionResponse',
-      'localName should be TransactionResponse');
   return ol.xml.pushParseAndPop(
       /** @type {ol.WFSTransactionResponse} */({}),
       ol.format.WFS.TRANSACTION_RESPONSE_PARSERS_, node, []);
@@ -935,8 +923,6 @@ ol.format.WFS.prototype.readProjection;
  * @inheritDoc
  */
 ol.format.WFS.prototype.readProjectionFromDocument = function(doc) {
-  ol.DEBUG && console.assert(doc.nodeType == Node.DOCUMENT_NODE,
-      'doc.nodeType should be a DOCUMENT');
   for (var n = doc.firstChild; n; n = n.nextSibling) {
     if (n.nodeType == Node.ELEMENT_NODE) {
       return this.readProjectionFromNode(n);
@@ -950,11 +936,6 @@ ol.format.WFS.prototype.readProjectionFromDocument = function(doc) {
  * @inheritDoc
  */
 ol.format.WFS.prototype.readProjectionFromNode = function(node) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'FeatureCollection',
-      'localName should be FeatureCollection');
-
   if (node.firstElementChild &&
       node.firstElementChild.firstElementChild) {
     node = node.firstElementChild.firstElementChild;

--- a/src/ol/format/wkt.js
+++ b/src/ol/format/wkt.js
@@ -205,7 +205,6 @@ ol.format.WKT.encodeGeometryLayout_ = function(geom) {
 ol.format.WKT.encode_ = function(geom) {
   var type = geom.getType();
   var geometryEncoder = ol.format.WKT.GeometryEncoder_[type];
-  ol.DEBUG && console.assert(geometryEncoder, 'geometryEncoder should be defined');
   var enc = geometryEncoder(geom);
   type = type.toUpperCase();
   if (geom instanceof ol.geom.SimpleGeometry) {
@@ -629,8 +628,6 @@ ol.format.WKT.Parser.prototype.match = function(type) {
 ol.format.WKT.Parser.prototype.parse = function() {
   this.consume_();
   var geometry = this.parseGeometry_();
-  ol.DEBUG && console.assert(this.token_.type == ol.format.WKT.TokenType_.EOF,
-      'token type should be end of file');
   return geometry;
 };
 

--- a/src/ol/format/wmscapabilities.js
+++ b/src/ol/format/wmscapabilities.js
@@ -43,8 +43,6 @@ ol.format.WMSCapabilities.prototype.read;
  * @return {Object} WMS Capability object.
  */
 ol.format.WMSCapabilities.prototype.readFromDocument = function(doc) {
-  ol.DEBUG && console.assert(doc.nodeType == Node.DOCUMENT_NODE,
-      'doc.nodeType should be DOCUMENT');
   for (var n = doc.firstChild; n; n = n.nextSibling) {
     if (n.nodeType == Node.ELEMENT_NODE) {
       return this.readFromNode(n);
@@ -59,11 +57,6 @@ ol.format.WMSCapabilities.prototype.readFromDocument = function(doc) {
  * @return {Object} WMS Capability object.
  */
 ol.format.WMSCapabilities.prototype.readFromNode = function(node) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'WMS_Capabilities' ||
-      node.localName == 'WMT_MS_Capabilities',
-      'localName should be WMS_Capabilities or WMT_MS_Capabilities');
   this.version = node.getAttribute('version').trim();
   var wmsCapabilityObject = ol.xml.pushParseAndPop({
     'version': this.version
@@ -79,12 +72,8 @@ ol.format.WMSCapabilities.prototype.readFromNode = function(node) {
  * @return {Object|undefined} Attribution object.
  */
 ol.format.WMSCapabilities.readAttribution_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Attribution',
-      'localName should be Attribution');
   return ol.xml.pushParseAndPop(
-      {}, ol.format.WMSCapabilities.ATTRIBUTION_PARSERS_, node, objectStack);
+        {}, ol.format.WMSCapabilities.ATTRIBUTION_PARSERS_, node, objectStack);
 };
 
 
@@ -95,11 +84,6 @@ ol.format.WMSCapabilities.readAttribution_ = function(node, objectStack) {
  * @return {Object} Bounding box object.
  */
 ol.format.WMSCapabilities.readBoundingBox_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'BoundingBox',
-      'localName should be BoundingBox');
-
   var extent = [
     ol.format.XSD.readDecimalString(node.getAttribute('minx')),
     ol.format.XSD.readDecimalString(node.getAttribute('miny')),
@@ -127,27 +111,23 @@ ol.format.WMSCapabilities.readBoundingBox_ = function(node, objectStack) {
  * @return {ol.Extent|undefined} Bounding box object.
  */
 ol.format.WMSCapabilities.readEXGeographicBoundingBox_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'EX_GeographicBoundingBox',
-      'localName should be EX_GeographicBoundingBox');
   var geographicBoundingBox = ol.xml.pushParseAndPop(
-      {},
-      ol.format.WMSCapabilities.EX_GEOGRAPHIC_BOUNDING_BOX_PARSERS_,
-      node, objectStack);
+        {},
+        ol.format.WMSCapabilities.EX_GEOGRAPHIC_BOUNDING_BOX_PARSERS_,
+        node, objectStack);
   if (!geographicBoundingBox) {
     return undefined;
   }
   var westBoundLongitude = /** @type {number|undefined} */
-      (geographicBoundingBox['westBoundLongitude']);
+        (geographicBoundingBox['westBoundLongitude']);
   var southBoundLatitude = /** @type {number|undefined} */
-      (geographicBoundingBox['southBoundLatitude']);
+        (geographicBoundingBox['southBoundLatitude']);
   var eastBoundLongitude = /** @type {number|undefined} */
-      (geographicBoundingBox['eastBoundLongitude']);
+        (geographicBoundingBox['eastBoundLongitude']);
   var northBoundLatitude = /** @type {number|undefined} */
-      (geographicBoundingBox['northBoundLatitude']);
+        (geographicBoundingBox['northBoundLatitude']);
   if (westBoundLongitude === undefined || southBoundLatitude === undefined ||
-      eastBoundLongitude === undefined || northBoundLatitude === undefined) {
+        eastBoundLongitude === undefined || northBoundLatitude === undefined) {
     return undefined;
   }
   return [
@@ -164,12 +144,8 @@ ol.format.WMSCapabilities.readEXGeographicBoundingBox_ = function(node, objectSt
  * @return {Object|undefined} Capability object.
  */
 ol.format.WMSCapabilities.readCapability_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Capability',
-      'localName should be Capability');
   return ol.xml.pushParseAndPop(
-      {}, ol.format.WMSCapabilities.CAPABILITY_PARSERS_, node, objectStack);
+        {}, ol.format.WMSCapabilities.CAPABILITY_PARSERS_, node, objectStack);
 };
 
 
@@ -180,12 +156,8 @@ ol.format.WMSCapabilities.readCapability_ = function(node, objectStack) {
  * @return {Object|undefined} Service object.
  */
 ol.format.WMSCapabilities.readService_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Service',
-      'localName should be Service');
   return ol.xml.pushParseAndPop(
-      {}, ol.format.WMSCapabilities.SERVICE_PARSERS_, node, objectStack);
+        {}, ol.format.WMSCapabilities.SERVICE_PARSERS_, node, objectStack);
 };
 
 
@@ -196,13 +168,9 @@ ol.format.WMSCapabilities.readService_ = function(node, objectStack) {
  * @return {Object|undefined} Contact information object.
  */
 ol.format.WMSCapabilities.readContactInformation_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType shpuld be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'ContactInformation',
-      'localName should be ContactInformation');
   return ol.xml.pushParseAndPop(
-      {}, ol.format.WMSCapabilities.CONTACT_INFORMATION_PARSERS_,
-      node, objectStack);
+        {}, ol.format.WMSCapabilities.CONTACT_INFORMATION_PARSERS_,
+        node, objectStack);
 };
 
 
@@ -213,13 +181,9 @@ ol.format.WMSCapabilities.readContactInformation_ = function(node, objectStack) 
  * @return {Object|undefined} Contact person object.
  */
 ol.format.WMSCapabilities.readContactPersonPrimary_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'ContactPersonPrimary',
-      'localName should be ContactPersonPrimary');
   return ol.xml.pushParseAndPop(
-      {}, ol.format.WMSCapabilities.CONTACT_PERSON_PARSERS_,
-      node, objectStack);
+        {}, ol.format.WMSCapabilities.CONTACT_PERSON_PARSERS_,
+        node, objectStack);
 };
 
 
@@ -230,13 +194,9 @@ ol.format.WMSCapabilities.readContactPersonPrimary_ = function(node, objectStack
  * @return {Object|undefined} Contact address object.
  */
 ol.format.WMSCapabilities.readContactAddress_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'ContactAddress',
-      'localName should be ContactAddress');
   return ol.xml.pushParseAndPop(
-      {}, ol.format.WMSCapabilities.CONTACT_ADDRESS_PARSERS_,
-      node, objectStack);
+        {}, ol.format.WMSCapabilities.CONTACT_ADDRESS_PARSERS_,
+        node, objectStack);
 };
 
 
@@ -247,12 +207,8 @@ ol.format.WMSCapabilities.readContactAddress_ = function(node, objectStack) {
  * @return {Array.<string>|undefined} Format array.
  */
 ol.format.WMSCapabilities.readException_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Exception',
-      'localName should be Exception');
   return ol.xml.pushParseAndPop(
-      [], ol.format.WMSCapabilities.EXCEPTION_PARSERS_, node, objectStack);
+        [], ol.format.WMSCapabilities.EXCEPTION_PARSERS_, node, objectStack);
 };
 
 
@@ -263,11 +219,8 @@ ol.format.WMSCapabilities.readException_ = function(node, objectStack) {
  * @return {Object|undefined} Layer object.
  */
 ol.format.WMSCapabilities.readCapabilityLayer_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Layer', 'localName should be Layer');
   return ol.xml.pushParseAndPop(
-      {}, ol.format.WMSCapabilities.LAYER_PARSERS_, node, objectStack);
+        {}, ol.format.WMSCapabilities.LAYER_PARSERS_, node, objectStack);
 };
 
 
@@ -278,27 +231,24 @@ ol.format.WMSCapabilities.readCapabilityLayer_ = function(node, objectStack) {
  * @return {Object|undefined} Layer object.
  */
 ol.format.WMSCapabilities.readLayer_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Layer', 'localName should be Layer');
   var parentLayerObject = /**  @type {Object.<string,*>} */
-      (objectStack[objectStack.length - 1]);
+        (objectStack[objectStack.length - 1]);
 
   var layerObject = ol.xml.pushParseAndPop(
-      {}, ol.format.WMSCapabilities.LAYER_PARSERS_, node, objectStack);
+        {}, ol.format.WMSCapabilities.LAYER_PARSERS_, node, objectStack);
 
   if (!layerObject) {
     return undefined;
   }
   var queryable =
-      ol.format.XSD.readBooleanString(node.getAttribute('queryable'));
+        ol.format.XSD.readBooleanString(node.getAttribute('queryable'));
   if (queryable === undefined) {
     queryable = parentLayerObject['queryable'];
   }
   layerObject['queryable'] = queryable !== undefined ? queryable : false;
 
   var cascaded = ol.format.XSD.readNonNegativeIntegerString(
-      node.getAttribute('cascaded'));
+        node.getAttribute('cascaded'));
   if (cascaded === undefined) {
     cascaded = parentLayerObject['cascaded'];
   }
@@ -311,27 +261,27 @@ ol.format.WMSCapabilities.readLayer_ = function(node, objectStack) {
   layerObject['opaque'] = opaque !== undefined ? opaque : false;
 
   var noSubsets =
-      ol.format.XSD.readBooleanString(node.getAttribute('noSubsets'));
+        ol.format.XSD.readBooleanString(node.getAttribute('noSubsets'));
   if (noSubsets === undefined) {
     noSubsets = parentLayerObject['noSubsets'];
   }
   layerObject['noSubsets'] = noSubsets !== undefined ? noSubsets : false;
 
   var fixedWidth =
-      ol.format.XSD.readDecimalString(node.getAttribute('fixedWidth'));
+        ol.format.XSD.readDecimalString(node.getAttribute('fixedWidth'));
   if (!fixedWidth) {
     fixedWidth = parentLayerObject['fixedWidth'];
   }
   layerObject['fixedWidth'] = fixedWidth;
 
   var fixedHeight =
-      ol.format.XSD.readDecimalString(node.getAttribute('fixedHeight'));
+        ol.format.XSD.readDecimalString(node.getAttribute('fixedHeight'));
   if (!fixedHeight) {
     fixedHeight = parentLayerObject['fixedHeight'];
   }
   layerObject['fixedHeight'] = fixedHeight;
 
-  // See 7.2.4.8
+    // See 7.2.4.8
   var addKeys = ['Style', 'CRS', 'AuthorityURL'];
   addKeys.forEach(function(key) {
     if (key in parentLayerObject) {
@@ -360,19 +310,15 @@ ol.format.WMSCapabilities.readLayer_ = function(node, objectStack) {
  * @return {Object} Dimension object.
  */
 ol.format.WMSCapabilities.readDimension_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Dimension',
-      'localName should be Dimension');
   var dimensionObject = {
     'name': node.getAttribute('name'),
     'units': node.getAttribute('units'),
     'unitSymbol': node.getAttribute('unitSymbol'),
     'default': node.getAttribute('default'),
     'multipleValues': ol.format.XSD.readBooleanString(
-        node.getAttribute('multipleValues')),
+          node.getAttribute('multipleValues')),
     'nearestValue': ol.format.XSD.readBooleanString(
-        node.getAttribute('nearestValue')),
+          node.getAttribute('nearestValue')),
     'current': ol.format.XSD.readBooleanString(node.getAttribute('current')),
     'values': ol.format.XSD.readString(node)
   };
@@ -387,11 +333,9 @@ ol.format.WMSCapabilities.readDimension_ = function(node, objectStack) {
  * @return {Object|undefined} Online resource object.
  */
 ol.format.WMSCapabilities.readFormatOnlineresource_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
   return ol.xml.pushParseAndPop(
-      {}, ol.format.WMSCapabilities.FORMAT_ONLINERESOURCE_PARSERS_,
-      node, objectStack);
+        {}, ol.format.WMSCapabilities.FORMAT_ONLINERESOURCE_PARSERS_,
+        node, objectStack);
 };
 
 
@@ -402,12 +346,8 @@ ol.format.WMSCapabilities.readFormatOnlineresource_ = function(node, objectStack
  * @return {Object|undefined} Request object.
  */
 ol.format.WMSCapabilities.readRequest_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Request',
-      'localName should be Request');
   return ol.xml.pushParseAndPop(
-      {}, ol.format.WMSCapabilities.REQUEST_PARSERS_, node, objectStack);
+        {}, ol.format.WMSCapabilities.REQUEST_PARSERS_, node, objectStack);
 };
 
 
@@ -418,12 +358,8 @@ ol.format.WMSCapabilities.readRequest_ = function(node, objectStack) {
  * @return {Object|undefined} DCP type object.
  */
 ol.format.WMSCapabilities.readDCPType_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'DCPType',
-      'localName should be DCPType');
   return ol.xml.pushParseAndPop(
-      {}, ol.format.WMSCapabilities.DCPTYPE_PARSERS_, node, objectStack);
+        {}, ol.format.WMSCapabilities.DCPTYPE_PARSERS_, node, objectStack);
 };
 
 
@@ -434,11 +370,8 @@ ol.format.WMSCapabilities.readDCPType_ = function(node, objectStack) {
  * @return {Object|undefined} HTTP object.
  */
 ol.format.WMSCapabilities.readHTTP_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'HTTP', 'localName should be HTTP');
   return ol.xml.pushParseAndPop(
-      {}, ol.format.WMSCapabilities.HTTP_PARSERS_, node, objectStack);
+        {}, ol.format.WMSCapabilities.HTTP_PARSERS_, node, objectStack);
 };
 
 
@@ -449,10 +382,8 @@ ol.format.WMSCapabilities.readHTTP_ = function(node, objectStack) {
  * @return {Object|undefined} Operation type object.
  */
 ol.format.WMSCapabilities.readOperationType_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
   return ol.xml.pushParseAndPop(
-      {}, ol.format.WMSCapabilities.OPERATIONTYPE_PARSERS_, node, objectStack);
+        {}, ol.format.WMSCapabilities.OPERATIONTYPE_PARSERS_, node, objectStack);
 };
 
 
@@ -463,10 +394,8 @@ ol.format.WMSCapabilities.readOperationType_ = function(node, objectStack) {
  * @return {Object|undefined} Online resource object.
  */
 ol.format.WMSCapabilities.readSizedFormatOnlineresource_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
   var formatOnlineresource =
-      ol.format.WMSCapabilities.readFormatOnlineresource_(node, objectStack);
+        ol.format.WMSCapabilities.readFormatOnlineresource_(node, objectStack);
   if (formatOnlineresource) {
     var size = [
       ol.format.XSD.readNonNegativeIntegerString(node.getAttribute('width')),
@@ -486,12 +415,8 @@ ol.format.WMSCapabilities.readSizedFormatOnlineresource_ = function(node, object
  * @return {Object|undefined} Authority URL object.
  */
 ol.format.WMSCapabilities.readAuthorityURL_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'AuthorityURL',
-      'localName should be AuthorityURL');
   var authorityObject =
-      ol.format.WMSCapabilities.readFormatOnlineresource_(node, objectStack);
+        ol.format.WMSCapabilities.readFormatOnlineresource_(node, objectStack);
   if (authorityObject) {
     authorityObject['name'] = node.getAttribute('name');
     return authorityObject;
@@ -507,12 +432,8 @@ ol.format.WMSCapabilities.readAuthorityURL_ = function(node, objectStack) {
  * @return {Object|undefined} Metadata URL object.
  */
 ol.format.WMSCapabilities.readMetadataURL_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'MetadataURL',
-      'localName should be MetadataURL');
   var metadataObject =
-      ol.format.WMSCapabilities.readFormatOnlineresource_(node, objectStack);
+        ol.format.WMSCapabilities.readFormatOnlineresource_(node, objectStack);
   if (metadataObject) {
     metadataObject['type'] = node.getAttribute('type');
     return metadataObject;
@@ -528,11 +449,8 @@ ol.format.WMSCapabilities.readMetadataURL_ = function(node, objectStack) {
  * @return {Object|undefined} Style object.
  */
 ol.format.WMSCapabilities.readStyle_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Style', 'localName should be Style');
   return ol.xml.pushParseAndPop(
-      {}, ol.format.WMSCapabilities.STYLE_PARSERS_, node, objectStack);
+        {}, ol.format.WMSCapabilities.STYLE_PARSERS_, node, objectStack);
 };
 
 
@@ -543,12 +461,8 @@ ol.format.WMSCapabilities.readStyle_ = function(node, objectStack) {
  * @return {Array.<string>|undefined} Keyword list.
  */
 ol.format.WMSCapabilities.readKeywordList_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'KeywordList',
-      'localName should be KeywordList');
   return ol.xml.pushParseAndPop(
-      [], ol.format.WMSCapabilities.KEYWORDLIST_PARSERS_, node, objectStack);
+        [], ol.format.WMSCapabilities.KEYWORDLIST_PARSERS_, node, objectStack);
 };
 
 

--- a/src/ol/format/wmsgetfeatureinfo.js
+++ b/src/ol/format/wmsgetfeatureinfo.js
@@ -70,10 +70,7 @@ ol.format.WMSGetFeatureInfo.layerIdentifier_ = '_layer';
  * @private
  */
 ol.format.WMSGetFeatureInfo.prototype.readFeatures_ = function(node, objectStack) {
-
   node.setAttribute('namespaceURI', this.featureNS_);
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
   var localName = node.localName;
   /** @type {Array.<ol.Feature>} */
   var features = [];
@@ -87,10 +84,6 @@ ol.format.WMSGetFeatureInfo.prototype.readFeatures_ = function(node, objectStack
         continue;
       }
       var context = objectStack[0];
-
-      ol.DEBUG && console.assert(layer.localName.indexOf(
-          ol.format.WMSGetFeatureInfo.layerIdentifier_) >= 0,
-          'localName of layer node should match layerIdentifier');
 
       var toRemove = ol.format.WMSGetFeatureInfo.layerIdentifier_;
       var layerName = layer.localName.replace(toRemove, '');

--- a/src/ol/format/wmtscapabilities.js
+++ b/src/ol/format/wmtscapabilities.js
@@ -45,8 +45,6 @@ ol.format.WMTSCapabilities.prototype.read;
  * @return {Object} WMTS Capability object.
  */
 ol.format.WMTSCapabilities.prototype.readFromDocument = function(doc) {
-  ol.DEBUG && console.assert(doc.nodeType == Node.DOCUMENT_NODE,
-      'doc.nodeType should be DOCUMENT');
   for (var n = doc.firstChild; n; n = n.nextSibling) {
     if (n.nodeType == Node.ELEMENT_NODE) {
       return this.readFromNode(n);
@@ -61,10 +59,6 @@ ol.format.WMTSCapabilities.prototype.readFromDocument = function(doc) {
  * @return {Object} WMTS Capability object.
  */
 ol.format.WMTSCapabilities.prototype.readFromNode = function(node) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Capabilities',
-      'localName should be Capabilities');
   var version = node.getAttribute('version').trim();
   var WMTSCapabilityObject = this.owsParser_.readFromNode(node);
   if (!WMTSCapabilityObject) {
@@ -72,7 +66,7 @@ ol.format.WMTSCapabilities.prototype.readFromNode = function(node) {
   }
   WMTSCapabilityObject['version'] = version;
   WMTSCapabilityObject = ol.xml.pushParseAndPop(WMTSCapabilityObject,
-      ol.format.WMTSCapabilities.PARSERS_, node, []);
+        ol.format.WMTSCapabilities.PARSERS_, node, []);
   return WMTSCapabilityObject ? WMTSCapabilityObject : null;
 };
 
@@ -84,13 +78,8 @@ ol.format.WMTSCapabilities.prototype.readFromNode = function(node) {
  * @return {Object|undefined} Attribution object.
  */
 ol.format.WMTSCapabilities.readContents_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Contents',
-      'localName should be Contents');
-
   return ol.xml.pushParseAndPop({},
-      ol.format.WMTSCapabilities.CONTENTS_PARSERS_, node, objectStack);
+        ol.format.WMTSCapabilities.CONTENTS_PARSERS_, node, objectStack);
 };
 
 
@@ -101,11 +90,8 @@ ol.format.WMTSCapabilities.readContents_ = function(node, objectStack) {
  * @return {Object|undefined} Layers object.
  */
 ol.format.WMTSCapabilities.readLayer_ = function(node, objectStack) {
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
-  ol.DEBUG && console.assert(node.localName == 'Layer', 'localName should be Layer');
   return ol.xml.pushParseAndPop({},
-      ol.format.WMTSCapabilities.LAYER_PARSERS_, node, objectStack);
+        ol.format.WMTSCapabilities.LAYER_PARSERS_, node, objectStack);
 };
 
 

--- a/src/ol/format/xmlfeature.js
+++ b/src/ol/format/xmlfeature.js
@@ -208,8 +208,6 @@ ol.format.XMLFeature.prototype.readProjectionFromNode = function(node) {
  */
 ol.format.XMLFeature.prototype.writeFeature = function(feature, opt_options) {
   var node = this.writeFeatureNode(feature, opt_options);
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
   return this.xmlSerializer_.serializeToString(node);
 };
 
@@ -229,8 +227,6 @@ ol.format.XMLFeature.prototype.writeFeatureNode = function(feature, opt_options)
  */
 ol.format.XMLFeature.prototype.writeFeatures = function(features, opt_options) {
   var node = this.writeFeaturesNode(features, opt_options);
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
   return this.xmlSerializer_.serializeToString(node);
 };
 
@@ -249,8 +245,6 @@ ol.format.XMLFeature.prototype.writeFeaturesNode = function(features, opt_option
  */
 ol.format.XMLFeature.prototype.writeGeometry = function(geometry, opt_options) {
   var node = this.writeGeometryNode(geometry, opt_options);
-  ol.DEBUG && console.assert(node.nodeType == Node.ELEMENT_NODE,
-      'node.nodeType should be ELEMENT');
   return this.xmlSerializer_.serializeToString(node);
 };
 

--- a/src/ol/format/xsd.js
+++ b/src/ol/format/xsd.js
@@ -154,9 +154,6 @@ ol.format.XSD.writeDecimalTextNode = function(node, decimal) {
  * @param {number} nonNegativeInteger Non negative integer.
  */
 ol.format.XSD.writeNonNegativeIntegerTextNode = function(node, nonNegativeInteger) {
-  ol.DEBUG && console.assert(nonNegativeInteger >= 0, 'value should be more than 0');
-  ol.DEBUG && console.assert(nonNegativeInteger == (nonNegativeInteger | 0),
-      'value should be an integer value');
   var string = nonNegativeInteger.toString();
   node.appendChild(ol.xml.DOCUMENT.createTextNode(string));
 };

--- a/src/ol/geom/circle.js
+++ b/src/ol/geom/circle.js
@@ -163,8 +163,6 @@ ol.geom.Circle.prototype.intersectsExtent = function(extent) {
  */
 ol.geom.Circle.prototype.setCenter = function(center) {
   var stride = this.stride;
-  ol.DEBUG && console.assert(center.length == stride,
-      'center array length should match stride');
   var radius = this.flatCoordinates[stride] - this.flatCoordinates[0];
   var flatCoordinates = center.slice();
   flatCoordinates[stride] = flatCoordinates[0] + radius;

--- a/src/ol/geom/flat/closest.js
+++ b/src/ol/geom/flat/closest.js
@@ -148,7 +148,6 @@ ol.geom.flat.closest.getClosestPoint = function(flatCoordinates, offset, end,
       return minSquaredDistance;
     }
   }
-  ol.DEBUG && console.assert(maxDelta > 0, 'maxDelta should be larger than 0');
   var tmpPoint = opt_tmpPoint ? opt_tmpPoint : [NaN, NaN];
   var index = offset + stride;
   while (index < end) {

--- a/src/ol/geom/flat/contains.js
+++ b/src/ol/geom/flat/contains.js
@@ -73,7 +73,6 @@ ol.geom.flat.contains.linearRingContainsXY = function(flatCoordinates, offset, e
  * @return {boolean} Contains (x, y).
  */
 ol.geom.flat.contains.linearRingsContainsXY = function(flatCoordinates, offset, ends, stride, x, y) {
-  ol.DEBUG && console.assert(ends.length > 0, 'ends should not be an empty array');
   if (ends.length === 0) {
     return false;
   }
@@ -102,7 +101,6 @@ ol.geom.flat.contains.linearRingsContainsXY = function(flatCoordinates, offset, 
  * @return {boolean} Contains (x, y).
  */
 ol.geom.flat.contains.linearRingssContainsXY = function(flatCoordinates, offset, endss, stride, x, y) {
-  ol.DEBUG && console.assert(endss.length > 0, 'endss should not be an empty array');
   if (endss.length === 0) {
     return false;
   }

--- a/src/ol/geom/flat/deflate.js
+++ b/src/ol/geom/flat/deflate.js
@@ -11,8 +11,6 @@ goog.require('ol');
  * @return {number} offset Offset.
  */
 ol.geom.flat.deflate.coordinate = function(flatCoordinates, offset, coordinate, stride) {
-  ol.DEBUG && console.assert(coordinate.length == stride,
-      'length of the coordinate array should match stride');
   var i, ii;
   for (i = 0, ii = coordinate.length; i < ii; ++i) {
     flatCoordinates[offset++] = coordinate[i];
@@ -32,8 +30,6 @@ ol.geom.flat.deflate.coordinates = function(flatCoordinates, offset, coordinates
   var i, ii;
   for (i = 0, ii = coordinates.length; i < ii; ++i) {
     var coordinate = coordinates[i];
-    ol.DEBUG && console.assert(coordinate.length == stride,
-        'length of coordinate array should match stride');
     var j;
     for (j = 0; j < stride; ++j) {
       flatCoordinates[offset++] = coordinate[j];

--- a/src/ol/geom/flat/geodesic.js
+++ b/src/ol/geom/flat/geodesic.js
@@ -65,8 +65,6 @@ ol.geom.flat.geodesic.line_ = function(interpolate, transform, squaredTolerance)
       // segment.
       flatCoordinates.push(b[0], b[1]);
       key = fracB.toString();
-      ol.DEBUG && console.assert(!(key in fractions),
-          'fractions object should contain key : ' + key);
       fractions[key] = true;
     } else {
       // Otherwise, we need to subdivide the current line segment.  Split it
@@ -76,8 +74,6 @@ ol.geom.flat.geodesic.line_ = function(interpolate, transform, squaredTolerance)
       geoStack.push(geoB, geoM, geoM, geoA);
     }
   }
-  ol.DEBUG && console.assert(maxIterations > 0,
-      'maxIterations should be more than 0');
 
   return flatCoordinates;
 };

--- a/src/ol/geom/flat/interiorpoint.js
+++ b/src/ol/geom/flat/interiorpoint.js
@@ -79,8 +79,6 @@ ol.geom.flat.interiorpoint.linearRings = function(flatCoordinates, offset,
  * @return {Array.<number>} Interior points.
  */
 ol.geom.flat.interiorpoint.linearRingss = function(flatCoordinates, offset, endss, stride, flatCenters) {
-  ol.DEBUG && console.assert(2 * endss.length == flatCenters.length,
-      'endss.length times 2 should be flatCenters.length');
   var interiorPoints = [];
   var i, ii;
   for (i = 0, ii = endss.length; i < ii; ++i) {

--- a/src/ol/geom/flat/interpolate.js
+++ b/src/ol/geom/flat/interpolate.js
@@ -15,16 +15,10 @@ goog.require('ol.math');
  * @return {Array.<number>} Destination.
  */
 ol.geom.flat.interpolate.lineString = function(flatCoordinates, offset, end, stride, fraction, opt_dest) {
-  // FIXME does not work when vertices are repeated
-  // FIXME interpolate extra dimensions
-  ol.DEBUG && console.assert(0 <= fraction && fraction <= 1,
-      'fraction should be in between 0 and 1');
   var pointX = NaN;
   var pointY = NaN;
   var n = (end - offset) / stride;
-  if (n === 0) {
-    ol.DEBUG && console.assert(false, 'n cannot be 0');
-  } else if (n == 1) {
+  if (n === 1) {
     pointX = flatCoordinates[offset];
     pointY = flatCoordinates[offset + 1];
   } else if (n == 2) {
@@ -32,7 +26,7 @@ ol.geom.flat.interpolate.lineString = function(flatCoordinates, offset, end, str
         fraction * flatCoordinates[offset + stride];
     pointY = (1 - fraction) * flatCoordinates[offset + 1] +
         fraction * flatCoordinates[offset + stride + 1];
-  } else {
+  } else if (n !== 0) {
     var x1 = flatCoordinates[offset];
     var y1 = flatCoordinates[offset + 1];
     var length = 0;
@@ -121,8 +115,6 @@ ol.geom.flat.interpolate.lineStringCoordinateAtM = function(flatCoordinates, off
     return flatCoordinates.slice((lo - 1) * stride, (lo - 1) * stride + stride);
   }
   var m1 = flatCoordinates[(lo + 1) * stride - 1];
-  ol.DEBUG && console.assert(m0 < m, 'm0 should be less than m');
-  ol.DEBUG && console.assert(m <= m1, 'm should be less than or equal to m1');
   var t = (m - m0) / (m1 - m0);
   coordinate = [];
   var i;
@@ -131,8 +123,6 @@ ol.geom.flat.interpolate.lineStringCoordinateAtM = function(flatCoordinates, off
         flatCoordinates[lo * stride + i], t));
   }
   coordinate.push(m);
-  ol.DEBUG && console.assert(coordinate.length == stride,
-      'length of coordinate array should match stride');
   return coordinate;
 };
 
@@ -186,7 +176,5 @@ ol.geom.flat.interpolate.lineStringsCoordinateAtM = function(
     }
     offset = end;
   }
-  ol.DEBUG && console.assert(false,
-      'ol.geom.flat.interpolate.lineStringsCoordinateAtM should have returned');
   return null;
 };

--- a/src/ol/geom/flat/intersectsextent.js
+++ b/src/ol/geom/flat/intersectsextent.js
@@ -107,7 +107,6 @@ ol.geom.flat.intersectsextent.linearRing = function(flatCoordinates, offset, end
  * @return {boolean} True if the geometry and the extent intersect.
  */
 ol.geom.flat.intersectsextent.linearRings = function(flatCoordinates, offset, ends, stride, extent) {
-  ol.DEBUG && console.assert(ends.length > 0, 'ends should not be an empty array');
   if (!ol.geom.flat.intersectsextent.linearRing(
       flatCoordinates, offset, ends[0], stride, extent)) {
     return false;
@@ -135,7 +134,6 @@ ol.geom.flat.intersectsextent.linearRings = function(flatCoordinates, offset, en
  * @return {boolean} True if the geometry and the extent intersect.
  */
 ol.geom.flat.intersectsextent.linearRingss = function(flatCoordinates, offset, endss, stride, extent) {
-  ol.DEBUG && console.assert(endss.length > 0, 'endss should not be an empty array');
   var i, ii;
   for (i = 0, ii = endss.length; i < ii; ++i) {
     var ends = endss[i];

--- a/src/ol/geom/geometry.js
+++ b/src/ol/geom/geometry.js
@@ -5,7 +5,6 @@ goog.require('ol.Object');
 goog.require('ol.extent');
 goog.require('ol.functions');
 goog.require('ol.proj');
-goog.require('ol.proj.Units');
 
 
 /**
@@ -244,10 +243,6 @@ ol.geom.Geometry.prototype.translate = function(deltaX, deltaY) {};
  * @api stable
  */
 ol.geom.Geometry.prototype.transform = function(source, destination) {
-  ol.DEBUG && console.assert(
-      ol.proj.get(source).getUnits() !== ol.proj.Units.TILE_PIXELS &&
-      ol.proj.get(destination).getUnits() !== ol.proj.Units.TILE_PIXELS,
-      'cannot transform geometries with TILE_PIXELS units');
   this.applyTransform(ol.proj.getTransform(source, destination));
   return this;
 };

--- a/src/ol/geom/linestring.js
+++ b/src/ol/geom/linestring.js
@@ -66,8 +66,6 @@ ol.inherits(ol.geom.LineString, ol.geom.SimpleGeometry);
  * @api stable
  */
 ol.geom.LineString.prototype.appendCoordinate = function(coordinate) {
-  ol.DEBUG && console.assert(coordinate.length == this.stride,
-      'length of coordinate array should match stride');
   if (!this.flatCoordinates) {
     this.flatCoordinates = coordinate.slice();
   } else {

--- a/src/ol/geom/multilinestring.js
+++ b/src/ol/geom/multilinestring.js
@@ -59,8 +59,6 @@ ol.inherits(ol.geom.MultiLineString, ol.geom.SimpleGeometry);
  * @api stable
  */
 ol.geom.MultiLineString.prototype.appendLineString = function(lineString) {
-  ol.DEBUG && console.assert(lineString.getLayout() == this.layout,
-      'layout of lineString should match the layout');
   if (!this.flatCoordinates) {
     this.flatCoordinates = lineString.getFlatCoordinates().slice();
   } else {
@@ -165,8 +163,6 @@ ol.geom.MultiLineString.prototype.getEnds = function() {
  * @api stable
  */
 ol.geom.MultiLineString.prototype.getLineString = function(index) {
-  ol.DEBUG && console.assert(0 <= index && index < this.ends_.length,
-      'index should be in between 0 and length of the this.ends_ array');
   if (index < 0 || this.ends_.length <= index) {
     return null;
   }
@@ -285,16 +281,6 @@ ol.geom.MultiLineString.prototype.setCoordinates = function(coordinates, opt_lay
  * @param {Array.<number>} ends Ends.
  */
 ol.geom.MultiLineString.prototype.setFlatCoordinates = function(layout, flatCoordinates, ends) {
-  if (!flatCoordinates) {
-    ol.DEBUG && console.assert(ends && ends.length === 0,
-        'ends must be truthy and ends.length should be 0');
-  } else if (ends.length === 0) {
-    ol.DEBUG && console.assert(flatCoordinates.length === 0,
-        'flatCoordinates should be an empty array');
-  } else {
-    ol.DEBUG && console.assert(flatCoordinates.length == ends[ends.length - 1],
-        'length of flatCoordinates array should match the last value of ends');
-  }
   this.setFlatCoordinatesInternal(layout, flatCoordinates);
   this.ends_ = ends;
   this.changed();
@@ -313,10 +299,6 @@ ol.geom.MultiLineString.prototype.setLineStrings = function(lineStrings) {
     var lineString = lineStrings[i];
     if (i === 0) {
       layout = lineString.getLayout();
-    } else {
-      // FIXME better handle the case of non-matching layouts
-      ol.DEBUG && console.assert(lineString.getLayout() == layout,
-          'layout of lineString should match layout');
     }
     ol.array.extend(flatCoordinates, lineString.getFlatCoordinates());
     ends.push(flatCoordinates.length);

--- a/src/ol/geom/multipoint.js
+++ b/src/ol/geom/multipoint.js
@@ -35,8 +35,6 @@ ol.inherits(ol.geom.MultiPoint, ol.geom.SimpleGeometry);
  * @api stable
  */
 ol.geom.MultiPoint.prototype.appendPoint = function(point) {
-  ol.DEBUG && console.assert(point.getLayout() == this.layout,
-      'the layout of point should match layout');
   if (!this.flatCoordinates) {
     this.flatCoordinates = point.getFlatCoordinates().slice();
   } else {
@@ -104,8 +102,6 @@ ol.geom.MultiPoint.prototype.getCoordinates = function() {
 ol.geom.MultiPoint.prototype.getPoint = function(index) {
   var n = !this.flatCoordinates ?
       0 : this.flatCoordinates.length / this.stride;
-  ol.DEBUG && console.assert(0 <= index && index < n,
-      'index should be in between 0 and n');
   if (index < 0 || n <= index) {
     return null;
   }

--- a/src/ol/geom/multipolygon.js
+++ b/src/ol/geom/multipolygon.js
@@ -88,8 +88,6 @@ ol.inherits(ol.geom.MultiPolygon, ol.geom.SimpleGeometry);
  * @api stable
  */
 ol.geom.MultiPolygon.prototype.appendPolygon = function(polygon) {
-  ol.DEBUG && console.assert(polygon.getLayout() == this.layout,
-      'layout of polygon should match layout');
   /** @type {Array.<number>} */
   var ends;
   if (!this.flatCoordinates) {
@@ -279,8 +277,6 @@ ol.geom.MultiPolygon.prototype.getSimplifiedGeometryInternal = function(squaredT
  * @api stable
  */
 ol.geom.MultiPolygon.prototype.getPolygon = function(index) {
-  ol.DEBUG && console.assert(0 <= index && index < this.endss_.length,
-      'index should be in between 0 and the length of this.endss_');
   if (index < 0 || this.endss_.length <= index) {
     return null;
   }
@@ -389,15 +385,6 @@ ol.geom.MultiPolygon.prototype.setCoordinates = function(coordinates, opt_layout
  * @param {Array.<Array.<number>>} endss Endss.
  */
 ol.geom.MultiPolygon.prototype.setFlatCoordinates = function(layout, flatCoordinates, endss) {
-  ol.DEBUG && console.assert(endss, 'endss must be truthy');
-  if (!flatCoordinates || flatCoordinates.length === 0) {
-    ol.DEBUG && console.assert(endss.length === 0, 'the length of endss should be 0');
-  } else {
-    ol.DEBUG && console.assert(endss.length > 0, 'endss cannot be an empty array');
-    var ends = endss[endss.length - 1];
-    ol.DEBUG && console.assert(flatCoordinates.length == ends[ends.length - 1],
-        'the length of flatCoordinates should be the last value of ends');
-  }
   this.setFlatCoordinatesInternal(layout, flatCoordinates);
   this.endss_ = endss;
   this.changed();
@@ -416,10 +403,6 @@ ol.geom.MultiPolygon.prototype.setPolygons = function(polygons) {
     var polygon = polygons[i];
     if (i === 0) {
       layout = polygon.getLayout();
-    } else {
-      // FIXME better handle the case of non-matching layouts
-      ol.DEBUG && console.assert(polygon.getLayout() == layout,
-          'layout of polygon should be layout');
     }
     var offset = flatCoordinates.length;
     ends = polygon.getEnds();

--- a/src/ol/geom/polygon.js
+++ b/src/ol/geom/polygon.js
@@ -88,8 +88,6 @@ ol.inherits(ol.geom.Polygon, ol.geom.SimpleGeometry);
  * @api stable
  */
 ol.geom.Polygon.prototype.appendLinearRing = function(linearRing) {
-  ol.DEBUG && console.assert(linearRing.getLayout() == this.layout,
-      'layout of linearRing should match layout');
   if (!this.flatCoordinates) {
     this.flatCoordinates = linearRing.getFlatCoordinates().slice();
   } else {
@@ -236,8 +234,6 @@ ol.geom.Polygon.prototype.getLinearRingCount = function() {
  * @api stable
  */
 ol.geom.Polygon.prototype.getLinearRing = function(index) {
-  ol.DEBUG && console.assert(0 <= index && index < this.ends_.length,
-      'index should be in between 0 and and length of this.ends_');
   if (index < 0 || this.ends_.length <= index) {
     return null;
   }
@@ -356,16 +352,6 @@ ol.geom.Polygon.prototype.setCoordinates = function(coordinates, opt_layout) {
  * @param {Array.<number>} ends Ends.
  */
 ol.geom.Polygon.prototype.setFlatCoordinates = function(layout, flatCoordinates, ends) {
-  if (!flatCoordinates) {
-    ol.DEBUG && console.assert(ends && ends.length === 0,
-        'ends must be an empty array');
-  } else if (ends.length === 0) {
-    ol.DEBUG && console.assert(flatCoordinates.length === 0,
-        'flatCoordinates should be an empty array');
-  } else {
-    ol.DEBUG && console.assert(flatCoordinates.length == ends[ends.length - 1],
-        'the length of flatCoordinates should be the last entry of ends');
-  }
   this.setFlatCoordinatesInternal(layout, flatCoordinates);
   this.ends_ = ends;
   this.changed();
@@ -460,7 +446,6 @@ ol.geom.Polygon.makeRegular = function(polygon, center, radius, opt_angle) {
   var layout = polygon.getLayout();
   var stride = polygon.getStride();
   var ends = polygon.getEnds();
-  ol.DEBUG && console.assert(ends.length === 1, 'only 1 ring is supported');
   var sides = flatCoordinates.length / stride - 1;
   var startAngle = opt_angle ? opt_angle : 0;
   var angle, offset;

--- a/src/ol/geom/simplegeometry.js
+++ b/src/ol/geom/simplegeometry.js
@@ -58,7 +58,6 @@ ol.geom.SimpleGeometry.getLayoutForStride_ = function(stride) {
   } else if (stride == 4) {
     layout = ol.geom.GeometryLayout.XYZM;
   }
-  ol.DEBUG && console.assert(layout, 'unsupported stride: ' + stride);
   return /** @type {ol.geom.GeometryLayout} */ (layout);
 };
 
@@ -76,7 +75,6 @@ ol.geom.SimpleGeometry.getStrideForLayout = function(layout) {
   } else if (layout == ol.geom.GeometryLayout.XYZM) {
     stride = 4;
   }
-  ol.DEBUG && console.assert(stride, 'unsupported layout: ' + layout);
   return /** @type {number} */ (stride);
 };
 

--- a/src/ol/graticule.js
+++ b/src/ol/graticule.js
@@ -18,119 +18,116 @@ goog.require('ol.style.Stroke');
  * @api
  */
 ol.Graticule = function(opt_options) {
-
   var options = opt_options || {};
 
-  /**
-   * @type {ol.Map}
-   * @private
-   */
+ /**
+  * @type {ol.Map}
+  * @private
+  */
   this.map_ = null;
 
-  /**
-   * @type {ol.proj.Projection}
-   * @private
-   */
+ /**
+  * @type {ol.proj.Projection}
+  * @private
+  */
   this.projection_ = null;
 
-  /**
-   * @type {number}
-   * @private
-   */
+ /**
+  * @type {number}
+  * @private
+  */
   this.maxLat_ = Infinity;
 
-  /**
-   * @type {number}
-   * @private
-   */
+ /**
+  * @type {number}
+  * @private
+  */
   this.maxLon_ = Infinity;
 
-  /**
-   * @type {number}
-   * @private
-   */
+ /**
+  * @type {number}
+  * @private
+  */
   this.minLat_ = -Infinity;
 
-  /**
-   * @type {number}
-   * @private
-   */
+ /**
+  * @type {number}
+  * @private
+  */
   this.minLon_ = -Infinity;
 
-  /**
-   * @type {number}
-   * @private
-   */
+ /**
+  * @type {number}
+  * @private
+  */
   this.maxLatP_ = Infinity;
 
-  /**
-   * @type {number}
-   * @private
-   */
+ /**
+  * @type {number}
+  * @private
+  */
   this.maxLonP_ = Infinity;
 
-  /**
-   * @type {number}
-   * @private
-   */
+ /**
+  * @type {number}
+  * @private
+  */
   this.minLatP_ = -Infinity;
 
-  /**
-   * @type {number}
-   * @private
-   */
+ /**
+  * @type {number}
+  * @private
+  */
   this.minLonP_ = -Infinity;
 
-  /**
-   * @type {number}
-   * @private
-   */
+ /**
+  * @type {number}
+  * @private
+  */
   this.targetSize_ = options.targetSize !== undefined ?
-      options.targetSize : 100;
+     options.targetSize : 100;
 
-  /**
-   * @type {number}
-   * @private
-   */
+ /**
+  * @type {number}
+  * @private
+  */
   this.maxLines_ = options.maxLines !== undefined ? options.maxLines : 100;
-  ol.DEBUG && console.assert(this.maxLines_ > 0,
-      'this.maxLines_ should be more than 0');
 
-  /**
-   * @type {Array.<ol.geom.LineString>}
-   * @private
-   */
+ /**
+  * @type {Array.<ol.geom.LineString>}
+  * @private
+  */
   this.meridians_ = [];
 
-  /**
-   * @type {Array.<ol.geom.LineString>}
-   * @private
-   */
+ /**
+  * @type {Array.<ol.geom.LineString>}
+  * @private
+  */
   this.parallels_ = [];
 
-  /**
-   * @type {ol.style.Stroke}
-   * @private
-   */
+ /**
+  * @type {ol.style.Stroke}
+  * @private
+  */
   this.strokeStyle_ = options.strokeStyle !== undefined ?
-      options.strokeStyle : ol.Graticule.DEFAULT_STROKE_STYLE_;
+     options.strokeStyle : ol.Graticule.DEFAULT_STROKE_STYLE_;
 
-  /**
-   * @type {ol.TransformFunction|undefined}
-   * @private
-   */
+ /**
+  * @type {ol.TransformFunction|undefined}
+  * @private
+  */
   this.fromLonLatTransform_ = undefined;
 
-  /**
-   * @type {ol.TransformFunction|undefined}
-   * @private
-   */
+ /**
+  * @type {ol.TransformFunction|undefined}
+  * @private
+  */
   this.toLonLatTransform_ = undefined;
 
-  /**
-   * @type {ol.Coordinate}
-   * @private
-   */
+ /**
+  * @type {ol.Coordinate}
+  * @private
+  */
   this.projectionCenterLonLat_ = null;
 
   this.setMap(options.map !== undefined ? options.map : null);
@@ -334,16 +331,10 @@ ol.Graticule.prototype.getMap = function() {
  */
 ol.Graticule.prototype.getMeridian_ = function(lon, minLat, maxLat,
                                                squaredTolerance, index) {
-  ol.DEBUG && console.assert(lon >= this.minLon_,
-      'lon should be larger than or equal to this.minLon_');
-  ol.DEBUG && console.assert(lon <= this.maxLon_,
-      'lon should be smaller than or equal to this.maxLon_');
   var flatCoordinates = ol.geom.flat.geodesic.meridian(lon,
-      minLat, maxLat, this.projection_, squaredTolerance);
-  ol.DEBUG && console.assert(flatCoordinates.length > 0,
-      'flatCoordinates cannot be empty');
+     minLat, maxLat, this.projection_, squaredTolerance);
   var lineString = this.meridians_[index] !== undefined ?
-      this.meridians_[index] : new ol.geom.LineString(null);
+     this.meridians_[index] : new ol.geom.LineString(null);
   lineString.setFlatCoordinates(ol.geom.GeometryLayout.XY, flatCoordinates);
   return lineString;
 };
@@ -370,16 +361,10 @@ ol.Graticule.prototype.getMeridians = function() {
  */
 ol.Graticule.prototype.getParallel_ = function(lat, minLon, maxLon,
                                                squaredTolerance, index) {
-  ol.DEBUG && console.assert(lat >= this.minLat_,
-      'lat should be larger than or equal to this.minLat_');
-  ol.DEBUG && console.assert(lat <= this.maxLat_,
-      'lat should be smaller than or equal to this.maxLat_');
   var flatCoordinates = ol.geom.flat.geodesic.parallel(lat,
-      this.minLon_, this.maxLon_, this.projection_, squaredTolerance);
-  ol.DEBUG && console.assert(flatCoordinates.length > 0,
-      'flatCoordinates cannot be empty');
+     this.minLon_, this.maxLon_, this.projection_, squaredTolerance);
   var lineString = this.parallels_[index] !== undefined ?
-      this.parallels_[index] : new ol.geom.LineString(null);
+     this.parallels_[index] : new ol.geom.LineString(null);
   lineString.setFlatCoordinates(ol.geom.GeometryLayout.XY, flatCoordinates);
   return lineString;
 };
@@ -461,7 +446,7 @@ ol.Graticule.prototype.updateProjectionInfo_ = function(projection) {
   var extent = projection.getExtent();
   var worldExtent = projection.getWorldExtent();
   var worldExtentP = ol.proj.transformExtent(worldExtent,
-      epsg4326Projection, projection);
+     epsg4326Projection, projection);
 
   var maxLat = worldExtent[3];
   var maxLon = worldExtent[2];
@@ -472,20 +457,6 @@ ol.Graticule.prototype.updateProjectionInfo_ = function(projection) {
   var maxLonP = worldExtentP[2];
   var minLatP = worldExtentP[1];
   var minLonP = worldExtentP[0];
-
-  ol.DEBUG && console.assert(maxLat !== undefined, 'maxLat should be defined');
-  ol.DEBUG && console.assert(maxLon !== undefined, 'maxLon should be defined');
-  ol.DEBUG && console.assert(minLat !== undefined, 'minLat should be defined');
-  ol.DEBUG && console.assert(minLon !== undefined, 'minLon should be defined');
-
-  ol.DEBUG && console.assert(maxLatP !== undefined,
-      'projected maxLat should be defined');
-  ol.DEBUG && console.assert(maxLonP !== undefined,
-      'projected maxLon should be defined');
-  ol.DEBUG && console.assert(minLatP !== undefined,
-      'projected minLat should be defined');
-  ol.DEBUG && console.assert(minLonP !== undefined,
-      'projected minLon should be defined');
 
   this.maxLat_ = maxLat;
   this.maxLon_ = maxLon;
@@ -499,13 +470,13 @@ ol.Graticule.prototype.updateProjectionInfo_ = function(projection) {
 
 
   this.fromLonLatTransform_ = ol.proj.getTransform(
-      epsg4326Projection, projection);
+     epsg4326Projection, projection);
 
   this.toLonLatTransform_ = ol.proj.getTransform(
-      projection, epsg4326Projection);
+     projection, epsg4326Projection);
 
   this.projectionCenterLonLat_ = this.toLonLatTransform_(
-      ol.extent.getCenter(extent));
+     ol.extent.getCenter(extent));
 
   this.projection_ = projection;
 };

--- a/src/ol/image.js
+++ b/src/ol/image.js
@@ -131,8 +131,6 @@ ol.Image.prototype.load = function() {
   if (this.state == ol.ImageState.IDLE || this.state == ol.ImageState.ERROR) {
     this.state = ol.ImageState.LOADING;
     this.changed();
-    ol.DEBUG && console.assert(!this.imageListenerKeys_,
-        'this.imageListenerKeys_ should be null');
     this.imageListenerKeys_ = [
       ol.events.listenOnce(this.image_, ol.events.EventType.ERROR,
           this.handleImageError_, this),

--- a/src/ol/imagebase.js
+++ b/src/ol/imagebase.js
@@ -96,7 +96,6 @@ ol.ImageBase.prototype.getPixelRatio = function() {
  * @return {number} Resolution.
  */
 ol.ImageBase.prototype.getResolution = function() {
-  ol.DEBUG && console.assert(this.resolution !== undefined, 'resolution not yet set');
   return /** @type {number} */ (this.resolution);
 };
 

--- a/src/ol/imagecanvas.js
+++ b/src/ol/imagecanvas.js
@@ -77,7 +77,6 @@ ol.ImageCanvas.prototype.handleLoad_ = function(err) {
  */
 ol.ImageCanvas.prototype.load = function() {
   if (this.state == ol.ImageState.IDLE) {
-    ol.DEBUG && console.assert(this.loader_, 'this.loader_ must be set');
     this.state = ol.ImageState.LOADING;
     this.changed();
     this.loader_(this.handleLoad_.bind(this));

--- a/src/ol/imagetile.js
+++ b/src/ol/imagetile.js
@@ -125,8 +125,6 @@ ol.ImageTile.prototype.load = function() {
   if (this.state == ol.TileState.IDLE || this.state == ol.TileState.ERROR) {
     this.state = ol.TileState.LOADING;
     this.changed();
-    ol.DEBUG && console.assert(!this.imageListenerKeys_,
-        'this.imageListenerKeys_ should be null');
     this.imageListenerKeys_ = [
       ol.events.listenOnce(this.image_, ol.events.EventType.ERROR,
           this.handleImageError_, this),

--- a/src/ol/index.js
+++ b/src/ol/index.js
@@ -9,12 +9,6 @@ goog.provide('ol');
 
 
 /**
- * @define {boolean} Enable debug mode. Default is `true`.
- */
-ol.DEBUG = true;
-
-
-/**
  * @define {boolean} Assume touch.  Default is `false`.
  */
 ol.ASSUME_TOUCH = false;

--- a/src/ol/interaction/draganddrop.js
+++ b/src/ol/interaction/draganddrop.js
@@ -100,8 +100,6 @@ ol.interaction.DragAndDrop.prototype.handleResult_ = function(file, event) {
   if (!projection) {
     var view = map.getView();
     projection = view.getProjection();
-    ol.DEBUG && console.assert(projection !== undefined,
-        'projection should be defined');
   }
   var formatConstructors = this.formatConstructors_;
   var features = [];

--- a/src/ol/interaction/dragpan.js
+++ b/src/ol/interaction/dragpan.js
@@ -62,8 +62,6 @@ ol.inherits(ol.interaction.DragPan, ol.interaction.Pointer);
  * @private
  */
 ol.interaction.DragPan.handleDragEvent_ = function(mapBrowserEvent) {
-  ol.DEBUG && console.assert(this.targetPointers.length >= 1,
-      'the length of this.targetPointers should be more than 1');
   var centroid =
       ol.interaction.Pointer.centroid(this.targetPointers);
   if (this.kinetic_) {

--- a/src/ol/interaction/draw.js
+++ b/src/ol/interaction/draw.js
@@ -476,7 +476,6 @@ ol.interaction.Draw.prototype.startDrawing_ = function(event) {
         new ol.geom.LineString(this.sketchLineCoords_));
   }
   var geometry = this.geometryFunction_(this.sketchCoords_);
-  ol.DEBUG && console.assert(geometry !== undefined, 'geometry should be defined');
   this.sketchFeature_ = new ol.Feature();
   if (this.geometryName_) {
     this.sketchFeature_.setGeometryName(this.geometryName_);
@@ -512,7 +511,6 @@ ol.interaction.Draw.prototype.modifyDrawing_ = function(event) {
   }
   last[0] = coordinate[0];
   last[1] = coordinate[1];
-  ol.DEBUG && console.assert(this.sketchCoords_, 'sketchCoords_ expected');
   this.geometryFunction_(
       /** @type {!ol.Coordinate|!Array.<ol.Coordinate>|!Array.<Array.<ol.Coordinate>>} */ (this.sketchCoords_),
       geometry);
@@ -680,10 +678,6 @@ ol.interaction.Draw.prototype.abortDrawing_ = function() {
  */
 ol.interaction.Draw.prototype.extend = function(feature) {
   var geometry = feature.getGeometry();
-  ol.DEBUG && console.assert(this.mode_ == ol.interaction.Draw.Mode_.LINE_STRING,
-      'interaction mode must be "line"');
-  ol.DEBUG && console.assert(geometry.getType() == ol.geom.GeometryType.LINE_STRING,
-      'feature geometry must be a line string');
   var lineString = /** @type {ol.geom.LineString} */ (geometry);
   this.sketchFeature_ = feature;
   this.sketchCoords_ = lineString.getCoordinates();

--- a/src/ol/interaction/modify.js
+++ b/src/ol/interaction/modify.js
@@ -931,8 +931,6 @@ ol.interaction.Modify.prototype.removeVertex_ = function() {
         segments.push(right.segment[1]);
       }
       if (left !== undefined && right !== undefined) {
-        ol.DEBUG && console.assert(newIndex >= 0, 'newIndex should be larger than 0');
-
         var newSegmentData = /** @type {ol.ModifySegmentDataType} */ ({
           depth: segmentData.depth,
           feature: segmentData.feature,

--- a/src/ol/interaction/pinchrotate.js
+++ b/src/ol/interaction/pinchrotate.js
@@ -73,8 +73,6 @@ ol.inherits(ol.interaction.PinchRotate, ol.interaction.Pointer);
  * @private
  */
 ol.interaction.PinchRotate.handleDragEvent_ = function(mapBrowserEvent) {
-  ol.DEBUG && console.assert(this.targetPointers.length >= 2,
-      'length of this.targetPointers should be greater than or equal to 2');
   var rotationDelta = 0.0;
 
   var touch0 = this.targetPointers[0];

--- a/src/ol/interaction/pinchzoom.js
+++ b/src/ol/interaction/pinchzoom.js
@@ -67,8 +67,6 @@ ol.inherits(ol.interaction.PinchZoom, ol.interaction.Pointer);
  * @private
  */
 ol.interaction.PinchZoom.handleDragEvent_ = function(mapBrowserEvent) {
-  ol.DEBUG && console.assert(this.targetPointers.length >= 2,
-      'length of this.targetPointers should be 2 or more');
   var scaleDelta = 1.0;
 
   var touch0 = this.targetPointers[0];
@@ -102,7 +100,6 @@ ol.interaction.PinchZoom.handleDragEvent_ = function(mapBrowserEvent) {
   map.render();
   ol.interaction.Interaction.zoomWithoutConstraints(
       map, view, resolution * scaleDelta, this.anchor_);
-
 };
 
 

--- a/src/ol/layer/group.js
+++ b/src/ol/layer/group.js
@@ -123,8 +123,6 @@ ol.layer.Group.prototype.handleLayersChanged_ = function(event) {
 ol.layer.Group.prototype.handleLayersAdd_ = function(collectionEvent) {
   var layer = /** @type {ol.layer.Base} */ (collectionEvent.element);
   var key = ol.getUid(layer).toString();
-  ol.DEBUG && console.assert(!(key in this.listenerKeys_),
-      'listeners already registered');
   this.listenerKeys_[key] = [
     ol.events.listen(layer, ol.ObjectEventType.PROPERTYCHANGE,
         this.handleLayerChange_, this),
@@ -142,7 +140,6 @@ ol.layer.Group.prototype.handleLayersAdd_ = function(collectionEvent) {
 ol.layer.Group.prototype.handleLayersRemove_ = function(collectionEvent) {
   var layer = /** @type {ol.layer.Base} */ (collectionEvent.element);
   var key = ol.getUid(layer).toString();
-  ol.DEBUG && console.assert(key in this.listenerKeys_, 'no listeners to unregister');
   this.listenerKeys_[key].forEach(ol.events.unlistenByKey);
   delete this.listenerKeys_[key];
   this.changed();

--- a/src/ol/layer/heatmap.js
+++ b/src/ol/layer/heatmap.js
@@ -90,13 +90,8 @@ ol.layer.Heatmap = function(opt_options) {
   } else {
     weightFunction = weight;
   }
-  ol.DEBUG && console.assert(typeof weightFunction === 'function',
-      'weightFunction should be a function');
 
   this.setStyle(function(feature, resolution) {
-    ol.DEBUG && console.assert(this.styleCache_, 'this.styleCache_ expected');
-    ol.DEBUG && console.assert(this.circleImage_ !== undefined,
-        'this.circleImage_ should be defined');
     var weight = weightFunction(feature);
     var opacity = weight !== undefined ? ol.math.clamp(weight, 0, 1) : 1;
     // cast to 8 bits
@@ -121,7 +116,6 @@ ol.layer.Heatmap = function(opt_options) {
   this.setRenderOrder(null);
 
   ol.events.listen(this, ol.render.EventType.RENDER, this.handleRender_, this);
-
 };
 ol.inherits(ol.layer.Heatmap, ol.layer.Vector);
 
@@ -163,8 +157,6 @@ ol.layer.Heatmap.createGradient_ = function(colors) {
 ol.layer.Heatmap.prototype.createCircle_ = function() {
   var radius = this.getRadius();
   var blur = this.getBlur();
-  ol.DEBUG && console.assert(radius !== undefined && blur !== undefined,
-      'radius and blur should be defined');
   var halfSize = radius + blur + 1;
   var size = 2 * halfSize;
   var context = ol.dom.createCanvasContext2D(size, size);
@@ -236,9 +228,6 @@ ol.layer.Heatmap.prototype.handleStyleChanged_ = function() {
  * @private
  */
 ol.layer.Heatmap.prototype.handleRender_ = function(event) {
-  ol.DEBUG && console.assert(event.type == ol.render.EventType.RENDER,
-      'event.type should be RENDER');
-  ol.DEBUG && console.assert(this.gradient_, 'this.gradient_ expected');
   var context = event.context;
   var canvas = context.canvas;
   var image = context.getImageData(0, 0, canvas.width, canvas.height);

--- a/src/ol/layer/vector.js
+++ b/src/ol/layer/vector.js
@@ -23,14 +23,8 @@ goog.require('ol.style.Style');
  * @api stable
  */
 ol.layer.Vector = function(opt_options) {
-
   var options = opt_options ?
-      opt_options : /** @type {olx.layer.VectorOptions} */ ({});
-
-  ol.DEBUG && console.assert(
-      options.renderOrder === undefined || !options.renderOrder ||
-      typeof options.renderOrder === 'function',
-      'renderOrder must be a comparator function');
+     opt_options : /** @type {olx.layer.VectorOptions} */ ({});
 
   var baseOptions = ol.obj.assign({}, options);
 
@@ -40,43 +34,42 @@ ol.layer.Vector = function(opt_options) {
   delete baseOptions.updateWhileInteracting;
   ol.layer.Layer.call(this, /** @type {olx.layer.LayerOptions} */ (baseOptions));
 
-  /**
-   * @type {number}
-   * @private
-   */
+ /**
+  * @type {number}
+  * @private
+  */
   this.renderBuffer_ = options.renderBuffer !== undefined ?
-      options.renderBuffer : 100;
+     options.renderBuffer : 100;
 
-  /**
-   * User provided style.
-   * @type {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction}
-   * @private
-   */
+ /**
+  * User provided style.
+  * @type {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction}
+  * @private
+  */
   this.style_ = null;
 
-  /**
-   * Style function for use within the library.
-   * @type {ol.StyleFunction|undefined}
-   * @private
-   */
+ /**
+  * Style function for use within the library.
+  * @type {ol.StyleFunction|undefined}
+  * @private
+  */
   this.styleFunction_ = undefined;
 
   this.setStyle(options.style);
 
-  /**
-   * @type {boolean}
-   * @private
-   */
+ /**
+  * @type {boolean}
+  * @private
+  */
   this.updateWhileAnimating_ = options.updateWhileAnimating !== undefined ?
-      options.updateWhileAnimating : false;
+     options.updateWhileAnimating : false;
 
-  /**
-   * @type {boolean}
-   * @private
-   */
+ /**
+  * @type {boolean}
+  * @private
+  */
   this.updateWhileInteracting_ = options.updateWhileInteracting !== undefined ?
-      options.updateWhileInteracting : false;
-
+     options.updateWhileInteracting : false;
 };
 ol.inherits(ol.layer.Vector, ol.layer.Layer);
 
@@ -168,10 +161,6 @@ ol.layer.Vector.prototype.getUpdateWhileInteracting = function() {
  *     Render order.
  */
 ol.layer.Vector.prototype.setRenderOrder = function(renderOrder) {
-  ol.DEBUG && console.assert(
-      renderOrder === undefined || !renderOrder ||
-      typeof renderOrder === 'function',
-      'renderOrder must be a comparator function');
   this.set(ol.layer.Vector.Property_.RENDER_ORDER, renderOrder);
 };
 

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -529,7 +529,6 @@ ol.Map.prototype.addOverlayInternal_ = function(overlay) {
  * @api
  */
 ol.Map.prototype.beforeRender = function(var_args) {
-  ol.DEBUG && console.warn('map.beforeRender() is deprecated.  Use view.animate() instead.');
   this.render();
   Array.prototype.push.apply(this.preRenderFunctions_, arguments);
 };
@@ -1025,8 +1024,6 @@ ol.Map.prototype.handleTargetChanged_ = function() {
   var targetElement;
   if (this.getTarget()) {
     targetElement = this.getTargetElement();
-    ol.DEBUG && console.assert(targetElement !== null,
-        'expects a non-null value for targetElement');
   }
 
   if (this.keyHandlerKeys_) {
@@ -1462,7 +1459,6 @@ ol.Map.createOptionsInternal = function(options) {
       ol.asserts.assert(false, 46); // Incorrect format for `renderer` option
     }
     if (rendererTypes.indexOf(/** @type {ol.renderer.Type} */ ('dom')) >= 0) {
-      ol.DEBUG && console.assert(false, 'The DOM render has been removed');
       rendererTypes = rendererTypes.concat(ol.DEFAULT_RENDERER_TYPES);
     }
   } else {

--- a/src/ol/mapbrowsereventhandler.js
+++ b/src/ol/mapbrowsereventhandler.js
@@ -156,20 +156,17 @@ ol.MapBrowserEventHandler.prototype.updateActivePointers_ = function(pointerEven
 ol.MapBrowserEventHandler.prototype.handlePointerUp_ = function(pointerEvent) {
   this.updateActivePointers_(pointerEvent);
   var newEvent = new ol.MapBrowserPointerEvent(
-      ol.MapBrowserEventType.POINTERUP, this.map_, pointerEvent);
+     ol.MapBrowserEventType.POINTERUP, this.map_, pointerEvent);
   this.dispatchEvent(newEvent);
 
-  // We emulate click events on left mouse button click, touch contact, and pen
-  // contact. isMouseActionButton returns true in these cases (evt.button is set
-  // to 0).
-  // See http://www.w3.org/TR/pointerevents/#button-states
+ // We emulate click events on left mouse button click, touch contact, and pen
+ // contact. isMouseActionButton returns true in these cases (evt.button is set
+ // to 0).
+ // See http://www.w3.org/TR/pointerevents/#button-states
   if (!this.dragging_ && this.isMouseActionButton_(pointerEvent)) {
-    ol.DEBUG && console.assert(this.down_, 'this.down_ must be truthy');
     this.emulateClick_(this.down_);
   }
 
-  ol.DEBUG && console.assert(this.activePointers_ >= 0,
-      'this.activePointers_ should be equal to or larger than 0');
   if (this.activePointers_ === 0) {
     this.dragListenerKeys_.forEach(ol.events.unlistenByKey);
     this.dragListenerKeys_.length = 0;

--- a/src/ol/math.js
+++ b/src/ol/math.js
@@ -107,13 +107,6 @@ ol.math.squaredDistance = function(x1, y1, x2, y2) {
 ol.math.solveLinearSystem = function(mat) {
   var n = mat.length;
 
-  if (ol.DEBUG) {
-    for (var row = 0; row < n; row++) {
-      console.assert(mat[row].length == n + 1,
-                          'every row should have correct number of columns');
-    }
-  }
-
   for (var i = 0; i < n; i++) {
     // Find max in the i-th column (ignoring i - 1 first rows)
     var maxRow = i;

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -463,8 +463,6 @@ ol.Overlay.prototype.updateRenderedPosition = function(pixel, mapSize) {
   var offset = this.getOffset();
 
   var positioning = this.getPositioning();
-  ol.DEBUG && console.assert(positioning !== undefined,
-      'positioning should be defined');
 
   var offsetX = offset[0];
   var offsetY = offset[1];

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -33,8 +33,6 @@ if (ol.ENABLE_PROJ4JS) {
    * @api
    */
   ol.proj.setProj4 = function(proj4) {
-    ol.DEBUG && console.assert(typeof proj4 == 'function',
-        'proj4 argument should be a function');
     ol.proj.proj4.set(proj4);
   };
 }
@@ -376,7 +374,6 @@ ol.proj.getTransformFromProjections = function(sourceProjection, destinationProj
     }
   }
   if (!transform) {
-    ol.DEBUG && console.assert(transform, 'transform should be defined');
     transform = ol.proj.identityTransform;
   }
   return transform;
@@ -391,8 +388,6 @@ ol.proj.getTransformFromProjections = function(sourceProjection, destinationProj
  */
 ol.proj.identityTransform = function(input, opt_output, opt_dimension) {
   if (opt_output !== undefined && input !== opt_output) {
-    // TODO: consider making this a warning instead
-    ol.DEBUG && console.assert(false, 'This should not be used internally.');
     for (var i = 0, ii = input.length; i < ii; ++i) {
       opt_output[i] = input[i];
     }

--- a/src/ol/proj/epsg3857.js
+++ b/src/ol/proj/epsg3857.js
@@ -109,8 +109,6 @@ ol.proj.EPSG3857.fromEPSG4326 = function(input, opt_output, opt_dimension) {
       output = new Array(length);
     }
   }
-  ol.DEBUG && console.assert(output.length % dimension === 0,
-      'modulus of output.length with dimension should be 0');
   var halfSize = ol.proj.EPSG3857.HALF_SIZE;
   for (var i = 0; i < length; i += dimension) {
     output[i] = halfSize * input[i] / 180;
@@ -147,8 +145,6 @@ ol.proj.EPSG3857.toEPSG4326 = function(input, opt_output, opt_dimension) {
       output = new Array(length);
     }
   }
-  ol.DEBUG && console.assert(output.length % dimension === 0,
-      'modulus of output.length with dimension should be 0');
   for (var i = 0; i < length; i += dimension) {
     output[i] = 180 * input[i] / ol.proj.EPSG3857.HALF_SIZE;
     output[i + 1] = 360 * Math.atan(

--- a/src/ol/proj/projection.js
+++ b/src/ol/proj/projection.js
@@ -36,72 +36,69 @@ goog.require('ol.proj.proj4');
  * @api stable
  */
 ol.proj.Projection = function(options) {
-
-  /**
-   * @private
-   * @type {string}
-   */
+ /**
+  * @private
+  * @type {string}
+  */
   this.code_ = options.code;
 
-  /**
-   * @private
-   * @type {ol.proj.Units}
-   */
+ /**
+  * @private
+  * @type {ol.proj.Units}
+  */
   this.units_ = /** @type {ol.proj.Units} */ (options.units);
 
-  /**
-   * @private
-   * @type {ol.Extent}
-   */
+ /**
+  * @private
+  * @type {ol.Extent}
+  */
   this.extent_ = options.extent !== undefined ? options.extent : null;
 
-  /**
-   * @private
-   * @type {ol.Extent}
-   */
+ /**
+  * @private
+  * @type {ol.Extent}
+  */
   this.worldExtent_ = options.worldExtent !== undefined ?
-      options.worldExtent : null;
+     options.worldExtent : null;
 
-  /**
-   * @private
-   * @type {string}
-   */
+ /**
+  * @private
+  * @type {string}
+  */
   this.axisOrientation_ = options.axisOrientation !== undefined ?
-      options.axisOrientation : 'enu';
+     options.axisOrientation : 'enu';
 
-  /**
-   * @private
-   * @type {boolean}
-   */
+ /**
+  * @private
+  * @type {boolean}
+  */
   this.global_ = options.global !== undefined ? options.global : false;
 
-  /**
-   * @private
-   * @type {boolean}
-   */
+ /**
+  * @private
+  * @type {boolean}
+  */
   this.canWrapX_ = !!(this.global_ && this.extent_);
 
-  /**
-  * @private
-  * @type {function(number, ol.Coordinate):number|undefined}
-  */
+ /**
+ * @private
+ * @type {function(number, ol.Coordinate):number|undefined}
+ */
   this.getPointResolutionFunc_ = options.getPointResolution;
 
-  /**
-   * @private
-   * @type {ol.tilegrid.TileGrid}
-   */
+ /**
+  * @private
+  * @type {ol.tilegrid.TileGrid}
+  */
   this.defaultTileGrid_ = null;
 
-  /**
-   * @private
-   * @type {number|undefined}
-   */
+ /**
+  * @private
+  * @type {number|undefined}
+  */
   this.metersPerUnit_ = options.metersPerUnit;
 
   var code = options.code;
-  ol.DEBUG && console.assert(code !== undefined,
-      'Option "code" is required for constructing instance');
   if (ol.ENABLE_PROJ4JS) {
     var proj4js = ol.proj.proj4.get();
     if (typeof proj4js == 'function') {
@@ -119,7 +116,6 @@ ol.proj.Projection = function(options) {
       }
     }
   }
-
 };
 
 

--- a/src/ol/proj/transforms.js
+++ b/src/ol/proj/transforms.js
@@ -51,10 +51,6 @@ ol.proj.transforms.remove = function(source, destination) {
   var sourceCode = source.getCode();
   var destinationCode = destination.getCode();
   var transforms = ol.proj.transforms.cache_;
-  ol.DEBUG && console.assert(sourceCode in transforms,
-      'sourceCode should be in transforms');
-  ol.DEBUG && console.assert(destinationCode in transforms[sourceCode],
-      'destinationCode should be in transforms of sourceCode');
   var transform = transforms[sourceCode][destinationCode];
   delete transforms[sourceCode][destinationCode];
   if (ol.obj.isEmpty(transforms[sourceCode])) {

--- a/src/ol/render/canvas/imagereplay.js
+++ b/src/ol/render/canvas/imagereplay.js
@@ -120,35 +120,15 @@ ol.render.canvas.ImageReplay.prototype.drawPoint = function(pointGeometry, featu
   if (!this.image_) {
     return;
   }
-  ol.DEBUG && console.assert(this.anchorX_ !== undefined,
-      'this.anchorX_ should be defined');
-  ol.DEBUG && console.assert(this.anchorY_ !== undefined,
-      'this.anchorY_ should be defined');
-  ol.DEBUG && console.assert(this.height_ !== undefined,
-      'this.height_ should be defined');
-  ol.DEBUG && console.assert(this.opacity_ !== undefined,
-      'this.opacity_ should be defined');
-  ol.DEBUG && console.assert(this.originX_ !== undefined,
-      'this.originX_ should be defined');
-  ol.DEBUG && console.assert(this.originY_ !== undefined,
-      'this.originY_ should be defined');
-  ol.DEBUG && console.assert(this.rotateWithView_ !== undefined,
-      'this.rotateWithView_ should be defined');
-  ol.DEBUG && console.assert(this.rotation_ !== undefined,
-      'this.rotation_ should be defined');
-  ol.DEBUG && console.assert(this.scale_ !== undefined,
-      'this.scale_ should be defined');
-  ol.DEBUG && console.assert(this.width_ !== undefined,
-      'this.width_ should be defined');
   this.beginGeometry(pointGeometry, feature);
   var flatCoordinates = pointGeometry.getFlatCoordinates();
   var stride = pointGeometry.getStride();
   var myBegin = this.coordinates.length;
   var myEnd = this.drawCoordinates_(
-      flatCoordinates, 0, flatCoordinates.length, stride);
+        flatCoordinates, 0, flatCoordinates.length, stride);
   this.instructions.push([
     ol.render.canvas.Instruction.DRAW_IMAGE, myBegin, myEnd, this.image_,
-    // Remaining arguments to DRAW_IMAGE are in alphabetical order
+      // Remaining arguments to DRAW_IMAGE are in alphabetical order
     this.anchorX_, this.anchorY_, this.height_, this.opacity_,
     this.originX_, this.originY_, this.rotateWithView_, this.rotation_,
     this.scale_, this.snapToPixel_, this.width_
@@ -156,7 +136,7 @@ ol.render.canvas.ImageReplay.prototype.drawPoint = function(pointGeometry, featu
   this.hitDetectionInstructions.push([
     ol.render.canvas.Instruction.DRAW_IMAGE, myBegin, myEnd,
     this.hitDetectionImage_,
-    // Remaining arguments to DRAW_IMAGE are in alphabetical order
+      // Remaining arguments to DRAW_IMAGE are in alphabetical order
     this.anchorX_, this.anchorY_, this.height_, this.opacity_,
     this.originX_, this.originY_, this.rotateWithView_, this.rotation_,
     this.scale_, this.snapToPixel_, this.width_
@@ -172,35 +152,15 @@ ol.render.canvas.ImageReplay.prototype.drawMultiPoint = function(multiPointGeome
   if (!this.image_) {
     return;
   }
-  ol.DEBUG && console.assert(this.anchorX_ !== undefined,
-      'this.anchorX_ should be defined');
-  ol.DEBUG && console.assert(this.anchorY_ !== undefined,
-      'this.anchorY_ should be defined');
-  ol.DEBUG && console.assert(this.height_ !== undefined,
-      'this.height_ should be defined');
-  ol.DEBUG && console.assert(this.opacity_ !== undefined,
-      'this.opacity_ should be defined');
-  ol.DEBUG && console.assert(this.originX_ !== undefined,
-      'this.originX_ should be defined');
-  ol.DEBUG && console.assert(this.originY_ !== undefined,
-      'this.originY_ should be defined');
-  ol.DEBUG && console.assert(this.rotateWithView_ !== undefined,
-      'this.rotateWithView_ should be defined');
-  ol.DEBUG && console.assert(this.rotation_ !== undefined,
-      'this.rotation_ should be defined');
-  ol.DEBUG && console.assert(this.scale_ !== undefined,
-      'this.scale_ should be defined');
-  ol.DEBUG && console.assert(this.width_ !== undefined,
-      'this.width_ should be defined');
   this.beginGeometry(multiPointGeometry, feature);
   var flatCoordinates = multiPointGeometry.getFlatCoordinates();
   var stride = multiPointGeometry.getStride();
   var myBegin = this.coordinates.length;
   var myEnd = this.drawCoordinates_(
-      flatCoordinates, 0, flatCoordinates.length, stride);
+        flatCoordinates, 0, flatCoordinates.length, stride);
   this.instructions.push([
     ol.render.canvas.Instruction.DRAW_IMAGE, myBegin, myEnd, this.image_,
-    // Remaining arguments to DRAW_IMAGE are in alphabetical order
+      // Remaining arguments to DRAW_IMAGE are in alphabetical order
     this.anchorX_, this.anchorY_, this.height_, this.opacity_,
     this.originX_, this.originY_, this.rotateWithView_, this.rotation_,
     this.scale_, this.snapToPixel_, this.width_
@@ -208,7 +168,7 @@ ol.render.canvas.ImageReplay.prototype.drawMultiPoint = function(multiPointGeome
   this.hitDetectionInstructions.push([
     ol.render.canvas.Instruction.DRAW_IMAGE, myBegin, myEnd,
     this.hitDetectionImage_,
-    // Remaining arguments to DRAW_IMAGE are in alphabetical order
+      // Remaining arguments to DRAW_IMAGE are in alphabetical order
     this.anchorX_, this.anchorY_, this.height_, this.opacity_,
     this.originX_, this.originY_, this.rotateWithView_, this.rotation_,
     this.scale_, this.snapToPixel_, this.width_
@@ -243,18 +203,11 @@ ol.render.canvas.ImageReplay.prototype.finish = function() {
  * @inheritDoc
  */
 ol.render.canvas.ImageReplay.prototype.setImageStyle = function(imageStyle) {
-  ol.DEBUG && console.assert(imageStyle, 'imageStyle should not be null');
   var anchor = imageStyle.getAnchor();
-  ol.DEBUG && console.assert(anchor, 'anchor should not be null');
   var size = imageStyle.getSize();
-  ol.DEBUG && console.assert(size, 'size should not be null');
   var hitDetectionImage = imageStyle.getHitDetectionImage(1);
-  ol.DEBUG && console.assert(hitDetectionImage,
-      'hitDetectionImage should not be null');
   var image = imageStyle.getImage(1);
-  ol.DEBUG && console.assert(image, 'image should not be null');
   var origin = imageStyle.getOrigin();
-  ol.DEBUG && console.assert(origin, 'origin should not be null');
   this.anchorX_ = anchor[0];
   this.anchorY_ = anchor[1];
   this.hitDetectionImage_ = hitDetectionImage;

--- a/src/ol/render/canvas/immediate.js
+++ b/src/ol/render/canvas/immediate.js
@@ -251,9 +251,6 @@ ol.render.canvas.Immediate.prototype.drawImages_ = function(flatCoordinates, off
   if (!this.image_) {
     return;
   }
-  ol.DEBUG && console.assert(offset === 0, 'offset should be 0');
-  ol.DEBUG && console.assert(end == flatCoordinates.length,
-      'end should be equal to the length of flatCoordinates');
   var pixelCoordinates = ol.geom.flat.transform.transform2D(
       flatCoordinates, offset, end, 2, this.transform_,
       this.pixelCoordinates_);
@@ -316,9 +313,6 @@ ol.render.canvas.Immediate.prototype.drawText_ = function(flatCoordinates, offse
     this.setContextStrokeState_(this.textStrokeState_);
   }
   this.setContextTextState_(this.textState_);
-  ol.DEBUG && console.assert(offset === 0, 'offset should be 0');
-  ol.DEBUG && console.assert(end == flatCoordinates.length,
-      'end should be equal to the length of flatCoordinates');
   var pixelCoordinates = ol.geom.flat.transform.transform2D(
       flatCoordinates, offset, end, stride, this.transform_,
       this.pixelCoordinates_);
@@ -487,7 +481,6 @@ ol.render.canvas.Immediate.prototype.drawGeometry = function(geometry) {
       this.drawCircle(/** @type {ol.geom.Circle} */ (geometry));
       break;
     default:
-      ol.DEBUG && console.assert(false, 'Unsupported geometry type: ' + type);
   }
 };
 
@@ -862,7 +855,6 @@ ol.render.canvas.Immediate.prototype.setImageStyle = function(imageStyle) {
     var imageImage = imageStyle.getImage(1);
     var imageOrigin = imageStyle.getOrigin();
     var imageSize = imageStyle.getSize();
-    ol.DEBUG && console.assert(imageImage, 'imageImage must be truthy');
     this.imageAnchorX_ = imageAnchor[0];
     this.imageAnchorY_ = imageAnchor[1];
     this.imageHeight_ = imageSize[1];

--- a/src/ol/render/canvas/linestringreplay.js
+++ b/src/ol/render/canvas/linestringreplay.js
@@ -110,13 +110,6 @@ ol.render.canvas.LineStringReplay.prototype.setStrokeStyle_ = function() {
   var lineJoin = state.lineJoin;
   var lineWidth = state.lineWidth;
   var miterLimit = state.miterLimit;
-  ol.DEBUG && console.assert(strokeStyle !== undefined,
-      'strokeStyle should be defined');
-  ol.DEBUG && console.assert(lineCap !== undefined, 'lineCap should be defined');
-  ol.DEBUG && console.assert(lineDash, 'lineDash should not be null');
-  ol.DEBUG && console.assert(lineJoin !== undefined, 'lineJoin should be defined');
-  ol.DEBUG && console.assert(lineWidth !== undefined, 'lineWidth should be defined');
-  ol.DEBUG && console.assert(miterLimit !== undefined, 'miterLimit should be defined');
   if (state.currentStrokeStyle != strokeStyle ||
       state.currentLineCap != lineCap ||
       !ol.array.equals(state.currentLineDash, lineDash) ||
@@ -148,7 +141,6 @@ ol.render.canvas.LineStringReplay.prototype.setStrokeStyle_ = function() {
  */
 ol.render.canvas.LineStringReplay.prototype.drawLineString = function(lineStringGeometry, feature) {
   var state = this.state_;
-  ol.DEBUG && console.assert(state, 'state should not be null');
   var strokeStyle = state.strokeStyle;
   var lineWidth = state.lineWidth;
   if (strokeStyle === undefined || lineWidth === undefined) {
@@ -176,7 +168,6 @@ ol.render.canvas.LineStringReplay.prototype.drawLineString = function(lineString
  */
 ol.render.canvas.LineStringReplay.prototype.drawMultiLineString = function(multiLineStringGeometry, feature) {
   var state = this.state_;
-  ol.DEBUG && console.assert(state, 'state should not be null');
   var strokeStyle = state.strokeStyle;
   var lineWidth = state.lineWidth;
   if (strokeStyle === undefined || lineWidth === undefined) {
@@ -210,7 +201,6 @@ ol.render.canvas.LineStringReplay.prototype.drawMultiLineString = function(multi
  */
 ol.render.canvas.LineStringReplay.prototype.finish = function() {
   var state = this.state_;
-  ol.DEBUG && console.assert(state, 'state should not be null');
   if (state.lastStroke != this.coordinates.length) {
     this.instructions.push([ol.render.canvas.Instruction.STROKE]);
   }
@@ -223,9 +213,6 @@ ol.render.canvas.LineStringReplay.prototype.finish = function() {
  * @inheritDoc
  */
 ol.render.canvas.LineStringReplay.prototype.setFillStrokeStyle = function(fillStyle, strokeStyle) {
-  ol.DEBUG && console.assert(this.state_, 'this.state_ should not be null');
-  ol.DEBUG && console.assert(!fillStyle, 'fillStyle should be null');
-  ol.DEBUG && console.assert(strokeStyle, 'strokeStyle should not be null');
   var strokeStyleColor = strokeStyle.getColor();
   this.state_.strokeStyle = ol.colorlike.asColorLike(strokeStyleColor ?
       strokeStyleColor : ol.render.canvas.defaultStrokeStyle);

--- a/src/ol/render/canvas/polygonreplay.js
+++ b/src/ol/render/canvas/polygonreplay.js
@@ -108,8 +108,6 @@ ol.render.canvas.PolygonReplay.prototype.drawFlatCoordinatess_ = function(flatCo
     this.instructions.push(fillInstruction);
   }
   if (stroke) {
-    ol.DEBUG && console.assert(state.lineWidth !== undefined,
-        'state.lineWidth should be defined');
     var strokeInstruction = [ol.render.canvas.Instruction.STROKE];
     this.instructions.push(strokeInstruction);
     this.hitDetectionInstructions.push(strokeInstruction);
@@ -123,15 +121,10 @@ ol.render.canvas.PolygonReplay.prototype.drawFlatCoordinatess_ = function(flatCo
  */
 ol.render.canvas.PolygonReplay.prototype.drawCircle = function(circleGeometry, feature) {
   var state = this.state_;
-  ol.DEBUG && console.assert(state, 'state should not be null');
   var fillStyle = state.fillStyle;
   var strokeStyle = state.strokeStyle;
   if (fillStyle === undefined && strokeStyle === undefined) {
     return;
-  }
-  if (strokeStyle !== undefined) {
-    ol.DEBUG && console.assert(state.lineWidth !== undefined,
-        'state.lineWidth should be defined');
   }
   this.setFillStrokeStyles_(circleGeometry);
   this.beginGeometry(circleGeometry, feature);
@@ -162,8 +155,6 @@ ol.render.canvas.PolygonReplay.prototype.drawCircle = function(circleGeometry, f
     this.instructions.push(fillInstruction);
   }
   if (state.strokeStyle !== undefined) {
-    ol.DEBUG && console.assert(state.lineWidth !== undefined,
-        'state.lineWidth should be defined');
     var strokeInstruction = [ol.render.canvas.Instruction.STROKE];
     this.instructions.push(strokeInstruction);
     this.hitDetectionInstructions.push(strokeInstruction);
@@ -177,14 +168,6 @@ ol.render.canvas.PolygonReplay.prototype.drawCircle = function(circleGeometry, f
  */
 ol.render.canvas.PolygonReplay.prototype.drawPolygon = function(polygonGeometry, feature) {
   var state = this.state_;
-  ol.DEBUG && console.assert(state, 'state should not be null');
-  var strokeStyle = state.strokeStyle;
-  ol.DEBUG && console.assert(state.fillStyle !== undefined || strokeStyle !== undefined,
-      'fillStyle or strokeStyle should be defined');
-  if (strokeStyle !== undefined) {
-    ol.DEBUG && console.assert(state.lineWidth !== undefined,
-        'state.lineWidth should be defined');
-  }
   this.setFillStrokeStyles_(polygonGeometry);
   this.beginGeometry(polygonGeometry, feature);
   // always fill the polygon for hit detection
@@ -212,15 +195,10 @@ ol.render.canvas.PolygonReplay.prototype.drawPolygon = function(polygonGeometry,
  */
 ol.render.canvas.PolygonReplay.prototype.drawMultiPolygon = function(multiPolygonGeometry, feature) {
   var state = this.state_;
-  ol.DEBUG && console.assert(state, 'state should not be null');
   var fillStyle = state.fillStyle;
   var strokeStyle = state.strokeStyle;
   if (fillStyle === undefined && strokeStyle === undefined) {
     return;
-  }
-  if (strokeStyle !== undefined) {
-    ol.DEBUG && console.assert(state.lineWidth !== undefined,
-        'state.lineWidth should be defined');
   }
   this.setFillStrokeStyles_(multiPolygonGeometry);
   this.beginGeometry(multiPolygonGeometry, feature);
@@ -253,7 +231,6 @@ ol.render.canvas.PolygonReplay.prototype.drawMultiPolygon = function(multiPolygo
  * @inheritDoc
  */
 ol.render.canvas.PolygonReplay.prototype.finish = function() {
-  ol.DEBUG && console.assert(this.state_, 'this.state_ should not be null');
   this.reverseHitDetectionInstructions();
   this.state_ = null;
   // We want to preserve topology when drawing polygons.  Polygons are
@@ -290,9 +267,6 @@ ol.render.canvas.PolygonReplay.prototype.getBufferedMaxExtent = function() {
  * @inheritDoc
  */
 ol.render.canvas.PolygonReplay.prototype.setFillStrokeStyle = function(fillStyle, strokeStyle) {
-  ol.DEBUG && console.assert(this.state_, 'this.state_ should not be null');
-  ol.DEBUG && console.assert(fillStyle || strokeStyle,
-      'fillStyle or strokeStyle should not be null');
   var state = this.state_;
   if (fillStyle) {
     var fillStyleColor = fillStyle.getColor();
@@ -360,12 +334,6 @@ ol.render.canvas.PolygonReplay.prototype.setFillStrokeStyles_ = function(geometr
     state.currentFillStyle = state.fillStyle;
   }
   if (strokeStyle !== undefined) {
-    ol.DEBUG && console.assert(lineCap !== undefined, 'lineCap should be defined');
-    ol.DEBUG && console.assert(lineDash, 'lineDash should not be null');
-    ol.DEBUG && console.assert(lineJoin !== undefined, 'lineJoin should be defined');
-    ol.DEBUG && console.assert(lineWidth !== undefined, 'lineWidth should be defined');
-    ol.DEBUG && console.assert(miterLimit !== undefined,
-        'miterLimit should be defined');
     if (state.currentStrokeStyle != strokeStyle ||
         state.currentLineCap != lineCap ||
         !ol.array.equals(state.currentLineDash, lineDash) ||

--- a/src/ol/render/canvas/replay.js
+++ b/src/ol/render/canvas/replay.js
@@ -2,7 +2,6 @@ goog.provide('ol.render.canvas.Replay');
 
 goog.require('ol');
 goog.require('ol.array');
-goog.require('ol.colorlike');
 goog.require('ol.extent');
 goog.require('ol.extent.Relationship');
 goog.require('ol.geom.flat.transform');
@@ -237,8 +236,6 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         this.coordinates, 0, this.coordinates.length, 2,
         transform, this.pixelCoordinates_);
     ol.transform.setFromArray(this.renderedTransform_, transform);
-    ol.DEBUG && console.assert(pixelCoordinates === this.pixelCoordinates_,
-        'pixelCoordinates should be the same as this.pixelCoordinates_');
   }
   var skipFeatures = !ol.obj.isEmpty(skippedFeaturesHash);
   var i = 0; // instruction index
@@ -287,8 +284,6 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         ++i;
         break;
       case ol.render.canvas.Instruction.CIRCLE:
-        ol.DEBUG && console.assert(typeof instruction[1] === 'number',
-            'second instruction should be a number');
         d = /** @type {number} */ (instruction[1]);
         var x1 = pixelCoordinates[d];
         var y1 = pixelCoordinates[d + 1];
@@ -306,11 +301,7 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         ++i;
         break;
       case ol.render.canvas.Instruction.DRAW_IMAGE:
-        ol.DEBUG && console.assert(typeof instruction[1] === 'number',
-            'second instruction should be a number');
         d = /** @type {number} */ (instruction[1]);
-        ol.DEBUG && console.assert(typeof instruction[2] === 'number',
-            'third instruction should be a number');
         dd = /** @type {number} */ (instruction[2]);
         var image =  /** @type {HTMLCanvasElement|HTMLVideoElement|Image} */
             (instruction[3]);
@@ -364,32 +355,14 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         ++i;
         break;
       case ol.render.canvas.Instruction.DRAW_TEXT:
-        ol.DEBUG && console.assert(typeof instruction[1] === 'number',
-            '2nd instruction should be a number');
         d = /** @type {number} */ (instruction[1]);
-        ol.DEBUG && console.assert(typeof instruction[2] === 'number',
-            '3rd instruction should be a number');
         dd = /** @type {number} */ (instruction[2]);
-        ol.DEBUG && console.assert(typeof instruction[3] === 'string',
-            '4th instruction should be a string');
         text = /** @type {string} */ (instruction[3]);
-        ol.DEBUG && console.assert(typeof instruction[4] === 'number',
-            '5th instruction should be a number');
         var offsetX = /** @type {number} */ (instruction[4]) * pixelRatio;
-        ol.DEBUG && console.assert(typeof instruction[5] === 'number',
-            '6th instruction should be a number');
         var offsetY = /** @type {number} */ (instruction[5]) * pixelRatio;
-        ol.DEBUG && console.assert(typeof instruction[6] === 'number',
-            '7th instruction should be a number');
         rotation = /** @type {number} */ (instruction[6]);
-        ol.DEBUG && console.assert(typeof instruction[7] === 'number',
-            '8th instruction should be a number');
         scale = /** @type {number} */ (instruction[7]) * pixelRatio;
-        ol.DEBUG && console.assert(typeof instruction[8] === 'boolean',
-            '9th instruction should be a boolean');
         fill = /** @type {boolean} */ (instruction[8]);
-        ol.DEBUG && console.assert(typeof instruction[9] === 'boolean',
-            '10th instruction should be a boolean');
         stroke = /** @type {boolean} */ (instruction[9]);
         rotateWithView = /** @type {boolean} */ (instruction[10]);
         if (rotateWithView) {
@@ -456,11 +429,7 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         ++i;
         break;
       case ol.render.canvas.Instruction.MOVE_TO_LINE_TO:
-        ol.DEBUG && console.assert(typeof instruction[1] === 'number',
-            '2nd instruction should be a number');
         d = /** @type {number} */ (instruction[1]);
-        ol.DEBUG && console.assert(typeof instruction[2] === 'number',
-            '3rd instruction should be a number');
         dd = /** @type {number} */ (instruction[2]);
         x = pixelCoordinates[d];
         y = pixelCoordinates[d + 1];
@@ -485,10 +454,6 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         ++i;
         break;
       case ol.render.canvas.Instruction.SET_FILL_STYLE:
-        ol.DEBUG && console.assert(
-            ol.colorlike.isColorLike(instruction[1]),
-            '2nd instruction should be a string, ' +
-            'CanvasPattern, or CanvasGradient');
         this.fillOrigin_ = instruction[2];
 
         if (pendingFill) {
@@ -500,20 +465,6 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         ++i;
         break;
       case ol.render.canvas.Instruction.SET_STROKE_STYLE:
-        ol.DEBUG && console.assert(ol.colorlike.isColorLike(instruction[1]),
-            '2nd instruction should be a string, CanvasPattern, or CanvasGradient');
-        ol.DEBUG && console.assert(typeof instruction[2] === 'number',
-            '3rd instruction should be a number');
-        ol.DEBUG && console.assert(typeof instruction[3] === 'string',
-            '4rd instruction should be a string');
-        ol.DEBUG && console.assert(typeof instruction[4] === 'string',
-            '5th instruction should be a string');
-        ol.DEBUG && console.assert(typeof instruction[5] === 'number',
-            '6th instruction should be a number');
-        ol.DEBUG && console.assert(instruction[6],
-            '7th instruction should not be null');
-        ol.DEBUG && console.assert(typeof instruction[8] === 'number',
-            '9th instruction should be a number');
         var usePixelRatio = instruction[7] !== undefined ?
             instruction[7] : true;
         var renderedPixelRatio = instruction[8];
@@ -544,12 +495,6 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         ++i;
         break;
       case ol.render.canvas.Instruction.SET_TEXT_STYLE:
-        ol.DEBUG && console.assert(typeof instruction[1] === 'string',
-            '2nd instruction should be a string');
-        ol.DEBUG && console.assert(typeof instruction[2] === 'string',
-            '3rd instruction should be a string');
-        ol.DEBUG && console.assert(typeof instruction[3] === 'string',
-            '4th instruction should be a string');
         context.font = /** @type {string} */ (instruction[1]);
         context.textAlign = /** @type {string} */ (instruction[2]);
         context.textBaseline = /** @type {string} */ (instruction[3]);
@@ -564,7 +509,6 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         ++i;
         break;
       default:
-        ol.DEBUG && console.assert(false, 'Unknown canvas render instruction');
         ++i; // consume the instruction anyway, to avoid an infinite loop
         break;
     }
@@ -575,9 +519,6 @@ ol.render.canvas.Replay.prototype.replay_ = function(
   if (pendingStroke) {
     context.stroke();
   }
-  // assert that all instructions were consumed
-  ol.DEBUG && console.assert(i == instructions.length,
-      'all instructions should be consumed');
   return undefined;
 };
 
@@ -637,12 +578,9 @@ ol.render.canvas.Replay.prototype.reverseHitDetectionInstructions = function() {
     instruction = hitDetectionInstructions[i];
     type = /** @type {ol.render.canvas.Instruction} */ (instruction[0]);
     if (type == ol.render.canvas.Instruction.END_GEOMETRY) {
-      ol.DEBUG && console.assert(begin == -1, 'begin should be -1');
       begin = i;
     } else if (type == ol.render.canvas.Instruction.BEGIN_GEOMETRY) {
       instruction[2] = i;
-      ol.DEBUG && console.assert(begin >= 0,
-          'begin should be larger than or equal to 0');
       ol.array.reverseSubArray(this.hitDetectionInstructions, begin, i);
       begin = -1;
     }
@@ -655,12 +593,8 @@ ol.render.canvas.Replay.prototype.reverseHitDetectionInstructions = function() {
  * @param {ol.Feature|ol.render.Feature} feature Feature.
  */
 ol.render.canvas.Replay.prototype.endGeometry = function(geometry, feature) {
-  ol.DEBUG && console.assert(this.beginGeometryInstruction1_,
-      'this.beginGeometryInstruction1_ should not be null');
   this.beginGeometryInstruction1_[2] = this.instructions.length;
   this.beginGeometryInstruction1_ = null;
-  ol.DEBUG && console.assert(this.beginGeometryInstruction2_,
-      'this.beginGeometryInstruction2_ should not be null');
   this.beginGeometryInstruction2_[2] = this.hitDetectionInstructions.length;
   this.beginGeometryInstruction2_ = null;
   var endGeometryInstruction =

--- a/src/ol/render/canvas/replaygroup.js
+++ b/src/ol/render/canvas/replaygroup.js
@@ -276,9 +276,6 @@ ol.render.canvas.ReplayGroup.prototype.getReplay = function(zIndex, replayType) 
   var replay = replays[replayType];
   if (replay === undefined) {
     var Constructor = ol.render.canvas.ReplayGroup.BATCH_CONSTRUCTORS_[replayType];
-    ol.DEBUG && console.assert(Constructor !== undefined,
-        replayType +
-        ' constructor missing from ol.render.canvas.ReplayGroup.BATCH_CONSTRUCTORS_');
     replay = new Constructor(this.tolerance_, this.maxExtent_,
         this.resolution_, this.overlaps_);
     replays[replayType] = replay;

--- a/src/ol/render/feature.js
+++ b/src/ol/render/feature.js
@@ -18,19 +18,11 @@ goog.require('ol.geom.GeometryType');
  * @param {Object.<string, *>} properties Properties.
  */
 ol.render.Feature = function(type, flatCoordinates, ends, properties) {
-
   /**
    * @private
    * @type {ol.Extent|undefined}
    */
   this.extent_;
-
-  ol.DEBUG && console.assert(type === ol.geom.GeometryType.POINT ||
-      type === ol.geom.GeometryType.MULTI_POINT ||
-      type === ol.geom.GeometryType.LINE_STRING ||
-      type === ol.geom.GeometryType.MULTI_LINE_STRING ||
-      type === ol.geom.GeometryType.POLYGON,
-      'Need a Point, MultiPoint, LineString, MultiLineString or Polygon type');
 
   /**
    * @private
@@ -55,7 +47,6 @@ ol.render.Feature = function(type, flatCoordinates, ends, properties) {
    * @type {Object.<string, *>}
    */
   this.properties_ = properties;
-
 };
 
 

--- a/src/ol/render/webgl/circlereplay.js
+++ b/src/ol/render/webgl/circlereplay.js
@@ -178,10 +178,6 @@ ol.render.webgl.CircleReplay.prototype.getDeleteResourcesFunction = function(con
   // be used by other CircleReplay instances (for other layers). And
   // they will be deleted when disposing of the ol.webgl.Context
   // object.
-  ol.DEBUG && console.assert(this.verticesBuffer,
-      'verticesBuffer must not be null');
-  ol.DEBUG && console.assert(this.indicesBuffer,
-      'indicesBuffer must not be null');
   var verticesBuffer = this.verticesBuffer;
   var indicesBuffer = this.indicesBuffer;
   return function() {
@@ -251,9 +247,6 @@ ol.render.webgl.CircleReplay.prototype.drawReplay = function(gl, context, skippe
   if (!ol.obj.isEmpty(skippedFeaturesHash)) {
     this.drawReplaySkipping_(gl, context, skippedFeaturesHash);
   } else {
-    ol.DEBUG && console.assert(this.styles_.length === this.styleIndices_.length,
-        'number of styles and styleIndices match');
-
     //Draw by style groups to minimize drawElements() calls.
     var i, start, end, nextStyle;
     end = this.startIndices[this.startIndices.length - 1];
@@ -275,11 +268,6 @@ ol.render.webgl.CircleReplay.prototype.drawReplay = function(gl, context, skippe
  */
 ol.render.webgl.CircleReplay.prototype.drawHitDetectionReplayOneByOne = function(gl, context, skippedFeaturesHash,
     featureCallback, opt_hitExtent) {
-  ol.DEBUG && console.assert(this.styles_.length === this.styleIndices_.length,
-      'number of styles and styleIndices match');
-  ol.DEBUG && console.assert(this.startIndices.length - 1 === this.startIndicesFeature.length,
-      'number of startIndices and startIndicesFeature match');
-
   var i, start, end, nextStyle, groupStart, feature, featureUid, featureIndex;
   featureIndex = this.startIndices.length - 2;
   end = this.startIndices[featureIndex + 1];
@@ -326,9 +314,6 @@ ol.render.webgl.CircleReplay.prototype.drawHitDetectionReplayOneByOne = function
  * @param {Object} skippedFeaturesHash Ids of features to skip.
  */
 ol.render.webgl.CircleReplay.prototype.drawReplaySkipping_ = function(gl, context, skippedFeaturesHash) {
-  ol.DEBUG && console.assert(this.startIndices.length - 1 === this.startIndicesFeature.length,
-      'number of startIndices and startIndicesFeature match');
-
   var i, start, end, nextStyle, groupStart, feature, featureUid, featureIndex, featureStart;
   featureIndex = this.startIndices.length - 2;
   end = start = this.startIndices[featureIndex + 1];
@@ -388,7 +373,6 @@ ol.render.webgl.CircleReplay.prototype.setStrokeStyle_ = function(gl, color, lin
  * @inheritDoc
  */
 ol.render.webgl.CircleReplay.prototype.setFillStrokeStyle = function(fillStyle, strokeStyle) {
-  ol.DEBUG && console.assert(this.state_, 'this.state_ should not be null');
   var strokeStyleColor, strokeStyleWidth;
   if (strokeStyle) {
     var strokeStyleLineDash = strokeStyle.getLineDash();

--- a/src/ol/render/webgl/circlereplay/defaultshader.js
+++ b/src/ol/render/webgl/circlereplay/defaultshader.js
@@ -35,9 +35,7 @@ ol.render.webgl.circlereplay.defaultshader.Fragment.OPTIMIZED_SOURCE = 'precisio
  * @const
  * @type {string}
  */
-ol.render.webgl.circlereplay.defaultshader.Fragment.SOURCE = ol.DEBUG ?
-    ol.render.webgl.circlereplay.defaultshader.Fragment.DEBUG_SOURCE :
-    ol.render.webgl.circlereplay.defaultshader.Fragment.OPTIMIZED_SOURCE;
+ol.render.webgl.circlereplay.defaultshader.Fragment.SOURCE = ol.render.webgl.circlereplay.defaultshader.Fragment.OPTIMIZED_SOURCE;
 
 
 ol.render.webgl.circlereplay.defaultshader.fragment = new ol.render.webgl.circlereplay.defaultshader.Fragment();
@@ -72,9 +70,7 @@ ol.render.webgl.circlereplay.defaultshader.Vertex.OPTIMIZED_SOURCE = 'varying ve
  * @const
  * @type {string}
  */
-ol.render.webgl.circlereplay.defaultshader.Vertex.SOURCE = ol.DEBUG ?
-    ol.render.webgl.circlereplay.defaultshader.Vertex.DEBUG_SOURCE :
-    ol.render.webgl.circlereplay.defaultshader.Vertex.OPTIMIZED_SOURCE;
+ol.render.webgl.circlereplay.defaultshader.Vertex.SOURCE = ol.render.webgl.circlereplay.defaultshader.Vertex.OPTIMIZED_SOURCE;
 
 
 ol.render.webgl.circlereplay.defaultshader.vertex = new ol.render.webgl.circlereplay.defaultshader.Vertex();
@@ -91,72 +87,60 @@ ol.render.webgl.circlereplay.defaultshader.Locations = function(gl, program) {
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_fillColor = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_fillColor' : 'n');
+  this.u_fillColor = gl.getUniformLocation(program, 'n');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_lineWidth = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_lineWidth' : 'k');
+  this.u_lineWidth = gl.getUniformLocation(program, 'k');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_offsetRotateMatrix = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_offsetRotateMatrix' : 'j');
+  this.u_offsetRotateMatrix = gl.getUniformLocation(program, 'j');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_offsetScaleMatrix = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_offsetScaleMatrix' : 'i');
+  this.u_offsetScaleMatrix = gl.getUniformLocation(program, 'i');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_opacity = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_opacity' : 'm');
+  this.u_opacity = gl.getUniformLocation(program, 'm');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_pixelRatio = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_pixelRatio' : 'l');
+  this.u_pixelRatio = gl.getUniformLocation(program, 'l');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_projectionMatrix = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_projectionMatrix' : 'h');
+  this.u_projectionMatrix = gl.getUniformLocation(program, 'h');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_size = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_size' : 'p');
+  this.u_size = gl.getUniformLocation(program, 'p');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_strokeColor = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_strokeColor' : 'o');
+  this.u_strokeColor = gl.getUniformLocation(program, 'o');
 
   /**
    * @type {number}
    */
-  this.a_instruction = gl.getAttribLocation(
-      program, ol.DEBUG ? 'a_instruction' : 'f');
+  this.a_instruction = gl.getAttribLocation(program, 'f');
 
   /**
    * @type {number}
    */
-  this.a_position = gl.getAttribLocation(
-      program, ol.DEBUG ? 'a_position' : 'e');
+  this.a_position = gl.getAttribLocation(program, 'e');
 
   /**
    * @type {number}
    */
-  this.a_radius = gl.getAttribLocation(
-      program, ol.DEBUG ? 'a_radius' : 'g');
+  this.a_radius = gl.getAttribLocation(program, 'g');
 };

--- a/src/ol/render/webgl/imagereplay.js
+++ b/src/ol/render/webgl/imagereplay.js
@@ -142,14 +142,6 @@ ol.inherits(ol.render.webgl.ImageReplay, ol.render.webgl.Replay);
  * @inheritDoc
  */
 ol.render.webgl.ImageReplay.prototype.getDeleteResourcesFunction = function(context) {
-  // We only delete our stuff here. The shaders and the program may
-  // be used by other ImageReplay instances (for other layers). And
-  // they will be deleted when disposing of the ol.webgl.Context
-  // object.
-  ol.DEBUG && console.assert(this.verticesBuffer,
-      'verticesBuffer must not be null');
-  ol.DEBUG && console.assert(this.indicesBuffer,
-      'indicesBuffer must not be null');
   var verticesBuffer = this.verticesBuffer;
   var indicesBuffer = this.indicesBuffer;
   var textures = this.textures_;
@@ -180,20 +172,6 @@ ol.render.webgl.ImageReplay.prototype.getDeleteResourcesFunction = function(cont
  * @private
  */
 ol.render.webgl.ImageReplay.prototype.drawCoordinates_ = function(flatCoordinates, offset, end, stride) {
-  ol.DEBUG && console.assert(this.anchorX_ !== undefined, 'anchorX is defined');
-  ol.DEBUG && console.assert(this.anchorY_ !== undefined, 'anchorY is defined');
-  ol.DEBUG && console.assert(this.height_ !== undefined, 'height is defined');
-  ol.DEBUG && console.assert(this.imageHeight_ !== undefined,
-      'imageHeight is defined');
-  ol.DEBUG && console.assert(this.imageWidth_ !== undefined, 'imageWidth is defined');
-  ol.DEBUG && console.assert(this.opacity_ !== undefined, 'opacity is defined');
-  ol.DEBUG && console.assert(this.originX_ !== undefined, 'originX is defined');
-  ol.DEBUG && console.assert(this.originY_ !== undefined, 'originY is defined');
-  ol.DEBUG && console.assert(this.rotateWithView_ !== undefined,
-      'rotateWithView is defined');
-  ol.DEBUG && console.assert(this.rotation_ !== undefined, 'rotation is defined');
-  ol.DEBUG && console.assert(this.scale_ !== undefined, 'scale is defined');
-  ol.DEBUG && console.assert(this.width_ !== undefined, 'width is defined');
   var anchorX = /** @type {number} */ (this.anchorX_);
   var anchorY = /** @type {number} */ (this.anchorY_);
   var height = /** @type {number} */ (this.height_);
@@ -321,21 +299,12 @@ ol.render.webgl.ImageReplay.prototype.finish = function(context) {
   var gl = context.getGL();
 
   this.groupIndices_.push(this.indices.length);
-  ol.DEBUG && console.assert(this.images_.length === this.groupIndices_.length,
-      'number of images and groupIndices match');
   this.hitDetectionGroupIndices_.push(this.indices.length);
-  ol.DEBUG && console.assert(this.hitDetectionImages_.length ===
-      this.hitDetectionGroupIndices_.length,
-      'number of hitDetectionImages and hitDetectionGroupIndices match');
 
   // create, bind, and populate the vertices buffer
   this.verticesBuffer = new ol.webgl.Buffer(this.vertices);
 
   var indices = this.indices;
-  var bits = context.hasOESElementIndexUint ? 32 : 16;
-  ol.DEBUG && console.assert(indices[indices.length - 1] < Math.pow(2, bits),
-      'Too large element index detected [%s] (OES_element_index_uint "%s")',
-      indices[indices.length - 1], context.hasOESElementIndexUint);
 
   // create, bind, and populate the indices buffer
   this.indicesBuffer = new ol.webgl.Buffer(indices);
@@ -345,14 +314,9 @@ ol.render.webgl.ImageReplay.prototype.finish = function(context) {
   var texturePerImage = {};
 
   this.createTextures_(this.textures_, this.images_, texturePerImage, gl);
-  ol.DEBUG && console.assert(this.textures_.length === this.groupIndices_.length,
-      'number of textures and groupIndices match');
 
   this.createTextures_(this.hitDetectionTextures_, this.hitDetectionImages_,
       texturePerImage, gl);
-  ol.DEBUG && console.assert(this.hitDetectionTextures_.length ===
-      this.hitDetectionGroupIndices_.length,
-      'number of hitDetectionTextures and hitDetectionGroupIndices match');
 
   this.anchorX_ = undefined;
   this.anchorY_ = undefined;
@@ -382,9 +346,6 @@ ol.render.webgl.ImageReplay.prototype.finish = function(context) {
  * @param {WebGLRenderingContext} gl Gl.
  */
 ol.render.webgl.ImageReplay.prototype.createTextures_ = function(textures, images, texturePerImage, gl) {
-  ol.DEBUG && console.assert(textures.length === 0,
-      'upon creation, textures is empty');
-
   var texture, image, uid, i;
   var ii = images.length;
   for (i = 0; i < ii; ++i) {
@@ -468,8 +429,6 @@ ol.render.webgl.ImageReplay.prototype.shutDownProgram = function(gl, locations) 
 ol.render.webgl.ImageReplay.prototype.drawReplay = function(gl, context, skippedFeaturesHash, hitDetection) {
   var textures = hitDetection ? this.hitDetectionTextures_ : this.textures_;
   var groupIndices = hitDetection ? this.hitDetectionGroupIndices_ : this.groupIndices_;
-  ol.DEBUG && console.assert(textures.length === groupIndices.length,
-      'number of textures and groupIndeces match');
 
   if (!ol.obj.isEmpty(skippedFeaturesHash)) {
     this.drawReplaySkipping_(
@@ -561,10 +520,6 @@ ol.render.webgl.ImageReplay.prototype.drawReplaySkipping_ = function(gl, context
  */
 ol.render.webgl.ImageReplay.prototype.drawHitDetectionReplayOneByOne = function(gl, context, skippedFeaturesHash,
     featureCallback, opt_hitExtent) {
-  ol.DEBUG && console.assert(this.hitDetectionTextures_.length ===
-      this.hitDetectionGroupIndices_.length,
-      'number of hitDetectionTextures and hitDetectionGroupIndices match');
-
   var i, groupStart, start, end, feature, featureUid;
   var featureIndex = this.startIndices.length - 1;
   for (i = this.hitDetectionTextures_.length - 1; i >= 0; --i) {
@@ -609,28 +564,12 @@ ol.render.webgl.ImageReplay.prototype.setImageStyle = function(imageStyle) {
   var image = imageStyle.getImage(1);
   var imageSize = imageStyle.getImageSize();
   var hitDetectionImage = imageStyle.getHitDetectionImage(1);
-  var hitDetectionImageSize = imageStyle.getHitDetectionImageSize();
   var opacity = imageStyle.getOpacity();
   var origin = imageStyle.getOrigin();
   var rotateWithView = imageStyle.getRotateWithView();
   var rotation = imageStyle.getRotation();
   var size = imageStyle.getSize();
   var scale = imageStyle.getScale();
-  ol.DEBUG && console.assert(anchor, 'imageStyle anchor is not null');
-  ol.DEBUG && console.assert(image, 'imageStyle image is not null');
-  ol.DEBUG && console.assert(imageSize,
-      'imageStyle imageSize is not null');
-  ol.DEBUG && console.assert(hitDetectionImage,
-      'imageStyle hitDetectionImage is not null');
-  ol.DEBUG && console.assert(hitDetectionImageSize,
-      'imageStyle hitDetectionImageSize is not null');
-  ol.DEBUG && console.assert(opacity !== undefined, 'imageStyle opacity is defined');
-  ol.DEBUG && console.assert(origin, 'imageStyle origin is not null');
-  ol.DEBUG && console.assert(rotateWithView !== undefined,
-      'imageStyle rotateWithView is defined');
-  ol.DEBUG && console.assert(rotation !== undefined, 'imageStyle rotation is defined');
-  ol.DEBUG && console.assert(size, 'imageStyle size is not null');
-  ol.DEBUG && console.assert(scale !== undefined, 'imageStyle scale is defined');
 
   var currentImage;
   if (this.images_.length === 0) {
@@ -639,8 +578,6 @@ ol.render.webgl.ImageReplay.prototype.setImageStyle = function(imageStyle) {
     currentImage = this.images_[this.images_.length - 1];
     if (ol.getUid(currentImage) != ol.getUid(image)) {
       this.groupIndices_.push(this.indices.length);
-      ol.DEBUG && console.assert(this.groupIndices_.length === this.images_.length,
-          'number of groupIndices and images match');
       this.images_.push(image);
     }
   }
@@ -652,9 +589,6 @@ ol.render.webgl.ImageReplay.prototype.setImageStyle = function(imageStyle) {
         this.hitDetectionImages_[this.hitDetectionImages_.length - 1];
     if (ol.getUid(currentImage) != ol.getUid(hitDetectionImage)) {
       this.hitDetectionGroupIndices_.push(this.indices.length);
-      ol.DEBUG && console.assert(this.hitDetectionGroupIndices_.length ===
-          this.hitDetectionImages_.length,
-          'number of hitDetectionGroupIndices and hitDetectionImages match');
       this.hitDetectionImages_.push(hitDetectionImage);
     }
   }

--- a/src/ol/render/webgl/imagereplay/defaultshader.js
+++ b/src/ol/render/webgl/imagereplay/defaultshader.js
@@ -35,9 +35,7 @@ ol.render.webgl.imagereplay.defaultshader.Fragment.OPTIMIZED_SOURCE = 'precision
  * @const
  * @type {string}
  */
-ol.render.webgl.imagereplay.defaultshader.Fragment.SOURCE = ol.DEBUG ?
-    ol.render.webgl.imagereplay.defaultshader.Fragment.DEBUG_SOURCE :
-    ol.render.webgl.imagereplay.defaultshader.Fragment.OPTIMIZED_SOURCE;
+ol.render.webgl.imagereplay.defaultshader.Fragment.SOURCE = ol.render.webgl.imagereplay.defaultshader.Fragment.OPTIMIZED_SOURCE;
 
 
 ol.render.webgl.imagereplay.defaultshader.fragment = new ol.render.webgl.imagereplay.defaultshader.Fragment();
@@ -72,9 +70,7 @@ ol.render.webgl.imagereplay.defaultshader.Vertex.OPTIMIZED_SOURCE = 'varying vec
  * @const
  * @type {string}
  */
-ol.render.webgl.imagereplay.defaultshader.Vertex.SOURCE = ol.DEBUG ?
-    ol.render.webgl.imagereplay.defaultshader.Vertex.DEBUG_SOURCE :
-    ol.render.webgl.imagereplay.defaultshader.Vertex.OPTIMIZED_SOURCE;
+ol.render.webgl.imagereplay.defaultshader.Vertex.SOURCE = ol.render.webgl.imagereplay.defaultshader.Vertex.OPTIMIZED_SOURCE;
 
 
 ol.render.webgl.imagereplay.defaultshader.vertex = new ol.render.webgl.imagereplay.defaultshader.Vertex();
@@ -91,60 +87,50 @@ ol.render.webgl.imagereplay.defaultshader.Locations = function(gl, program) {
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_image = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_image' : 'l');
+  this.u_image = gl.getUniformLocation(program, 'l');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_offsetRotateMatrix = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_offsetRotateMatrix' : 'j');
+  this.u_offsetRotateMatrix = gl.getUniformLocation(program, 'j');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_offsetScaleMatrix = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_offsetScaleMatrix' : 'i');
+  this.u_offsetScaleMatrix = gl.getUniformLocation(program, 'i');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_opacity = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_opacity' : 'k');
+  this.u_opacity = gl.getUniformLocation(program, 'k');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_projectionMatrix = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_projectionMatrix' : 'h');
+  this.u_projectionMatrix = gl.getUniformLocation(program, 'h');
 
   /**
    * @type {number}
    */
-  this.a_offsets = gl.getAttribLocation(
-      program, ol.DEBUG ? 'a_offsets' : 'e');
+  this.a_offsets = gl.getAttribLocation(program, 'e');
 
   /**
    * @type {number}
    */
-  this.a_opacity = gl.getAttribLocation(
-      program, ol.DEBUG ? 'a_opacity' : 'f');
+  this.a_opacity = gl.getAttribLocation(program, 'f');
 
   /**
    * @type {number}
    */
-  this.a_position = gl.getAttribLocation(
-      program, ol.DEBUG ? 'a_position' : 'c');
+  this.a_position = gl.getAttribLocation(program, 'c');
 
   /**
    * @type {number}
    */
-  this.a_rotateWithView = gl.getAttribLocation(
-      program, ol.DEBUG ? 'a_rotateWithView' : 'g');
+  this.a_rotateWithView = gl.getAttribLocation(program, 'g');
 
   /**
    * @type {number}
    */
-  this.a_texCoord = gl.getAttribLocation(
-      program, ol.DEBUG ? 'a_texCoord' : 'd');
+  this.a_texCoord = gl.getAttribLocation(program, 'd');
 };

--- a/src/ol/render/webgl/immediate.js
+++ b/src/ol/render/webgl/immediate.js
@@ -129,7 +129,7 @@ ol.render.webgl.Immediate.prototype.drawGeometry = function(geometry) {
       this.drawCircle(/** @type {ol.geom.Circle} */ (geometry), null);
       break;
     default:
-      ol.DEBUG && console.assert(false, 'Unsupported geometry type: ' + type);
+      // pass
   }
 };
 
@@ -145,7 +145,6 @@ ol.render.webgl.Immediate.prototype.drawFeature = function(feature, style) {
     return;
   }
   this.setStyle(style);
-  ol.DEBUG && console.assert(geometry, 'geometry must be truthy');
   this.drawGeometry(geometry);
 };
 

--- a/src/ol/render/webgl/linestringreplay.js
+++ b/src/ol/render/webgl/linestringreplay.js
@@ -149,8 +149,6 @@ ol.render.webgl.LineStringReplay.prototype.drawCoordinates_ = function(flatCoord
         p2 = startCoords;
         break;
       } else {
-        //For the compiler not to complain. This will never be [0, 0].
-        ol.DEBUG && console.assert(p0, 'p0 should be defined');
         p0 = p0 || [0, 0];
 
         numVertices = this.addVertices_(p0, p1, [0, 0],
@@ -232,9 +230,6 @@ ol.render.webgl.LineStringReplay.prototype.drawCoordinates_ = function(flatCoord
   }
 
   if (closed) {
-    //Link the last triangle/rhombus to the first one.
-    //n will never be numVertices / 7 here. However, the compiler complains otherwise.
-    ol.DEBUG && console.assert(n, 'n should be defined');
     n = n || numVertices / 7;
     sign = ol.geom.flat.orient.linearRingIsClockwise([p0[0], p0[1], p1[0], p1[1], p2[0], p2[1]], 0, 6, 2)
         ? 1 : -1;
@@ -425,11 +420,6 @@ ol.render.webgl.LineStringReplay.prototype.finish = function(context) {
  * @inheritDoc
  */
 ol.render.webgl.LineStringReplay.prototype.getDeleteResourcesFunction = function(context) {
-  // We only delete our stuff here. The shaders and the program may
-  // be used by other LineStringReplay instances (for other layers). And
-  // they will be deleted when disposing of the ol.webgl.Context
-  // object.
-  ol.DEBUG && console.assert(this.verticesBuffer, 'verticesBuffer must not be null');
   var verticesBuffer = this.verticesBuffer;
   var indicesBuffer = this.indicesBuffer;
   return function() {
@@ -514,9 +504,6 @@ ol.render.webgl.LineStringReplay.prototype.drawReplay = function(gl, context, sk
   if (!ol.obj.isEmpty(skippedFeaturesHash)) {
     this.drawReplaySkipping_(gl, context, skippedFeaturesHash);
   } else {
-    ol.DEBUG && console.assert(this.styles_.length === this.styleIndices_.length,
-        'number of styles and styleIndices match');
-
     //Draw by style groups to minimize drawElements() calls.
     var i, start, end, nextStyle;
     end = this.startIndices[this.startIndices.length - 1];
@@ -546,9 +533,6 @@ ol.render.webgl.LineStringReplay.prototype.drawReplay = function(gl, context, sk
  * @param {Object} skippedFeaturesHash Ids of features to skip.
  */
 ol.render.webgl.LineStringReplay.prototype.drawReplaySkipping_ = function(gl, context, skippedFeaturesHash) {
-  ol.DEBUG && console.assert(this.startIndices.length - 1 === this.startIndicesFeature.length,
-      'number of startIndices and startIndicesFeature match');
-
   var i, start, end, nextStyle, groupStart, feature, featureUid, featureIndex, featureStart;
   featureIndex = this.startIndices.length - 2;
   end = start = this.startIndices[featureIndex + 1];
@@ -587,11 +571,6 @@ ol.render.webgl.LineStringReplay.prototype.drawReplaySkipping_ = function(gl, co
  */
 ol.render.webgl.LineStringReplay.prototype.drawHitDetectionReplayOneByOne = function(gl, context, skippedFeaturesHash,
     featureCallback, opt_hitExtent) {
-  ol.DEBUG && console.assert(this.styles_.length === this.styleIndices_.length,
-      'number of styles and styleIndices match');
-  ol.DEBUG && console.assert(this.startIndices.length - 1 === this.startIndicesFeature.length,
-      'number of startIndices and startIndicesFeature match');
-
   var i, start, end, nextStyle, groupStart, feature, featureUid, featureIndex;
   featureIndex = this.startIndices.length - 2;
   end = this.startIndices[featureIndex + 1];
@@ -647,7 +626,6 @@ ol.render.webgl.LineStringReplay.prototype.setStrokeStyle_ = function(gl, color,
  * @inheritDoc
  */
 ol.render.webgl.LineStringReplay.prototype.setFillStrokeStyle = function(fillStyle, strokeStyle) {
-  ol.DEBUG && console.assert(this.state_, 'this.state_ should not be null');
   var strokeStyleLineCap = strokeStyle.getLineCap();
   this.state_.lineCap = strokeStyleLineCap !== undefined ?
       strokeStyleLineCap : ol.render.webgl.defaultLineCap;

--- a/src/ol/render/webgl/linestringreplay/defaultshader.js
+++ b/src/ol/render/webgl/linestringreplay/defaultshader.js
@@ -35,9 +35,7 @@ ol.render.webgl.linestringreplay.defaultshader.Fragment.OPTIMIZED_SOURCE = 'prec
  * @const
  * @type {string}
  */
-ol.render.webgl.linestringreplay.defaultshader.Fragment.SOURCE = ol.DEBUG ?
-    ol.render.webgl.linestringreplay.defaultshader.Fragment.DEBUG_SOURCE :
-    ol.render.webgl.linestringreplay.defaultshader.Fragment.OPTIMIZED_SOURCE;
+ol.render.webgl.linestringreplay.defaultshader.Fragment.SOURCE = ol.render.webgl.linestringreplay.defaultshader.Fragment.OPTIMIZED_SOURCE;
 
 
 ol.render.webgl.linestringreplay.defaultshader.fragment = new ol.render.webgl.linestringreplay.defaultshader.Fragment();
@@ -72,9 +70,7 @@ ol.render.webgl.linestringreplay.defaultshader.Vertex.OPTIMIZED_SOURCE = 'varyin
  * @const
  * @type {string}
  */
-ol.render.webgl.linestringreplay.defaultshader.Vertex.SOURCE = ol.DEBUG ?
-    ol.render.webgl.linestringreplay.defaultshader.Vertex.DEBUG_SOURCE :
-    ol.render.webgl.linestringreplay.defaultshader.Vertex.OPTIMIZED_SOURCE;
+ol.render.webgl.linestringreplay.defaultshader.Vertex.SOURCE = ol.render.webgl.linestringreplay.defaultshader.Vertex.OPTIMIZED_SOURCE;
 
 
 ol.render.webgl.linestringreplay.defaultshader.vertex = new ol.render.webgl.linestringreplay.defaultshader.Vertex();
@@ -91,78 +87,65 @@ ol.render.webgl.linestringreplay.defaultshader.Locations = function(gl, program)
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_color = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_color' : 'n');
+  this.u_color = gl.getUniformLocation(program, 'n');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_lineWidth = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_lineWidth' : 'k');
+  this.u_lineWidth = gl.getUniformLocation(program, 'k');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_miterLimit = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_miterLimit' : 'l');
+  this.u_miterLimit = gl.getUniformLocation(program, 'l');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_offsetRotateMatrix = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_offsetRotateMatrix' : 'j');
+  this.u_offsetRotateMatrix = gl.getUniformLocation(program, 'j');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_offsetScaleMatrix = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_offsetScaleMatrix' : 'i');
+  this.u_offsetScaleMatrix = gl.getUniformLocation(program, 'i');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_opacity = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_opacity' : 'm');
+  this.u_opacity = gl.getUniformLocation(program, 'm');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_pixelRatio = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_pixelRatio' : 'p');
+  this.u_pixelRatio = gl.getUniformLocation(program, 'p');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_projectionMatrix = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_projectionMatrix' : 'h');
+  this.u_projectionMatrix = gl.getUniformLocation(program, 'h');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_size = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_size' : 'o');
+  this.u_size = gl.getUniformLocation(program, 'o');
 
   /**
    * @type {number}
    */
-  this.a_direction = gl.getAttribLocation(
-      program, ol.DEBUG ? 'a_direction' : 'g');
+  this.a_direction = gl.getAttribLocation(program, 'g');
 
   /**
    * @type {number}
    */
-  this.a_lastPos = gl.getAttribLocation(
-      program, ol.DEBUG ? 'a_lastPos' : 'd');
+  this.a_lastPos = gl.getAttribLocation(program, 'd');
 
   /**
    * @type {number}
    */
-  this.a_nextPos = gl.getAttribLocation(
-      program, ol.DEBUG ? 'a_nextPos' : 'f');
+  this.a_nextPos = gl.getAttribLocation(program, 'f');
 
   /**
    * @type {number}
    */
-  this.a_position = gl.getAttribLocation(
-      program, ol.DEBUG ? 'a_position' : 'e');
+  this.a_position = gl.getAttribLocation(program, 'e');
 };

--- a/src/ol/render/webgl/polygonreplay.js
+++ b/src/ol/render/webgl/polygonreplay.js
@@ -296,8 +296,6 @@ ol.render.webgl.PolygonReplay.prototype.triangulate_ = function(list, rtree) {
           // Due to the behavior of OL's PIP algorithm, the ear clipping cannot
           // introduce touching segments. However, the original data may have some.
           if (!this.resolveLocalSelfIntersections_(list, rtree, true)) {
-            // Something went wrong.
-            ol.DEBUG && console.assert(false, 'Unexpected simple polygon geometry');
             break;
           }
         }
@@ -809,14 +807,6 @@ ol.render.webgl.PolygonReplay.prototype.finish = function(context) {
  * @inheritDoc
  */
 ol.render.webgl.PolygonReplay.prototype.getDeleteResourcesFunction = function(context) {
-  // We only delete our stuff here. The shaders and the program may
-  // be used by other PolygonReplay instances (for other layers). And
-  // they will be deleted when disposing of the ol.webgl.Context
-  // object.
-  ol.DEBUG && console.assert(this.verticesBuffer,
-      'verticesBuffer must not be null');
-  ol.DEBUG && console.assert(this.indicesBuffer,
-      'indicesBuffer must not be null');
   var verticesBuffer = this.verticesBuffer;
   var indicesBuffer = this.indicesBuffer;
   var lineDeleter = this.lineStringReplay.getDeleteResourcesFunction(context);
@@ -884,9 +874,6 @@ ol.render.webgl.PolygonReplay.prototype.drawReplay = function(gl, context, skipp
   if (!ol.obj.isEmpty(skippedFeaturesHash)) {
     this.drawReplaySkipping_(gl, context, skippedFeaturesHash);
   } else {
-    ol.DEBUG && console.assert(this.styles_.length === this.styleIndices_.length,
-        'number of styles and styleIndices match');
-
     //Draw by style groups to minimize drawElements() calls.
     var i, start, end, nextStyle;
     end = this.startIndices[this.startIndices.length - 1];
@@ -913,11 +900,6 @@ ol.render.webgl.PolygonReplay.prototype.drawReplay = function(gl, context, skipp
  */
 ol.render.webgl.PolygonReplay.prototype.drawHitDetectionReplayOneByOne = function(gl, context, skippedFeaturesHash,
     featureCallback, opt_hitExtent) {
-  ol.DEBUG && console.assert(this.styles_.length === this.styleIndices_.length,
-      'number of styles and styleIndices match');
-  ol.DEBUG && console.assert(this.startIndices.length - 1 === this.startIndicesFeature.length,
-      'number of startIndices and startIndicesFeature match');
-
   var i, start, end, nextStyle, groupStart, feature, featureUid, featureIndex;
   featureIndex = this.startIndices.length - 2;
   end = this.startIndices[featureIndex + 1];
@@ -962,9 +944,6 @@ ol.render.webgl.PolygonReplay.prototype.drawHitDetectionReplayOneByOne = functio
  * @param {Object} skippedFeaturesHash Ids of features to skip.
  */
 ol.render.webgl.PolygonReplay.prototype.drawReplaySkipping_ = function(gl, context, skippedFeaturesHash) {
-  ol.DEBUG && console.assert(this.startIndices.length - 1 === this.startIndicesFeature.length,
-      'number of startIndices and startIndicesFeature match');
-
   var i, start, end, nextStyle, groupStart, feature, featureUid, featureIndex, featureStart;
   featureIndex = this.startIndices.length - 2;
   end = start = this.startIndices[featureIndex + 1];
@@ -1012,7 +991,6 @@ ol.render.webgl.PolygonReplay.prototype.setFillStyle_ = function(gl, color) {
  * @inheritDoc
  */
 ol.render.webgl.PolygonReplay.prototype.setFillStrokeStyle = function(fillStyle, strokeStyle) {
-  ol.DEBUG && console.assert(this.state_, 'this.state_ should not be null');
   var fillStyleColor = fillStyle ? fillStyle.getColor() : [0, 0, 0, 0];
   if (!(fillStyleColor instanceof CanvasGradient) &&
       !(fillStyleColor instanceof CanvasPattern)) {

--- a/src/ol/render/webgl/polygonreplay/defaultshader.js
+++ b/src/ol/render/webgl/polygonreplay/defaultshader.js
@@ -35,9 +35,7 @@ ol.render.webgl.polygonreplay.defaultshader.Fragment.OPTIMIZED_SOURCE = 'precisi
  * @const
  * @type {string}
  */
-ol.render.webgl.polygonreplay.defaultshader.Fragment.SOURCE = ol.DEBUG ?
-    ol.render.webgl.polygonreplay.defaultshader.Fragment.DEBUG_SOURCE :
-    ol.render.webgl.polygonreplay.defaultshader.Fragment.OPTIMIZED_SOURCE;
+ol.render.webgl.polygonreplay.defaultshader.Fragment.SOURCE = ol.render.webgl.polygonreplay.defaultshader.Fragment.OPTIMIZED_SOURCE;
 
 
 ol.render.webgl.polygonreplay.defaultshader.fragment = new ol.render.webgl.polygonreplay.defaultshader.Fragment();
@@ -72,9 +70,7 @@ ol.render.webgl.polygonreplay.defaultshader.Vertex.OPTIMIZED_SOURCE = 'attribute
  * @const
  * @type {string}
  */
-ol.render.webgl.polygonreplay.defaultshader.Vertex.SOURCE = ol.DEBUG ?
-    ol.render.webgl.polygonreplay.defaultshader.Vertex.DEBUG_SOURCE :
-    ol.render.webgl.polygonreplay.defaultshader.Vertex.OPTIMIZED_SOURCE;
+ol.render.webgl.polygonreplay.defaultshader.Vertex.SOURCE = ol.render.webgl.polygonreplay.defaultshader.Vertex.OPTIMIZED_SOURCE;
 
 
 ol.render.webgl.polygonreplay.defaultshader.vertex = new ol.render.webgl.polygonreplay.defaultshader.Vertex();
@@ -91,36 +87,30 @@ ol.render.webgl.polygonreplay.defaultshader.Locations = function(gl, program) {
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_color = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_color' : 'e');
+  this.u_color = gl.getUniformLocation(program, 'e');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_offsetRotateMatrix = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_offsetRotateMatrix' : 'd');
+  this.u_offsetRotateMatrix = gl.getUniformLocation(program, 'd');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_offsetScaleMatrix = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_offsetScaleMatrix' : 'c');
+  this.u_offsetScaleMatrix = gl.getUniformLocation(program, 'c');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_opacity = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_opacity' : 'f');
+  this.u_opacity = gl.getUniformLocation(program, 'f');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_projectionMatrix = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_projectionMatrix' : 'b');
+  this.u_projectionMatrix = gl.getUniformLocation(program, 'b');
 
   /**
    * @type {number}
    */
-  this.a_position = gl.getAttribLocation(
-      program, ol.DEBUG ? 'a_position' : 'a');
+  this.a_position = gl.getAttribLocation(program, 'a');
 };

--- a/src/ol/render/webgl/replay.js
+++ b/src/ol/render/webgl/replay.js
@@ -284,14 +284,8 @@ ol.render.webgl.Replay.prototype.replay = function(context,
     gl.stencilFunc(gl.NOTEQUAL, 1, 255);
   }
 
-  // bind the vertices buffer
-  ol.DEBUG && console.assert(this.verticesBuffer,
-      'verticesBuffer must not be null');
   context.bindBuffer(ol.webgl.ARRAY_BUFFER, this.verticesBuffer);
 
-  // bind the indices buffer
-  ol.DEBUG && console.assert(this.indicesBuffer,
-      'indicesBuffer must not be null');
   context.bindBuffer(ol.webgl.ELEMENT_ARRAY_BUFFER, this.indicesBuffer);
 
   var locations = this.setUpProgram(gl, context, size, pixelRatio);
@@ -311,11 +305,11 @@ ol.render.webgl.Replay.prototype.replay = function(context,
   }
 
   gl.uniformMatrix4fv(locations.u_projectionMatrix, false,
-      ol.vec.Mat4.fromTransform(this.tmpMat4_, projectionMatrix));
+     ol.vec.Mat4.fromTransform(this.tmpMat4_, projectionMatrix));
   gl.uniformMatrix4fv(locations.u_offsetScaleMatrix, false,
-      ol.vec.Mat4.fromTransform(this.tmpMat4_, offsetScaleMatrix));
+     ol.vec.Mat4.fromTransform(this.tmpMat4_, offsetScaleMatrix));
   gl.uniformMatrix4fv(locations.u_offsetRotateMatrix, false,
-      ol.vec.Mat4.fromTransform(this.tmpMat4_, offsetRotateMatrix));
+     ol.vec.Mat4.fromTransform(this.tmpMat4_, offsetRotateMatrix));
   gl.uniform1f(locations.u_opacity, opacity);
 
   // draw!
@@ -337,10 +331,10 @@ ol.render.webgl.Replay.prototype.replay = function(context,
     }
     gl.clear(gl.STENCIL_BUFFER_BIT);
     gl.stencilFunc(/** @type {number} */ (tmpStencilFunc),
-        /** @type {number} */ (tmpStencilRef), /** @type {number} */ (tmpStencilMaskVal));
+       /** @type {number} */ (tmpStencilRef), /** @type {number} */ (tmpStencilMaskVal));
     gl.stencilMask(/** @type {number} */ (tmpStencilMask));
     gl.stencilOp(/** @type {number} */ (tmpStencilOpFail),
-        /** @type {number} */ (tmpStencilOpZFail), /** @type {number} */ (tmpStencilOpPass));
+       /** @type {number} */ (tmpStencilOpZFail), /** @type {number} */ (tmpStencilOpPass));
   }
 
   return result;

--- a/src/ol/render/webgl/replaygroup.js
+++ b/src/ol/render/webgl/replaygroup.js
@@ -107,9 +107,6 @@ ol.render.webgl.ReplayGroup.prototype.getReplay = function(zIndex, replayType) {
   var replay = replays[replayType];
   if (replay === undefined) {
     var Constructor = ol.render.webgl.ReplayGroup.BATCH_CONSTRUCTORS_[replayType];
-    ol.DEBUG && console.assert(Constructor !== undefined,
-        replayType +
-        ' constructor missing from ol.render.webgl.ReplayGroup.BATCH_CONSTRUCTORS_');
     replay = new Constructor(this.tolerance_, this.maxExtent_);
     replays[replayType] = replay;
   }

--- a/src/ol/renderer/canvas/imagelayer.js
+++ b/src/ol/renderer/canvas/imagelayer.js
@@ -3,7 +3,6 @@ goog.provide('ol.renderer.canvas.ImageLayer');
 goog.require('ol');
 goog.require('ol.ViewHint');
 goog.require('ol.extent');
-goog.require('ol.proj');
 goog.require('ol.renderer.canvas.IntermediateCanvas');
 goog.require('ol.transform');
 
@@ -78,8 +77,6 @@ ol.renderer.canvas.ImageLayer.prototype.prepareFrame = function(frameState, laye
     if (!ol.ENABLE_RASTER_REPROJECTION) {
       var sourceProjection = imageSource.getProjection();
       if (sourceProjection) {
-        ol.DEBUG && console.assert(ol.proj.equivalent(projection, sourceProjection),
-            'projection and sourceProjection are equivalent');
         projection = sourceProjection;
       }
     }

--- a/src/ol/renderer/layer.js
+++ b/src/ol/renderer/layer.js
@@ -116,20 +116,12 @@ ol.renderer.Layer.prototype.loadImage = function(image) {
   var imageState = image.getState();
   if (imageState != ol.ImageState.LOADED &&
       imageState != ol.ImageState.ERROR) {
-    // the image is either "idle" or "loading", register the change
-    // listener (a noop if the listener was already registered)
-    ol.DEBUG && console.assert(imageState == ol.ImageState.IDLE ||
-        imageState == ol.ImageState.LOADING,
-        'imageState is "idle" or "loading"');
     ol.events.listen(image, ol.events.EventType.CHANGE,
         this.handleImageChange_, this);
   }
   if (imageState == ol.ImageState.IDLE) {
     image.load();
     imageState = image.getState();
-    ol.DEBUG && console.assert(imageState == ol.ImageState.LOADING ||
-        imageState == ol.ImageState.LOADED,
-        'imageState is "loading" or "loaded"');
   }
   return imageState == ol.ImageState.LOADED;
 };

--- a/src/ol/renderer/map.js
+++ b/src/ol/renderer/map.js
@@ -53,8 +53,6 @@ ol.renderer.Map.prototype.calculateMatrices2D = function(frameState) {
   var viewState = frameState.viewState;
   var coordinateToPixelTransform = frameState.coordinateToPixelTransform;
   var pixelToCoordinateTransform = frameState.pixelToCoordinateTransform;
-  ol.DEBUG && console.assert(coordinateToPixelTransform,
-      'frameState has a coordinateToPixelTransform');
 
   ol.transform.compose(coordinateToPixelTransform,
       frameState.size[0] / 2, frameState.size[1] / 2,
@@ -223,8 +221,6 @@ ol.renderer.Map.prototype.getLayerRenderer = function(layer) {
  * @return {ol.renderer.Layer} Layer renderer.
  */
 ol.renderer.Map.prototype.getLayerRendererByKey = function(layerKey) {
-  ol.DEBUG && console.assert(layerKey in this.layerRenderers_,
-      'given layerKey (%s) exists in layerRenderers', layerKey);
   return this.layerRenderers_[layerKey];
 };
 
@@ -268,13 +264,9 @@ ol.renderer.Map.prototype.handleLayerRendererChange_ = function() {
  * @private
  */
 ol.renderer.Map.prototype.removeLayerRendererByKey_ = function(layerKey) {
-  ol.DEBUG && console.assert(layerKey in this.layerRenderers_,
-      'given layerKey (%s) exists in layerRenderers', layerKey);
   var layerRenderer = this.layerRenderers_[layerKey];
   delete this.layerRenderers_[layerKey];
 
-  ol.DEBUG && console.assert(layerKey in this.layerRendererListeners_,
-      'given layerKey (%s) exists in layerRendererListeners', layerKey);
   ol.events.unlistenByKey(this.layerRendererListeners_[layerKey]);
   delete this.layerRendererListeners_[layerKey];
 

--- a/src/ol/renderer/vector.js
+++ b/src/ol/renderer/vector.js
@@ -87,8 +87,6 @@ ol.renderer.vector.renderFeature = function(
         imageStyle.load();
       }
       imageState = imageStyle.getImageState();
-      ol.DEBUG && console.assert(imageState == ol.ImageState.LOADING,
-          'imageState should be LOADING');
       imageStyle.listenImageChange(listener, thisArg);
       loading = true;
     }

--- a/src/ol/renderer/webgl/defaultmapshader.js
+++ b/src/ol/renderer/webgl/defaultmapshader.js
@@ -35,9 +35,7 @@ ol.renderer.webgl.defaultmapshader.Fragment.OPTIMIZED_SOURCE = 'precision medium
  * @const
  * @type {string}
  */
-ol.renderer.webgl.defaultmapshader.Fragment.SOURCE = ol.DEBUG ?
-    ol.renderer.webgl.defaultmapshader.Fragment.DEBUG_SOURCE :
-    ol.renderer.webgl.defaultmapshader.Fragment.OPTIMIZED_SOURCE;
+ol.renderer.webgl.defaultmapshader.Fragment.SOURCE = ol.renderer.webgl.defaultmapshader.Fragment.OPTIMIZED_SOURCE;
 
 
 ol.renderer.webgl.defaultmapshader.fragment = new ol.renderer.webgl.defaultmapshader.Fragment();
@@ -72,9 +70,7 @@ ol.renderer.webgl.defaultmapshader.Vertex.OPTIMIZED_SOURCE = 'varying vec2 a;att
  * @const
  * @type {string}
  */
-ol.renderer.webgl.defaultmapshader.Vertex.SOURCE = ol.DEBUG ?
-    ol.renderer.webgl.defaultmapshader.Vertex.DEBUG_SOURCE :
-    ol.renderer.webgl.defaultmapshader.Vertex.OPTIMIZED_SOURCE;
+ol.renderer.webgl.defaultmapshader.Vertex.SOURCE = ol.renderer.webgl.defaultmapshader.Vertex.OPTIMIZED_SOURCE;
 
 
 ol.renderer.webgl.defaultmapshader.vertex = new ol.renderer.webgl.defaultmapshader.Vertex();
@@ -91,36 +87,30 @@ ol.renderer.webgl.defaultmapshader.Locations = function(gl, program) {
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_opacity = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_opacity' : 'f');
+  this.u_opacity = gl.getUniformLocation(program, 'f');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_projectionMatrix = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_projectionMatrix' : 'e');
+  this.u_projectionMatrix = gl.getUniformLocation(program, 'e');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_texCoordMatrix = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_texCoordMatrix' : 'd');
+  this.u_texCoordMatrix = gl.getUniformLocation(program, 'd');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_texture = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_texture' : 'g');
+  this.u_texture = gl.getUniformLocation(program, 'g');
 
   /**
    * @type {number}
    */
-  this.a_position = gl.getAttribLocation(
-      program, ol.DEBUG ? 'a_position' : 'b');
+  this.a_position = gl.getAttribLocation(program, 'b');
 
   /**
    * @type {number}
    */
-  this.a_texCoord = gl.getAttribLocation(
-      program, ol.DEBUG ? 'a_texCoord' : 'c');
+  this.a_texCoord = gl.getAttribLocation(program, 'c');
 };

--- a/src/ol/renderer/webgl/imagelayer.js
+++ b/src/ol/renderer/webgl/imagelayer.js
@@ -5,7 +5,6 @@ goog.require('ol.ViewHint');
 goog.require('ol.dom');
 goog.require('ol.extent');
 goog.require('ol.functions');
-goog.require('ol.proj');
 goog.require('ol.renderer.webgl.Layer');
 goog.require('ol.source.ImageVector');
 goog.require('ol.transform');
@@ -118,8 +117,6 @@ ol.renderer.webgl.ImageLayer.prototype.prepareFrame = function(frameState, layer
     if (!ol.ENABLE_RASTER_REPROJECTION) {
       var sourceProjection = imageSource.getProjection();
       if (sourceProjection) {
-        ol.DEBUG && console.assert(ol.proj.equivalent(projection, sourceProjection),
-            'projection and sourceProjection are equivalent');
         projection = sourceProjection;
       }
     }
@@ -149,8 +146,6 @@ ol.renderer.webgl.ImageLayer.prototype.prepareFrame = function(frameState, layer
   }
 
   if (image) {
-    ol.DEBUG && console.assert(texture, 'texture is truthy');
-
     var canvas = this.mapRenderer.getContext().getCanvas();
 
     this.updateProjectionMatrix_(canvas.width, canvas.height,

--- a/src/ol/renderer/webgl/map.js
+++ b/src/ol/renderer/webgl/map.js
@@ -28,7 +28,6 @@ goog.require('ol.webgl.ContextEventType');
  * @param {ol.Map} map Map.
  */
 ol.renderer.webgl.Map = function(container, map) {
-
   ol.renderer.Map.call(this, container, map);
 
   /**
@@ -77,7 +76,6 @@ ol.renderer.webgl.Map = function(container, map) {
     preserveDrawingBuffer: false,
     stencil: true
   });
-  ol.DEBUG && console.assert(this.gl_, 'got a WebGLRenderingContext');
 
   /**
    * @private
@@ -129,12 +127,12 @@ ol.renderer.webgl.Map = function(container, map) {
       });
 
 
- /**
-  * @param {ol.Map} map Map.
-  * @param {?olx.FrameState} frameState Frame state.
-  * @return {boolean} false.
-  * @this {ol.renderer.webgl.Map}
-  */
+  /**
+   * @param {ol.Map} map Map.
+   * @param {?olx.FrameState} frameState Frame state.
+   * @return {boolean} false.
+   * @this {ol.renderer.webgl.Map}
+   */
   this.loadNextTileTexture_ =
       function(map, frameState) {
         if (!this.tileTextureQueue_.isEmpty()) {
@@ -157,7 +155,6 @@ ol.renderer.webgl.Map = function(container, map) {
   this.textureCacheFrameMarkerCount_ = 0;
 
   this.initializeGL_();
-
 };
 ol.inherits(ol.renderer.webgl.Map, ol.renderer.Map);
 

--- a/src/ol/renderer/webgl/tilelayershader.js
+++ b/src/ol/renderer/webgl/tilelayershader.js
@@ -35,9 +35,7 @@ ol.renderer.webgl.tilelayershader.Fragment.OPTIMIZED_SOURCE = 'precision mediump
  * @const
  * @type {string}
  */
-ol.renderer.webgl.tilelayershader.Fragment.SOURCE = ol.DEBUG ?
-    ol.renderer.webgl.tilelayershader.Fragment.DEBUG_SOURCE :
-    ol.renderer.webgl.tilelayershader.Fragment.OPTIMIZED_SOURCE;
+ol.renderer.webgl.tilelayershader.Fragment.SOURCE = ol.renderer.webgl.tilelayershader.Fragment.OPTIMIZED_SOURCE;
 
 
 ol.renderer.webgl.tilelayershader.fragment = new ol.renderer.webgl.tilelayershader.Fragment();
@@ -72,9 +70,7 @@ ol.renderer.webgl.tilelayershader.Vertex.OPTIMIZED_SOURCE = 'varying vec2 a;attr
  * @const
  * @type {string}
  */
-ol.renderer.webgl.tilelayershader.Vertex.SOURCE = ol.DEBUG ?
-    ol.renderer.webgl.tilelayershader.Vertex.DEBUG_SOURCE :
-    ol.renderer.webgl.tilelayershader.Vertex.OPTIMIZED_SOURCE;
+ol.renderer.webgl.tilelayershader.Vertex.SOURCE = ol.renderer.webgl.tilelayershader.Vertex.OPTIMIZED_SOURCE;
 
 
 ol.renderer.webgl.tilelayershader.vertex = new ol.renderer.webgl.tilelayershader.Vertex();
@@ -91,24 +87,20 @@ ol.renderer.webgl.tilelayershader.Locations = function(gl, program) {
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_texture = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_texture' : 'e');
+  this.u_texture = gl.getUniformLocation(program, 'e');
 
   /**
    * @type {WebGLUniformLocation}
    */
-  this.u_tileOffset = gl.getUniformLocation(
-      program, ol.DEBUG ? 'u_tileOffset' : 'd');
+  this.u_tileOffset = gl.getUniformLocation(program, 'd');
 
   /**
    * @type {number}
    */
-  this.a_position = gl.getAttribLocation(
-      program, ol.DEBUG ? 'a_position' : 'b');
+  this.a_position = gl.getAttribLocation(program, 'b');
 
   /**
    * @type {number}
    */
-  this.a_texCoord = gl.getAttribLocation(
-      program, ol.DEBUG ? 'a_texCoord' : 'c');
+  this.a_texCoord = gl.getAttribLocation(program, 'c');
 };

--- a/src/ol/reproj/image.js
+++ b/src/ol/reproj/image.js
@@ -194,8 +194,6 @@ ol.reproj.Image.prototype.load = function() {
  * @private
  */
 ol.reproj.Image.prototype.unlistenSource_ = function() {
-  ol.DEBUG && console.assert(this.sourceListenerKey_,
-      'this.sourceListenerKey_ should not be null');
   ol.events.unlistenByKey(/** @type {!ol.EventsKey} */ (this.sourceListenerKey_));
   this.sourceListenerKey_ = null;
 };

--- a/src/ol/reproj/tile.js
+++ b/src/ol/reproj/tile.js
@@ -173,12 +173,6 @@ ol.reproj.Tile = function(sourceProj, sourceTileGrid,
     var sourceRange = sourceTileGrid.getTileRangeForExtentAndZ(
         sourceExtent, this.sourceZ_);
 
-    var tilesRequired = sourceRange.getWidth() * sourceRange.getHeight();
-    if (ol.DEBUG && !(tilesRequired < ol.RASTER_REPROJECTION_MAX_SOURCE_TILES)) {
-      console.assert(false, 'reasonable number of tiles is required');
-      this.state = ol.TileState.ERROR;
-      return;
-    }
     for (var srcX = sourceRange.minX; srcX <= sourceRange.maxX; srcX++) {
       for (var srcY = sourceRange.minY; srcY <= sourceRange.maxY; srcY++) {
         var tile = getTileFunction(this.sourceZ_, srcX, srcY, pixelRatio);
@@ -263,9 +257,6 @@ ol.reproj.Tile.prototype.load = function() {
 
     var leftToLoad = 0;
 
-    ol.DEBUG && console.assert(!this.sourcesListenerKeys_,
-        'this.sourcesListenerKeys_ should be null');
-
     this.sourcesListenerKeys_ = [];
     this.sourceTiles_.forEach(function(tile, i, arr) {
       var state = tile.getState();
@@ -281,8 +272,6 @@ ol.reproj.Tile.prototype.load = function() {
                   state == ol.TileState.EMPTY) {
                 ol.events.unlistenByKey(sourceListenKey);
                 leftToLoad--;
-                ol.DEBUG && console.assert(leftToLoad >= 0,
-                    'leftToLoad should not be negative');
                 if (leftToLoad === 0) {
                   this.unlistenSources_();
                   this.reproject_();

--- a/src/ol/reproj/triangulation.js
+++ b/src/ol/reproj/triangulation.js
@@ -115,10 +115,6 @@ ol.reproj.Triangulation = function(sourceProj, targetProj, targetExtent,
       ol.RASTER_REPROJECTION_MAX_SUBDIVISION);
 
   if (this.wrapsXInSource_) {
-    // Fix coordinates (ol.proj returns wrapped coordinates, "unwrap" here).
-    // This significantly simplifies the rest of the reprojection process.
-
-    ol.DEBUG && console.assert(this.sourceWorldWidth_ !== null);
     var leftBound = Infinity;
     this.triangles_.forEach(function(triangle, i, arr) {
       leftBound = Math.min(leftBound,

--- a/src/ol/source/bingmaps.js
+++ b/src/ol/source/bingmaps.js
@@ -116,7 +116,6 @@ ol.source.BingMaps.prototype.getImagerySet = function() {
  * @param {BingMapsImageryMetadataResponse} response Response.
  */
 ol.source.BingMaps.prototype.handleImageryMetadataResponse = function(response) {
-
   if (response.statusCode != 200 ||
       response.statusDescription != 'OK' ||
       response.authenticationResultCode != 'ValidCredentials' ||
@@ -132,8 +131,6 @@ ol.source.BingMaps.prototype.handleImageryMetadataResponse = function(response) 
   }
   //var copyright = response.copyright;  // FIXME do we need to display this?
   var resource = response.resourceSets[0].resources[0];
-  ol.DEBUG && console.assert(resource.imageWidth == resource.imageHeight,
-      'resource has imageWidth equal to imageHeight, i.e. is square');
   var maxZoom = this.maxZoom_ == -1 ? resource.zoomMax : this.maxZoom_;
 
   var sourceProjection = this.getProjection();
@@ -164,9 +161,6 @@ ol.source.BingMaps.prototype.handleImageryMetadataResponse = function(response) 
              * @return {string|undefined} Tile URL.
              */
             function(tileCoord, pixelRatio, projection) {
-              ol.DEBUG && console.assert(ol.proj.equivalent(
-                  projection, sourceProjection),
-                  'projections are equivalent');
               if (!tileCoord) {
                 return undefined;
               } else {
@@ -216,5 +210,4 @@ ol.source.BingMaps.prototype.handleImageryMetadataResponse = function(response) 
   this.setLogo(brandLogoUri);
 
   this.setState(ol.source.State.READY);
-
 };

--- a/src/ol/source/cluster.js
+++ b/src/ol/source/cluster.js
@@ -149,7 +149,6 @@ ol.source.Cluster.prototype.cluster_ = function() {
         ol.extent.buffer(extent, mapDistance, extent);
 
         var neighbors = this.source_.getFeaturesInExtent(extent);
-        ol.DEBUG && console.assert(neighbors.length >= 1, 'at least one neighbor found');
         neighbors = neighbors.filter(function(neighbor) {
           var uid = ol.getUid(neighbor).toString();
           if (!(uid in clustered)) {
@@ -163,9 +162,6 @@ ol.source.Cluster.prototype.cluster_ = function() {
       }
     }
   }
-  ol.DEBUG && console.assert(
-      Object.keys(clustered).length == this.source_.getFeatures().length,
-      'number of clustered equals number of features in the source');
 };
 
 

--- a/src/ol/source/image.js
+++ b/src/ol/source/image.js
@@ -22,7 +22,6 @@ goog.require('ol.source.Source');
  * @api
  */
 ol.source.Image = function(options) {
-
   ol.source.Source.call(this, {
     attributions: options.attributions,
     extent: options.extent,
@@ -37,11 +36,6 @@ ol.source.Image = function(options) {
    */
   this.resolutions_ = options.resolutions !== undefined ?
       options.resolutions : null;
-  ol.DEBUG && console.assert(!this.resolutions_ ||
-      ol.array.isSorted(this.resolutions_,
-          function(a, b) {
-            return b - a;
-          }, true), 'resolutions must be null or sorted in descending order');
 
 
   /**
@@ -56,7 +50,6 @@ ol.source.Image = function(options) {
    * @type {number}
    */
   this.reprojectedRevision_ = 0;
-
 };
 ol.inherits(ol.source.Image, ol.source.Source);
 

--- a/src/ol/source/imagearcgisrest.js
+++ b/src/ol/source/imagearcgisrest.js
@@ -194,9 +194,6 @@ ol.source.ImageArcGISRest.prototype.getImageLoadFunction = function() {
  * @private
  */
 ol.source.ImageArcGISRest.prototype.getRequestUrl_ = function(extent, size, pixelRatio, projection, params) {
-
-  ol.DEBUG && console.assert(this.url_ !== undefined, 'url is defined');
-
   // ArcGIS Server only wants the numeric portion of the projection ID.
   var srid = projection.getCode().split(':').pop();
 
@@ -209,8 +206,8 @@ ol.source.ImageArcGISRest.prototype.getRequestUrl_ = function(extent, size, pixe
   var url = this.url_;
 
   var modifiedUrl = url
-    .replace(/MapServer\/?$/, 'MapServer/export')
-    .replace(/ImageServer\/?$/, 'ImageServer/exportImage');
+   .replace(/MapServer\/?$/, 'MapServer/export')
+   .replace(/ImageServer\/?$/, 'ImageServer/exportImage');
   if (modifiedUrl == url) {
     ol.asserts.assert(false, 50); // `options.featureTypes` should be an Array
   }

--- a/src/ol/source/imagewms.js
+++ b/src/ol/source/imagewms.js
@@ -134,10 +134,6 @@ ol.source.ImageWMS.GETFEATUREINFO_IMAGE_SIZE_ = [101, 101];
  * @api stable
  */
 ol.source.ImageWMS.prototype.getGetFeatureInfoUrl = function(coordinate, resolution, projection, params) {
-
-  ol.DEBUG && console.assert(!('VERSION' in params),
-      'key VERSION is not allowed in params');
-
   if (this.url_ === undefined) {
     return undefined;
   }

--- a/src/ol/source/raster.js
+++ b/src/ol/source/raster.js
@@ -415,8 +415,6 @@ ol.source.Raster.createRenderer_ = function(source) {
     renderer = ol.source.Raster.createTileRenderer_(source);
   } else if (source instanceof ol.source.Image) {
     renderer = ol.source.Raster.createImageRenderer_(source);
-  } else {
-    ol.DEBUG && console.assert(false, 'Unsupported source type: ' + source);
   }
   return renderer;
 };

--- a/src/ol/source/stamen.js
+++ b/src/ol/source/stamen.js
@@ -16,15 +16,10 @@ goog.require('ol.source.XYZ');
  * @api stable
  */
 ol.source.Stamen = function(options) {
-
   var i = options.layer.indexOf('-');
   var provider = i == -1 ? options.layer : options.layer.slice(0, i);
-  ol.DEBUG && console.assert(provider in ol.source.Stamen.ProviderConfig,
-      'known provider configured');
   var providerConfig = ol.source.Stamen.ProviderConfig[provider];
 
-  ol.DEBUG && console.assert(options.layer in ol.source.Stamen.LayerConfig,
-      'known layer configured');
   var layerConfig = ol.source.Stamen.LayerConfig[options.layer];
 
   var url = options.url !== undefined ? options.url :
@@ -42,7 +37,6 @@ ol.source.Stamen = function(options) {
     tileLoadFunction: options.tileLoadFunction,
     url: url
   });
-
 };
 ol.inherits(ol.source.Stamen, ol.source.XYZ);
 

--- a/src/ol/source/tilejson.js
+++ b/src/ol/source/tilejson.js
@@ -116,9 +116,6 @@ ol.source.TileJSON.prototype.handleTileJSONResponse = function(tileJSON) {
     extent = ol.extent.applyTransform(tileJSON.bounds, transform);
   }
 
-  if (tileJSON.scheme !== undefined) {
-    ol.DEBUG && console.assert(tileJSON.scheme == 'xyz', 'tileJSON-scheme is "xyz"');
-  }
   var minZoom = tileJSON.minzoom || 0;
   var maxZoom = tileJSON.maxzoom || 22;
   var tileGrid = ol.tilegrid.createXYZ({

--- a/src/ol/source/tileutfgrid.js
+++ b/src/ol/source/tileutfgrid.js
@@ -175,9 +175,6 @@ ol.source.TileUTFGrid.prototype.handleTileJSONResponse = function(tileJSON) {
     extent = ol.extent.applyTransform(tileJSON.bounds, transform);
   }
 
-  if (tileJSON.scheme !== undefined) {
-    ol.DEBUG && console.assert(tileJSON.scheme == 'xyz', 'tileJSON-scheme is "xyz"');
-  }
   var minZoom = tileJSON.minzoom || 0;
   var maxZoom = tileJSON.maxzoom || 22;
   var tileGrid = ol.tilegrid.createXYZ({
@@ -230,7 +227,6 @@ ol.source.TileUTFGrid.prototype.getTile = function(z, x, y, pixelRatio, projecti
   if (this.tileCache.containsKey(tileCoordKey)) {
     return /** @type {!ol.Tile} */ (this.tileCache.get(tileCoordKey));
   } else {
-    ol.DEBUG && console.assert(projection, 'argument projection is truthy');
     var tileCoord = [z, x, y];
     var urlTileCoord =
         this.getTileCoordForTileUrlFunction(tileCoord, projection);

--- a/src/ol/source/tilewms.js
+++ b/src/ol/source/tilewms.js
@@ -115,10 +115,6 @@ ol.inherits(ol.source.TileWMS, ol.source.TileImage);
  * @api stable
  */
 ol.source.TileWMS.prototype.getGetFeatureInfoUrl = function(coordinate, resolution, projection, params) {
-
-  ol.DEBUG && console.assert(!('VERSION' in params),
-      'key VERSION is not allowed in params');
-
   var projectionObj = ol.proj.get(projection);
 
   var tileGrid = this.getTileGrid();

--- a/src/ol/source/wmts.js
+++ b/src/ol/source/wmts.js
@@ -296,19 +296,10 @@ ol.source.WMTS.prototype.updateDimensions = function(dimensions) {
  * @api
  */
 ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
-
-  // TODO: add support for TileMatrixLimits
-  ol.DEBUG && console.assert(config['layer'],
-      'config "layer" must not be null');
-
   var layers = wmtsCap['Contents']['Layer'];
   var l = ol.array.find(layers, function(elt, index, array) {
     return elt['Identifier'] == config['layer'];
   });
-  ol.DEBUG && console.assert(l, 'found a matching layer in Contents/Layer');
-
-  ol.DEBUG && console.assert(l['TileMatrixSetLink'].length > 0,
-      'layer has TileMatrixSetLink');
   var tileMatrixSets = wmtsCap['Contents']['TileMatrixSet'];
   var idx, matrixSet, matrixLimits;
   if (l['TileMatrixSetLink'].length > 1) {
@@ -344,8 +335,6 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
   matrixLimits = /** @type {Array.<Object>} */
       (l['TileMatrixSetLink'][idx]['TileMatrixSetLimits']);
 
-  ol.DEBUG && console.assert(matrixSet, 'TileMatrixSet must not be null');
-
   var format = /** @type {string} */ (l['Format'][0]);
   if ('format' in config) {
     format = config['format'];
@@ -367,13 +356,9 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
     l['Dimension'].forEach(function(elt, index, array) {
       var key = elt['Identifier'];
       var value = elt['Default'];
-      if (value !== undefined) {
-        ol.DEBUG && console.assert(ol.array.includes(elt['Value'], value),
-            'default value contained in values');
-      } else {
+      if (value === undefined) {
         value = elt['Value'][0];
       }
-      ol.DEBUG && console.assert(value !== undefined, 'value could be found');
       dimensions[key] = value;
     });
   }
@@ -382,8 +367,6 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
   var matrixSetObj = ol.array.find(matrixSets, function(elt, index, array) {
     return elt['Identifier'] == matrixSet;
   });
-  ol.DEBUG && console.assert(matrixSetObj,
-      'found matrixSet in Contents/TileMatrixSet');
 
   var projection;
   if ('projection' in config) {
@@ -419,21 +402,14 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
   var requestEncoding = config['requestEncoding'];
   requestEncoding = requestEncoding !== undefined ? requestEncoding : '';
 
-  ol.DEBUG && console.assert(
-      ol.array.includes(['REST', 'RESTful', 'KVP', ''], requestEncoding),
-      'requestEncoding (%s) is one of "REST", "RESTful", "KVP" or ""',
-      requestEncoding);
-
   if ('OperationsMetadata' in wmtsCap && 'GetTile' in wmtsCap['OperationsMetadata']) {
     var gets = wmtsCap['OperationsMetadata']['GetTile']['DCP']['HTTP']['Get'];
-    ol.DEBUG && console.assert(gets.length >= 1);
 
     for (var i = 0, ii = gets.length; i < ii; ++i) {
       var constraint = ol.array.find(gets[i]['Constraint'], function(element) {
         return element['name'] == 'GetEncoding';
       });
       var encodings = constraint['AllowedValues']['Value'];
-      ol.DEBUG && console.assert(encodings.length >= 1);
 
       if (requestEncoding === '') {
         // requestEncoding not provided, use the first encoding from the list
@@ -457,7 +433,6 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
       }
     });
   }
-  ol.DEBUG && console.assert(urls.length > 0, 'At least one URL found');
 
   return {
     urls: urls,
@@ -471,5 +446,4 @@ ol.source.WMTS.optionsFromCapabilities = function(wmtsCap, config) {
     dimensions: dimensions,
     wrapX: wrapX
   };
-
 };

--- a/src/ol/structs/lrucache.js
+++ b/src/ol/structs/lrucache.js
@@ -2,7 +2,6 @@ goog.provide('ol.structs.LRUCache');
 
 goog.require('ol');
 goog.require('ol.asserts');
-goog.require('ol.obj');
 
 
 /**
@@ -40,53 +39,6 @@ ol.structs.LRUCache = function() {
   this.newest_ = null;
 
 };
-
-
-if (ol.DEBUG) {
-  /**
-   * FIXME empty description for jsdoc
-   */
-  ol.structs.LRUCache.prototype.assertValid = function() {
-    if (this.count_ === 0) {
-      console.assert(ol.obj.isEmpty(this.entries_),
-          'entries must be an empty object (count = 0)');
-      console.assert(!this.oldest_,
-          'oldest must be null (count = 0)');
-      console.assert(!this.newest_,
-          'newest must be null (count = 0)');
-    } else {
-      console.assert(Object.keys(this.entries_).length == this.count_,
-          'number of entries matches count');
-      console.assert(this.oldest_,
-          'we have an oldest entry');
-      console.assert(!this.oldest_.older,
-          'no entry is older than oldest');
-      console.assert(this.newest_,
-          'we have a newest entry');
-      console.assert(!this.newest_.newer,
-          'no entry is newer than newest');
-      var i, entry;
-      var older = null;
-      i = 0;
-      for (entry = this.oldest_; entry; entry = entry.newer) {
-        console.assert(entry.older === older,
-            'entry.older links to correct older');
-        older = entry;
-        ++i;
-      }
-      console.assert(i == this.count_, 'iterated correct amount of times');
-      var newer = null;
-      i = 0;
-      for (entry = this.newest_; entry; entry = entry.older) {
-        console.assert(entry.newer === newer,
-            'entry.newer links to correct newer');
-        newer = entry;
-        ++i;
-      }
-      console.assert(i == this.count_, 'iterated correct amount of times');
-    }
-  };
-}
 
 
 /**
@@ -169,7 +121,6 @@ ol.structs.LRUCache.prototype.getKeys = function() {
   for (entry = this.newest_; entry; entry = entry.older) {
     keys[i++] = entry.key_;
   }
-  ol.DEBUG && console.assert(i == this.count_, 'iterated correct number of times');
   return keys;
 };
 
@@ -184,7 +135,6 @@ ol.structs.LRUCache.prototype.getValues = function() {
   for (entry = this.newest_; entry; entry = entry.older) {
     values[i++] = entry.value_;
   }
-  ol.DEBUG && console.assert(i == this.count_, 'iterated correct number of times');
   return values;
 };
 
@@ -193,7 +143,6 @@ ol.structs.LRUCache.prototype.getValues = function() {
  * @return {T} Last value.
  */
 ol.structs.LRUCache.prototype.peekLast = function() {
-  ol.DEBUG && console.assert(this.oldest_, 'oldest must not be null');
   return this.oldest_.value_;
 };
 
@@ -202,7 +151,6 @@ ol.structs.LRUCache.prototype.peekLast = function() {
  * @return {string} Last key.
  */
 ol.structs.LRUCache.prototype.peekLastKey = function() {
-  ol.DEBUG && console.assert(this.oldest_, 'oldest must not be null');
   return this.oldest_.key_;
 };
 
@@ -211,11 +159,7 @@ ol.structs.LRUCache.prototype.peekLastKey = function() {
  * @return {T} value Value.
  */
 ol.structs.LRUCache.prototype.pop = function() {
-  ol.DEBUG && console.assert(this.oldest_, 'oldest must not be null');
-  ol.DEBUG && console.assert(this.newest_, 'newest must not be null');
   var entry = this.oldest_;
-  ol.DEBUG && console.assert(entry.key_ in this.entries_,
-      'oldest is indexed in entries');
   delete this.entries_[entry.key_];
   if (entry.newer) {
     entry.newer.older = null;
@@ -244,8 +188,6 @@ ol.structs.LRUCache.prototype.replace = function(key, value) {
  * @param {T} value Value.
  */
 ol.structs.LRUCache.prototype.set = function(key, value) {
-  ol.DEBUG && console.assert(!(key in {}),
-      'key is not a standard property of objects (e.g. "__proto__")');
   ol.asserts.assert(!(key in this.entries_),
       16); // Tried to set a value for a key that is used already
   var entry = /** @type {ol.LRUCacheEntry} */ ({

--- a/src/ol/structs/priorityqueue.js
+++ b/src/ol/structs/priorityqueue.js
@@ -62,29 +62,6 @@ ol.structs.PriorityQueue = function(priorityFunction, keyFunction) {
 ol.structs.PriorityQueue.DROP = Infinity;
 
 
-if (ol.DEBUG) {
-  /**
-   * FIXME empty description for jsdoc
-   */
-  ol.structs.PriorityQueue.prototype.assertValid = function() {
-    var elements = this.elements_;
-    var priorities = this.priorities_;
-    var n = elements.length;
-    console.assert(priorities.length == n);
-    var i, priority;
-    for (i = 0; i < (n >> 1) - 1; ++i) {
-      priority = priorities[i];
-      console.assert(priority <= priorities[this.getLeftChildIndex_(i)],
-          'priority smaller than or equal to priority of left child (%s <= %s)',
-          priority, priorities[this.getLeftChildIndex_(i)]);
-      console.assert(priority <= priorities[this.getRightChildIndex_(i)],
-          'priority smaller than or equal to priority of right child (%s <= %s)',
-          priority, priorities[this.getRightChildIndex_(i)]);
-    }
-  };
-}
-
-
 /**
  * FIXME empty description for jsdoc
  */
@@ -101,8 +78,6 @@ ol.structs.PriorityQueue.prototype.clear = function() {
  */
 ol.structs.PriorityQueue.prototype.dequeue = function() {
   var elements = this.elements_;
-  ol.DEBUG && console.assert(elements.length > 0,
-      'must have elements in order to be able to dequeue');
   var priorities = this.priorities_;
   var element = elements[0];
   if (elements.length == 1) {
@@ -114,8 +89,6 @@ ol.structs.PriorityQueue.prototype.dequeue = function() {
     this.siftUp_(0);
   }
   var elementKey = this.keyFunction_(element);
-  ol.DEBUG && console.assert(elementKey in this.queuedElements_,
-      'key %s is not listed as queued', elementKey);
   delete this.queuedElements_[elementKey];
   return element;
 };

--- a/src/ol/style/atlasmanager.js
+++ b/src/ol/style/atlasmanager.js
@@ -118,10 +118,6 @@ ol.style.AtlasManager.prototype.getInfo_ = function(atlases, id) {
  *    entry, or `null` if the entry is not part of the atlases.
  */
 ol.style.AtlasManager.prototype.mergeInfos_ = function(info, hitInfo) {
-  ol.DEBUG && console.assert(info.offsetX === hitInfo.offsetX,
-      'in order to merge, offsetX of info and hitInfo must be equal');
-  ol.DEBUG && console.assert(info.offsetY === hitInfo.offsetY,
-      'in order to merge, offsetY of info and hitInfo must be equal');
   return /** @type {ol.AtlasManagerInfo} */ ({
     offsetX: info.offsetX,
     offsetY: info.offsetY,
@@ -219,6 +215,5 @@ ol.style.AtlasManager.prototype.add_ = function(isHitAtlas, id, width, height,
       ++ii;
     }
   }
-  ol.DEBUG && console.assert(false, 'Failed to add to atlasmanager');
   return null;
 };

--- a/src/ol/style/iconimage.js
+++ b/src/ol/style/iconimage.js
@@ -220,10 +220,6 @@ ol.style.IconImage.prototype.getSrc = function() {
  */
 ol.style.IconImage.prototype.load = function() {
   if (this.imageState_ == ol.ImageState.IDLE) {
-    ol.DEBUG && console.assert(this.src_ !== undefined,
-        'this.src_ must not be undefined');
-    ol.DEBUG && console.assert(!this.imageListenerKeys_,
-        'no listener keys existing');
     this.imageState_ = ol.ImageState.LOADING;
     this.imageListenerKeys_ = [
       ol.events.listenOnce(this.image_, ol.events.EventType.ERROR,

--- a/src/ol/style/iconimagecache.js
+++ b/src/ol/style/iconimagecache.js
@@ -37,8 +37,6 @@ ol.style.IconImageCache = function() {
  * @return {string} Cache key.
  */
 ol.style.IconImageCache.getKey = function(src, crossOrigin, color) {
-  ol.DEBUG && console.assert(crossOrigin !== undefined,
-      'argument crossOrigin must be defined');
   var colorString = color ? ol.color.asString(color) : 'null';
   return crossOrigin + ':' + src + ':' + colorString;
 };

--- a/src/ol/style/regularshape.js
+++ b/src/ol/style/regularshape.js
@@ -21,11 +21,6 @@ goog.require('ol.style.Image');
  * @api
  */
 ol.style.RegularShape = function(options) {
-
-  ol.DEBUG && console.assert(
-      options.radius !== undefined || options.radius1 !== undefined,
-      'must provide either "radius" or "radius1"');
-
   /**
    * @private
    * @type {Array.<string>}
@@ -139,7 +134,6 @@ ol.style.RegularShape = function(options) {
     scale: 1,
     snapToPixel: snapToPixel
   });
-
 };
 ol.inherits(ol.style.RegularShape, ol.style.Image);
 
@@ -392,7 +386,6 @@ ol.style.RegularShape.prototype.render_ = function(atlasManager) {
     var info = atlasManager.add(
         id, size, size, this.draw_.bind(this, renderOptions),
         renderHitDetectionCallback);
-    ol.DEBUG && console.assert(info, 'shape size is too large');
 
     this.canvas_ = info.image;
     this.origin_ = [info.offsetX, info.offsetY];

--- a/src/ol/tilegrid/tilegrid.js
+++ b/src/ol/tilegrid/tilegrid.js
@@ -114,11 +114,7 @@ ol.tilegrid.TileGrid = function(options) {
   this.tmpSize_ = [0, 0];
 
   if (options.sizes !== undefined) {
-    ol.DEBUG && console.assert(options.sizes.length == this.resolutions_.length,
-        'number of sizes and resolutions must be equal');
     this.fullTileRanges_ = options.sizes.map(function(size, z) {
-      ol.DEBUG && console.assert(size[0] !== 0, 'width must not be 0');
-      ol.DEBUG && console.assert(size[1] !== 0, 'height must not be 0');
       var tileRange = new ol.TileRange(
           Math.min(0, size[0]), Math.max(size[0] - 1, -1),
           Math.min(0, size[1]), Math.max(size[1] - 1, -1));
@@ -218,9 +214,6 @@ ol.tilegrid.TileGrid.prototype.getOrigin = function(z) {
   if (this.origin_) {
     return this.origin_;
   } else {
-    ol.DEBUG && console.assert(this.minZoom <= z && z <= this.maxZoom,
-        'given z is not in allowed range (%s <= %s <= %s)',
-        this.minZoom, z, this.maxZoom);
     return this.origins_[z];
   }
 };
@@ -233,9 +226,6 @@ ol.tilegrid.TileGrid.prototype.getOrigin = function(z) {
  * @api stable
  */
 ol.tilegrid.TileGrid.prototype.getResolution = function(z) {
-  ol.DEBUG && console.assert(this.minZoom <= z && z <= this.maxZoom,
-      'given z is not in allowed range (%s <= %s <= %s)',
-      this.minZoom, z, this.maxZoom);
   return this.resolutions_[z];
 };
 
@@ -426,10 +416,6 @@ ol.tilegrid.TileGrid.prototype.getTileCoordForCoordAndZ = function(coordinate, z
  * @return {number} Tile resolution.
  */
 ol.tilegrid.TileGrid.prototype.getTileCoordResolution = function(tileCoord) {
-  ol.DEBUG && console.assert(
-      this.minZoom <= tileCoord[0] && tileCoord[0] <= this.maxZoom,
-      'z of given tilecoord is not in allowed range (%s <= %s <= %s',
-      this.minZoom, tileCoord[0], this.maxZoom);
   return this.resolutions_[tileCoord[0]];
 };
 
@@ -446,9 +432,6 @@ ol.tilegrid.TileGrid.prototype.getTileSize = function(z) {
   if (this.tileSize_) {
     return this.tileSize_;
   } else {
-    ol.DEBUG && console.assert(this.minZoom <= z && z <= this.maxZoom,
-        'z is not in allowed range (%s <= %s <= %s',
-        this.minZoom, z, this.maxZoom);
     return this.tileSizes_[z];
   }
 };
@@ -462,9 +445,6 @@ ol.tilegrid.TileGrid.prototype.getFullTileRange = function(z) {
   if (!this.fullTileRanges_) {
     return null;
   } else {
-    ol.DEBUG && console.assert(this.minZoom <= z && z <= this.maxZoom,
-        'z is not in allowed range (%s <= %s <= %s',
-        this.minZoom, z, this.maxZoom);
     return this.fullTileRanges_[z];
   }
 };

--- a/src/ol/tilegrid/wmts.js
+++ b/src/ol/tilegrid/wmts.js
@@ -17,12 +17,6 @@ goog.require('ol.tilegrid.TileGrid');
  * @api
  */
 ol.tilegrid.WMTS = function(options) {
-
-  ol.DEBUG && console.assert(
-      options.resolutions.length == options.matrixIds.length,
-      'options resolutions and matrixIds must have equal length (%s == %s)',
-      options.resolutions.length, options.matrixIds.length);
-
   /**
    * @private
    * @type {!Array.<string>}
@@ -39,7 +33,6 @@ ol.tilegrid.WMTS = function(options) {
     tileSizes: options.tileSizes,
     sizes: options.sizes
   });
-
 };
 ol.inherits(ol.tilegrid.WMTS, ol.tilegrid.TileGrid);
 
@@ -49,8 +42,6 @@ ol.inherits(ol.tilegrid.WMTS, ol.tilegrid.TileGrid);
  * @return {string} MatrixId..
  */
 ol.tilegrid.WMTS.prototype.getMatrixId = function(z) {
-  ol.DEBUG && console.assert(0 <= z && z < this.matrixIds_.length,
-      'attempted to retrieve matrixId for illegal z (%s)', z);
   return this.matrixIds_[z];
 };
 

--- a/src/ol/tilequeue.js
+++ b/src/ol/tilequeue.js
@@ -97,7 +97,6 @@ ol.TileQueue.prototype.handleTileChange = function(event) {
     }
     this.tileChangeCallback_();
   }
-  ol.DEBUG && console.assert(Object.keys(this.tilesLoadingKeys_).length === this.tilesLoading_);
 };
 
 
@@ -118,6 +117,5 @@ ol.TileQueue.prototype.loadMoreTiles = function(maxTotalLoading, maxNewLoads) {
       ++newLoads;
       tile.load();
     }
-    ol.DEBUG && console.assert(Object.keys(this.tilesLoadingKeys_).length === this.tilesLoading_);
   }
 };

--- a/src/ol/tileurlfunction.js
+++ b/src/ol/tileurlfunction.js
@@ -66,8 +66,6 @@ ol.TileUrlFunction.createFromTemplates = function(templates, tileGrid) {
  * @return {ol.TileUrlFunctionType} Tile URL function.
  */
 ol.TileUrlFunction.createFromTileUrlFunctions = function(tileUrlFunctions) {
-  ol.DEBUG && console.assert(tileUrlFunctions.length > 0,
-      'Length of tile url functions should be greater than 0');
   if (tileUrlFunctions.length === 1) {
     return tileUrlFunctions[0];
   }

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -571,10 +571,6 @@ ol.View.prototype.getResolutionForValueFunction = function(opt_power) {
        */
       function(value) {
         var resolution = maxResolution / Math.pow(power, value * max);
-        ol.DEBUG && console.assert(resolution >= minResolution &&
-            resolution <= maxResolution,
-            'calculated resolution outside allowed bounds (%s <= %s <= %s)',
-            minResolution, resolution, maxResolution);
         return resolution;
       });
 };
@@ -610,8 +606,6 @@ ol.View.prototype.getValueForResolutionFunction = function(opt_power) {
       function(resolution) {
         var value =
             (Math.log(maxResolution / resolution) / Math.log(power)) / max;
-        ol.DEBUG && console.assert(value >= 0 && value <= 1,
-            'calculated value (%s) ouside allowed range (0-1)', value);
         return value;
       });
 };
@@ -621,8 +615,6 @@ ol.View.prototype.getValueForResolutionFunction = function(opt_power) {
  * @return {olx.ViewState} View state.
  */
 ol.View.prototype.getState = function() {
-  ol.DEBUG && console.assert(this.isDef(),
-      'the view was not defined (had no center and/or resolution)');
   var center = /** @type {ol.Coordinate} */ (this.getCenter());
   var projection = this.getProjection();
   var resolution = /** @type {number} */ (this.getResolution());
@@ -719,7 +711,6 @@ ol.View.prototype.fit = function(geometryOrExtent, opt_options) {
 
   // calculate rotated extent
   var rotation = this.getRotation();
-  ol.DEBUG && console.assert(rotation !== undefined, 'rotation was not defined');
   var cosAngle = Math.cos(-rotation);
   var sinAngle = Math.sin(-rotation);
   var minRotX = +Infinity;
@@ -845,11 +836,7 @@ ol.View.prototype.setCenter = function(center) {
  * @return {number} New value.
  */
 ol.View.prototype.setHint = function(hint, delta) {
-  ol.DEBUG && console.assert(0 <= hint && hint < this.hints_.length,
-      'illegal hint (%s), must be between 0 and %s', hint, this.hints_.length);
   this.hints_[hint] += delta;
-  ol.DEBUG && console.assert(this.hints_[hint] >= 0,
-      'Hint at %s must be positive, was %s', hint, this.hints_[hint]);
   this.changed();
   return this.hints_[hint];
 };
@@ -1008,8 +995,6 @@ ol.View.createRotationConstraint_ = function(options) {
     } else if (typeof constrainRotation === 'number') {
       return ol.RotationConstraint.createSnapToN(constrainRotation);
     } else {
-      ol.DEBUG && console.assert(false,
-          'illegal option for constrainRotation (%s)', constrainRotation);
       return ol.RotationConstraint.none;
     }
   } else {

--- a/src/ol/webgl/context.js
+++ b/src/ol/webgl/context.js
@@ -82,9 +82,7 @@ ol.webgl.Context = function(canvas, gl) {
 
   // use the OES_element_index_uint extension if available
   if (this.hasOESElementIndexUint) {
-    var ext = gl.getExtension('OES_element_index_uint');
-    ol.DEBUG && console.assert(ext,
-        'Failed to get extension "OES_element_index_uint"');
+    gl.getExtension('OES_element_index_uint');
   }
 
   ol.events.listen(this.canvas_, ol.webgl.ContextEventType.LOST,
@@ -113,9 +111,6 @@ ol.webgl.Context.prototype.bindBuffer = function(target, buf) {
   } else {
     var buffer = gl.createBuffer();
     gl.bindBuffer(target, buffer);
-    ol.DEBUG && console.assert(target == ol.webgl.ARRAY_BUFFER ||
-        target == ol.webgl.ELEMENT_ARRAY_BUFFER,
-        'target is supposed to be an ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER');
     var /** @type {ArrayBufferView} */ arrayBuffer;
     if (target == ol.webgl.ARRAY_BUFFER) {
       arrayBuffer = new Float32Array(arr);
@@ -138,8 +133,6 @@ ol.webgl.Context.prototype.bindBuffer = function(target, buf) {
 ol.webgl.Context.prototype.deleteBuffer = function(buf) {
   var gl = this.getGL();
   var bufferKey = String(ol.getUid(buf));
-  ol.DEBUG && console.assert(bufferKey in this.bufferCache_,
-      'attempted to delete uncached buffer');
   var bufferCacheEntry = this.bufferCache_[bufferKey];
   if (!gl.isContextLost()) {
     gl.deleteBuffer(bufferCacheEntry.buffer);
@@ -218,10 +211,6 @@ ol.webgl.Context.prototype.getShader = function(shaderObject) {
     var shader = gl.createShader(shaderObject.getType());
     gl.shaderSource(shader, shaderObject.getSource());
     gl.compileShader(shader);
-    ol.DEBUG && console.assert(
-        gl.getShaderParameter(shader, ol.webgl.COMPILE_STATUS) ||
-        gl.isContextLost(),
-        gl.getShaderInfoLog(shader) || 'illegal state, shader not compiled or context lost');
     this.shaderCache_[shaderKey] = shader;
     return shader;
   }
@@ -248,10 +237,6 @@ ol.webgl.Context.prototype.getProgram = function(
     gl.attachShader(program, this.getShader(fragmentShaderObject));
     gl.attachShader(program, this.getShader(vertexShaderObject));
     gl.linkProgram(program);
-    ol.DEBUG && console.assert(
-        gl.getProgramParameter(program, ol.webgl.LINK_STATUS) ||
-        gl.isContextLost(),
-        gl.getProgramInfoLog(program) || 'illegal state, shader not linked or context lost');
     this.programCache_[programKey] = program;
     return program;
   }

--- a/src/ol/webgl/shader.mustache
+++ b/src/ol/webgl/shader.mustache
@@ -35,9 +35,7 @@ ol.inherits({{className}}.Fragment, ol.webgl.Fragment);
  * @const
  * @type {string}
  */
-{{className}}.Fragment.SOURCE = ol.DEBUG ?
-    {{className}}.Fragment.DEBUG_SOURCE :
-    {{className}}.Fragment.OPTIMIZED_SOURCE;
+{{className}}.Fragment.SOURCE = {{className}}.Fragment.OPTIMIZED_SOURCE;
 
 
 {{className}}.fragment = new {{className}}.Fragment();
@@ -72,9 +70,7 @@ ol.inherits({{className}}.Vertex, ol.webgl.Vertex);
  * @const
  * @type {string}
  */
-{{className}}.Vertex.SOURCE = ol.DEBUG ?
-    {{className}}.Vertex.DEBUG_SOURCE :
-    {{className}}.Vertex.OPTIMIZED_SOURCE;
+{{className}}.Vertex.SOURCE = {{className}}.Vertex.OPTIMIZED_SOURCE;
 
 
 {{className}}.vertex = new {{className}}.Vertex();
@@ -92,15 +88,13 @@ ol.inherits({{className}}.Vertex, ol.webgl.Vertex);
   /**
    * @type {WebGLUniformLocation}
    */
-  this.{{originalName}} = gl.getUniformLocation(
-      program, ol.DEBUG ? '{{originalName}}' : '{{shortName}}');
+  this.{{originalName}} = gl.getUniformLocation(program, '{{shortName}}');
 {{/getUniforms}}
 {{#getAttributes}}
 
   /**
    * @type {number}
    */
-  this.{{originalName}} = gl.getAttribLocation(
-      program, ol.DEBUG ? '{{originalName}}' : '{{shortName}}');
+  this.{{originalName}} = gl.getAttribLocation(program, '{{shortName}}');
 {{/getAttributes}}
 };

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -133,12 +133,8 @@ ol.xml.makeArrayExtender = function(valueReader, opt_this) {
       function(node, objectStack) {
         var value = valueReader.call(opt_this, node, objectStack);
         if (value !== undefined) {
-          ol.DEBUG && console.assert(Array.isArray(value),
-              'valueReader function is expected to return an array of values');
           var array = /** @type {Array.<*>} */
               (objectStack[objectStack.length - 1]);
-          ol.DEBUG && console.assert(Array.isArray(array),
-              'objectStack is supposed to be an array of arrays');
           ol.array.extend(array, value);
         }
       });
@@ -164,8 +160,6 @@ ol.xml.makeArrayPusher = function(valueReader, opt_this) {
             node, objectStack);
         if (value !== undefined) {
           var array = objectStack[objectStack.length - 1];
-          ol.DEBUG && console.assert(Array.isArray(array),
-              'objectStack is supposed to be an array of arrays');
           array.push(value);
         }
       });
@@ -206,8 +200,6 @@ ol.xml.makeReplacer = function(valueReader, opt_this) {
  * @template T
  */
 ol.xml.makeObjectPropertyPusher = function(valueReader, opt_property, opt_this) {
-  ol.DEBUG && console.assert(valueReader !== undefined,
-      'undefined valueReader, expected function(this: T, Node, Array.<*>)');
   return (
       /**
        * @param {Node} node Node.
@@ -242,8 +234,6 @@ ol.xml.makeObjectPropertyPusher = function(valueReader, opt_property, opt_this) 
  * @template T
  */
 ol.xml.makeObjectPropertySetter = function(valueReader, opt_property, opt_this) {
-  ol.DEBUG && console.assert(valueReader !== undefined,
-      'undefined valueReader, expected function(this: T, Node, Array.<*>)');
   return (
       /**
        * @param {Node} node Node.
@@ -279,9 +269,6 @@ ol.xml.makeChildAppender = function(nodeWriter, opt_this) {
         node, value, objectStack);
     var parent = objectStack[objectStack.length - 1];
     var parentNode = parent.node;
-    ol.DEBUG && console.assert(ol.xml.isNode(parentNode) ||
-        ol.xml.isDocument(parentNode),
-        'expected parentNode %s to be a Node or a Document', parentNode);
     parentNode.appendChild(node);
   };
 };
@@ -340,8 +327,6 @@ ol.xml.makeSimpleNodeFactory = function(opt_nodeName, opt_namespaceURI) {
       function(value, objectStack, opt_nodeName) {
         var context = objectStack[objectStack.length - 1];
         var node = context.node;
-        ol.DEBUG && console.assert(ol.xml.isNode(node) || ol.xml.isDocument(node),
-            'expected node %s to be a Node or a Document', node);
         var nodeName = fixedNodeName;
         if (nodeName === undefined) {
           nodeName = opt_nodeName;
@@ -350,7 +335,6 @@ ol.xml.makeSimpleNodeFactory = function(opt_nodeName, opt_namespaceURI) {
         if (opt_namespaceURI === undefined) {
           namespaceURI = node.namespaceURI;
         }
-        ol.DEBUG && console.assert(nodeName !== undefined, 'nodeName was undefined');
         return ol.xml.createElementNS(namespaceURI, /** @type {string} */ (nodeName));
       }
   );

--- a/tasks/readme.md
+++ b/tasks/readme.md
@@ -55,9 +55,6 @@ Below is a complete `build.json` configuration file that would generate a 'full'
       "externs/tilejson.js",
       "externs/topojson.js"
     ],
-    "define": [
-      "ol.DEBUG=false"
-    ],
     "compilation_level": "ADVANCED",
     "output_wrapper": "(function(){%output%})();",
     "use_types_for_optimization": true,

--- a/test/spec/ol/math.test.js
+++ b/test/spec/ol/math.test.js
@@ -27,7 +27,6 @@ describe('ol.math.clamp', function() {
 
 });
 
-
 describe('ol.math.cosh', function() {
 
   it('returns the correct value at -Infinity', function() {
@@ -51,7 +50,6 @@ describe('ol.math.cosh', function() {
   });
 
 });
-
 
 describe('ol.math.roundUpToPowerOfTwo', function() {
 
@@ -92,8 +90,8 @@ describe('ol.math.roundUpToPowerOfTwo', function() {
 
 });
 
-
 describe('ol.math.solveLinearSystem', function() {
+
   it('calculates correctly', function() {
     var result = ol.math.solveLinearSystem([
       [2, 1, 3, 1],
@@ -104,6 +102,7 @@ describe('ol.math.solveLinearSystem', function() {
     expect(result[1]).to.roughlyEqual(0.4, 1e-9);
     expect(result[2]).to.roughlyEqual(0, 1e-9);
   });
+
   it('can handle singular matrix', function() {
     var result = ol.math.solveLinearSystem([
       [2, 1, 3, 1],
@@ -112,32 +111,8 @@ describe('ol.math.solveLinearSystem', function() {
     ]);
     expect(result).to.be(null);
   });
-  it('raises an exception when the matrix is malformed', function() {
-    var origAssert = console.assert;
-    console.assert = function(assertion, message) {
-      if (!assertion) {
-        throw new Error(message);
-      }
-    };
-    expect(function() {
-      ol.math.solveLinearSystem([
-        [2, 1, 3, 1],
-        [2, 6, 8, 3],
-        [6, 8, 18]
-      ]);
-    }).to.throwException();
 
-    expect(function() {
-      ol.math.solveLinearSystem([
-        [2, 1, 3, 1],
-        [2, 6, 8, 3],
-        [6, 8, 18, 5, 0]
-      ]);
-    }).to.throwException();
-    console.assert = origAssert;
-  });
 });
-
 
 describe('ol.math.toDegrees', function() {
   it('returns the correct value at -π', function() {
@@ -150,7 +125,6 @@ describe('ol.math.toDegrees', function() {
     expect(ol.math.toDegrees(Math.PI)).to.be(180);
   });
 });
-
 
 describe('ol.math.toRadians', function() {
   it('returns the correct value at -180', function() {
@@ -186,16 +160,16 @@ describe('ol.math.modulo', function() {
     expect(ol.math.modulo(1, -5)).to.be(-4);
     expect(ol.math.modulo(6, -5)).to.be(-4);
   });
+});
 
-  describe('ol.math.lerp', function() {
-    it('correctly interpolated numbers', function() {
-      expect(ol.math.lerp(0, 0, 0)).to.be(0);
-      expect(ol.math.lerp(0, 1, 0)).to.be(0);
-      expect(ol.math.lerp(1, 11, 5)).to.be(51);
-    });
-    it('correctly interpolates floats', function() {
-      expect(ol.math.lerp(0, 1, 0.5)).to.be(0.5);
-      expect(ol.math.lerp(0.25, 0.75, 0.5)).to.be(0.5);
-    });
+describe('ol.math.lerp', function() {
+  it('correctly interpolated numbers', function() {
+    expect(ol.math.lerp(0, 0, 0)).to.be(0);
+    expect(ol.math.lerp(0, 1, 0)).to.be(0);
+    expect(ol.math.lerp(1, 11, 5)).to.be(51);
+  });
+  it('correctly interpolates floats', function() {
+    expect(ol.math.lerp(0, 1, 0.5)).to.be(0.5);
+    expect(ol.math.lerp(0.25, 0.75, 0.5)).to.be(0.5);
   });
 });

--- a/test/spec/ol/structs/priorityqueue.test.js
+++ b/test/spec/ol/structs/priorityqueue.test.js
@@ -26,27 +26,12 @@ describe('ol.structs.PriorityQueue', function() {
       console.assert = origAssert;
     });
 
-    it('is valid', function() {
-      expect(function() {
-        pq.assertValid();
-      }).not.to.throwException();
-    });
-
     it('is empty', function() {
       expect(pq.isEmpty()).to.be(true);
     });
 
-    it('dequeue raises an exception', function() {
-      expect(function() {
-        pq.dequeue();
-      }).to.throwException();
-    });
-
     it('enqueue adds an element', function() {
       var added = pq.enqueue(0);
-      expect(function() {
-        pq.assertValid();
-      }).not.to.throwException();
       expect(added).to.be(true);
       expect(pq.elements_).to.eql([0]);
       expect(pq.priorities_).to.eql([0]);
@@ -54,22 +39,9 @@ describe('ol.structs.PriorityQueue', function() {
 
     it('do not enqueue element with DROP priority', function() {
       var added = pq.enqueue(Infinity);
-      expect(function() {
-        pq.assertValid();
-      }).not.to.throwException();
       expect(added).to.be(false);
       expect(pq.elements_).to.eql([]);
       expect(pq.priorities_).to.eql([]);
-    });
-
-    it('maintains the pq property while elements are enqueued', function() {
-      var i;
-      for (i = 0; i < 32; ++i) {
-        pq.enqueue(Math.random());
-        expect(function() {
-          pq.assertValid();
-        }).not.to.throwException();
-      }
     });
 
   });

--- a/test/spec/ol/structs/rbush.test.js
+++ b/test/spec/ol/structs/rbush.test.js
@@ -117,27 +117,6 @@ describe('ol.structs.RBush', function() {
 
     });
 
-    describe('#insert', function() {
-
-      it('throws an exception if called while iterating over all values',
-          function() {
-            expect(function() {
-              rBush.forEach(function(value) {
-                rBush.insert([0, 0, 1, 1], {});
-              });
-            }).to.throwException();
-          });
-
-      it('throws an exception if called while iterating over an extent',
-          function() {
-            expect(function() {
-              rBush.forEachInExtent([-10, -10, 10, 10], function(value) {
-                rBush.insert([0, 0, 1, 1], {});
-              });
-            }).to.throwException();
-          });
-    });
-
     describe('#isEmpty', function() {
 
       it('returns false', function() {
@@ -157,45 +136,6 @@ describe('ol.structs.RBush', function() {
         }
       });
 
-      it('throws an exception if called while iterating over all values',
-          function() {
-            expect(function() {
-              rBush.forEach(function(value) {
-                rBush.remove(value);
-              });
-            }).to.throwException();
-          });
-
-      it('throws an exception if called while iterating over an extent',
-          function() {
-            expect(function() {
-              rBush.forEachInExtent([-10, -10, 10, 10], function(value) {
-                rBush.remove(value);
-              });
-            }).to.throwException();
-          });
-
-    });
-
-    describe('#update', function() {
-
-      it('throws an exception if called while iterating over all values',
-          function() {
-            expect(function() {
-              rBush.forEach(function(value) {
-                rBush.update([0, 0, 1, 1], objs[1]);
-              });
-            }).to.throwException();
-          });
-
-      it('throws an exception if called while iterating over an extent',
-          function() {
-            expect(function() {
-              rBush.forEachInExtent([-10, -10, 10, 10], function(value) {
-                rBush.update([0, 0, 1, 1], objs[1]);
-              });
-            }).to.throwException();
-          });
     });
 
   });

--- a/test/spec/ol/tilequeue.test.js
+++ b/test/spec/ol/tilequeue.test.js
@@ -95,9 +95,6 @@ describe('ol.TileQueue', function() {
       addRandomPriorityTiles(tq, 100);
 
       tq.heapify_();
-      expect(function() {
-        tq.assertValid();
-      }).not.to.throwException();
     });
   });
 
@@ -123,9 +120,6 @@ describe('ol.TileQueue', function() {
       tq.reprioritize();
       expect(tq.elements_.length).to.eql(50);
       expect(tq.priorities_.length).to.eql(50);
-      expect(function() {
-        tq.assertValid();
-      }).not.to.throwException();
 
     });
   });

--- a/test_rendering/spec/ol/style/polygon.test.js
+++ b/test_rendering/spec/ol/style/polygon.test.js
@@ -86,7 +86,7 @@ describe('ol.rendering.style.Polygon', function() {
     }
 
     it('tests the canvas renderer', function(done) {
-      map = createMap('webgl');
+      map = createMap('canvas');
       createFeatures();
       expectResemble(map, 'spec/ol/style/expected/polygon-types-canvas.png',
           IMAGE_TOLERANCE, done);


### PR DESCRIPTION
This proposes that we get rid of the `ol.DEBUG` build flag.

Justification:
 * These build flags are hard to use outside of the Closure Compiler.  Even with the Compiler, they only work in a "global" context, so will not work with ES6 modules (or anything that wraps code in a closure before passing to the Compiler).  This means that people include a lot of unnecessary code in their applications.
 * Most of the uses are logical expressions that guard a `console.assert()` call.  This causes trouble where `console.assert` is not defined.  It could make sense to `throw` in these situations instead - the `console.assert()` call is a bit odd because it allows execution to continue so things still break in unexpected ways after the call.
 * We need to stop piling unnecessary code into the library and relying on the Compiler to remove it all for us.
 * I think we can do a lot more to improve the experience for people developing applications with OpenLayers.  This feature doesn't feel like it is providing much.

I'm open to hearing alternative perspectives.